### PR TITLE
Change prettier's printWidth to 100 to match console

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,4 @@
 arrowParens: always
 singleQuote: true
 trailingComma: all
+printWidth: 100

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,8 +20,6 @@ const config: Config.InitialOptions = {
   transform: {
     '^.+\\.[t|j]sx?$': 'ts-jest',
   },
-  transformIgnorePatterns: [
-    '<rootDir>/node_modules/(?!(@patternfly|@openshift-console\\S*?)/.*)',
-  ],
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@patternfly|@openshift-console\\S*?)/.*)'],
 };
 export default config;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,10 +4,7 @@ import * as path from 'path';
 
 import CopyPlugin from 'copy-webpack-plugin';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
-import {
-  Configuration as WebpackConfiguration,
-  EnvironmentPlugin,
-} from 'webpack';
+import { Configuration as WebpackConfiguration, EnvironmentPlugin } from 'webpack';
 import { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
 import { ConsoleRemotePlugin } from '@openshift-console/dynamic-plugin-sdk-webpack';
@@ -71,8 +68,7 @@ const config: Configuration = {
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
-      'Access-Control-Allow-Headers':
-        'X-Requested-With, Content-Type, Authorization',
+      'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type, Authorization',
     },
     devMiddleware: {
       writeToDisk: true,


### PR DESCRIPTION
The default `printWidth` of 80 is being used.  Updating to 100 to match the configuration in openshift/console.

Note: The code changes are required for the linters to pass.

See: https://github.com/openshift/console/blob/master/frontend/.prettierrc
Signed-off-by: Scott J Dickerson <sdickers@redhat.com>