### PR TITLE
Update README and helm to use kubev2v instead of konveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 # OpenShift Console Plugin For Forklift
 
 [![Operator Repository on Quay](https://quay.io/repository/kubevirt-ui/forklift-console-plugin/status "Plugin Repository on Quay")](https://quay.io/repository/kubevirt-ui/forklift-console-plugin)
-[![codecov](https://codecov.io/gh/konveyor/forklift-console-plugin/branch/main/graph/badge.svg?token=NsQ3mmCTNw)](https://codecov.io/gh/konveyor/forklift-console-plugin)
+[![codecov](https://codecov.io/gh/kubev2v/forklift-console-plugin/branch/main/graph/badge.svg?token=NsQ3mmCTNw)](https://codecov.io/gh/kubev2v/forklift-console-plugin)
 
 Forklift is a suite of migration tools that facilitate the migration of VM workloads to [OpenShift Virtualization](https://cloud.redhat.com/learn/topics/virtualization/).
 
 ## Prerequisites
 
-* [__Forklift Operator__](https://https://github.com/konveyor/forklift-operator/)
+* [__Forklift Operator__](https://github.com/kubev2v/forklift-operator/)
 * [__OpenShift Console 4.12+__](https://www.openshift.com/)
 
 ## Development
@@ -53,7 +53,7 @@ plugin to a cluster by using [helm](https://helm.sh/).
 
 ```bash
 # Add the forklift helm repo
-helm repo add forklift https://konveyor.github.io/forklift-console-plugin
+helm repo add forklift https://kubev2v.github.io/forklift-console-plugin
 
 # Install the forklift console plugin using current namespace
 helm install forklift-console-plugin forklift/forklift-console-plugin

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -67,7 +67,7 @@ yarn helm:build
 
 ```bash
 # add the forklift helm repo
-helm repo add forklift https://konveyor.github.io/forklift-console-plugin
+helm repo add forklift https://kubev2v.github.io/forklift-console-plugin
 
 # install the chart using the repository package
 helm install forklift forklift/forklift-console-plugin

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "forklift-console-plugin",
   "version": "0.0.1",
   "private": true,
-  "repository": "git@github.com:konveyor/forklift-console-plugin.git",
+  "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf dist",
@@ -22,7 +22,7 @@
     "test:coverage": "jest --coverage",
     "test:updateSnapshot": "jest --updateSnapshot",
     "helm:lint": "helm lint deployment/forklift-console-plugin/",
-    "helm:index": "helm repo index ./tmp/ --url https://konveyor.github.io/forklift-console-plugin",
+    "helm:index": "helm repo index ./tmp/ --url https://kubev2v.github.io/forklift-console-plugin",
     "helm:build": "mkdir -p tmp && helm package -d tmp deployment/forklift-console-plugin/ && yarn helm:index"
   },
   "devDependencies": {


### PR DESCRIPTION
Update README and helm to use kubev2v instead of konveyor

Signed-off-by: yzamir <yzamir@redhat.com>