### PR TITLE
Fix kind download hint

### DIFF
--- a/scripts/configure-kind.sh
+++ b/scripts/configure-kind.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # ------------
 
 # Hint - install kind [ linux-amd64 ]
-#curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+#curl -LO https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
 #sudo install kind-linux-amd64 /usr/local/bin/kind
 
 echo "Starting local kind cluster..."


### PR DESCRIPTION
The hint for installing kind point to minikube's download url, this PR fixes the hint to point to kind download url