### PR TITLE
Replace direct usage of '/mtv' with PATH_PREFIX

### DIFF
--- a/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/PlanWizard.tsx
@@ -152,12 +152,12 @@ export const PlanWizard: React.FunctionComponent = () => {
   const storageMappingsQuery = useMappingsQuery(MappingType.Storage);
 
   const editRouteMatch = useRouteMatch<{ planName: string }>({
-    path: '/mtv/plans/:planName/edit',
+    path: `${PATH_PREFIX}/plans/:planName/edit`,
     strict: true,
     sensitive: true,
   });
   const duplicateRouteMatch = useRouteMatch<{ planName: string }>({
-    path: '/mtv/plans/:planName/duplicate',
+    path: `${PATH_PREFIX}/plans/:planName/duplicate`,
     strict: true,
     sensitive: true,
   });

--- a/pkg/web/src/app/Providers/HostsPage.tsx
+++ b/pkg/web/src/app/Providers/HostsPage.tsx
@@ -26,7 +26,7 @@ export interface IHostsMatchParams {
 
 export const HostsPage: React.FunctionComponent = () => {
   const match = useRouteMatch<IHostsMatchParams>({
-    path: '/providers/vsphere/:providerName',
+    path: `${PATH_PREFIX}/providers/vsphere/:providerName`,
     strict: true,
     sensitive: true,
   });


### PR DESCRIPTION
Fixes missing path prefix in HostsPage.

Steps to recreate the problem (using mock data):
1. go to Providers -> VMware
2. find `vcenter-1` povider
3. follow the link in the Hosts column

Expected result:  sub-page with host table is displayed
Actual result:  an error is displayed `No matching host found`


Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>