### PR TITLE
Check for empty state nodes in TableView

### DIFF
--- a/src/components/StandardPage/StandardPage.tsx
+++ b/src/components/StandardPage/StandardPage.tsx
@@ -146,15 +146,13 @@ export function StandardPage<T>({
           aria-label={title}
           Row={RowMapper}
         >
-          {[
-            !loaded && <Loading key="loading" />,
-            errorFetchingData && <ErrorState key="error" />,
-            noResults && (customNoResultsFound ?? <NoResultsFound key="no_result" />),
-            noMatchingResults &&
-              (customNoResultsMatchFilter ?? (
-                <NoResultsMatchFilter key="no_match" clearAllFilters={clearAllFilters} />
-              )),
-          ].filter(Boolean)}
+          {!loaded && <Loading key="loading" />}
+          {errorFetchingData && <ErrorState key="error" />}
+          {noResults && (customNoResultsFound ?? <NoResultsFound key="no_result" />)}
+          {noMatchingResults &&
+            (customNoResultsMatchFilter ?? (
+              <NoResultsMatchFilter key="no_match" clearAllFilters={clearAllFilters} />
+            ))}
         </TableView>
       </PageSection>
     </>

--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -28,8 +28,8 @@ export function TableView<T>({
   children,
 }: TableViewProps<T>) {
   const { t } = useTranslation();
-
   const [activeSort, setActiveSort, comparator] = useSort(allColumns);
+  const hasChildren = children.filter(Boolean).length > 0;
 
   entities.sort(comparator);
 
@@ -56,14 +56,14 @@ export function TableView<T>({
         </Tr>
       </Thead>
       <Tbody>
-        {children.length > 0 && (
+        {hasChildren && (
           <Tr>
             <Td colSpan={visibleColumns.length || 1}>
               <Bullseye>{children}</Bullseye>
             </Td>
           </Tr>
         )}
-        {children.length === 0 &&
+        {!hasChildren &&
           entities.map((entity, index) => (
             <Row key={entity?.[uidFieldId] ?? index} entity={entity} columns={visibleColumns} />
           ))}


### PR DESCRIPTION
The parent component can use simplified syntax for providing 'children' prop.

Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>