### PR TITLE
Change quay repo from kubevirt-ui to kubev2v

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenShift Console Plugin For Forklift
 
-[![Operator Repository on Quay](https://quay.io/repository/kubevirt-ui/forklift-console-plugin/status "Plugin Repository on Quay")](https://quay.io/repository/kubevirt-ui/forklift-console-plugin)
+[![Operator Repository on Quay](https://quay.io/repository/kubev2v/forklift-console-plugin/status "Plugin Repository on Quay")](https://quay.io/repository/kubev2v/forklift-console-plugin)
 [![codecov](https://codecov.io/gh/kubev2v/forklift-console-plugin/branch/main/graph/badge.svg?token=NsQ3mmCTNw)](https://codecov.io/gh/kubev2v/forklift-console-plugin)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kubev2v_forklift-console-plugin&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kubev2v_forklift-console-plugin)
 

--- a/deployment/forklift-console-plugin/values.yaml
+++ b/deployment/forklift-console-plugin/values.yaml
@@ -1,5 +1,5 @@
 plugin: forklift-console-plugin
 name: forklift-console-plugin
-image: quay.io/kubevirt-ui/forklift-console-plugin:release-v0.1
+image: quay.io/kubev2v/forklift-console-plugin:release-v0.1
 
 forkliftNamespace: konveyor-forklift

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -17,7 +17,7 @@
 |-----------|-------------|---------------|
 | plugin | name of "app" label used for objects |  forklift-console-plugin
 | name | the deployment name | forklift-console-plugin
-| image | the plugin container image | quay.io/kubevirt-ui/forklift-console-plugin:[latest release branch]
+| image | the plugin container image | quay.io/kubev2v/forklift-console-plugin:[latest release branch]
 | forkliftNamespace | forklift-operator namespace | konveyor-forklift
 
 ## Running the helm chart locally

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -9,7 +9,7 @@ push it to an image registry.
 
 ```sh
 # build the image and tag it
-podman build -t quay.io/kubevirt-ui/forklift-console-plugin:latest .
+podman build -t quay.io/kubev2v/forklift-console-plugin:latest .
 ```
 
 ### Push the image
@@ -19,7 +19,7 @@ podman build -t quay.io/kubevirt-ui/forklift-console-plugin:latest .
 podman login quay.io
 
 # push the image 
-podman push quay.io/kubevirt-ui/forklift-console-plugin:latest
+podman push quay.io/kubev2v/forklift-console-plugin:latest
 ```
 
 NOTE: If you have a Mac with Apple silicon, you will need to add the flag
@@ -31,5 +31,5 @@ to run in-cluster.
 Run the local image, expose and proxy the server to port 9001 (nginx default port is 8080).
 
 ```sh
-podman run -it --rm -p 9001:8080 quay.io/kubevirt-ui/forklift-console-plugin:latest
+podman run -it --rm -p 9001:8080 quay.io/kubev2v/forklift-console-plugin:latest
 ```


### PR DESCRIPTION
Change quay repo from kubevirt-ui to kubev2v

we have a new quay.io image repository, this PR moves the image references to the new repository

Signed-off-by: yzamir <yzamir@redhat.com>