### PR TITLE
Update the branch used as default image in helm

### DIFF
--- a/deployment/forklift-console-plugin/values.yaml
+++ b/deployment/forklift-console-plugin/values.yaml
@@ -1,5 +1,5 @@
 plugin: forklift-console-plugin
 name: forklift-console-plugin
-image: quay.io/kubev2v/forklift-console-plugin:release-v0.1
+image: quay.io/kubev2v/forklift-console-plugin:release-v2.4.0
 
 forkliftNamespace: konveyor-forklift


### PR DESCRIPTION
Update the branch used as default image in helm

We moved our stable branch from elease-v0.1 to release-v2.4.0

Signed-off-by: Yaacov <kobi.zamir@gmail.com>