### PR TITLE
Use upstream namespace as default value for webpack

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,7 +87,7 @@ const config: WebpackConfiguration & {
     new EnvironmentPlugin({
       DATA_SOURCE: 'remote',
       BRAND_TYPE: 'Konveyor',
-      NAMESPACE: 'openshift-mtv',
+      NAMESPACE: 'konveyor-forklift',
       NODE_ENV: isProd ? 'production' : 'development',
     }),
   ],


### PR DESCRIPTION
Use upstream namespace as default value for webpack

It makes sense to default to forklift upstream namespace in this repository.

Signed-off-by: yzamir <yzamir@redhat.com>