### PR TITLE
Mark host provider with default label

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -7,6 +7,7 @@
   "Cannot remove provider": "Cannot remove provider",
   "Clear all filters": "Clear all filters",
   "Clusters": "Clusters",
+  "default": "default",
   "Delete": "Delete",
   "Delete Provider": "Delete Provider",
   "Edit Provider": "Edit Provider",

--- a/pkg/web/src/app/queries/mocks/providers.mock.ts
+++ b/pkg/web/src/app/queries/mocks/providers.mock.ts
@@ -365,6 +365,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         name: 'ocpv-3',
         uid: 'mock-uid-ocpv-3',
       },
+      spec: {
+        ...openshiftProvider1.object.spec,
+        url: '',
+      },
     },
   };
 

--- a/src/modules/Providers/ProviderRow.tsx
+++ b/src/modules/Providers/ProviderRow.tsx
@@ -67,8 +67,15 @@ const TextWithIcon = ({ value, Icon }: { value: string; Icon: JSXElementConstruc
   </>
 );
 
-const ProviderLink = ({ value, entity }: CellProps) => (
-  <ResourceLink kind={entity.kind} name={value} namespace={entity?.namespace} />
+const ProviderLink = ({ value, entity, t }: CellProps) => (
+  <>
+    <ResourceLink kind={entity.kind} name={value} namespace={entity?.namespace} />{' '}
+    {!entity.url && (
+      <Label isCompact color="grey">
+        {t('default')}
+      </Label>
+    )}
+  </>
 );
 
 const HostCell = ({ value, entity: { ready, name, type } }: CellProps) => (

--- a/src/modules/Providers/__tests__/mergedMockData.json
+++ b/src/modules/Providers/__tests__/mergedMockData.json
@@ -242,7 +242,7 @@
         "secretName": "boston",
         "type": "openshift",
         "uid": "mock-uid-ocpv-3",
-        "url": "https://my_OCPv_url",
+        "url": "",
         "vmCount": 26
     }
 ]


### PR DESCRIPTION
Note that host provider is detected by checking if `url` is empty. This is the same approach for detecting host provider as already present in kebeb actions (for blocking edit/delete).

![image](https://user-images.githubusercontent.com/64194103/203841285-33c74dde-b7f4-45dc-bac5-1092b917bd31.png)

Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>