### PR TITLE
Build Row key from entity UID and columns IDs

### DIFF
--- a/src/components/TableView/TableView.tsx
+++ b/src/components/TableView/TableView.tsx
@@ -30,7 +30,7 @@ export function TableView<T>({
 }: TableViewProps<T>) {
   const { t } = useTranslation();
   const hasChildren = children.filter(Boolean).length > 0;
-
+  const columnSignature = visibleColumns.map(({ id }) => id).join();
   return (
     <TableComposable aria-label={ariaLabel} variant="compact" isStickyHeader>
       <Thead>
@@ -63,7 +63,11 @@ export function TableView<T>({
         )}
         {!hasChildren &&
           entities.map((entity, index) => (
-            <Row key={entity?.[uidFieldId] ?? index} entity={entity} columns={visibleColumns} />
+            <Row
+              key={`${columnSignature}_${entity?.[uidFieldId] ?? index}`}
+              entity={entity}
+              columns={visibleColumns}
+            />
           ))}
       </Tbody>
     </TableComposable>


### PR DESCRIPTION
React should invalidate cached rows after order of columns is changed.

Fixes problem with table crashing with:
"Rendered fewer hooks than expected. This may be caused by an accidental early return statement."

Steps to re-create problem:
1. go to Provider list page
2. in column Management Dialog hide actions column (last column without label)