### PR TITLE
Put current filters as query params in the URL

### DIFF
--- a/src/components/Filter/GroupedEnumFilter.tsx
+++ b/src/components/Filter/GroupedEnumFilter.tsx
@@ -46,17 +46,21 @@ export const GroupedEnumFilter = ({
 
   const deleteGroup = (groupId: string): void =>
     onSelectedEnumIdsChange(
-      selectedEnumIds.filter((enumId) => id2enum?.[enumId]?.groupId !== groupId),
+      selectedEnumIds
+        .filter((id) => id2enum[id])
+        .filter((enumId) => id2enum[enumId].groupId !== groupId),
     );
 
   const deleteFilter = (id: string): void =>
-    onSelectedEnumIdsChange(selectedEnumIds.filter((enumId) => enumId !== id));
+    onSelectedEnumIdsChange(
+      selectedEnumIds.filter((id) => id2enum[id]).filter((enumId) => enumId !== id),
+    );
 
   const hasFilter = (id: string): boolean =>
     !!id2enum[id] && !!selectedEnumIds.find((enumId) => enumId === id);
 
   const addFilter = (id: string): void => {
-    onSelectedEnumIdsChange([...selectedEnumIds, id]);
+    onSelectedEnumIdsChange([...selectedEnumIds.filter((id) => id2enum[id]), id]);
   };
 
   // put the IDs needed for compareTo (although not part of the interface)
@@ -79,6 +83,7 @@ export const GroupedEnumFilter = ({
         (acc, { toLabel, groupId }) => (
           <ToolbarFilter
             chips={selectedEnumIds
+              .filter((id) => id2enum[id])
               .map((id) => id2enum[id])
               .filter((enumVal) => enumVal.groupId === groupId)
               .map(({ id, toLabel }) => ({ key: id, node: toLabel(t) }))}

--- a/src/components/Filter/__tests__/useUrlFilters.test.tsx
+++ b/src/components/Filter/__tests__/useUrlFilters.test.tsx
@@ -1,0 +1,91 @@
+import { NAME } from '_/utils/constants';
+
+import { act, cleanup, renderHook } from '@testing-library/react-hooks';
+
+import { useUrlFilters } from '../useUrlFilters';
+
+afterEach(cleanup);
+beforeEach(() => {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { assign: jest.fn() },
+  });
+  window.location.pathname = '';
+  window.history.pushState = jest.fn();
+});
+
+describe('parse filters from the URL on initialization', () => {
+  const cases: [string, string, string[]][] = [
+    ['gets initialized with single value', '?name=%5B"foo"%5D', ['foo']],
+    ['gets initialized with 2 values', '?name=%5B"foo"%2C"bar"%5D', ['foo', 'bar']],
+    ['ignores empty JSON array', '?name=%5B%5D', undefined],
+    ['ignores data different then JSON array', '?name="foo"', undefined],
+    ['ignores corrupted data', '?name=%5B%foo', undefined],
+  ];
+
+  cases.forEach(([description, search, output]) =>
+    it(description, () => {
+      window.location.search = search;
+      const {
+        result: {
+          current: [selectedFilters],
+        },
+      } = renderHook(() =>
+        useUrlFilters({
+          fields: [{ id: NAME, toLabel: () => NAME }],
+        }),
+      );
+      expect(selectedFilters[NAME]).toStrictEqual(output);
+    }),
+  );
+
+  it('ignores unknown field', () => {
+    window.location.search = '?ready=%5B"True"%5D';
+    const {
+      result: {
+        current: [selectedFilters],
+      },
+    } = renderHook(() =>
+      useUrlFilters({
+        fields: [{ id: NAME, toLabel: () => NAME }],
+      }),
+    );
+    expect(Object.entries(selectedFilters).length).toStrictEqual(0);
+  });
+
+  it('supports prefixing params', () => {
+    window.location.search = '?barname=%5B"foo"%5D';
+    const {
+      result: {
+        current: [selectedFilters],
+      },
+    } = renderHook(() =>
+      useUrlFilters({
+        fields: [{ id: NAME, toLabel: () => NAME }],
+        filterPrefix: 'bar',
+      }),
+    );
+    expect(selectedFilters[NAME]).toStrictEqual(['foo']);
+  });
+});
+
+describe('display currrently selected filters in the URL', () => {
+  test.each([
+    ['displays single value', '?foo=bar', ['foo'], '?foo=bar&name=%5B%22foo%22%5D'],
+    ['updates a value', '?foo=bar&name=%5B"foo"%5D', ['bar'], '?foo=bar&name=%5B%22bar%22%5D'],
+    ['removes a filter', '?foo=bar&name=%5B"foo"%5D', [], '?foo=bar'],
+  ])('%s', (description, initialUrl, update, pushedState) => {
+    window.location.search = initialUrl;
+    const {
+      result: {
+        current: [, setSelectedFilters],
+      },
+    } = renderHook(() =>
+      useUrlFilters({
+        fields: [{ id: NAME, toLabel: () => NAME }],
+      }),
+    );
+    act(() => setSelectedFilters({ [NAME]: update }));
+    expect(window.history.pushState).toBeCalledWith({}, '', pushedState);
+  });
+});

--- a/src/components/Filter/index.ts
+++ b/src/components/Filter/index.ts
@@ -6,3 +6,4 @@ export * from './helpers';
 export * from './matchers';
 export * from './PrimaryFilters';
 export * from './types';
+export * from './useUrlFilters';

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -64,10 +64,14 @@ export interface MetaFilterProps {
    * 2) value: a string array with filter-specific interpretation.
    * i.e. { NAME: ["foo", "bar"]}
    */
-  selectedFilters: { [id: string]: string[] };
+  selectedFilters: GlobalFilters;
   fieldFilters: FieldFilter[];
-  onFilterUpdate(filters: { [id: string]: string[] }): void;
+  onFilterUpdate(filters: GlobalFilters): void;
   supportedFilterTypes: {
     [type: string]: (props: FilterTypeProps) => JSX.Element;
   };
+}
+
+export interface GlobalFilters {
+  [id: string]: string[];
 }

--- a/src/components/Filter/useUrlFilters.ts
+++ b/src/components/Filter/useUrlFilters.ts
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { useSearchParams } from '_/hooks/useSearchParams';
+
+import { Field } from '../types';
+
+import { GlobalFilters } from './types';
+
+/**
+ * @returns parsed object or undefined if exception was thrown
+ */
+const safeParse = (str: string) => {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return undefined;
+  }
+};
+
+/**
+ * Init and maintain a set of filters on the search part of the URL.
+ *
+ *  1. filters are displayed in the URL as URL-encoded JSON array of strings. The use of intermediate JSON encoding ensures that we can encode arbitrary data.
+ *  2. params in the URL are parsed only during initialization, afterwards they are a read-only side effect
+ *  3. the single source of truth is the internal filter state maintained by the hook
+ *
+ * @param fields list of supported fields(read-only meta-data)
+ * @param filterPrefix prefix for the field IDs to avoid name conflicts with other query params in the URL
+ * @returns [selectedFilters, setSelectedFilters]
+ */
+export const useUrlFilters = ({
+  fields,
+  filterPrefix = '',
+}: {
+  fields: Field[];
+  filterPrefix?: string;
+}): [GlobalFilters, (filters: GlobalFilters) => void] => {
+  const [searchParams, updateSearchParams] = useSearchParams();
+  const [selectedFilters, setSelectedFilters] = useState(() =>
+    Object.fromEntries(
+      fields
+        .map(({ id }) => ({
+          id,
+          // discard any corrupted filters i.e. partially copy-pasted
+          params: safeParse(searchParams[`${filterPrefix}${id}`]),
+        }))
+        // discard filters with invalid structure (basic validation)
+        // each filter should validate if values make sense (i.e. enum values in range)
+        .filter(({ params }) => Array.isArray(params) && params.length)
+        .map(({ id, params }) => [id, params]),
+    ),
+  );
+  const setStateAndUrl = useMemo(
+    () => (filters: GlobalFilters) => {
+      setSelectedFilters(filters);
+      updateSearchParams(
+        Object.fromEntries(
+          fields
+            .map(({ id }) => ({ id, filters: filters[id] }))
+            .map(({ id, filters }) => [
+              id,
+              Array.isArray(filters) && filters.length ? JSON.stringify(filters) : undefined,
+            ]),
+        ),
+      );
+    },
+    [setSelectedFilters, updateSearchParams],
+  );
+  return [selectedFilters, setStateAndUrl];
+};

--- a/src/components/StandardPage/StandardPage.tsx
+++ b/src/components/StandardPage/StandardPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import {
   AttributeValueFilter,
   createMetaMatcher,
@@ -8,8 +8,9 @@ import {
   GroupedEnumFilter,
   PrimaryFilters,
   toFieldFilter,
+  useUrlFilters,
 } from 'src/components/Filter';
-import { ManageColumnsToolbar, RowProps, TableView } from 'src/components/TableView';
+import { ManageColumnsToolbar, RowProps, TableView, useSort } from 'src/components/TableView';
 import { Field } from 'src/components/types';
 import { useTranslation } from 'src/utils/i18n';
 
@@ -25,8 +26,6 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-
-import { useSort } from '../TableView/sort';
 
 import { ErrorState, Loading, NoResultsFound, NoResultsMatchFilter } from './ResultStates';
 import { UserSettings } from './types';
@@ -87,6 +86,12 @@ export interface StandardPageProps<T> {
   pagination?: number | 'on' | 'off';
 
   /**
+   * Prefix for filters stored in the query params part of the URL.
+   * By default no prefix is used - the field ID is used directly.
+   */
+  filterPrefix?: string;
+
+  /**
    * User settings store to initialize the page according to user preferences.
    */
   userSettings?: UserSettings;
@@ -111,9 +116,13 @@ export function StandardPage<T>({
   customNoResultsMatchFilter,
   pagination = DEFAULT_PER_PAGE,
   userSettings,
+  filterPrefix = '',
 }: StandardPageProps<T>) {
   const { t } = useTranslation();
-  const [selectedFilters, setSelectedFilters] = useState({});
+  const [selectedFilters, setSelectedFilters] = useUrlFilters({
+    fields: fieldsMetadata,
+    filterPrefix,
+  });
   const clearAllFilters = () => setSelectedFilters({});
   const [fields, setFields] = useFields(namespace, fieldsMetadata, userSettings?.fields);
   const [activeSort, setActiveSort, comparator] = useSort(fields);

--- a/src/components/TableView/index.ts
+++ b/src/components/TableView/index.ts
@@ -1,3 +1,4 @@
 export * from './ManageColumnsToolbar';
+export * from './sort';
 export * from './TableView';
 export * from './types';

--- a/src/hooks/useSearchParams.tsx
+++ b/src/hooks/useSearchParams.tsx
@@ -24,13 +24,16 @@ export const toMap = (search: string): MappedSearchParams => {
 export const useSearchParams = (): [MappedSearchParams, SetURLSearchParams] => {
   const [searchParams, internalSetSearchParams] = React.useState(toMap(location.search));
 
+  const removeUndefinedKeys = (obj: { [k: string]: string }): { [k: string]: string } =>
+    Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined));
+
   /**
-   * Update and add to the existing search parameters on the URL and the internal state.
+   * Merge new search parameter into existing parameters. Any key with an undefined value will be removed from the existing params.
    *
    * @param {MappedSearchParams} params
    */
   const updateSearchParams: SetURLSearchParams = (params) => {
-    const combinedPrams = { ...searchParams, ...params };
+    const combinedPrams = removeUndefinedKeys({ ...searchParams, ...params });
     const urlSearchParams = new URLSearchParams(combinedPrams);
     history.pushState({}, '', location.pathname + '?' + urlSearchParams.toString());
 


### PR DESCRIPTION
1. filters are displayed as URL-encoded JSON array of strings
2. the single source of truth is the internal filter state maintained by the hook
3. values parsed from query params are used to initialize the filter during initialization

Reference-Url: https://bugzilla.redhat.com/2070720
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>


[filters_Screencast from 11-30-2022 05:55:42 PM.webm](https://user-images.githubusercontent.com/64194103/204860457-26986832-f241-43f7-ad4b-c209f6cdc66a.webm)
