### PR TITLE
Render errors received from inventory API

### DIFF
--- a/pkg/web/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
+++ b/pkg/web/src/app/common/components/ResolvedQuery/ResolvedQueries.tsx
@@ -101,11 +101,15 @@ export const ResolvedQueries: React.FunctionComponent<IResolvedQueriesProps> = (
                       {(result.error as KubeClientError).response?.data?.message}
                     </>
                   ) : null}
-                  {(result.error as Response).status
-                    ? `${(result.error as Response).status}: ${
-                        (result.error as Response).statusText
-                      }`
-                    : null}
+                  {(result.error as Response).headers?.has('forklift-error-message') ? (
+                    <>
+                      Request failed with status code {(result.error as Response).status}
+                      <br />
+                      {(result.error as Response).headers.get('forklift-error-message')}
+                    </>
+                  ) : (result.error as Response).status ? (
+                    `${(result.error as Response).status}: ${(result.error as Response).statusText}`
+                  ) : null}
                   {typeof result.error === 'string' ? result.error : null}
                 </>
               ) : null}


### PR DESCRIPTION
The frontend handles errors of type KubeClientError that are returned
from the K8s API properly. However, errors that are returned from the
inventory API are of a different type and it's not trivial to tweak
gin-gonic to return such errors.

Therefore, changing the frontend to render errors that are returned from
the inventory API differently, these errors are identified by the header
'forkift-error-message'.