### PR TITLE
Add url to secret for webhooks

### DIFF
--- a/pkg/web/src/app/client/helpers.ts
+++ b/pkg/web/src/app/client/helpers.ts
@@ -64,6 +64,7 @@ export function convertFormValuesToSecret(
   if (values.providerType === 'vsphere') {
     const vmwareValues = values as VMwareProviderFormValues;
     secretData = {
+      url: btoa(vmwareHostnameToUrl(vmwareValues.hostname)),
       user: btoa(vmwareValues.username),
       password: btoa(vmwareValues.password),
       thumbprint: btoa(vmwareValues.fingerprint),
@@ -72,6 +73,7 @@ export function convertFormValuesToSecret(
   if (values.providerType === 'ovirt') {
     const rhvValues = values as RHVProviderFormValues;
     secretData = {
+      url: btoa(ovirtHostnameToUrl(rhvValues.hostname)),
       user: btoa(rhvValues.username),
       password: btoa(rhvValues.password),
       cacert: btoa(rhvValues.caCert),
@@ -80,6 +82,7 @@ export function convertFormValuesToSecret(
   if (values.providerType === 'openshift') {
     const openshiftValues = values as OpenshiftProviderFormValues;
     secretData = {
+      url: btoa((values as OpenshiftProviderFormValues).url),
       token: btoa(openshiftValues.saToken),
     };
   }
@@ -97,6 +100,7 @@ export function convertFormValuesToSecret(
       labels: {
         createdForResourceType,
         createdForResource: values.name,
+        createdForProviderType: values.providerType || '',
       },
       ownerReferences: !providerBeingEdited
         ? []

--- a/pkg/web/src/app/queries/types/common.types.ts
+++ b/pkg/web/src/app/queries/types/common.types.ts
@@ -25,6 +25,7 @@ export interface IMetaObjectMeta {
   labels?: {
     createdForResourceType?: string;
     createdForResource?: string;
+    createdForProviderType?: string;
   };
   ownerReferences?: IObjectReference[];
 }

--- a/pkg/web/src/app/queries/types/secrets.types.ts
+++ b/pkg/web/src/app/queries/types/secrets.types.ts
@@ -2,6 +2,7 @@ import { IMetaObjectGenerateName, IMetaTypeMeta, IMetaObjectMeta } from './commo
 
 export interface ISecret extends IMetaTypeMeta {
   data: {
+    url?: string;
     user?: string;
     password?: string;
     thumbprint?: string;


### PR DESCRIPTION
Add the URL for the provider to the secret so that when the controller starts
the provider connection test knows which address to validate.
The webhook is watching specific secrets with specific labels so
we need to post the provider secrets with the label "createdForResourceType=providers".

Related to:
https://github.com/kubev2v/forklift-ui/pull/982