### PR TITLE
Store column order and visibility in local storage

### DIFF
--- a/src/components/StandardPage/StandardPage.tsx
+++ b/src/components/StandardPage/StandardPage.tsx
@@ -29,6 +29,7 @@ import { FilterIcon } from '@patternfly/react-icons';
 import { useSort } from '../TableView/sort';
 
 import { ErrorState, Loading, NoResultsFound, NoResultsMatchFilter } from './ResultStates';
+import { UserSettings } from './types';
 import { useFields } from './useFields';
 
 /**
@@ -81,6 +82,11 @@ export interface StandardPageProps<T> {
    * 'auto' - display if unfiltered number of items is greater then current 'items per page' value
    */
   pagination?: 'auto' | 'on' | 'off';
+
+  /**
+   * User settings store to initialize the page according to user preferences.
+   */
+  userSettings?: UserSettings;
 }
 
 // counting from one seems recommneded - zero breaks some cases
@@ -106,11 +112,12 @@ export function StandardPage<T>({
   customNoResultsFound,
   customNoResultsMatchFilter,
   pagination = 'auto',
+  userSettings,
 }: StandardPageProps<T>) {
   const { t } = useTranslation();
   const [selectedFilters, setSelectedFilters] = useState({});
   const clearAllFilters = () => setSelectedFilters({});
-  const [fields, setFields] = useFields(namespace, fieldsMetadata);
+  const [fields, setFields] = useFields(namespace, fieldsMetadata, userSettings?.fields);
   const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
   const [page, setPage] = useState(DEFAULT_FIRST_PAGE);
   const [activeSort, setActiveSort, comparator] = useSort(fields);

--- a/src/components/StandardPage/__tests__/useFields.test.tsx
+++ b/src/components/StandardPage/__tests__/useFields.test.tsx
@@ -1,6 +1,6 @@
 import { NAME, NAMESPACE } from 'src/utils/constants';
 
-import { cleanup, renderHook } from '@testing-library/react-hooks';
+import { act, cleanup, renderHook } from '@testing-library/react-hooks';
 
 import { useFields } from '../useFields';
 
@@ -46,5 +46,145 @@ describe('manage fields', () => {
       { id: NAME, isVisible: true },
       { id: NAMESPACE, isVisible: false },
     ]);
+  });
+});
+
+describe('initialize fields from user settings', () => {
+  it('uses a reverse order', () => {
+    const {
+      result: {
+        current: [fields],
+      },
+    } = renderHook(() =>
+      useFields(
+        undefined,
+        [
+          { id: NAME, toLabel: () => '', isVisible: true },
+          { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        ],
+        {
+          data: [
+            { id: NAMESPACE, isVisible: true },
+            { id: NAME, isVisible: true },
+          ],
+          save: () => undefined,
+          clear: () => undefined,
+        },
+      ),
+    );
+    expect(fields).toMatchObject([
+      { id: NAMESPACE, isVisible: true },
+      { id: NAME, isVisible: true },
+    ]);
+  });
+
+  it('tries to hide identity column', () => {
+    const {
+      result: {
+        current: [fields],
+      },
+    } = renderHook(() =>
+      useFields(
+        'some-namespace',
+        [
+          { id: NAME, toLabel: () => '', isVisible: true, isIdentity: true },
+          { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        ],
+        {
+          data: [
+            { id: NAME, isVisible: false },
+            { id: NAMESPACE, isVisible: false },
+          ],
+          save: () => undefined,
+          clear: () => undefined,
+        },
+      ),
+    );
+    expect(fields).toMatchObject([
+      { id: NAME, isVisible: true },
+      { id: NAMESPACE, isVisible: false },
+    ]);
+  });
+  it('filters out duplicated and unsupported fields', () => {
+    const {
+      result: {
+        current: [fields],
+      },
+    } = renderHook(() =>
+      useFields(
+        undefined,
+        [
+          { id: NAME, toLabel: () => '', isVisible: true },
+          { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        ],
+        {
+          data: [
+            { id: NAME, isVisible: false },
+            { id: NAME, isVisible: true },
+            { id: 'foo', isVisible: false },
+          ],
+          save: () => undefined,
+          clear: () => undefined,
+        },
+      ),
+    );
+    expect(fields).toMatchObject([
+      { id: NAME, isVisible: false },
+      { id: NAMESPACE, isVisible: true },
+    ]);
+  });
+});
+
+describe('saves fields to user settings', () => {
+  it('saves re-order and hidden NAME field)', () => {
+    const saveSettings = jest.fn();
+    const {
+      result: {
+        current: [, setFields],
+      },
+    } = renderHook(() =>
+      useFields(
+        undefined,
+        [
+          { id: NAME, toLabel: () => '', isVisible: true },
+          { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        ],
+        { data: [], save: saveSettings, clear: () => undefined },
+      ),
+    );
+    act(() =>
+      setFields([
+        { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        { id: NAME, toLabel: () => '', isVisible: false },
+      ]),
+    );
+    expect(saveSettings).toBeCalledWith([
+      { id: NAMESPACE, isVisible: true },
+      { id: NAME, isVisible: false },
+    ]);
+  });
+  it('clears settings if equal to defaults)', () => {
+    const clearSettings = jest.fn();
+    const {
+      result: {
+        current: [, setFields],
+      },
+    } = renderHook(() =>
+      useFields(
+        undefined,
+        [
+          { id: NAME, toLabel: () => '', isVisible: true },
+          { id: NAMESPACE, toLabel: () => '', isVisible: true },
+        ],
+        { data: [], save: () => undefined, clear: clearSettings },
+      ),
+    );
+    act(() =>
+      setFields([
+        { id: NAME, toLabel: () => '', isVisible: true },
+        { id: NAMESPACE, toLabel: () => '', isVisible: true },
+      ]),
+    );
+    expect(clearSettings).toBeCalled();
   });
 });

--- a/src/components/StandardPage/index.ts
+++ b/src/components/StandardPage/index.ts
@@ -1,2 +1,4 @@
 export * from './ResultStates';
 export * from './StandardPage';
+export * from './types';
+export * from './userSettings';

--- a/src/components/StandardPage/types.ts
+++ b/src/components/StandardPage/types.ts
@@ -1,0 +1,9 @@
+export interface UserSettings {
+  fields?: FieldSettings;
+}
+
+export interface FieldSettings {
+  data: { id: string; isVisible?: boolean }[];
+  save: (fields: { id: string; isVisible?: boolean }[]) => void;
+  clear: () => void;
+}

--- a/src/components/StandardPage/useFields.tsx
+++ b/src/components/StandardPage/useFields.tsx
@@ -3,18 +3,70 @@ import { NAMESPACE } from 'src/utils/constants';
 
 import { Field } from '../types';
 
+import { FieldSettings } from './types';
+
+const sameOrderAndVisibility = (a: Field[], b: Field[]): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.id !== b[i]?.id || Boolean(a[i]?.isVisible) !== Boolean(b[i]?.isVisible)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 /**
  * Keeps the list of fields. Toggles the visibility of the namespace field based on currently used namspace.
  *
+ * User settings support:
+ * 1. fields are loaded from user settings only during intialization
+ * 2. saving fields to user settings is a side effect
+ * 3. internal state maintained by the hook remains the single source of truth
+ *
  * @param currentNamespace
  * @param defaultFields used for initialization
+ * @param userSettings
  * @returns [fields, setFields]
  */
 export const useFields = (
   currentNamespace: string,
   defaultFields: Field[],
+  userSettings?: FieldSettings,
 ): [Field[], React.Dispatch<React.SetStateAction<Field[]>>] => {
-  const [fields, setFields] = useState<Field[]>(defaultFields.map((it) => ({ ...it })));
+  const {
+    data: fieldsFromSettings = [],
+    save: saveFieldsInSettings = () => undefined,
+    clear: clearSettings = () => undefined,
+  } = userSettings || {};
+
+  const [fields, setFields] = useState<Field[]>(() => {
+    const supportedIds: { [id: string]: Field } = defaultFields.reduce(
+      (acc, it) => ({ ...acc, [it.id]: it }),
+      {},
+    );
+    const savedIds = new Set(fieldsFromSettings.map(({ id }) => id));
+    // used to detect duplicates
+    const idsToBeVisited = new Set(savedIds);
+
+    return [
+      // put fields saved via user settings (if any)
+      ...fieldsFromSettings
+        // ignore duplicates:ID is removed from the helper map on the first visit
+        .filter((it) => idsToBeVisited.delete(it.id))
+        // ignore unsupported fields
+        .filter(({ id }) => supportedIds[id])
+        .map(({ id, isVisible }) => ({
+          ...supportedIds[id],
+          // keep the invariant that identity columns are always visible
+          isVisible: isVisible || supportedIds[id].isIdentity,
+        })),
+      // put all remaining fields (all fields if there are no settings)
+      ...defaultFields.filter(({ id }) => !savedIds.has(id)).map((it) => ({ ...it })),
+    ];
+  });
   const namespaceAwareFields: Field[] = useMemo(
     () =>
       fields.map(({ id, isVisible = false, ...rest }) => ({
@@ -24,5 +76,19 @@ export const useFields = (
       })),
     [currentNamespace, fields],
   );
-  return [namespaceAwareFields, setFields];
+
+  const setInternalStateAndSaveUserSettings = useMemo(
+    () => (fields: Field[]) => {
+      setFields(fields);
+      if (sameOrderAndVisibility(fields, defaultFields)) {
+        // don't store settings if equal to deault settings
+        clearSettings();
+      } else {
+        saveFieldsInSettings(fields.map(({ id, isVisible }) => ({ id, isVisible })));
+      }
+    },
+    [setFields, saveFieldsInSettings],
+  );
+
+  return [namespaceAwareFields, setInternalStateAndSaveUserSettings];
 };

--- a/src/components/StandardPage/userSettings.ts
+++ b/src/components/StandardPage/userSettings.ts
@@ -1,0 +1,62 @@
+import { UserSettings } from '_/components/StandardPage';
+import {
+  loadFromLocalStorage,
+  removeFromLocalStorage,
+  saveToLocalStorage,
+} from '_/utils/localStorage';
+
+const parseOrClean = (key) => {
+  try {
+    return JSON.parse(loadFromLocalStorage(key)) ?? {};
+  } catch (e) {
+    removeFromLocalStorage(key);
+    console.error(`Removed invalid key [${key}] from local storage`);
+  }
+  return {};
+};
+
+const toField = ({ id, isVisible }) => ({ id, isVisible });
+
+const sanitizeFields = (fields: unknown): { id: string; isVisible?: boolean }[] =>
+  Array.isArray(fields)
+    ? fields
+        // array should contain objects
+        .filter((it) => it && typeof it === 'object')
+        // cherry-pick desired props
+        .map(toField)
+        // verify that ID is string
+        .filter(({ id }) => id && typeof id === 'string')
+    : [];
+
+/**
+ * Deserialize user settings for a StandardPage component with provided page ID.
+ *
+ * 1. user settings are stored in local storage as JSON encoded string
+ * 2. if data cannot be decoded it's removed from the local storage (auto clean-up)
+ *
+ * @param pageId key suffix - together with PLUGIN_NAME used to load/save data.
+ */
+export const loadUserSettings = ({ pageId }): UserSettings => {
+  const key = `${process.env.PLUGIN_NAME}-${pageId}`;
+  const { fields } = parseOrClean(key);
+
+  return {
+    fields: {
+      data: sanitizeFields(fields),
+      save: (fields) =>
+        saveToLocalStorage(
+          key,
+          JSON.stringify({ ...parseOrClean(key), fields: fields.map(toField) }),
+        ),
+      clear: () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { fields, ...rest } = parseOrClean(key);
+        if (!Object.keys(rest).length) {
+          removeFromLocalStorage(key);
+        } else {
+          saveToLocalStorage(JSON.stringify({ ...rest }), key);
+        }
+      },
+    },
+  };
+};

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,11 @@
+export function saveToLocalStorage(key, value) {
+  window?.localStorage?.setItem(key, value);
+}
+
+export function loadFromLocalStorage(key) {
+  return window?.localStorage?.getItem(key);
+}
+
+export function removeFromLocalStorage(key) {
+  return window?.localStorage?.removeItem(key);
+}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -89,6 +89,7 @@ const config: WebpackConfiguration & {
       BRAND_TYPE: 'Konveyor',
       NAMESPACE: 'konveyor-forklift',
       NODE_ENV: isProd ? 'production' : 'development',
+      PLUGIN_NAME: 'forklift-console-plugin',
     }),
   ],
   devtool: 'source-map',


### PR DESCRIPTION
1. fields are loaded from local storage only during initialization
2. saving fields to local storage is a side effect
3. internal state maintained by the useFields hook remains the single source of truth

Reference-Url: https://github.com/oVirt/ovirt-web-ui/blob/34a013cfacdc4428d0fafda2bd88cdd2f03a039d/src/storage.js#L5
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>