### PR TITLE
Update ENV and META constants for plugin environment

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -30,5 +30,6 @@ const config: Config.InitialOptions = {
       isolatedModules: true,
     },
   },
+  setupFiles: ['<rootDir>/src/__mocks__/envvars.ts'],
 };
 export default config;

--- a/pkg/web/src/app/Mappings/components/MappingBuilder/helpers.ts
+++ b/pkg/web/src/app/Mappings/components/MappingBuilder/helpers.ts
@@ -16,7 +16,7 @@ import {
 } from '@app/queries/types';
 import { IMappingBuilderItem } from './MappingBuilder';
 import { getMappingSourceByRef, getMappingTargetByRef } from '../helpers';
-import { CLUSTER_API_VERSION, META, ProviderType } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV, ProviderType } from '@app/common/constants';
 import { nameAndNamespace } from '@app/queries/helpers';
 import { filterSourcesBySelectedVMs } from '@app/Plans/components/Wizard/helpers';
 import { IDisk, IMappingResourcesResult, INicProfile } from '@app/queries';
@@ -112,7 +112,7 @@ export const getMappingFromBuilderItems = ({
         : mappingName
         ? { name: mappingName }
         : { generateName: '' }),
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       ...(owner
         ? {
             ownerReferences: [getObjectRef(owner)],

--- a/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
+++ b/pkg/web/src/app/Plans/components/Wizard/helpers.tsx
@@ -28,7 +28,7 @@ import {
   getMappingFromBuilderItems,
 } from '@app/Mappings/components/MappingBuilder/helpers';
 import { PlanWizardFormState, PlanWizardMode } from './PlanWizard';
-import { CLUSTER_API_VERSION, META, ProviderType } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV, ProviderType } from '@app/common/constants';
 import {
   getAggregateQueryStatus,
   getFirstQueryError,
@@ -516,7 +516,7 @@ export const generatePlan = (
   kind: 'Plan',
   metadata: {
     name: forms.general.values.planName,
-    namespace: META.namespace,
+    namespace: ENV.NAMESPACE,
   },
   spec: {
     description: forms.general.values.planDescription,
@@ -784,7 +784,7 @@ export const generateHook = (
   kind: 'Hook',
   metadata: {
     ...(existingHook ? { name: existingHook.name } : { generateName: generateName || '' }),
-    namespace: META.namespace,
+    namespace: ENV.NAMESPACE,
     ...(owner ? { ownerReferences: [getObjectRef(owner)] } : {}),
   },
   spec: {

--- a/pkg/web/src/app/client/helpers.ts
+++ b/pkg/web/src/app/client/helpers.ts
@@ -5,7 +5,7 @@ import KubeClient, {
   CoreNamespacedResource,
   KubeResource,
 } from '@migtools/lib-ui';
-import { META, ProviderType, CLUSTER_API_VERSION } from '@app/common/constants';
+import { ENV, ProviderType, CLUSTER_API_VERSION } from '@app/common/constants';
 import { IProviderObject, ISecret } from '@app/queries/types';
 import {
   AddProviderFormValues,
@@ -49,11 +49,11 @@ export enum ForkliftResourceKind {
 
 export const secretResource = new CoreNamespacedResource(
   CoreNamespacedResourceKind.Secret,
-  META.namespace
+  ENV.NAMESPACE
   //are we moving the secrets to the config namespace?
 );
 
-export const providerResource = new ForkliftResource(ForkliftResourceKind.Provider, META.namespace);
+export const providerResource = new ForkliftResource(ForkliftResourceKind.Provider, ENV.NAMESPACE);
 
 export function convertFormValuesToSecret(
   values: AddProviderFormValues,
@@ -94,7 +94,7 @@ export function convertFormValuesToSecret(
       ...(!providerBeingEdited
         ? {
             generateName: `${values.name}-`,
-            namespace: META.namespace,
+            namespace: ENV.NAMESPACE,
           }
         : nameAndNamespace(providerBeingEdited.spec.secret)),
       labels: {
@@ -153,7 +153,7 @@ export const convertFormValuesToProvider = (
     kind: 'Provider',
     metadata: {
       name,
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
     },
     spec: {
       type: values.providerType,
@@ -210,7 +210,7 @@ export const checkIfResourceExists = async (
 };
 
 /** Translate resource into namespaced k8s api ptch */
-export const listPath = (resource: KubeResource, namespace: string = META.namespace) => {
+export const listPath = (resource: KubeResource, namespace: string = ENV.NAMESPACE) => {
   const isCRD = !!resource.gvk().group;
 
   return isCRD
@@ -219,14 +219,14 @@ export const listPath = (resource: KubeResource, namespace: string = META.namesp
         resource.gvk().group,
         resource.gvk().version,
         'namespaces',
-        namespace || META.namespace,
+        namespace || ENV.NAMESPACE,
         resource.gvk().kindPlural,
       ].join('/')
     : [
         '/api/kubernetes/api',
         resource.gvk().version,
         'namespaces',
-        namespace || META.namespace,
+        namespace || ENV.NAMESPACE,
         resource.gvk().kindPlural,
       ].join('/');
 };
@@ -235,7 +235,7 @@ export const listPath = (resource: KubeResource, namespace: string = META.namesp
 export const namedPath = (
   resource: KubeResource,
   name: string,
-  namespace: string = META.namespace
+  namespace: string = ENV.NAMESPACE
 ) => {
   return [listPath(resource, namespace), name].join('/');
 };

--- a/pkg/web/src/app/common/constants.ts
+++ b/pkg/web/src/app/common/constants.ts
@@ -1,8 +1,25 @@
 import * as yup from 'yup';
+import { BrandType, IEnvVars } from './types';
 
-import { IEnvVars, IMetaVars } from './types';
+/**
+ * Collect and expose the various webpack `EnvironmentPlugin` values to the app.  Since
+ * the webpack plugin does straight simple string replace, the values need to be full
+ * identifiers.  Default values aren't needed since the default values are given in
+ * `EnvironmentPlugin`'s definition in __webpack.config.js__.
+ */
+export const ENV: IEnvVars = {
+  DATA_SOURCE: process.env.DATA_SOURCE,
+  BRAND_TYPE: process.env.BRAND_TYPE as BrandType,
+  NAMESPACE: process.env.NAMESPACE,
+  NODE_ENV: process.env.NODE_ENV,
+  PLUGIN_NAME: process.env.PLUGIN_NAME,
+};
 
-export const ENV: IEnvVars = window['_env'] || {};
+if (ENV.NODE_ENV === 'development') {
+  console.info('forklift-console-plugin ENV:', JSON.stringify(ENV));
+}
+
+export const APP_BRAND: BrandType = (process.env.BRAND_TYPE as BrandType) || BrandType.Konveyor;
 
 export const APP_TITLE =
   ENV.BRAND_TYPE === 'RedHat' ? 'Migration Toolkit for Virtualization' : 'Forklift';
@@ -75,26 +92,6 @@ export enum StepType {
   Empty = 'Empty',
   Canceled = 'Canceled',
 }
-
-export const META: IMetaVars =
-  process.env.DATA_SOURCE !== 'mock' && process.env.NODE_ENV !== 'test'
-    ? {
-        ...(window['_meta'] || {}),
-        namespace: process.env.NAMESPACE || 'konveyor-forklift',
-      }
-    : {
-        clusterApi: '/mock/api',
-        devServerPort: 'mock-port',
-        oauth: {
-          clientId: 'mock-client-id',
-          redirectUrl: '/mock/redirect/uri',
-          userScope: '/mock/user-scope',
-          clientSecret: 'mock-client-secret',
-        },
-        namespace: 'mock-namespace',
-        inventoryApi: '/mock/api',
-        inventoryPayloadApi: '/mock/api',
-      };
 
 export const dnsLabelNameSchema = yup
   .string()

--- a/pkg/web/src/app/common/types.ts
+++ b/pkg/web/src/app/common/types.ts
@@ -1,32 +1,16 @@
-import { BrandType } from '@app/global-flags';
-import { UseMutationResult, UseQueryResult } from 'react-query';
+import type { UseMutationResult, UseQueryResult } from 'react-query';
 
-export interface IMetaVars {
-  clusterApi: string;
-  devServerPort: string;
-  oauth: {
-    clientId: string;
-    redirectUrl: string;
-    userScope: string;
-    clientSecret: string;
-  };
-  namespace: string;
-  inventoryApi: string;
-  inventoryPayloadApi: string;
+export enum BrandType {
+  Konveyor = 'Konveyor',
+  RedHat = 'RedHat',
 }
 
 export interface IEnvVars {
-  AUTH_REQUIRED: string;
   NODE_ENV: string;
   DATA_SOURCE: string;
   BRAND_TYPE: BrandType;
-  FORKLIFT_OPERATOR_VERSION: string;
-  FORKLIFT_CONTROLLER_GIT_COMMIT: string;
-  FORKLIFT_MUST_GATHER_GIT_COMMIT: string;
-  FORKLIFT_OPERATOR_GIT_COMMIT: string;
-  FORKLIFT_UI_GIT_COMMIT: string;
-  FORKLIFT_VALIDATION_GIT_COMMIT: string;
-  FORKLIFT_CLUSTER_VERSION: string;
+  NAMESPACE: string;
+  PLUGIN_NAME: string;
 }
 
 export type UnknownResult = Pick<

--- a/pkg/web/src/app/global-flags.ts
+++ b/pkg/web/src/app/global-flags.ts
@@ -1,6 +1,0 @@
-export enum BrandType {
-  Konveyor = 'Konveyor',
-  RedHat = 'RedHat',
-}
-
-export const APP_BRAND: BrandType = (process.env.BRAND_TYPE as BrandType) || BrandType.Konveyor;

--- a/pkg/web/src/app/queries/hooks.ts
+++ b/pkg/web/src/app/queries/hooks.ts
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import yaml from 'js-yaml';
 
 import { IKubeList } from '@app/client/types';
-import { META } from '@app/common/constants';
+import { ENV } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
 import { mockKubeList, sortKubeListByName, useMockableQuery } from './helpers';
 import { MOCK_HOOKS } from './mocks/hooks.mock';
@@ -12,7 +12,7 @@ import { IHook } from './types';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 
-const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, META.namespace);
+const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, ENV.NAMESPACE);
 
 export const useHooksQuery = (): UseQueryResult<IKubeList<IHook>> => {
   const sortKubeListByNameCallback = React.useCallback(

--- a/pkg/web/src/app/queries/hosts.ts
+++ b/pkg/web/src/app/queries/hosts.ts
@@ -17,12 +17,12 @@ import { useAuthorizedK8sClient } from './fetchHelpers';
 import { IKubeList, IKubeResponse, KubeClientError } from '@app/client/types';
 import { SelectNetworkFormValues } from '@app/Providers/components/VMwareProviderHostsTable/SelectNetworkModal';
 import { secretResource, ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 import { getObjectRef } from '@app/common/helpers';
 import { isManagementNetworkSelected } from '@app/Providers/components/VMwareProviderHostsTable/helpers';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
-export const hostConfigResource = new ForkliftResource(ForkliftResourceKind.Host, META.namespace);
+export const hostConfigResource = new ForkliftResource(ForkliftResourceKind.Host, ENV.NAMESPACE);
 
 export const useHostsQuery = (provider: IVMwareProvider | null) => {
   const sortByNameCallback = React.useCallback((data): IHost[] => sortByName(data), []);
@@ -68,7 +68,7 @@ export const getExistingHostConfigs = (
 
 const getHostConfigRef = (provider: IVMwareProvider, host: IHost) => ({
   name: truncateK8sString(provider.name, `-${host.id}-config`),
-  namespace: META.namespace,
+  namespace: ENV.NAMESPACE,
 });
 
 const generateSecret = (
@@ -87,7 +87,7 @@ const generateSecret = (
   metadata: {
     ...(secretBeingReusedRef || {
       generateName: truncateK8sString(provider.name, `-${host.id}-`, true),
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
     }),
     labels: {
       createdForResourceType: ForkliftResourceKind.Host,

--- a/pkg/web/src/app/queries/mappings.ts
+++ b/pkg/web/src/app/queries/mappings.ts
@@ -21,7 +21,7 @@ import {
 } from './helpers';
 
 import { checkIfResourceExists, ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
-import { dnsLabelNameSchema, META } from '@app/common/constants';
+import { dnsLabelNameSchema, ENV } from '@app/common/constants';
 import { KubeClientError, IKubeList, IKubeResponse, IKubeStatus } from '@app/client/types';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mocks/mappings.mock';
 import { usePollingContext } from '@app/common/context';
@@ -43,7 +43,7 @@ export const getMappingResource = (
     mappingType === MappingType.Network
       ? ForkliftResourceKind.NetworkMap
       : ForkliftResourceKind.StorageMap;
-  const resource = new ForkliftResource(kind, META.namespace);
+  const resource = new ForkliftResource(kind, ENV.NAMESPACE);
   return { kind, resource };
 };
 

--- a/pkg/web/src/app/queries/migrations.ts
+++ b/pkg/web/src/app/queries/migrations.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { UseMutationResult, UseQueryResult, useQueryClient } from 'react-query';
 import { ForkliftResource, ForkliftResourceKind, checkIfResourceExists } from '@app/client/helpers';
 import { IKubeList, IKubeResponse, KubeClientError } from '@app/client/types';
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 import {
   isSameResource,
   mockKubeList,
@@ -20,7 +20,7 @@ import { SourceVM } from './types/vms.types';
 import { MOCK_MIGRATIONS } from './mocks/migrations.mock';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
-const migrationResource = new ForkliftResource(ForkliftResourceKind.Migration, META.namespace);
+const migrationResource = new ForkliftResource(ForkliftResourceKind.Migration, ENV.NAMESPACE);
 
 export const useCreateMigrationMutation = (
   onSuccess?: (migration: IMigration) => void
@@ -34,7 +34,7 @@ export const useCreateMigrationMutation = (
         kind: 'Migration',
         metadata: {
           name: `${plan.metadata.name}-${Date.now()}`,
-          namespace: META.namespace,
+          namespace: ENV.NAMESPACE,
           ownerReferences: [getObjectRef(plan)],
         },
         spec: {

--- a/pkg/web/src/app/queries/mocks/hosts.mock.ts
+++ b/pkg/web/src/app/queries/mocks/hosts.mock.ts
@@ -1,4 +1,4 @@
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 import { nameAndNamespace } from '../helpers';
 import { IHost, IHostConfig } from '../types/hosts.types';
 import { MOCK_INVENTORY_PROVIDERS } from './providers.mock';
@@ -66,7 +66,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       kind: 'Host',
       metadata: {
         name: `host-${host1.id}-config`,
-        namespace: META.namespace,
+        namespace: ENV.NAMESPACE,
       },
       spec: {
         id: host1.id,
@@ -83,7 +83,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
       kind: 'Host',
       metadata: {
         name: `host-${host3.id}-config`,
-        namespace: META.namespace,
+        namespace: ENV.NAMESPACE,
       },
       spec: {
         id: host3.id,

--- a/pkg/web/src/app/queries/mocks/mappings.mock.ts
+++ b/pkg/web/src/app/queries/mocks/mappings.mock.ts
@@ -4,7 +4,7 @@ import { MOCK_INVENTORY_PROVIDERS } from './providers.mock';
 import { MOCK_OPENSHIFT_NETWORKS, MOCK_VMWARE_NETWORKS } from './networks.mock';
 import { MOCK_VMWARE_DATASTORES } from './storages.mock';
 import { nameAndNamespace } from '../helpers';
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 
 export let MOCK_NETWORK_MAPPINGS: INetworkMapping[] = [];
 export let MOCK_STORAGE_MAPPINGS: IStorageMapping[] = [];
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'StorageMap',
     metadata: {
       name: 'vcenter1-datastore-to-ocpv-storageclass1',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {
@@ -59,7 +59,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'StorageMap',
     metadata: {
       name: 'vcenter3-datastore-to-ocpv-storageclass2',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {
@@ -85,7 +85,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'StorageMap',
     metadata: {
       name: 'vcenter1-invalid-storage-mapping',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {
@@ -118,7 +118,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'NetworkMap',
     metadata: {
       name: 'vcenter1-netstore-to-ocp1-network1',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {
@@ -163,7 +163,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'NetworkMap',
     metadata: {
       name: 'vcenter1-netstore-to-ocp1-network2',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {
@@ -199,7 +199,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'NetworkMap',
     metadata: {
       name: 'vcenter3-invalid-network-map',
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
       annotations: { 'forklift.konveyor.io/shared': 'true' },
     },
     spec: {

--- a/pkg/web/src/app/queries/mocks/migrations.mock.ts
+++ b/pkg/web/src/app/queries/mocks/migrations.mock.ts
@@ -1,4 +1,4 @@
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 import { nameAndNamespace } from '../helpers';
 import { IMigration } from '../types/migrations.types';
 import { MOCK_PLANS } from './plans.mock';
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     kind: 'Migration',
     metadata: {
       name: `plan-${index}-mock-migration`,
-      namespace: META.namespace,
+      namespace: ENV.NAMESPACE,
     },
     spec: {
       plan: nameAndNamespace(MOCK_PLANS[index].metadata),

--- a/pkg/web/src/app/queries/mocks/plans.mock.ts
+++ b/pkg/web/src/app/queries/mocks/plans.mock.ts
@@ -1,6 +1,6 @@
 import { IPlan, IVMStatus } from '../types';
 import { MOCK_INVENTORY_PROVIDERS } from '@app/queries/mocks/providers.mock';
-import { CLUSTER_API_VERSION, META } from '@app/common/constants';
+import { CLUSTER_API_VERSION, ENV } from '@app/common/constants';
 import { MOCK_NETWORK_MAPPINGS, MOCK_STORAGE_MAPPINGS } from './mappings.mock';
 import { MOCK_OPENSHIFT_NAMESPACES } from './namespaces.mock';
 import { MOCK_HOOKS } from './hooks.mock';
@@ -253,7 +253,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-0-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-01',
@@ -390,7 +390,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-2-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-03',
@@ -456,7 +456,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-3-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-04',
@@ -550,7 +550,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-4-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-05',
@@ -758,7 +758,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-6-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-07',
@@ -791,7 +791,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-7-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-08',
@@ -820,7 +820,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-8-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-09',
@@ -869,7 +869,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-9-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-10',
@@ -907,7 +907,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             conditions: [],
             migration: {
               name: 'plan-10-mock-migration',
-              namespace: META.namespace,
+              namespace: ENV.NAMESPACE,
             },
             plan: {
               name: 'plantest-11',

--- a/pkg/web/src/app/queries/plans.ts
+++ b/pkg/web/src/app/queries/plans.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as yup from 'yup';
 import { checkIfResourceExists, ForkliftResource, ForkliftResourceKind } from '@app/client/helpers';
 import { IKubeList, IKubeResponse, IKubeStatus, KubeClientError } from '@app/client/types';
-import { dnsLabelNameSchema, META } from '@app/common/constants';
+import { dnsLabelNameSchema, ENV } from '@app/common/constants';
 import { usePollingContext } from '@app/common/context';
 import { UseMutationResult, UseQueryResult, useQueryClient } from 'react-query';
 import {
@@ -22,10 +22,10 @@ import { generateHook, generateMappings, generatePlan } from '@app/Plans/compone
 import { IMetaObjectMeta } from '@app/queries/types/common.types';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
-const planResource = new ForkliftResource(ForkliftResourceKind.Plan, META.namespace);
+const planResource = new ForkliftResource(ForkliftResourceKind.Plan, ENV.NAMESPACE);
 const networkMapResource = getMappingResource(MappingType.Network).resource;
 const storageMapResource = getMappingResource(MappingType.Storage).resource;
-const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, META.namespace);
+const hookResource = new ForkliftResource(ForkliftResourceKind.Hook, ENV.NAMESPACE);
 
 export const usePlansQuery = (): UseQueryResult<IKubeList<IPlan>> => {
   const sortKubeListByNameCallback = React.useCallback(

--- a/src/__mocks__/envvars.ts
+++ b/src/__mocks__/envvars.ts
@@ -1,0 +1,21 @@
+/*
+ * Setup the `process.env` variables to their default values as per webpack.config.js's
+ * `EnvironmentPlugin` definitions
+ */
+
+import { EnvironmentPlugin } from 'webpack';
+
+import config from '../../webpack.config';
+
+const environmentPlugin = config.plugins.find(
+  (plugin) => plugin.constructor.name === 'EnvironmentPlugin',
+) as EnvironmentPlugin;
+
+const environmentDefaults = {
+  ...environmentPlugin.defaultValues,
+  NODE_ENV: 'test',
+};
+
+for (const envKey in environmentDefaults) {
+  process.env[envKey] = environmentDefaults[envKey];
+}


### PR DESCRIPTION
The file `pkg/web/src/app/common/constants.ts` ported from forklift-ui was still setup assuming it was running in a standalone environment. Code to access the environment vars and config meta data was broken since the values were injected in the original html page.

Consolidate the types and usage to ENV only.  Its values are sourced directly from the webpack `EnvironmentPlugin` source string replacements.

Added `envvars.ts` as a jest setup file.  This allows the env vars to use the same default values from the webpack builds.

These changes allow the setting of `ENV.BRAND_TYPE` as intended.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>