### PR TITLE
Fix displaying providers in invalid state

### DIFF
--- a/pkg/web/src/app/queries/mocks/providers.mock.ts
+++ b/pkg/web/src/app/queries/mocks/providers.mock.ts
@@ -50,7 +50,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             message: 'Connection test, succeeded.',
             reason: 'Tested',
             status: 'True',
-            type: 'ConnectionTested',
+            type: 'ConnectionTestSucceeded',
           },
           {
             category: 'Advisory',
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             message: 'Connection test, succeeded.',
             reason: 'Tested',
             status: 'True',
-            type: 'ConnectionTested',
+            type: 'ConnectionTestSucceeded',
           },
           {
             category: 'Advisory',
@@ -150,7 +150,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             message: 'Loading the inventory.',
             reason: 'Started',
             status: 'True',
-            type: 'InventoryLoading',
+            type: 'LoadInventory',
           },
         ],
       },
@@ -294,7 +294,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
             message: 'Connection test, succeeded.',
             reason: 'Tested',
             status: 'True',
-            type: 'ConnectionTested',
+            type: 'ConnectionTestSucceeded',
           },
           {
             category: 'Advisory',

--- a/src/modules/Providers/ProvidersPage.tsx
+++ b/src/modules/Providers/ProvidersPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { fromI18nEnum } from '_/components/Filter/helpers';
 import withQueryClient from '_/components/QueryClientHoc';
+import { groupVersionKindForReference } from '_/utils/resources';
 import { loadUserSettings, StandardPage, UserSettings } from 'src/components/StandardPage';
 import { Field } from 'src/components/types';
 import * as C from 'src/utils/constants';
@@ -120,12 +121,12 @@ const fieldsMetadata: Field[] = [
   },
 ];
 
-export const ProvidersPage = ({ namespace, kind }: ResourceConsolePageProps) => {
+export const ProvidersPage = ({ namespace, kind: reference }: ResourceConsolePageProps) => {
   const { t } = useTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'Providers' }));
   const dataSource = useProvidersWithInventory({
-    kind,
     namespace,
+    groupVersionKind: groupVersionKindForReference(reference),
   });
 
   // data hook triggers frequent re-renders although data remains the same:

--- a/src/modules/Providers/__tests__/mergeData.test.ts
+++ b/src/modules/Providers/__tests__/mergeData.test.ts
@@ -56,14 +56,16 @@ describe('grouping pairs', () => {
   test('empty input', () => {
     expect(groupPairs([], { openshift: [], ovirt: [], vsphere: [] })).toHaveLength(0);
   });
-  it('skipps items without pairs', () => {
-    expect(
-      groupPairs([MOCK_INVENTORY_PROVIDERS.openshift[0].object as ProviderResource], {
-        openshift: [MOCK_INVENTORY_PROVIDERS.openshift[1]],
-        ovirt: [],
-        vsphere: [],
-      }),
-    ).toHaveLength(0);
+  it('skipps inventory without resource', () => {
+    const result = groupPairs([MOCK_INVENTORY_PROVIDERS.openshift[0].object as ProviderResource], {
+      openshift: [MOCK_INVENTORY_PROVIDERS.openshift[1]],
+      ovirt: [],
+      vsphere: [],
+    });
+    expect(result).toHaveLength(1);
+    const [[provider, inventory]] = result;
+    expect(inventory).toStrictEqual({});
+    expect(provider).toEqual(MOCK_INVENTORY_PROVIDERS.openshift[0].object);
   });
   it('skipps items without UID', () => {
     const provider = MOCK_INVENTORY_PROVIDERS.openshift[0];

--- a/src/modules/Providers/__tests__/mergedMockData.json
+++ b/src/modules/Providers/__tests__/mergedMockData.json
@@ -1,275 +1,310 @@
 [
     {
-        "clusterCount": 2,
-        "conditions": {
-            "connected": {
-                "message": "Connection test, succeeded.",
-                "status": "True"
-            },
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "hostCount": 2,
-        "gvk": {
-            "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
-        },
         "name": "vcenter-1",
         "namespace": "openshift-migration",
-        "networkCount": 8,
-        "ready": "True",
-        "secretName": "boston",
-        "storageCount": 3,
+        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
         "type": "vsphere",
         "uid": "mock-uid-vcenter-1",
-        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
-        "vmCount": 41
-    },
-    {
-        "clusterCount": 2,
-        "conditions": {},
-        "hostCount": 2,
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "boston",
+        "clusterCount": 2,
+        "hostCount": 2,
+        "vmCount": 41,
+        "networkCount": 8,
+        "storageCount": 3,
+        "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
         "name": "vcenter-2",
         "namespace": "openshift-migration",
-        "networkCount": 8,
-        "ready": "Unknown",
-        "secretName": "boston",
-        "storageCount": 3,
+        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
         "type": "vsphere",
         "uid": "mock-uid-vcenter-2",
-        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
-        "vmCount": 41
-    },
-    {
-        "clusterCount": 2,
-        "conditions": {
-            "connected": {
-                "message": "Connection test, succeeded.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "hostCount": 2,
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "boston",
+        "clusterCount": 2,
+        "hostCount": 2,
+        "vmCount": 41,
+        "networkCount": 8,
+        "storageCount": 3,
+        "ready": "Unknown",
+        "positiveConditions": {},
+        "negativeConditions": {
+            "URLNotValid": {
+                "status": "True",
+                "message": "The provider is not responding."
+            }
+        }
+    },
+    {
         "name": "vcenter-3",
         "namespace": "openshift-migration",
-        "networkCount": 8,
-        "ready": "Unknown",
-        "secretName": "boston",
-        "storageCount": 3,
+        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
         "type": "vsphere",
         "uid": "mock-uid-vcenter-3",
-        "url": "https://vcenter.v2v.bos.redhat.com/sdk",
-        "vmCount": 41
-    },
-    {
-        "clusterCount": 2,
-        "conditions": {
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "hostCount": 4,
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "boston",
+        "clusterCount": 2,
+        "hostCount": 2,
+        "vmCount": 41,
+        "networkCount": 8,
+        "storageCount": 3,
+        "ready": "Unknown",
+        "positiveConditions": {
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            },
+            "LoadInventory": {
+                "status": "True",
+                "message": "Loading the inventory."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
         "name": "rhv-1",
         "namespace": "konveyor-forklift",
-        "networkCount": 15,
-        "ready": "True",
-        "secretName": "rhv",
-        "storageCount": 9,
+        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
         "type": "ovirt",
         "uid": "mock-uid-rhv-1",
-        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
-        "vmCount": 36
-    },
-    {
-        "clusterCount": 2,
-        "conditions": {
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "hostCount": 4,
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "rhv",
+        "clusterCount": 2,
+        "hostCount": 4,
+        "vmCount": 36,
+        "networkCount": 15,
+        "storageCount": 9,
+        "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
         "name": "rhv-2",
         "namespace": "konveyor-forklift",
-        "networkCount": 15,
-        "ready": "True",
-        "secretName": "rhv",
-        "storageCount": 9,
+        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
         "type": "ovirt",
         "uid": "mock-uid-rhv-2",
-        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
-        "vmCount": 36
-    },
-    {
-        "clusterCount": 2,
-        "conditions": {
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "hostCount": 4,
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "rhv",
+        "clusterCount": 2,
+        "hostCount": 4,
+        "vmCount": 36,
+        "networkCount": 15,
+        "storageCount": 9,
+        "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
         "name": "rhv-3",
         "namespace": "konveyor-forklift",
-        "networkCount": 15,
-        "ready": "True",
-        "secretName": "rhv",
-        "storageCount": 9,
+        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
         "type": "ovirt",
         "uid": "mock-uid-rhv-3",
-        "url": "https://rhvm.v2v.bos.redhat.com/ovirt-engine/api",
-        "vmCount": 36
-    },
-    {
-        "conditions": {
-            "connected": {
-                "message": "Connection test, succeeded.",
-                "status": "True"
-            },
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
-        "defaultTransferNetwork": "ocp-network-3",
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
+        "secretName": "rhv",
+        "clusterCount": 2,
+        "hostCount": 4,
+        "vmCount": 36,
+        "networkCount": 15,
+        "storageCount": 9,
+        "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
         "name": "ocpv-1",
         "namespace": "openshift-migration",
-        "networkCount": 8,
-        "ready": "True",
-        "secretName": "boston",
+        "url": "https://my_OCPv_url",
         "type": "openshift",
         "uid": "mock-uid-ocpv-1",
-        "url": "https://my_OCPv_url",
-        "vmCount": 26
-    },
-    {
-        "conditions": {},
-        "defaultTransferNetwork": "ocp-network-3",
         "gvk": {
             "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
+            "version": "v1beta1",
+            "kind": "Provider"
         },
-        "name": "ocpv-2",
-        "namespace": "openshift-migration",
-        "networkCount": 8,
-        "ready": "Unknown",
         "secretName": "boston",
-        "type": "openshift",
-        "uid": "mock-uid-ocpv-2",
-        "url": "https://my_OCPv_url",
-        "vmCount": 26
-    },
-    {
-        "conditions": {
-            "connected": {
-                "message": "Connection test, succeeded.",
-                "status": "True"
-            },
-            "inventory": {
-                "message": "The inventory has been loaded.",
-                "status": "True"
-            },
-            "ready": {
-                "message": "The provider is ready.",
-                "status": "True"
-            },
-            "validated": {
-                "message": "Validation has been completed.",
-                "status": "True"
-            }
-        },
         "defaultTransferNetwork": "ocp-network-3",
-        "gvk": {
-            "group": "forklift.konveyor.io",
-            "kind": "Provider",
-            "version": "v1beta1"
-        },
-        "name": "ocpv-3",
-        "namespace": "openshift-migration",
+        "vmCount": 26,
         "networkCount": 8,
         "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
+    },
+    {
+        "name": "ocpv-2",
+        "namespace": "openshift-migration",
+        "url": "https://my_OCPv_url",
+        "type": "openshift",
+        "uid": "mock-uid-ocpv-2",
+        "gvk": {
+            "group": "forklift.konveyor.io",
+            "version": "v1beta1",
+            "kind": "Provider"
+        },
         "secretName": "boston",
+        "defaultTransferNetwork": "ocp-network-3",
+        "vmCount": 26,
+        "networkCount": 8,
+        "ready": "Unknown",
+        "positiveConditions": {},
+        "negativeConditions": {
+            "URLNotValid": {
+                "status": "True",
+                "message": "The provider is not responding."
+            }
+        }
+    },
+    {
+        "name": "ocpv-3",
+        "namespace": "openshift-migration",
+        "url": "",
         "type": "openshift",
         "uid": "mock-uid-ocpv-3",
-        "url": "",
-        "vmCount": 26
+        "gvk": {
+            "group": "forklift.konveyor.io",
+            "version": "v1beta1",
+            "kind": "Provider"
+        },
+        "secretName": "boston",
+        "defaultTransferNetwork": "ocp-network-3",
+        "vmCount": 26,
+        "networkCount": 8,
+        "ready": "True",
+        "positiveConditions": {
+            "Ready": {
+                "status": "True",
+                "message": "The provider is ready."
+            },
+            "InventoryCreated": {
+                "status": "True",
+                "message": "The inventory has been loaded."
+            },
+            "Validated": {
+                "status": "True",
+                "message": "Validation has been completed."
+            },
+            "ConnectionTestSucceeded": {
+                "status": "True",
+                "message": "Connection test, succeeded."
+            }
+        },
+        "negativeConditions": {}
     }
 ]

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -19,6 +19,15 @@ export const groupVersionKindForObj = (obj: K8sResourceCommon) => {
 };
 
 /**
+ * Get the group version kind object from a k8s reference
+ * @param  {K8sResourceCommon} reference in format "group~version~kind"
+ */
+export const groupVersionKindForReference = (reference: string) => {
+  const [group, version, kind] = reference.split('~');
+  return { group, version, kind };
+};
+
+/**
  * Get reference group version kind string for k8s objects
  * @param  {K8sResourceCommon} obj
  */


### PR DESCRIPTION
Improvements:
1. support conditions ConnectionTestSucceeded and ConnectionTestFailed: starting with commit 8f662f2c4dbe6a745013ba38ca03676f73f570b0 forklift-controller dropped condition ConnectionTested
2. include providers without loaded inventory
3. use K8sGroupVersionKind instead of depreacted "kind" prop to fetch resources
4. update the catalogue of supported conditions to match types defined in [1]

[1] https://github.com/kubev2v/forklift-controller/blob/e73b65a01cda13890538c57f1cda2261f206d7f3/pkg/controller/provider/validation.go#L21

Reference-Url: https://github.com/kubev2v/forklift-controller/pull/192
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>