### PR TITLE
Remove extra slash from inventory URL

### DIFF
--- a/pkg/web/src/app/queries/providers.ts
+++ b/pkg/web/src/app/queries/providers.ts
@@ -61,7 +61,7 @@ export const useInventoryProvidersQuery = () => {
   const result = useMockableQuery<IProvidersByType>(
     {
       queryKey: 'inventory-providers',
-      queryFn: async () => await consoleFetchJSON(getInventoryApiUrl('/providers?detail=1')),
+      queryFn: async () => await consoleFetchJSON(getInventoryApiUrl('providers?detail=1')),
       refetchInterval: usePollingContext().refetchInterval,
       select: sortIndexedDataByNameCallback,
     },


### PR DESCRIPTION
Due to the slash 2 requests are needed to retrieve data:
1. initial request receives response code 301 Moved Permanently
2. subsequent request fetches the data

Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>