### PR TITLE
Add an empty state based welcome view to the providers page

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -3,10 +3,12 @@
   "{{type}} provider {{name}} will no longer be selectable as a migration target.": "{{type}} provider {{name}} will no longer be selectable as a migration target.",
   "Actions": "Actions",
   "Add Provider": "Add Provider",
+  "Add source and target providers for the migration.": "Add source and target providers for the migration.",
   "Cancel": "Cancel",
   "Cannot remove provider": "Cannot remove provider",
   "Clear all filters": "Clear all filters",
   "Clusters": "Clusters",
+  "Create a migration plan and select VMs from the source provider for migration.": "Create a migration plan and select VMs from the source provider for migration.",
   "default": "default",
   "Delete": "Delete",
   "Delete Provider": "Delete Provider",
@@ -20,7 +22,9 @@
   "KubeVirt": "KubeVirt",
   "Loading": "Loading",
   "Manage Columns": "Manage Columns",
+  "Map source datastores or storage domains and networks to target storage classes and networks.": "Map source datastores or storage domains and networks to target storage classes and networks.",
   "Mappings for Import": "Mappings for Import",
+  "Migrating workloads to {{openshift}} is a multi-step process.": "Migrating workloads to {{openshift}} is a multi-step process.",
   "Name": "Name",
   "Namespace": "Namespace",
   "Networks": "Networks",
@@ -35,6 +39,7 @@
   "Ready": "Ready",
   "Reorder": "Reorder",
   "Restore default colums": "Restore default colums",
+  "Run the migration plan.": "Run the migration plan.",
   "Save": "Save",
   "Select a default migration network for the provider. This network will be used for migrating data to all namespaces to which it is attached.": "Select a default migration network for the provider. This network will be used for migrating data to all namespaces to which it is attached.",
   "Select Filter": "Select Filter",
@@ -51,5 +56,6 @@
   "Unable to retrieve data": "Unable to retrieve data",
   "Unknown": "Unknown",
   "VMs": "VMs",
-  "VMware": "VMware"
+  "VMware": "VMware",
+  "Welcome to {{appTitle}}": "Welcome to {{appTitle}}"
 }

--- a/src/components/QueryClientHoc.tsx
+++ b/src/components/QueryClientHoc.tsx
@@ -13,7 +13,7 @@ const queryClient = new QueryClient({
   },
 });
 
-const withQueryClient = (Component) =>
+const withQueryClient = (Component) => {
   function QueryClientHoc(props) {
     return (
       <QueryClientProvider client={queryClient}>
@@ -21,6 +21,12 @@ const withQueryClient = (Component) =>
         {process.env.NODE_ENV !== 'test' ? <ReactQueryDevtools /> : null}
       </QueryClientProvider>
     );
-  };
+  }
+
+  const componentName = Component.displayName || Component.name || 'Component';
+  QueryClientHoc.displayName = `QueryClientHoc(${componentName})`;
+
+  return QueryClientHoc;
+};
 
 export default withQueryClient;

--- a/src/components/RedHatProgressionIcon.tsx
+++ b/src/components/RedHatProgressionIcon.tsx
@@ -1,0 +1,19 @@
+import { createIcon } from '@patternfly/react-icons/dist/esm/createIcon';
+
+/**
+ * The svg path is a combine path version of the Red Hat brand asset library,
+ * standard icons, Diagrams and graphs group, Progression black icon.
+ */
+export const RedHatProgressionIconConfig = {
+  name: 'MigrationIcon',
+  height: 36,
+  width: 36,
+  svgPath:
+    'm16.61 22.92c0.1-0.27-1.84-2-2.17-2.36-0.56-0.58-1.46 0.32-0.88 0.88l0.93 0.94h-4.49a3.38 3.38 0 0 1 0-6.75h2a0.62 0.62 0 0 0 0-1.24h-2c-6.11 0.19-6.11 9 0 9.25h4.49l-0.93 0.94a0.62225 0.62225 0 0 0 0.88 0.88l2-2a0.6 0.6 0 0 0 0.17-0.54zm-0.1-7.3h5.49a4.13 4.13 0 0 0 0-8.25h-8a0.62 0.62 0 0 0 0 1.24h8a2.88 2.88 0 0 1 0 5.75h-5.49l0.93-0.94c0.58-0.56-0.32-1.47-0.88-0.88l-2 2a0.64 0.64 0 0 0 0 0.88l2 2a0.62225 0.62225 0 0 0 0.88-0.88zm6.93 8.94c-0.56-0.58-1.47 0.32-0.88 0.88l2 2a0.61 0.61 0 0 0 0.88 0l6-6c0.58-0.56-0.31-1.47-0.88-0.88l-5.56 5.56zm7.56 1.82a0.62 0.62 0 0 0-0.62 0.62v3.38h-10.76v-10.76h7.38a0.62 0.62 0 0 0 0-1.24h-8a0.62 0.62 0 0 0-0.62 0.62v12a0.62 0.62 0 0 0 0.62 0.62h12a0.62 0.62 0 0 0 0.62-0.62v-4a0.62 0.62 0 0 0-0.62-0.62zm-19.38-15.38v-6a0.62 0.62 0 0 0-0.62-0.62h-6a0.62 0.62 0 0 0-0.62 0.62v6a0.62 0.62 0 0 0 0.62 0.62h6a0.62 0.62 0 0 0 0.62-0.62zm-1.24-0.62h-4.76v-4.76h4.76z',
+  yOffset: 0,
+  xOffset: 0,
+};
+
+export const RedHatProgressionIcon = createIcon(RedHatProgressionIconConfig);
+
+export default RedHatProgressionIcon;

--- a/src/modules/Providers/EmptyStateProviders.tsx
+++ b/src/modules/Providers/EmptyStateProviders.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import RedHatProgressionIcon from '_/components/RedHatProgressionIcon';
+import { useTranslation } from '_/utils/i18n';
+
+import * as APP_C from '@app/common/constants';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Text,
+  TextContent,
+  TextList,
+  TextListItem,
+  Title,
+} from '@patternfly/react-core';
+
+import { AddProviderButton } from './ProvidersPage';
+
+const EmptyStateProviders: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <EmptyState variant={EmptyStateVariant.large} isFullHeight>
+      <EmptyStateIcon icon={RedHatProgressionIcon} />
+
+      <Title headingLevel="h4" size="lg">
+        {t('Welcome to {{appTitle}}', { appTitle: APP_C.APP_TITLE })}
+      </Title>
+
+      <EmptyStateBody style={{ textAlign: 'left' }}>
+        <Bullseye>
+          <TextContent>
+            <Text>
+              {t('Migrating workloads to {{openshift}} is a multi-step process.', {
+                openshift: APP_C.PROVIDER_TYPE_NAMES.openshift,
+              })}
+            </Text>
+            <TextList component="ol">
+              <TextListItem>{t('Add source and target providers for the migration.')}</TextListItem>
+              <TextListItem>
+                {t(
+                  'Map source datastores or storage domains and networks to target storage classes and networks.',
+                )}
+              </TextListItem>
+              <TextListItem>
+                {t(
+                  'Create a migration plan and select VMs from the source provider for migration.',
+                )}
+              </TextListItem>
+              <TextListItem>{t('Run the migration plan.')}</TextListItem>
+            </TextList>
+          </TextContent>
+        </Bullseye>
+      </EmptyStateBody>
+
+      <AddProviderButton />
+    </EmptyState>
+  );
+};
+
+export default EmptyStateProviders;

--- a/src/modules/Providers/ProvidersPage.tsx
+++ b/src/modules/Providers/ProvidersPage.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { fromI18nEnum } from '_/components/Filter/helpers';
 import withQueryClient from '_/components/QueryClientHoc';
+import { loadUserSettings, StandardPage, UserSettings } from '_/components/StandardPage';
+import { Field } from '_/components/types';
+import * as C from '_/utils/constants';
+import { CONDITIONS, PROVIDERS } from '_/utils/enums';
+import { useTranslation } from '_/utils/i18n';
 import { groupVersionKindForReference } from '_/utils/resources';
-import { loadUserSettings, StandardPage, UserSettings } from 'src/components/StandardPage';
-import { Field } from 'src/components/types';
-import * as C from 'src/utils/constants';
-import { CONDITIONS, PROVIDERS } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
-import { ResourceConsolePageProps } from 'src/utils/types';
+import { ResourceConsolePageProps } from '_/utils/types';
 
 import { ProviderType, SOURCE_PROVIDER_TYPES } from '@app/common/constants';
 import { AddEditProviderModal } from '@app/Providers/components/AddEditProviderModal';
@@ -16,6 +16,7 @@ import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Button } from '@patternfly/react-core';
 
 import { MergedProvider, useProvidersWithInventory } from './data';
+import EmptyStateProviders from './EmptyStateProviders';
 import ProviderRow from './ProviderRow';
 
 const fieldsMetadata: Field[] = [
@@ -121,7 +122,7 @@ const fieldsMetadata: Field[] = [
   },
 ];
 
-export const ProvidersPage = ({ namespace, kind: reference }: ResourceConsolePageProps) => {
+const ProvidersPage: React.FC<ResourceConsolePageProps> = ({ namespace, kind: reference }) => {
   const { t } = useTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'Providers' }));
   const dataSource = useProvidersWithInventory({
@@ -141,31 +142,29 @@ export const ProvidersPage = ({ namespace, kind: reference }: ResourceConsolePag
   );
 };
 
-const Page = ({
-  dataSource,
-  namespace,
-  title,
-  userSettings,
-}: {
+const Page: React.FC<{
   dataSource: [MergedProvider[], boolean, boolean];
   namespace: string;
   title: string;
   userSettings: UserSettings;
-}) => (
-  <StandardPage<MergedProvider>
-    addButton={<AddProviderButton />}
-    dataSource={dataSource}
-    RowMapper={ProviderRow}
-    fieldsMetadata={fieldsMetadata}
-    namespace={namespace}
-    title={title}
-    userSettings={userSettings}
-  />
-);
+}> = ({ dataSource, namespace, title, userSettings }) =>
+  (dataSource[0]?.length ?? 0) <= 0 ? (
+    <EmptyStateProviders />
+  ) : (
+    <StandardPage<MergedProvider>
+      addButton={<AddProviderButton />}
+      dataSource={dataSource}
+      RowMapper={ProviderRow}
+      fieldsMetadata={fieldsMetadata}
+      namespace={namespace}
+      title={title}
+      userSettings={userSettings}
+    />
+  );
 
 const PageMemo = React.memo(Page);
 
-const AddProviderButton = () => {
+const AddProviderButton: React.FC = () => {
   const { t } = useTranslation();
   const launchModal = useModal();
 
@@ -176,7 +175,9 @@ const AddProviderButton = () => {
   );
 };
 
-const AddProviderModal = ({ closeModal }: { closeModal: () => void }) => {
+const AddProviderModal: React.FC<{
+  closeModal: () => void;
+}> = ({ closeModal }) => {
   return (
     <EditProviderContext.Provider value={{ openEditProviderModal: () => undefined, plans: [] }}>
       <AddEditProviderModal onClose={closeModal} providerBeingEdited={null} />
@@ -185,3 +186,4 @@ const AddProviderModal = ({ closeModal }: { closeModal: () => void }) => {
 };
 
 export default ProvidersPage;
+export { AddProviderButton };

--- a/src/modules/Providers/ProvidersWrapper.tsx
+++ b/src/modules/Providers/ProvidersWrapper.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
 import withQueryClient from 'src/components/QueryClientHoc';
 
 import ProvidersPage from './ProvidersPage';
 
-const Page = withQueryClient(ProvidersPage);
+const ProvidersWrapper: React.FC = withQueryClient(ProvidersPage);
+ProvidersWrapper.displayName = 'ProvidersWrapper';
 
-export default Page;
+export default ProvidersWrapper;


### PR DESCRIPTION
Based on the forklift-ui welcome page, add an empty state based welcome screen.  It is intended to give directions to the user about what needs to be created for a migration to be performed.

Similar screens still need to be added to the Mappings and Plans pages.

This is the empty state welcome view on a console for a cluster with only the forklift controller installed:

![Screenshot 2023-01-09 at 11-48-19 Providers · Red Hat OpenShift](https://user-images.githubusercontent.com/3985964/211375596-7fa57b92-c237-4205-9cf8-9cae2932a3d4.png)

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>
Fixes: #30

Adjacent changes:
  - Setup the icon on the empty state screen as a normal react-icon icon.  This will make it easy to change in future.
  - `QueryClientHoc` and `ProvidersWrapper` have display names added.  This allows in browser dev tools to have better display information when looking at the component tree.
 