### PR TITLE
Update webpack prod build optimization configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "stylelint": "^14.9.1",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^26.0.0",
+    "terser-webpack-plugin": "^5.3.6",
     "ts-jest": "^28.0.7",
     "ts-loader": "^9.3.1",
     "ts-node": "^10.8.1",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -3,6 +3,7 @@
 import * as path from 'path';
 
 import CopyPlugin from 'copy-webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import { type Configuration as WebpackConfiguration, EnvironmentPlugin } from 'webpack';
 import { type Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
@@ -96,6 +97,15 @@ const config: WebpackConfiguration & {
   optimization: {
     chunkIds: isProd ? 'deterministic' : 'named',
     minimize: isProd ? true : false,
+    minimizer: [
+      // Keep class names and function names in sources to aid debug and diagnostics of prod builds
+      new TerserPlugin({
+        terserOptions: {
+          keep_classnames: true,
+          keep_fnames: true,
+        },
+      }),
+    ],
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8421,6 +8421,17 @@ terser-webpack-plugin@^5.1.3:
     serialize-javascript "^6.0.0"
     terser "^5.14.1"
 
+terser-webpack-plugin@^5.3.6:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz#5590aec31aa3c6f771ce1b1acca60639eab3195c"
+  integrity sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.14"
+    jest-worker "^27.4.5"
+    schema-utils "^3.1.1"
+    serialize-javascript "^6.0.0"
+    terser "^5.14.1"
+
 terser@^5.14.1:
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"


### PR DESCRIPTION
In react dev tools and browser stack traces, component function names and class names are available.  With the default webpack minimizer TersePlugin configurations, these names are removed.  Update the `terserOptions` for production builds to keep the names.  This can help with production problem troubleshooting.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>