### PR TITLE
Refactor legacy Provider related components

### DIFF
--- a/pkg/web/src/app/Providers/EditProviderContext.tsx
+++ b/pkg/web/src/app/Providers/EditProviderContext.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import type { IPlan, IProviderObject } from '@app/queries/types';
+
+/**
+ * @deprecated
+ */
+export const EditProviderContext = React.createContext<{
+  openEditProviderModal: (providerObject: IProviderObject) => void;
+  plans: IPlan[];
+}>({
+  openEditProviderModal: () => undefined,
+  plans: [],
+});

--- a/pkg/web/src/app/Providers/ProvidersPage.tsx
+++ b/pkg/web/src/app/Providers/ProvidersPage.tsx
@@ -39,6 +39,9 @@ export interface IProvidersMatchParams {
   providerType: ProviderType;
 }
 
+/**
+ * @deprecated
+ */
 export const ProvidersPage: React.FunctionComponent = () => {
   const namespace = ENV.DEFAULT_NAMESPACE;
   const history = useHistory();

--- a/pkg/web/src/app/Providers/ProvidersPage.tsx
+++ b/pkg/web/src/app/Providers/ProvidersPage.tsx
@@ -27,17 +27,13 @@ import { useClusterProvidersQuery, useInventoryProvidersQuery, usePlansQuery } f
 
 import { ProvidersTable } from './components/ProvidersTable';
 import { AddEditProviderModal } from './components/AddEditProviderModal';
+import { EditProviderContext } from './EditProviderContext';
 
-import { IPlan, IProviderObject } from '@app/queries/types';
+import { IProviderObject } from '@app/queries/types';
 import { ResolvedQueries } from '@app/common/components/ResolvedQuery';
 import { getAggregateQueryStatus } from '@app/queries/helpers';
 import { useRouteMatch } from 'react-router';
 
-export const EditProviderContext = React.createContext({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  openEditProviderModal: (_provider: IProviderObject): void => undefined,
-  plans: [] as IPlan[],
-});
 export interface IProvidersMatchParams {
   url: string;
   providerType: ProviderType;

--- a/pkg/web/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
+++ b/pkg/web/src/app/Providers/components/CloudAnalyticsInfoAlert.tsx
@@ -4,6 +4,9 @@ import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useLocalStorage } from '@migtools/lib-ui';
 import { CLOUD_MA_LINK, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 
+/**
+ * @deprecated
+ */
 export const CloudAnalyticsInfoAlert: React.FunctionComponent = () => {
   const [isAlertHidden, setIsAlertHidden] = useLocalStorage('isProvidersPageMAAlertHidden', false);
 

--- a/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftNetworkList.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftNetworkList.tsx
@@ -14,6 +14,9 @@ interface IOpenShiftNetworkListProps {
   provider: ICorrelatedProvider<IOpenShiftProvider>;
 }
 
+/**
+ * @deprecated
+ */
 export const OpenShiftNetworkList: React.FunctionComponent<IOpenShiftNetworkListProps> = ({
   provider,
 }: IOpenShiftNetworkListProps) => {

--- a/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftProvidersTable.tsx
@@ -41,6 +41,9 @@ interface IExpandedItem {
   column: 'Networks' | 'Storage classes';
 }
 
+/**
+ * @deprecated
+ */
 export const OpenShiftProvidersTable: React.FunctionComponent<IOpenShiftProvidersTableProps> = ({
   providers,
 }: IOpenShiftProvidersTableProps) => {

--- a/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftStorageClassList.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/OpenShift/OpenShiftStorageClassList.tsx
@@ -13,6 +13,9 @@ interface IOpenShiftStorageClassListProps {
   storageClasses: IAnnotatedStorageClass[];
 }
 
+/**
+ * @deprecated
+ */
 export const OpenShiftStorageClassList: React.FunctionComponent<
   IOpenShiftStorageClassListProps
 > = ({ provider, storageClasses }: IOpenShiftStorageClassListProps) => {

--- a/pkg/web/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
@@ -1,42 +1,23 @@
 import * as React from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
 import { useDeleteProviderMutation } from '@app/queries';
-import {
-  ICorrelatedProvider,
-  INameNamespaceRef,
-  InventoryProvider,
-  IPlan,
-} from '@app/queries/types';
+import { ICorrelatedProvider, InventoryProvider } from '@app/queries/types';
 import { PATH_PREFIX, ProviderType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 import { ConfirmModal } from '@app/common/components/ConfirmModal';
 import { EditProviderContext } from '@app/Providers/EditProviderContext';
 import { ConditionalTooltip } from '@app/common/components/ConditionalTooltip';
-import { hasCondition } from '@app/common/helpers';
-import { isSameResource } from '@app/queries/helpers';
 import { useHistory } from 'react-router-dom';
 import { useClusterProvidersQuery } from '@app/queries';
-
-export const hasRunningMigration = ({
-  plans = [],
-  providerMetadata,
-}: {
-  plans: IPlan[];
-  providerMetadata: INameNamespaceRef;
-}): boolean =>
-  !!plans
-    .filter((plan) => hasCondition(plan.status?.conditions || [], 'Executing'))
-    .find((runningPlan) => {
-      const { source, destination } = runningPlan.spec.provider;
-      return (
-        isSameResource(providerMetadata, source) || isSameResource(providerMetadata, destination)
-      );
-    });
+import { hasRunningMigration } from './helpers';
 
 interface IProviderActionsDropdownProps {
   provider: ICorrelatedProvider<InventoryProvider>;
   providerType: ProviderType;
 }
 
+/**
+ * @deprecated
+ */
 export const ProviderActionsDropdown: React.FunctionComponent<IProviderActionsDropdownProps> = ({
   provider,
   providerType,

--- a/pkg/web/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/ProviderActionsDropdown.tsx
@@ -9,7 +9,7 @@ import {
 } from '@app/queries/types';
 import { PATH_PREFIX, ProviderType, PROVIDER_TYPE_NAMES } from '@app/common/constants';
 import { ConfirmModal } from '@app/common/components/ConfirmModal';
-import { EditProviderContext } from '@app/Providers/ProvidersPage';
+import { EditProviderContext } from '@app/Providers/EditProviderContext';
 import { ConditionalTooltip } from '@app/common/components/ConditionalTooltip';
 import { hasCondition } from '@app/common/helpers';
 import { isSameResource } from '@app/queries/helpers';

--- a/pkg/web/src/app/Providers/components/ProvidersTable/ProvidersTable.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/ProvidersTable.tsx
@@ -11,6 +11,9 @@ interface IProvidersTableProps {
   activeProviderType: ProviderType;
 }
 
+/**
+ * @deprecated
+ */
 export const ProvidersTable: React.FunctionComponent<IProvidersTableProps> = ({
   inventoryProvidersByType,
   clusterProviders,

--- a/pkg/web/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
@@ -37,6 +37,9 @@ interface ISourceProvidersTableProps {
   providerType: ProviderType;
 }
 
+/**
+ * @deprecated
+ */
 export const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTableProps> = ({
   providers,
   providerType,

--- a/pkg/web/src/app/Providers/components/ProvidersTable/helpers.ts
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/helpers.ts
@@ -1,7 +1,17 @@
 import { ProviderType } from '@app/common/constants';
+import { hasCondition } from '@app/common/helpers';
 import { isSameResource } from '@app/queries/helpers';
-import { InventoryProvider, ICorrelatedProvider, IProviderObject } from '@app/queries/types';
+import {
+  InventoryProvider,
+  ICorrelatedProvider,
+  IProviderObject,
+  IPlan,
+  INameNamespaceRef,
+} from '@app/queries/types';
 
+/**
+ * @deprecated
+ */
 export const correlateProviders = <T extends InventoryProvider>(
   clusterProviders: IProviderObject[],
   inventoryProviders: T[],
@@ -16,3 +26,19 @@ export const correlateProviders = <T extends InventoryProvider>(
           isSameResource(inventoryProvider, provider.metadata)
         ) || null,
     }));
+
+export const hasRunningMigration = ({
+  plans = [],
+  providerMetadata,
+}: {
+  plans: IPlan[];
+  providerMetadata: INameNamespaceRef;
+}): boolean =>
+  !!plans
+    .filter((plan) => hasCondition(plan.status?.conditions || [], 'Executing'))
+    .find((runningPlan) => {
+      const { source, destination } = runningPlan.spec.provider;
+      return (
+        isSameResource(providerMetadata, source) || isSameResource(providerMetadata, destination)
+      );
+    });

--- a/pkg/web/src/app/Providers/components/ProvidersTable/index.ts
+++ b/pkg/web/src/app/Providers/components/ProvidersTable/index.ts
@@ -1,1 +1,2 @@
 export { ProvidersTable } from './ProvidersTable';
+export { hasRunningMigration } from './helpers';

--- a/src/modules/Providers/ProvidersPage.tsx
+++ b/src/modules/Providers/ProvidersPage.tsx
@@ -11,7 +11,6 @@ import { ResourceConsolePageProps } from '_/utils/types';
 
 import { ProviderType, SOURCE_PROVIDER_TYPES } from '@app/common/constants';
 import { AddEditProviderModal } from '@app/Providers/components/AddEditProviderModal';
-import { EditProviderContext } from '@app/Providers/ProvidersPage';
 import { Button } from '@patternfly/react-core';
 import { useModal } from '@shim/dynamic-plugin-sdk';
 
@@ -190,13 +189,11 @@ const AddProviderModal: React.FC<{
   closeModal: () => void;
 }> = ({ closeModal, currentNamespace }) => {
   return (
-    <EditProviderContext.Provider value={{ openEditProviderModal: () => undefined, plans: [] }}>
-      <AddEditProviderModal
-        onClose={closeModal}
-        providerBeingEdited={null}
-        namespace={currentNamespace}
-      />
-    </EditProviderContext.Provider>
+    <AddEditProviderModal
+      onClose={closeModal}
+      providerBeingEdited={null}
+      namespace={currentNamespace}
+    />
   );
 };
 AddProviderModal.displayName = 'AddProviderModal';

--- a/src/modules/Providers/providerActions.tsx
+++ b/src/modules/Providers/providerActions.tsx
@@ -8,13 +8,12 @@ import { SelectOpenShiftNetworkModal } from '@app/common/components/SelectOpenSh
 import { ProviderType } from '@app/common/constants';
 import { AddEditProviderModal } from '@app/Providers/components/AddEditProviderModal';
 import { hasRunningMigration } from '@app/Providers/components/ProvidersTable/ProviderActionsDropdown';
-import { EditProviderContext } from '@app/Providers/ProvidersPage';
 import {
   useDeleteProviderMutation,
   useOCPMigrationNetworkMutation,
   usePlansQuery,
 } from '@app/queries';
-import { IOpenShiftProvider, IPlan, IProviderObject } from '@app/queries/types';
+import { IOpenShiftProvider, IProviderObject } from '@app/queries/types';
 import { useModal } from '@shim/dynamic-plugin-sdk';
 
 import { type MergedProvider } from './data';
@@ -42,11 +41,7 @@ export const useMergedProviderActions = ({ entity }: { entity: MergedProvider })
       [
         {
           id: 'edit',
-          cta: () =>
-            launchModal(withQueryClient(EditModal), {
-              entity,
-              plans: plansQuery?.data?.items,
-            }),
+          cta: () => launchModal(withQueryClient(EditModal), { entity }),
           label: t('Edit Provider'),
           disabled: editingDisabled,
           disabledTooltip: editingDisabled ? disabledTooltip : '',
@@ -70,23 +65,13 @@ export const useMergedProviderActions = ({ entity }: { entity: MergedProvider })
   return [actions, true, undefined];
 };
 
-const EditModal = ({
-  entity,
-  closeModal,
-  plans = [],
-}: {
-  closeModal: () => void;
-  entity: MergedProvider;
-  plans: IPlan[];
-}) => {
+const EditModal = ({ entity, closeModal }: { closeModal: () => void; entity: MergedProvider }) => {
   return (
-    <EditProviderContext.Provider value={{ openEditProviderModal: () => undefined, plans }}>
-      <AddEditProviderModal
-        onClose={closeModal}
-        providerBeingEdited={toIProviderObject(entity)}
-        namespace={entity.namespace}
-      />
-    </EditProviderContext.Provider>
+    <AddEditProviderModal
+      onClose={closeModal}
+      providerBeingEdited={toIProviderObject(entity)}
+      namespace={entity.namespace}
+    />
   );
 };
 EditModal.displayName = 'EditModal';

--- a/src/modules/Providers/providerActions.tsx
+++ b/src/modules/Providers/providerActions.tsx
@@ -7,7 +7,7 @@ import { ConfirmModal } from '@app/common/components/ConfirmModal';
 import { SelectOpenShiftNetworkModal } from '@app/common/components/SelectOpenShiftNetworkModal';
 import { ProviderType } from '@app/common/constants';
 import { AddEditProviderModal } from '@app/Providers/components/AddEditProviderModal';
-import { hasRunningMigration } from '@app/Providers/components/ProvidersTable/ProviderActionsDropdown';
+import { hasRunningMigration } from '@app/Providers/components/ProvidersTable';
 import {
   useDeleteProviderMutation,
   useOCPMigrationNetworkMutation,


### PR DESCRIPTION
Refactor legacy Provider related components to minimize their cross use by console plugin components.  These changes also help simplify future work on the Add/Edit Providers modal.

1. Refactor `EditProviderContext`
      - Move `EditProviderContext` to its own file
      - Mark it as deprecated since it is only used by legacy components
      - Adjust use of `EditProviderContext` to the new location
      - Drop use of `EditProviderContext` from `AddEditProviderModal` since
        the modal has no use the the data in the context
      - Remove the context's use from the `src/modules/Providers` components

2.  Refactor `hasRunningMigration`
      - moved `hasRunningMigration` to **helpers.ts** so it is not tied
        to a component directly
      - **providerActions.tsx** changed to use the new import location

3. Mark unused legacy Providers components as `@deprecated`
    
    - The legacy components around Providers that are no longer in use by
    the console plugin code have been marked as `@deprecated`.  This
    provides a visual indication in IDEs that old things are being used.
    
    - In future these deprecated components should be removed.


Signed-off-by: Scott J Dickerson <sdickers@redhat.com>