### PR TITLE
Fix eslint for ci and ide on package/legacy

### DIFF
--- a/packages/legacy/.eslintrc.js
+++ b/packages/legacy/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.export = {
   "root": true,
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -8,7 +8,7 @@
     "js": true,
     "useJSXTextNode": true,
     "project": ["tsconfig.json"],
-    "tsconfigRootDir": "./"
+    "tsconfigRootDir": __dirname,
   },
   "extends": [
     "eslint:recommended",
@@ -58,4 +58,4 @@
     "browser": true,
     "node": true
   }
-}
+};


### PR DESCRIPTION
eslint with typescript in a monorepo has a few quirks.  One big one is having to set `parserOptions.tsconfigRootDir` such that eslint works from CI/CLI and within an IDE (vscode with eslint extension).  The workaround is to use a javascript config file and the directive `__dirname` to pull the file's actual directory name.  With that in place, vscode linting works again!

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>