### PR TITLE
Support re-ordered params in SearchInput

### DIFF
--- a/packages/common/src/components/Filter/FreetextFilter.tsx
+++ b/packages/common/src/components/Filter/FreetextFilter.tsx
@@ -43,7 +43,12 @@ export const FreetextFilter = ({
         <SearchInput
           placeholder={placeholderLabel}
           value={inputValue}
-          onChange={setInputValue}
+          onChange={(event, value) => {
+            // starting with react-core 4.273.0 parameters were re-ordered
+            // the workaround can be removed when last supported Console version is 4.13
+            const isReactCoreBefore4_273_0 = typeof value === 'object';
+            setInputValue(isReactCoreBefore4_273_0 ? event : value);
+          }}
           onSearch={onTextInput}
           onClear={() => setInputValue('')}
         />


### PR DESCRIPTION
Starting with react-core 4.273.0 the order of parameters in onChange callback was changed. The new version is used by Console ver >= 4.13.

Reference-Url: https://github.com/patternfly/patternfly-react/commit/1995c5f2808e842443483421951b114e1f841fbd
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>