### PR TITLE
Use current quay org for ci/deploy-forklift.sh

### DIFF
--- a/ci/deploy-forklift.sh
+++ b/ci/deploy-forklift.sh
@@ -8,7 +8,7 @@ if ! kubectl get CatalogSource 2>/dev/null; then
   exit 1
 fi
 
-FORKLIFT_IMAGE=quay.io/konveyor/forklift-operator-index:latest
+FORKLIFT_IMAGE=quay.io/kubev2v/forklift-operator-index:latest
 FORKLIFT_NAMESPACE=konveyor-forklift
 
 cat << EOF | kubectl apply -f -


### PR DESCRIPTION
Adjust the `FORKLIFT_IMAGE` from the forklift 2.3.4 terminal line in the `konveyor` quay.io org to the current `kubev2v` org. This will keep CI and devs using the most current forklift controller.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>