### PR TITLE
Support pages without primary filters

### DIFF
--- a/packages/common/src/components/StandardPage/StandardPage.tsx
+++ b/packages/common/src/components/StandardPage/StandardPage.tsx
@@ -149,6 +149,8 @@ export function StandardPage<T>({
   const noResults = loaded && !error && flattenData.length == 0;
   const noMatchingResults = loaded && !error && filteredData.length === 0 && flattenData.length > 0;
 
+  const primaryFilters = fields.filter((field) => field.filter?.primary).map(toFieldFilter);
+
   return (
     <>
       <PageSection variant="light">
@@ -163,12 +165,14 @@ export function StandardPage<T>({
         <Toolbar clearAllFilters={clearAllFilters} clearFiltersButtonText={t('Clear all filters')}>
           <ToolbarContent>
             <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
-              <PrimaryFilters
-                fieldFilters={fields.filter((field) => field.filter?.primary).map(toFieldFilter)}
-                onFilterUpdate={setSelectedFilters}
-                selectedFilters={selectedFilters}
-                supportedFilterTypes={supportedFilters}
-              />
+              {primaryFilters.length > 0 && (
+                <PrimaryFilters
+                  fieldFilters={primaryFilters}
+                  onFilterUpdate={setSelectedFilters}
+                  selectedFilters={selectedFilters}
+                  supportedFilterTypes={supportedFilters}
+                />
+              )}
               <AttributeValueFilter
                 fieldFilters={fields
                   .filter(({ filter }) => filter && !filter.primary)

--- a/packages/common/src/components/StandardPage/__tests__/__snapshots__/StandardPage.test.tsx.snap
+++ b/packages/common/src/components/StandardPage/__tests__/__snapshots__/StandardPage.test.tsx.snap
@@ -70,9 +70,6 @@ exports[`empty result set returned, no filters  1`] = `
             </div>
             <div
               class="pf-c-toolbar__group pf-m-filter-group"
-            />
-            <div
-              class="pf-c-toolbar__group pf-m-filter-group"
             >
               <div
                 class="pf-c-toolbar__item"


### PR DESCRIPTION
Fixes problem with alignment if primary filter is missing. This is useful for cases like #160 where we have only attribute-value filter.
