### PR TITLE
Support custom value matchers in StandardPage component

### DIFF
--- a/packages/common/src/components/Filter/matchers.ts
+++ b/packages/common/src/components/Filter/matchers.ts
@@ -1,5 +1,7 @@
 import { Field } from '../types';
 
+import { ValueMatcher } from './types';
+
 /**
  * Create matcher for one filter type.
  * Features:
@@ -17,7 +19,7 @@ export const createMatcher =
   }: {
     selectedFilters: { [id: string]: string[] };
     filterType: string;
-    matchValue: (value: string) => (filterValue: string) => boolean;
+    matchValue: (value: unknown) => (filterValue: string) => boolean;
     fields: Field[];
   }) =>
   (entity): boolean =>
@@ -52,7 +54,11 @@ const groupedEnumMatcher = {
   matchValue: enumMatcher.matchValue,
 };
 
-const defaultValueMatchers = [freetextMatcher, enumMatcher, groupedEnumMatcher];
+export const defaultValueMatchers: ValueMatcher[] = [
+  freetextMatcher,
+  enumMatcher,
+  groupedEnumMatcher,
+];
 
 /**
  * Create matcher for multiple filter types.
@@ -65,10 +71,7 @@ export const createMetaMatcher =
   (
     selectedFilters: { [id: string]: string[] },
     fields: Field[],
-    valueMatchers: {
-      filterType: string;
-      matchValue: (value: string) => (filter: string) => boolean;
-    }[] = defaultValueMatchers,
+    valueMatchers: ValueMatcher[] = defaultValueMatchers,
   ) =>
   (entity): boolean =>
     valueMatchers

--- a/packages/common/src/components/Filter/types.ts
+++ b/packages/common/src/components/Filter/types.ts
@@ -75,3 +75,8 @@ export interface MetaFilterProps {
 export interface GlobalFilters {
   [id: string]: string[];
 }
+
+export interface ValueMatcher {
+  filterType: string;
+  matchValue: (value: unknown) => (filter: string) => boolean;
+}

--- a/packages/common/src/components/StandardPage/StandardPage.tsx
+++ b/packages/common/src/components/StandardPage/StandardPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import {
   AttributeValueFilter,
   createMetaMatcher,
+  defaultValueMatchers,
   EnumFilter,
   FilterTypeProps,
   FreetextFilter,
@@ -9,6 +10,7 @@ import {
   PrimaryFilters,
   toFieldFilter,
   useUrlFilters,
+  ValueMatcher,
 } from 'common/src/components/Filter';
 import {
   ManageColumnsToolbar,
@@ -71,6 +73,13 @@ export interface StandardPageProps<T> {
   supportedFilters?: {
     [type: string]: (props: FilterTypeProps) => JSX.Element;
   };
+
+  /**
+   * Extract value from fields and compare to selected filter.
+   * The default matchers support the default filters.
+   */
+  supportedMatchers?: ValueMatcher[];
+
   title: string;
   /**
    * Information displayed when the data source returned no items.
@@ -122,6 +131,7 @@ export function StandardPage<T>({
   pagination = DEFAULT_PER_PAGE,
   userSettings,
   filterPrefix = '',
+  supportedMatchers = defaultValueMatchers,
 }: StandardPageProps<T>) {
   const { t } = useTranslation();
   const [selectedFilters, setSelectedFilters] = useUrlFilters({
@@ -133,7 +143,10 @@ export function StandardPage<T>({
   const [activeSort, setActiveSort, comparator] = useSort(fields);
 
   const filteredData = useMemo(
-    () => flattenData.filter(createMetaMatcher(selectedFilters, fields)).sort(comparator),
+    () =>
+      flattenData
+        .filter(createMetaMatcher(selectedFilters, fields, supportedMatchers))
+        .sort(comparator),
     [flattenData, selectedFilters, fields, comparator],
   );
 


### PR DESCRIPTION
Re-use existing fitlers (i.e. free text) to filter complex data types.

Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>