### PR TITLE
Drop use of the `Q.allSettled()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2601,12 +2601,6 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
     },
-    "node_modules/@types/q": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
-      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
-      "dev": true
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -14254,16 +14248,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -19233,7 +19217,6 @@
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
         "@types/ejs": "^3.0.6",
         "@types/node": "^18.0.0",
-        "@types/q": "^1.5.4",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.1",
         "style-loader": "^3.3.1",
@@ -19265,7 +19248,6 @@
         "@types/file-saver": "^2.0.3",
         "@types/netmask": "^1.0.30",
         "@types/node": "^18.0.0",
-        "@types/q": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0"
       },
@@ -19279,7 +19261,6 @@
         "dayjs": "^1.11.5",
         "file-saver": "1.3.x",
         "netmask": "^2.0.2",
-        "q": "^1.5.1",
         "react": "^17.0.1",
         "react-query": "^3.39.2",
         "react-router": "5.2.0",
@@ -20579,7 +20560,6 @@
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
         "@types/ejs": "^3.0.6",
         "@types/node": "^18.0.0",
-        "@types/q": "^1.5.4",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.1",
         "style-loader": "^3.3.1",
@@ -20599,7 +20579,6 @@
         "@types/file-saver": "^2.0.3",
         "@types/netmask": "^1.0.30",
         "@types/node": "^18.0.0",
-        "@types/q": "^1.5.4",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0"
       }
@@ -21402,12 +21381,6 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
-    },
-    "@types/q": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
-      "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==",
       "dev": true
     },
     "@types/qs": {
@@ -30448,12 +30421,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "peer": true
     },
     "qs": {
       "version": "6.11.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,8 +4,8 @@
     "description": "Common config files used by monorepo packages",
     "private": true,
     "scripts": {
-      "clean": "rm -rf ./dist && rm -rf ./coverage",
-      "clean:all": "npm run clean && rm -rf ./node_modules",
-      "test": "echo 'this package is untested'; exit 0"
+        "clean": "rm -rf ./dist && rm -rf ./coverage",
+        "clean:all": "npm run clean && rm -rf ./node_modules",
+        "test": "echo 'this package is untested'; exit 0"
     }
-  }
+}

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -33,7 +33,6 @@
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
     "@types/ejs": "^3.0.6",
     "@types/node": "^18.0.0",
-    "@types/q": "^1.5.4",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
     "style-loader": "^3.3.1",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -68,7 +68,6 @@
     "dayjs": "^1.11.5",
     "file-saver": "1.3.x",
     "netmask": "^2.0.2",
-    "q": "^1.5.1",
     "react": "^17.0.1",
     "react-query": "^3.39.2",
     "react-router": "5.2.0",
@@ -80,7 +79,6 @@
     "@types/file-saver": "^2.0.3",
     "@types/netmask": "^1.0.30",
     "@types/node": "^18.0.0",
-    "@types/q": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0"
   }

--- a/packages/legacy/src/client/helpers.ts
+++ b/packages/legacy/src/client/helpers.ts
@@ -1,4 +1,3 @@
-import Q from 'q';
 import KubeClient, {
   NamespacedResource,
   CoreNamespacedResourceKind,
@@ -219,7 +218,7 @@ export const checkIfResourceExists = async (
   const secretResource = createSecretResource(
     resource instanceof NamespacedResource ? resource.namespace : undefined
   );
-  const results = await Q.allSettled([
+  const results = await Promise.allSettled([
     client.list(secretResource, getTokenSecretLabelSelector(resourceKind, resourceName)),
     client.get(resource, resourceName),
   ]);

--- a/packages/legacy/src/queries/providers.ts
+++ b/packages/legacy/src/queries/providers.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useQueryClient, UseQueryResult, UseMutationResult } from 'react-query';
 import * as yup from 'yup';
-import Q from 'q';
 
 import { usePollingContext } from 'legacy/src/common/context';
 import {
@@ -180,7 +179,7 @@ export const useCreateProviderMutation = (
         []
       );
 
-      const rollbackResultPromises = await Q.allSettled(
+      const rollbackResultPromises = await Promise.allSettled(
         rollbackObjs.map((r) => {
           return client.delete(kindToResourceMap[r.kind], r.name);
         })

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -8,7 +8,9 @@
     "url": "https://github.com/kubev2v/forklift-console-plugin.git",
     "directory": "packages/lib-webpack"
   },
-  "files": ["./dist/*"],
+  "files": [
+    "./dist/*"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The old Q promise library was being used solely for the `allSettled()` function [1].  This allows multiple async function / promises to run in parallel and collect the full results of each.  Use of the Q library just for this function is no longer necessary.  The standard `Promise` object contains the same `allSettled()` function with the same signiture [2].

[1] - https://github.com/kriskowal/q#combination
[2] - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled

The libraries were remove by running:
```
npm remove q -ws packages/legacy
npm remove @types/q -ws packages/legacy
```
Any changes to other package.json files were done by npm during the remove operation.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>