### PR TITLE
Remove unneaded workspaces path prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "workspaces": [
-        "./packages/*"
+        "packages/*"
       ],
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
   "license": "Apache-2.0",
   "workspaces": [
-    "./packages/*"
+    "packages/*"
   ],
   "scripts": {
     "clean": "rm -rf dist && rm -rf coverage && npm run clean -ws",


### PR DESCRIPTION
npm workspaces do not nead a `./` prefix, this prefix may offend atuomation tools reading the package files.
removing the prefix for house cleaning.

Signed-off-by: Yaacov <kobi.zamir@gmail.com>