### PR TITLE
Remove unneeded requirement on immutable package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17856,19 +17856,10 @@
         "@openshift/dynamic-plugin-sdk": "~1.0.0",
         "@patternfly/react-core": "4.221.3",
         "@patternfly/react-table": "4.90.3",
-        "immutable": "3.x",
         "react": "^17.0.1",
         "react-i18next": "^11.7.3",
         "react-query": "^3.39.2",
         "react-router": "5.2.0"
-      }
-    },
-    "packages/common/node_modules/immutable": {
-      "version": "3.8.2",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "packages/config": {
@@ -18972,12 +18963,6 @@
       "version": "file:packages/common",
       "requires": {
         "@types/node": "^18.0.0"
-      },
-      "dependencies": {
-        "immutable": {
-          "version": "3.8.2",
-          "peer": true
-        }
       }
     },
     "@kubev2v/config": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -49,7 +49,6 @@
     "@openshift/dynamic-plugin-sdk": "~1.0.0",
     "@patternfly/react-core": "4.221.3",
     "@patternfly/react-table": "4.90.3",
-    "immutable": "3.x",
     "react": "^17.0.1",
     "react-i18next": "^11.7.3",
     "react-query": "^3.39.2",

--- a/packages/common/src/polyfills/console-dynamic-plugin-sdk/api/internal-types.ts
+++ b/packages/common/src/polyfills/console-dynamic-plugin-sdk/api/internal-types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { QuickStart } from '@patternfly/quickstarts';
-import { Map as ImmutableMap } from 'immutable';
 import {
   FirehoseResult,
   HealthState,
@@ -243,16 +242,6 @@ export enum ActionMenuVariant {
   DROPDOWN = 'default',
 }
 
-type Request<R> = {
-  active: boolean;
-  timeout: NodeJS.Timer;
-  inFlight: boolean;
-  data: R;
-  error: any;
-};
-
-export type RequestMap<R> = ImmutableMap<string, Request<R>>;
-
 export type Fetch = (url: string) => Promise<any>;
 export type WatchURLProps = {
   url: string;
@@ -263,20 +252,6 @@ export type WatchPrometheusQueryProps = {
   query: string;
   namespace?: string;
   timespan?: number;
-};
-
-export type UseDashboardResources = ({
-  prometheusQueries,
-  urls,
-  notificationAlertLabelSelectors,
-}: {
-  prometheusQueries?: WatchPrometheusQueryProps[];
-  urls?: WatchURLProps[];
-  notificationAlertLabelSelectors?: { [k: string]: string };
-}) => {
-  urlResults: RequestMap<any>;
-  prometheusResults: RequestMap<PrometheusResponse>;
-  notificationAlerts: { alerts: Alert[]; loaded: boolean; loadError: Error };
 };
 
 export type UseUserSettings = <T>(


### PR DESCRIPTION
Remove unneeded requirement on immutable package

Issue:
the common package uses `immutable` to export a method we don't consume.
removing this method allow us to removed dependency on `immutable`