### PR TITLE
Color the create new plan button blue

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -124,7 +124,7 @@ const Page = ({
   userSettings: UserSettings;
 }) => (
   <StandardPage<FlatPlan>
-    addButton={<CreatePlanButton variant="secondary" namespace={namespace} />}
+    addButton={<CreatePlanButton namespace={namespace} />}
     dataSource={dataSource}
     RowMapper={PlanRow}
     fieldsMetadata={fieldsMetadata}


### PR DESCRIPTION
Issue: create new plan button is white, should be blue

Fix: paint the button using cobalt blue 

Screenshots:
Before
![create-plan-white](https://user-images.githubusercontent.com/2181522/218969243-2e642e2e-a4b0-48cf-820c-5c4f75c9692a.png)

After
![create-plan-blue](https://user-images.githubusercontent.com/2181522/218969194-294c2e0b-09fd-426f-911a-525bf7a43b49.png)