### PR TITLE
Polyfills eslintrc is sub-dir, should not have project field

### DIFF
--- a/packages/common/src/polyfills/.eslintrc
+++ b/packages/common/src/polyfills/.eslintrc
@@ -6,9 +6,7 @@
     "tsx": true,
     "jsx": true,
     "js": true,
-    "useJSXTextNode": true,
-    "project": ["./tsconfig.json", "./qe-tests/tsconfig.json"],
-    "tsconfigRootDir": "."
+    "useJSXTextNode": true
   },
   "extends": [
     "eslint:recommended",


### PR DESCRIPTION
Polyfills eslintrc is sub-dir, should not have project field.

Polyfills are not a project, but they have uniqe `eslintrc` file, cleaning up the file to remove links the old (none existing) polyfills project tsconfig file