### PR TITLE
Check version before fallback to polyfill emplimentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,13 +1608,14 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk": {
-      "version": "0.0.17",
-      "license": "Apache-2.0",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.18.tgz",
+      "integrity": "sha512-1aNdM4RVdWAcIChHulHdK4PuJofiN/aHsd1r9HIfdwd9sc8TcWVPHK3o1ppVysxFqhiyLABVpmG/tc1Gg+bwCg==",
       "peer": true,
       "dependencies": {
         "@patternfly/quickstarts": "2.0.1",
-        "@patternfly/react-core": "4.235.7",
-        "@patternfly/react-table": "4.104.7",
+        "@patternfly/react-core": "4.239.0",
+        "@patternfly/react-table": "4.108.0",
         "classnames": "2.x",
         "immutable": "3.x",
         "lodash": "^4.17.21",
@@ -1774,13 +1775,14 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/@patternfly/react-core": {
-      "version": "4.235.7",
-      "license": "MIT",
+      "version": "4.239.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.239.0.tgz",
+      "integrity": "sha512-6CmYABCJLUXTlzCk6C3WouMNZpS0BCT+aHU8CvYpFQ/NrpYp3MJaDsYbqgCRWV42rmIO5iXun/4WhXBJzJEoQg==",
       "peer": true,
       "dependencies": {
-        "@patternfly/react-icons": "^4.86.7",
-        "@patternfly/react-styles": "^4.85.7",
-        "@patternfly/react-tokens": "^4.87.7",
+        "@patternfly/react-icons": "^4.90.0",
+        "@patternfly/react-styles": "^4.89.0",
+        "@patternfly/react-tokens": "^4.91.0",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -1792,14 +1794,15 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/@patternfly/react-table": {
-      "version": "4.104.7",
-      "license": "MIT",
+      "version": "4.108.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.108.0.tgz",
+      "integrity": "sha512-EUvd3rlkE1UXobAm7L6JHgNE3TW8IYTaVwwH/px4Mkn5mBayDO6f+w6QM3OeoDQVZcXK6IYFe7QQaYd/vWIJCQ==",
       "peer": true,
       "dependencies": {
-        "@patternfly/react-core": "^4.235.7",
-        "@patternfly/react-icons": "^4.86.7",
-        "@patternfly/react-styles": "^4.85.7",
-        "@patternfly/react-tokens": "^4.87.7",
+        "@patternfly/react-core": "^4.239.0",
+        "@patternfly/react-icons": "^4.90.0",
+        "@patternfly/react-styles": "^4.89.0",
+        "@patternfly/react-tokens": "^4.91.0",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       },
@@ -1818,7 +1821,8 @@
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/tslib": {
       "version": "2.5.0",
-      "license": "0BSD",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "peer": true
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
@@ -17852,7 +17856,7 @@
         "@types/node": "^18.0.0"
       },
       "peerDependencies": {
-        "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+        "@openshift-console/dynamic-plugin-sdk": "0.0.18",
         "@openshift/dynamic-plugin-sdk": "~1.0.0",
         "@patternfly/react-core": "4.221.3",
         "@patternfly/react-table": "4.90.3",
@@ -17889,7 +17893,7 @@
         "webpack-dev-server": "^4.7.4"
       },
       "peerDependencies": {
-        "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+        "@openshift-console/dynamic-plugin-sdk": "0.0.18",
         "@openshift/dynamic-plugin-sdk": "~1.0.0",
         "@patternfly/react-core": "4.221.3",
         "@patternfly/react-table": "4.90.3",
@@ -17913,7 +17917,7 @@
       },
       "peerDependencies": {
         "@migtools/lib-ui": "^8.4.1",
-        "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+        "@openshift-console/dynamic-plugin-sdk": "0.0.18",
         "@patternfly/react-core": "4.221.3",
         "@patternfly/react-table": "4.90.3",
         "axios": "^0.21.2",
@@ -17941,7 +17945,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+        "@openshift-console/dynamic-plugin-sdk": "0.0.18",
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
         "@openshift/dynamic-plugin-sdk": "~1.0.0",
         "@openshift/dynamic-plugin-sdk-webpack": "~1.0.0"
@@ -19038,12 +19042,14 @@
       }
     },
     "@openshift-console/dynamic-plugin-sdk": {
-      "version": "0.0.17",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.18.tgz",
+      "integrity": "sha512-1aNdM4RVdWAcIChHulHdK4PuJofiN/aHsd1r9HIfdwd9sc8TcWVPHK3o1ppVysxFqhiyLABVpmG/tc1Gg+bwCg==",
       "peer": true,
       "requires": {
         "@patternfly/quickstarts": "2.0.1",
-        "@patternfly/react-core": "4.235.7",
-        "@patternfly/react-table": "4.104.7",
+        "@patternfly/react-core": "4.239.0",
+        "@patternfly/react-table": "4.108.0",
         "classnames": "2.x",
         "immutable": "3.x",
         "lodash": "^4.17.21",
@@ -19061,12 +19067,14 @@
       },
       "dependencies": {
         "@patternfly/react-core": {
-          "version": "4.235.7",
+          "version": "4.239.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.239.0.tgz",
+          "integrity": "sha512-6CmYABCJLUXTlzCk6C3WouMNZpS0BCT+aHU8CvYpFQ/NrpYp3MJaDsYbqgCRWV42rmIO5iXun/4WhXBJzJEoQg==",
           "peer": true,
           "requires": {
-            "@patternfly/react-icons": "^4.86.7",
-            "@patternfly/react-styles": "^4.85.7",
-            "@patternfly/react-tokens": "^4.87.7",
+            "@patternfly/react-icons": "^4.90.0",
+            "@patternfly/react-styles": "^4.89.0",
+            "@patternfly/react-tokens": "^4.91.0",
             "focus-trap": "6.9.2",
             "react-dropzone": "9.0.0",
             "tippy.js": "5.1.2",
@@ -19074,13 +19082,15 @@
           }
         },
         "@patternfly/react-table": {
-          "version": "4.104.7",
+          "version": "4.108.0",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.108.0.tgz",
+          "integrity": "sha512-EUvd3rlkE1UXobAm7L6JHgNE3TW8IYTaVwwH/px4Mkn5mBayDO6f+w6QM3OeoDQVZcXK6IYFe7QQaYd/vWIJCQ==",
           "peer": true,
           "requires": {
-            "@patternfly/react-core": "^4.235.7",
-            "@patternfly/react-icons": "^4.86.7",
-            "@patternfly/react-styles": "^4.85.7",
-            "@patternfly/react-tokens": "^4.87.7",
+            "@patternfly/react-core": "^4.239.0",
+            "@patternfly/react-icons": "^4.90.0",
+            "@patternfly/react-styles": "^4.89.0",
+            "@patternfly/react-tokens": "^4.91.0",
             "lodash": "^4.17.19",
             "tslib": "^2.0.0"
           }
@@ -19091,6 +19101,8 @@
         },
         "tslib": {
           "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
           "peer": true
         }
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -45,7 +45,7 @@
     "test:updateSnapshot": "TZ=UTC jest --updateSnapshot"
   },
   "peerDependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.18",
     "@openshift/dynamic-plugin-sdk": "~1.0.0",
     "@patternfly/react-core": "4.221.3",
     "@patternfly/react-table": "4.90.3",

--- a/packages/common/src/polyfills/console-dynamic-plugin-sdk/app/modal-support/useModal.ts
+++ b/packages/common/src/polyfills/console-dynamic-plugin-sdk/app/modal-support/useModal.ts
@@ -1,5 +1,8 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import * as React from 'react';
 import { LaunchModal, ModalContext } from './ModalProvider';
+import { useModal as useModalSDK} from '@openshift-console/dynamic-plugin-sdk'
+import { IS_CONSOLE_VERSION_4_11 } from 'common/src/polyfills/version/release-version';
 
 type UseModalLauncher = () => LaunchModal;
 
@@ -16,7 +19,12 @@ type UseModalLauncher = () => LaunchModal;
  * }
  * ```
  */
-export const useModal: UseModalLauncher = () => {
+const useModalPolyfill: UseModalLauncher = () => {
   const { launchModal } = React.useContext(ModalContext);
   return launchModal;
 };
+
+/**
+ * Test console version and fallback to poyfill on older versions
+ */
+export const useModal = IS_CONSOLE_VERSION_4_11 ? useModalPolyfill : useModalSDK;

--- a/packages/common/src/polyfills/sdk-shim/withModalProvider.tsx
+++ b/packages/common/src/polyfills/sdk-shim/withModalProvider.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import * as React from 'react';
 import { ModalProvider } from '../console-dynamic-plugin-sdk/app/modal-support/ModalProvider';
+import { IS_CONSOLE_VERSION_4_11 } from 'common/src/polyfills/version/release-version';
 
 /** withModalProvider
  *
@@ -10,8 +12,13 @@ import { ModalProvider } from '../console-dynamic-plugin-sdk/app/modal-support/M
  * Componenet {React.FC} is the component that will be wrapped with
  * the modal provider context.
  */
-export const withModalProvider = <T extends object>(Component: React.ComponentType<T>): React.FC<T> => {
-  function ModalProviderHoc(props) {
+export const withModalProvider = <T extends object>(Component: React.ComponentType<T>): React.ComponentType<T> => {
+  // On console version 4.12 and above we do not need the modal provider.
+  if (!IS_CONSOLE_VERSION_4_11) {
+    return Component;
+  }
+
+  const ModalProviderHoc = (props) => {
     return (
       <ModalProvider>
         <Component {...props} />

--- a/packages/common/src/polyfills/version/__tests__/release-version.test.ts
+++ b/packages/common/src/polyfills/version/__tests__/release-version.test.ts
@@ -1,0 +1,35 @@
+import { getReleaseVersionSemanticVersioning } from '../release-version';
+
+describe('getReleaseVersionSemanticVersioning', () => {
+  it('calculate semantic version currectly', () => {
+    expect(getReleaseVersionSemanticVersioning('1.2.3', '')).toEqual([1,2,3]);
+  });
+
+  it('fall back currectly on empty string', () => {
+    expect(getReleaseVersionSemanticVersioning('', '')).toEqual([0,0,0]);
+  });
+
+  it('fall back currectly on undefined', () => {
+    expect(getReleaseVersionSemanticVersioning(undefined, '')).toEqual([0,0,0]);
+  });
+
+  it('fall back currectly on numberic input', () => {
+    expect(getReleaseVersionSemanticVersioning(123, '')).toEqual([0,0,0]);
+  });
+
+  it('fall back currectly on garbage', () => {
+    expect(getReleaseVersionSemanticVersioning('just some words', '')).toEqual([0,0,0]);
+  });
+
+  it('fall back currectly on none a.b.c version', () => {
+    expect(getReleaseVersionSemanticVersioning('1.2.3-beta', '')).toEqual([1,2,3]);
+  });
+
+  it('fall back currectly on old git versions', () => {
+    expect(getReleaseVersionSemanticVersioning('', 'v6.0.6-20465-gf354c93297')).toEqual([-1,0,0]);
+  });
+
+  it('fall back currectly on new git versions', () => {
+    expect(getReleaseVersionSemanticVersioning('', 'v6.0.6-21316-g106dab445e')).toEqual([0,0,0]);
+  });
+});

--- a/packages/common/src/polyfills/version/release-version.ts
+++ b/packages/common/src/polyfills/version/release-version.ts
@@ -1,0 +1,64 @@
+// default return values
+const OLD_DEV = [-1 ,0 ,0];
+const DEV = [0, 0, 0]
+
+// consoleVersion for 4.11 dev code was on the 20000 range:
+// for example: v6.0.6-20465-gf354c93297
+// on 4.12 it jumped to 21000:
+// for example: v6.0.6-21012-gcc711bd0ea
+// Note: this is not a documented or defined, fallback to this
+//       check only when all other methods failed.
+const OLD_CONSOLE_VERSION_PREFIX = 'v6.0.6-20';
+
+/**
+ * get console semantic version, from the console releaseVersion.
+ * use git version (consoleVersion) as fallback way to guess release.
+ * 
+ * @param {string} releaseVersion is openshift console release value, available only for release
+ * @param {string} consoleVersion is auto generated from git
+ * 
+ * @returns a tupple with the console release version, on none release it will return 0, 0, 0,
+ *          on old development server, return -1, 0, 0
+ */
+export const getReleaseVersionSemanticVersioning = (releaseVersion, consoleVersion) => {
+    if (!releaseVersion || typeof releaseVersion !== 'string') {
+        // if we don't have releaseVersion try consoleVersion
+        if (consoleVersion && typeof consoleVersion === 'string' && consoleVersion.startsWith(OLD_CONSOLE_VERSION_PREFIX)) {
+            return OLD_DEV;
+        }
+
+        return DEV;
+    }
+    const [major, minor, bugfix] = releaseVersion.split('.').map((v) => parseInt(v, 10));
+
+    return [major || 0, minor || 0, bugfix || 0]
+}
+
+/**
+ * get the console release version
+ * 
+ * @returns a tupple with the console release version, on none release it will return 0, 0, 0,
+ *          on old development server, return -1, 0, 0
+ */
+const getReleaseVersion = () => {
+    const releaseVersion = window['SERVER_FLAGS']?.releaseVersion;
+    const consoleVersion = window['SERVER_FLAGS']?.consoleVersion;
+
+    return getReleaseVersionSemanticVersioning(releaseVersion, consoleVersion)
+}
+
+/**
+ * Specific version check based on getReleaseVersion
+ * 
+ * @returns true if version is 4.11 or lower
+ */
+const isConsoleVersion_4_11 = () => {
+    const [major, minor] = getReleaseVersion();
+
+    if (major === 0) return false;
+    if (major === -1) return true;
+
+    return ((major === 4 && minor <= 11) || (major < 4));
+};
+
+export const IS_CONSOLE_VERSION_4_11 = isConsoleVersion_4_11();

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -20,7 +20,7 @@
     "@migtools/lib-ui": "^8.4.1"
   },
   "peerDependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.18",
     "@openshift/dynamic-plugin-sdk": "~1.0.0",
     "@patternfly/react-core": "4.221.3",
     "@patternfly/react-table": "4.90.3",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "@migtools/lib-ui": "^8.4.1",
-    "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.18",
     "@patternfly/react-core": "4.221.3",
     "@patternfly/react-table": "4.90.3",
     "axios": "^0.21.2",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "peerDependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "0.0.17",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.18",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
     "@openshift/dynamic-plugin-sdk": "~1.0.0",
     "@openshift/dynamic-plugin-sdk-webpack": "~1.0.0"


### PR DESCRIPTION
Issue: currently we use polyfills always, we should only fall back to them on older versions

FIx: ask console version and fallback only on older versions
