### PR TITLE
Use flex for cells with labels

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -145,19 +145,19 @@ const Ref = ({
 const NameCell = ({ entity: e }: CellProps) => {
   const { t } = useTranslation();
   return (
-    <>
-      <Ref gvk={e.gvk} name={e.name} namespace={e.namespace} />{' '}
+    <span className="forklift-table__flex-cell">
+      <Ref gvk={e.gvk} name={e.name} namespace={e.namespace} />
       {e.type === 'Cold' && (
-        <Label isCompact color="blue">
+        <Label isCompact color="blue" className="forklift-table__flex-cell-label">
           {PLAN_TYPE.Cold(t).toLowerCase()}
         </Label>
       )}
       {e.type === 'Warm' && (
-        <Label isCompact color="orange">
+        <Label isCompact color="orange" className="forklift-table__flex-cell-label">
           {PLAN_TYPE.Warm(t).toLowerCase()}
         </Label>
       )}
-    </>
+    </span>
   );
 };
 NameCell.displayName = 'NameCell';

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
@@ -14,19 +14,22 @@ exports[`Plan rows plantest-01 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-01, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-01, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>
@@ -218,19 +221,22 @@ exports[`Plan rows plantest-02 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-02, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-02, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>
@@ -425,19 +431,22 @@ exports[`Plan rows plantest-03 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-03, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-03, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>
@@ -660,19 +669,22 @@ exports[`Plan rows plantest-04 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-04, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-04, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>
@@ -895,19 +907,22 @@ exports[`Plan rows plantest-05 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-05, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-05, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>
@@ -1087,19 +1102,22 @@ exports[`Plan rows plantest-06 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-06, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-orange pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              warm
+              name: plantest-06, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-orange pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                warm
+              </span>
             </span>
           </span>
         </td>
@@ -1294,19 +1312,22 @@ exports[`Plan rows plantest-07 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-07, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-orange pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              warm
+              name: plantest-07, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-orange pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                warm
+              </span>
             </span>
           </span>
         </td>
@@ -1473,19 +1494,22 @@ exports[`Plan rows plantest-08 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-08, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-orange pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              warm
+              name: plantest-08, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-orange pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                warm
+              </span>
             </span>
           </span>
         </td>
@@ -1653,19 +1677,22 @@ exports[`Plan rows plantest-09 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-09, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-orange pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              warm
+              name: plantest-09, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-orange pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                warm
+              </span>
             </span>
           </span>
         </td>
@@ -1857,19 +1884,22 @@ exports[`Plan rows plantest-10 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-10, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-orange pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              warm
+              name: plantest-10, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-orange pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                warm
+              </span>
             </span>
           </span>
         </td>
@@ -2092,19 +2122,22 @@ exports[`Plan rows plantest-11 1`] = `
           class=""
           data-label="Name"
         >
-          <div
-            class="ResourceLink_mock"
-          >
-            name: plantest-11, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
-          </div>
-           
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
-            <span
-              class="pf-c-label__content"
+            <div
+              class="ResourceLink_mock"
             >
-              cold
+              name: plantest-11, gvk: forklift.konveyor.io~v1beta1~Plan, ns: openshift-migration
+            </div>
+            <span
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
+            >
+              <span
+                class="pf-c-label__content"
+              >
+                cold
+              </span>
             </span>
           </span>
         </td>

--- a/packages/forklift-console-plugin/src/modules/Plans/styles.css
+++ b/packages/forklift-console-plugin/src/modules/Plans/styles.css
@@ -4,3 +4,11 @@
   width: 100%;
   text-align: left;
 }
+
+.forklift-table__flex-cell {
+  display: flex;
+}
+
+.forklift-table__flex-cell-label {
+  margin-left: var(--pf-global--spacer--sm);
+}

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
@@ -20,6 +20,8 @@ import { Td, Tr } from '@patternfly/react-table';
 import { MergedProvider, SupportedConditions } from './data';
 import { ProviderActions } from './providerActions';
 
+import './styles.css';
+
 interface CellProps {
   value: string;
   entity: MergedProvider;
@@ -138,25 +140,23 @@ const HostCell = ({ value, entity: { ready, name, type }, currentNamespace }: Ce
 HostCell.displayName = 'HostCell';
 
 const TypeCell = ({ value, t }: CellProps) => (
-  <>
+  <span className="forklift-table__flex-cell">
     {PROVIDERS?.[value]?.(t)}
     {SOURCE_PROVIDER_TYPES.includes(value as ProviderType) && (
       <>
-        {' '}
-        <Label isCompact color="green">
+        <Label isCompact color="green" className="forklift-table__flex-cell-label">
           {t('Source').toLowerCase()}
         </Label>
       </>
     )}
     {TARGET_PROVIDER_TYPES.includes(value as ProviderType) && (
       <>
-        {' '}
-        <Label isCompact color="blue">
+        <Label isCompact color="blue" className="forklift-table__flex-cell-label">
           {t('Target').toLowerCase()}
         </Label>
       </>
     )}
-  </>
+  </span>
 );
 TypeCell.displayName = 'TypeCell';
 

--- a/packages/forklift-console-plugin/src/modules/Providers/__tests__/__snapshots__/ProviderRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Providers/__tests__/__snapshots__/ProviderRow.test.tsx.snap
@@ -84,14 +84,18 @@ exports[`Provider rows ocpv-1 1`] = `
           class=""
           data-label="Type"
         >
-          KubeVirt 
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            KubeVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
             >
-              target
+              <span
+                class="pf-c-label__content"
+              >
+                target
+              </span>
             </span>
           </span>
         </td>
@@ -256,14 +260,18 @@ exports[`Provider rows ocpv-2 1`] = `
           class=""
           data-label="Type"
         >
-          KubeVirt 
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            KubeVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
             >
-              target
+              <span
+                class="pf-c-label__content"
+              >
+                target
+              </span>
             </span>
           </span>
         </td>
@@ -435,14 +443,18 @@ exports[`Provider rows ocpv-3 1`] = `
           class=""
           data-label="Type"
         >
-          KubeVirt 
           <span
-            class="pf-c-label pf-m-blue pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            KubeVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-blue pf-m-compact forklift-table__flex-cell-label"
             >
-              target
+              <span
+                class="pf-c-label__content"
+              >
+                target
+              </span>
             </span>
           </span>
         </td>
@@ -607,14 +619,18 @@ exports[`Provider rows rhv-1 1`] = `
           class=""
           data-label="Type"
         >
-          oVirt 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            oVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>
@@ -811,14 +827,18 @@ exports[`Provider rows rhv-2 1`] = `
           class=""
           data-label="Type"
         >
-          oVirt 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            oVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>
@@ -1015,14 +1035,18 @@ exports[`Provider rows rhv-3 1`] = `
           class=""
           data-label="Type"
         >
-          oVirt 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            oVirt
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>
@@ -1219,14 +1243,18 @@ exports[`Provider rows vcenter-1 1`] = `
           class=""
           data-label="Type"
         >
-          VMware 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            VMware
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>
@@ -1427,14 +1455,18 @@ exports[`Provider rows vcenter-2 1`] = `
           class=""
           data-label="Type"
         >
-          VMware 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            VMware
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>
@@ -1631,14 +1663,18 @@ exports[`Provider rows vcenter-3 1`] = `
           class=""
           data-label="Type"
         >
-          VMware 
           <span
-            class="pf-c-label pf-m-green pf-m-compact"
+            class="forklift-table__flex-cell"
           >
+            VMware
             <span
-              class="pf-c-label__content"
+              class="pf-c-label pf-m-green pf-m-compact forklift-table__flex-cell-label"
             >
-              source
+              <span
+                class="pf-c-label__content"
+              >
+                source
+              </span>
             </span>
           </span>
         </td>

--- a/packages/forklift-console-plugin/src/modules/Providers/styles.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/styles.css
@@ -1,0 +1,7 @@
+.forklift-table__flex-cell {
+  display: flex;
+}
+
+.forklift-table__flex-cell-label {
+  margin-left: var(--pf-global--spacer--sm);
+}


### PR DESCRIPTION
Issue: labels drop to next line in small cells

Fix: use flex flow

Screenshot:
after:
![with-flex](https://user-images.githubusercontent.com/2181522/219070653-b8f8cc07-cb1d-4b67-90fb-53ef7697ed7f.png)

before
![no-flex](https://user-images.githubusercontent.com/2181522/219070733-b77f8103-84ba-4131-abb6-ed978dfe5554.png)


