### PR TITLE
Add `insecureSkipVerify` support for vmware Providers

### DIFF
--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -244,11 +244,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
     ? createProviderMutation
     : patchProviderMutation;
 
-  const certificateConfirmButtonRef = React.useRef<HTMLElement>(null);
-
-  const scrollVerifyButtonIntoView = () =>
-    certificateConfirmButtonRef.current?.scrollIntoView({ behavior: 'smooth' });
-
   return (
     <Modal
       className="AddEditProviderModal"
@@ -393,7 +388,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                   <ValidatedTextInput
                     inputProps={{
                       placeholder: usernamePlaceholder,
-                      onFocus: scrollVerifyButtonIntoView,
                     }}
                     field={fields.username}
                     isRequired
@@ -402,7 +396,6 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                 ) : null}
                 {fields?.password ? (
                   <ValidatedPasswordInput
-                    inputProps={{ onFocus: scrollVerifyButtonIntoView }}
                     field={fields.password}
                     isRequired
                     fieldId="password"

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -147,7 +147,8 @@ const useAddProviderFormState = (
     }),
     ovirt: useFormState({
       ...sourceProviderFields,
-      insecureSkipVerify,
+      // TODO: Enable once ovirt support is ready
+      // insecureSkipVerify,
       caCert: useFormField('', yup.string().label('CA certificate').required()),
       caCertFilename: useFormField('', yup.string()),
     }),
@@ -477,32 +478,32 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
 
                 {fields?.fingerprint ? (
                   <ValidatedTextInput
-                  field={fields.fingerprint}
-                  isRequired
-                  fieldId="fingerprint"
-                  formGroupProps={{
-                    labelIcon: (
-                      <Popover
-                        bodyContent={
-                          <div>
-                            The provider currently requires the SHA-1 fingerprint of the vCenter Server's
-                            TLS certificate in all circumstances. vSphere calls this the server's <code>thumbprint</code>.
-                          </div>
-                        }
-                      >
-                      <Button
-                        variant="plain"
-                        aria-label="More info for vsphere fingerprint field"
-                        onClick={(e) => e.preventDefault()}
-                        aria-describedby="fingerprint-info"
-                        className="pf-c-form__group-label-help"
-                      >
-                        <HelpIcon noVerticalAlign />
-                      </Button>
-                    </Popover>
-                    ),
-                  }}
-                />
+                    field={fields.fingerprint}
+                    isRequired
+                    fieldId="fingerprint"
+                    formGroupProps={{
+                      labelIcon: (
+                        <Popover
+                          bodyContent={
+                            <div>
+                              The provider currently requires the SHA-1 fingerprint of the vCenter Server's
+                              TLS certificate in all circumstances. vSphere calls this the server's <code>thumbprint</code>.
+                            </div>
+                          }
+                        >
+                        <Button
+                          variant="plain"
+                          aria-label="More info for vsphere fingerprint field"
+                          onClick={(e) => e.preventDefault()}
+                          aria-describedby="fingerprint-info"
+                          className="pf-c-form__group-label-help"
+                        >
+                          <HelpIcon noVerticalAlign />
+                        </Button>
+                      </Popover>
+                      ),
+                    }}
+                  />
                 ) : null }
 
                 {fields?.caCert && fields?.caCertFilename ? (

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/helpers.ts
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/helpers.ts
@@ -70,11 +70,12 @@ export const useAddEditProviderPrefillEffect = (
           ovirtFields.password.prefill(atob(secret?.data.password || ''));
           ovirtFields.hostname.prefill(ovirtUrlToHostname(spec.url || ''));
           ovirtFields.caCert.prefill(atob(secret?.data.cacert || ''));
-          ovirtFields.insecureSkipVerify.prefill(
-            secret?.data.insecureSkipVerify
-              ? stringToBoolean(atob(secret?.data.insecureSkipVerify))
-              : false
-          );
+          // TODO: Enable once ovirt support is ready
+          // ovirtFields.insecureSkipVerify.prefill(
+          //   secret?.data.insecureSkipVerify
+          //     ? stringToBoolean(atob(secret?.data.insecureSkipVerify))
+          //     : false
+          // );
         }
         if (providerType === 'openstack') {
           const openstackFields = forms.openstack.fields;

--- a/packages/legacy/src/client/helpers.ts
+++ b/packages/legacy/src/client/helpers.ts
@@ -116,7 +116,8 @@ export function convertFormValuesToSecret(
       user: btoa(rhvValues.username),
       password: btoa(rhvValues.password),
       cacert: btoa(rhvValues.caCert),
-      insecureSkipVerify: btoa(booleanToString(rhvValues.insecureSkipVerify) ?? ''),
+      // TODO: Enable once ovirt support is ready
+      // insecureSkipVerify: btoa(booleanToString(rhvValues.insecureSkipVerify) ?? ''),
     };
   }
   if (values.providerType === 'openstack') {

--- a/packages/legacy/src/client/helpers.ts
+++ b/packages/legacy/src/client/helpers.ts
@@ -7,6 +7,7 @@ import KubeClient, {
   CoreClusterResource,
 } from '@migtools/lib-ui';
 import { ProviderType, CLUSTER_API_VERSION } from 'legacy/src/common/constants';
+import { booleanToString } from 'legacy/src/common/helpers';
 import { IProviderObject, ISecret } from 'legacy/src/queries/types';
 import {
   AddProviderFormValues,
@@ -105,6 +106,7 @@ export function convertFormValuesToSecret(
       user: btoa(vmwareValues.username),
       password: btoa(vmwareValues.password),
       thumbprint: btoa(vmwareValues.fingerprint),
+      insecureSkipVerify: btoa(booleanToString(vmwareValues.insecureSkipVerify) ?? ''),
     };
   }
   if (values.providerType === 'ovirt') {
@@ -114,6 +116,7 @@ export function convertFormValuesToSecret(
       user: btoa(rhvValues.username),
       password: btoa(rhvValues.password),
       cacert: btoa(rhvValues.caCert),
+      insecureSkipVerify: btoa(booleanToString(rhvValues.insecureSkipVerify) ?? ''),
     };
   }
   if (values.providerType === 'openstack') {
@@ -125,8 +128,8 @@ export function convertFormValuesToSecret(
       domainName:btoa(openstackValues.domainName),
       projectName:btoa(openstackValues.projectName),
       region:btoa(openstackValues.region),
-      insecure:btoa(String((openstackValues.insecure))),
-      cacert: !openstackValues.insecure ? btoa(openstackValues.caCertIfSecure) : null
+      insecure:btoa(booleanToString(openstackValues.insecureSkipVerify) ?? ''),
+      cacert: !openstackValues.insecureSkipVerify ? btoa(openstackValues.caCertIfSecure) : null
     };
   }
   if (values.providerType === 'openshift') {

--- a/packages/legacy/src/common/helpers.ts
+++ b/packages/legacy/src/common/helpers.ts
@@ -182,3 +182,39 @@ export const getUniqueItemsByName = <T extends { name: string }>(allItems: T[]):
   });
   return uniqueItems;
 };
+
+/**
+ * Follow the golang `ParseBool` to return a boolean value represented by the string.
+ * It accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False.
+ * Any other values return undefined.
+ */
+export const stringToBoolean = (s: string, defaultReturn: boolean = undefined): boolean => {
+  switch (s) {
+    case '1':
+    case 't':
+    case 'T':
+    case 'true':
+    case 'TRUE':
+    case 'True':
+      return true;
+
+    case '0':
+    case 'f':
+    case 'F':
+    case 'false':
+    case 'FALSE':
+    case 'False':
+      return false;
+
+    default:
+      return defaultReturn;
+  };
+};
+
+/**
+ * Follow the golang `FormatBool` to return "true" or "false" according to the
+ * value of `b`.
+ */
+export const booleanToString = (b: boolean): string => {
+  return b ? 'true' : 'false';
+};

--- a/packages/legacy/src/queries/types/secrets.types.ts
+++ b/packages/legacy/src/queries/types/secrets.types.ts
@@ -13,6 +13,7 @@ export interface ISecret extends IMetaTypeMeta {
     thumbprint?: string;
     token?: string;
     cacert?: string;
+    insecureSkipVerify?: string;
   };
   metadata: IMetaObjectGenerateName | IMetaObjectMeta;
   type: string;


### PR DESCRIPTION
Fixes: #115 

Add `insecureSkipVerify` support for vmware Providers.  This is shown on the modal as checkbox with label "Skip certificate validation (if checked, the provider's certificate won't be validated)".  A `false` will verify certificates, and a `true` will skip the verification.

Changes:

  - Reusing the openstack `insecure` checkbox and field, enable
    the checkbox for vmware Providers.

  - `AddEditProviderModal` has some minor refactoring mostly to move
    the `insecureSkipVerify` checkbox above all of the thumbprint
    or certificate fields.

  - Removed field `isCertificateValid` and related handling from the
    vmware provider fields since it is no longer used.

  - `stringToBoolean()` and `booleanToString()` added to match the golang
    equivalent functions used by the controller.  Use of these helpers
    will ensure the values are valid both for UI use and for controller
    use.

  - In the edit prefill and secrets creation helpers, setup the secret
    to be stored as a string and to be parsed from a string to a normal
    boolean when in use by the modal.

  - Refactoring in helper hook `useAddEditProviderPrefillEffect()` to
    have a single block of code for each provider type for edit
    prefills.  This matches the `convertFormValuesToSecret()` function.

  - Remove the scroll to verify button handling in `AddEditProviderModal`
    since it is no longer relevant.  The verify button has been removed.

Signed-off-by: Scott J Dickerson <sdickers@redhat.com>

Adding vmware provider:
![screenshot-localhost_9000-2023 02 17-17_49_24](https://user-images.githubusercontent.com/3985964/219812277-0800c0c4-9687-4e5a-97ce-0bcf39c42117.png)

Adding oVirt provider is unchanged.

Adding openstack provider is unchanged.

