### PR TITLE
Check data is loaded before testing for empty data

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -153,9 +153,10 @@ const Page: React.FC<{
   title: string;
   userSettings: UserSettings;
 }> = ({ dataSource, namespace, title, userSettings }) => {
-  const showEmptyState = (dataSource[0]?.length ?? 0) === 0;
+  const [data, loaded, error] = dataSource;
+  const loadedDataIsEmpty = loaded && !error && data?.length === 0;
 
-  return showEmptyState ? (
+  return loadedDataIsEmpty ? (
     <EmptyStateProviders namespace={namespace} />
   ) : (
     <StandardPage<MergedProvider>


### PR DESCRIPTION
Show empty state only when loading done

Fixes: #176

Issue: while loading, the length of the data list is empty, and we show the empty state if list length is zero, even if it's just because it's still loading.

Fix: check that the data finished loading before checking the data length

