### PR TITLE
Use warmer color palette for CRD labels

### DIFF
--- a/packages/types/src/constants/HookModel.v1beta1.ts
+++ b/packages/types/src/constants/HookModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const HookModel = {
   plural: 'hooks',
 
   abbr: 'HO',
-  color: undefined,
+  color: '#afb345',
   id: 'hooks.forklift.konveyor.io',
   namespaced: true,
   crd: true,

--- a/packages/types/src/constants/HostModel.v1beta1.ts
+++ b/packages/types/src/constants/HostModel.v1beta1.ts
@@ -13,7 +13,7 @@ export const HostModel = {
   kind: 'Host',
   plural: 'hosts',
 
-  abbr: 'HO',
+  abbr: 'H',
   color: undefined,
   id: 'hosts.forklift.konveyor.io',
   namespaced: true,

--- a/packages/types/src/constants/MigrationModel.v1beta1.ts
+++ b/packages/types/src/constants/MigrationModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const MigrationModel = {
   plural: 'migrations',
 
   abbr: 'MI',
-  color: '#db7c1d',
+  color: '#e4788d',
   id: 'migrations.forklift.konveyor.io',
   namespaced: true,
   crd: true,

--- a/packages/types/src/constants/NetworkMapModel.v1beta1.ts
+++ b/packages/types/src/constants/NetworkMapModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const NetworkMapModel = {
   plural: 'networkmaps',
 
   abbr: 'NM',
-  color: '#f7b525',
+  color: '#e1b945',
   id: 'networkmaps.forklift.konveyor.io',
   namespaced: true,
   crd: true,

--- a/packages/types/src/constants/PlanModel.v1beta1.ts
+++ b/packages/types/src/constants/PlanModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const PlanModel = {
   plural: 'plans',
 
   abbr: 'PL',
-  color: '#0f930b',
+  color: '#6f6d42',
   id: 'plans.forklift.konveyor.io',
   namespaced: true,
   crd: true,

--- a/packages/types/src/constants/ProviderModel.v1beta1.ts
+++ b/packages/types/src/constants/ProviderModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const ProviderModel = {
   plural: 'providers',
 
   abbr: 'PR',
-  color: '#b51cb8',
+  color: '#d5515e',
   id: 'providers.forklift.konveyor.io',
   namespaced: true,
   crd: true,

--- a/packages/types/src/constants/StorageMapModel.v1beta1.ts
+++ b/packages/types/src/constants/StorageMapModel.v1beta1.ts
@@ -14,7 +14,7 @@ export const StorageMapModel = {
   plural: 'storagemaps',
 
   abbr: 'SM',
-  color: '#f7b525',
+  color: '#e1b945',
   id: 'storagemaps.forklift.konveyor.io',
   namespaced: true,
   crd: true,


### PR DESCRIPTION
Use warmer color palette for CRD labels

After last week demo we got feedback about the colors:
a. hook label used default color
b. providers and plans used "cold" colors

this PR updates all colors to be "warm" and adds color to the hooks CRD label

Screenshots:
Before:
![current-palet](https://user-images.githubusercontent.com/2181522/220042670-df85d4e8-3197-4415-aa46-45225938abba.png)

After:
![warm-palet](https://user-images.githubusercontent.com/2181522/220042687-f0269cac-175b-4a26-9fef-3f81f363da05.png)

