### PR TITLE
Replace ProviderResource with V1beta1Provider interface

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Mappings/__tests__/mergeData.test.ts
+++ b/packages/forklift-console-plugin/src/modules/Mappings/__tests__/mergeData.test.ts
@@ -2,9 +2,10 @@ import {
   MOCK_NETWORK_MAPPINGS,
   MOCK_STORAGE_MAPPINGS,
 } from 'legacy/src/queries/mocks/mappings.mock';
-import { NetworkMapResource, ProviderResource, StorageMapResource } from 'src/utils/types';
+import { NetworkMapResource, StorageMapResource } from 'src/utils/types';
 
 import { MOCK_CLUSTER_PROVIDERS } from '@kubev2v/legacy/queries/mocks/providers.mock';
+import { V1beta1Provider } from '@kubev2v/types';
 
 import {
   groupByTarget as groupNetworkByTarget,
@@ -25,7 +26,7 @@ describe('merging network data', () => {
 
   test('standard mock data', () => {
     const mappings = MOCK_NETWORK_MAPPINGS as NetworkMapResource[];
-    const providers = MOCK_CLUSTER_PROVIDERS as ProviderResource[];
+    const providers = MOCK_CLUSTER_PROVIDERS as V1beta1Provider[];
     const merged = mergeNetworkData(mappings, providers);
     // do a stringify-parse run to remove undefined properties which clutter the results(if mismatch happens)
     expect(JSON.parse(JSON.stringify(merged))).toEqual(MERGED_NETWORK_DATA);
@@ -39,7 +40,7 @@ describe('merging storage data', () => {
 
   test('standard mock data', () => {
     const mappings = MOCK_STORAGE_MAPPINGS as StorageMapResource[];
-    const providers = MOCK_CLUSTER_PROVIDERS as ProviderResource[];
+    const providers = MOCK_CLUSTER_PROVIDERS as V1beta1Provider[];
     const merged = mergeStoragekData(mappings, providers);
     // do a stringify-parse run to remove undefined properties which clutter the results(if mismatch happens)
     expect(JSON.parse(JSON.stringify(merged))).toEqual(MERGED_STORAGE_DATA);

--- a/packages/forklift-console-plugin/src/modules/Mappings/dataCommon.ts
+++ b/packages/forklift-console-plugin/src/modules/Mappings/dataCommon.ts
@@ -3,8 +3,8 @@ import { Mapping } from 'legacy/src/queries/types';
 import * as C from 'src/utils/constants';
 import { useProviders } from 'src/utils/fetch';
 import { groupVersionKindForObj, ResourceKind } from 'src/utils/resources';
-import { ProviderResource } from 'src/utils/types';
 
+import { V1beta1Provider } from '@kubev2v/types';
 import {
   K8sGroupVersionKind,
   OwnerReference,
@@ -51,7 +51,7 @@ export const useMappings = <T, K>(
     groupVersionKind: { group, version },
   }: { namespace: string; name?: string; groupVersionKind: K8sGroupVersionKind },
   useMappings: (p: WatchK8sResource, k: Omit<K8sGroupVersionKind, 'kind'>) => WatchK8sResult<T[]>,
-  mergeData: (m: T[], p: ProviderResource[]) => K[],
+  mergeData: (m: T[], p: V1beta1Provider[]) => K[],
 ): [K[], boolean, boolean] => {
   const [providers] = useProviders({ namespace }, { group, version });
   const [mappings, loaded, error] = useMappings({ namespace, name }, { group, version });

--- a/packages/forklift-console-plugin/src/modules/Mappings/dataForNetwork.ts
+++ b/packages/forklift-console-plugin/src/modules/Mappings/dataForNetwork.ts
@@ -7,8 +7,9 @@ import {
 import * as C from 'src/utils/constants';
 import { useNetworkMappings } from 'src/utils/fetch';
 import { groupVersionKindForObj, resolveProviderRef } from 'src/utils/resources';
-import { NetworkMapResource, ProviderRef, ProviderResource } from 'src/utils/types';
+import { NetworkMapResource, ProviderRef } from 'src/utils/types';
 
+import { V1beta1Provider } from '@kubev2v/types';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 import { CommonMapping, OwnerRef, resolveOwnerRef, useMappings } from './dataCommon';
@@ -77,7 +78,7 @@ export const groupByTarget = (
 
 export const mergeData = (
   mappings: NetworkMapResource[],
-  providers: ProviderResource[],
+  providers: V1beta1Provider[],
 ): FlatNetworkMapping[] => {
   return mappings
     .map(

--- a/packages/forklift-console-plugin/src/modules/Mappings/dataForStorage.ts
+++ b/packages/forklift-console-plugin/src/modules/Mappings/dataForStorage.ts
@@ -2,8 +2,9 @@ import { IdOrNameRef, IStorageMapping } from 'legacy/src/queries/types';
 import * as C from 'src/utils/constants';
 import { useStorageMappings } from 'src/utils/fetch';
 import { groupVersionKindForObj, resolveProviderRef } from 'src/utils/resources';
-import { ProviderRef, ProviderResource, StorageMapResource } from 'src/utils/types';
+import { ProviderRef, StorageMapResource } from 'src/utils/types';
 
+import { V1beta1Provider } from '@kubev2v/types';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 import { CommonMapping, OwnerRef, resolveOwnerRef, useMappings } from './dataCommon';
@@ -47,7 +48,7 @@ export const groupByTarget = (tuples: [string, IdOrNameRef][]): [Storage, IdOrNa
 
 export const mergeData = (
   mappings: StorageMapResource[],
-  providers: ProviderResource[],
+  providers: V1beta1Provider[],
 ): FlatStorageMapping[] => {
   return mappings
     .map(

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/mergeData.test.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/mergeData.test.ts
@@ -1,8 +1,9 @@
-import { MigrationResource, PlanResource, ProviderResource } from 'src/utils/types';
+import { MigrationResource, PlanResource } from 'src/utils/types';
 
 import { MOCK_MIGRATIONS } from '@kubev2v/legacy/queries/mocks/migrations.mock';
 import { MOCK_PLANS } from '@kubev2v/legacy/queries/mocks/plans.mock';
 import { MOCK_CLUSTER_PROVIDERS } from '@kubev2v/legacy/queries/mocks/providers.mock';
+import { V1beta1Provider } from '@kubev2v/types';
 
 import { mergeData } from '../data';
 
@@ -22,7 +23,7 @@ describe('merging k8s resources:Plans, Migrations, Providers', () => {
     jest.useFakeTimers().setSystemTime(new Date(NOW));
 
     const migrations = MOCK_MIGRATIONS as MigrationResource[];
-    const providers = MOCK_CLUSTER_PROVIDERS as ProviderResource[];
+    const providers = MOCK_CLUSTER_PROVIDERS as V1beta1Provider[];
     const merged = mergeData(plans, migrations, providers);
     // do a stringify-parse run to remove undefined properties which clutter the results(if mismatch happens)
     expect(JSON.parse(JSON.stringify(merged))).toEqual(MERGED_MOCK_DATA);

--- a/packages/forklift-console-plugin/src/modules/Plans/data.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/data.ts
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 import * as C from 'src/utils/constants';
 import { useMigrations, usePlans, useProviders } from 'src/utils/fetch';
 import { groupVersionKindForObj, resolveProviderRef } from 'src/utils/resources';
-import { MigrationResource, PlanResource, ProviderRef, ProviderResource } from 'src/utils/types';
+import { MigrationResource, PlanResource, ProviderRef } from 'src/utils/types';
 
 import { PlanState } from '@kubev2v/legacy/common/constants';
 import { getPlanState } from '@kubev2v/legacy/Plans/components/helpers';
 import { findLatestMigration } from '@kubev2v/legacy/queries';
 import { IPlan, PlanType } from '@kubev2v/legacy/queries/types';
+import { V1beta1Provider } from '@kubev2v/types';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 export interface FlatPlan {
   //plan.metadata.name
@@ -47,7 +48,7 @@ interface LatestMigration {
 export const mergeData = (
   plans: PlanResource[],
   migrations: MigrationResource[],
-  providers: ProviderResource[],
+  providers: V1beta1Provider[],
 ): FlatPlan[] =>
   plans
     .map(

--- a/packages/forklift-console-plugin/src/modules/Providers/__tests__/mergeData.test.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/__tests__/mergeData.test.ts
@@ -1,9 +1,8 @@
-import { ProviderResource } from 'src/utils/types';
-
 import {
   MOCK_CLUSTER_PROVIDERS,
   MOCK_INVENTORY_PROVIDERS,
 } from '@kubev2v/legacy/queries/mocks/providers.mock';
+import { V1beta1Provider } from '@kubev2v/types';
 import { ObjectMetadata } from '@openshift-console/dynamic-plugin-sdk';
 
 import { groupPairs, mergeData, toSupportedConditions } from '../data';
@@ -35,6 +34,8 @@ describe('extracting conditions', () => {
           type: 'URLNotValid',
           status: undefined,
           message: 'Not responding',
+          category: 'Critical',
+          lastTransitionTime: '2020-08-21T18:36:41.468Z',
         },
       ]),
     ).toEqual({ URLNotValid: { status: 'Unknown', message: 'Not responding' } });
@@ -46,6 +47,8 @@ describe('extracting conditions', () => {
           type: 'FooBar',
           status: 'False',
           message: 'BarFoo',
+          category: 'Critical',
+          lastTransitionTime: '2020-08-21T18:36:41.468Z',
         },
       ]),
     ).toEqual({ FooBar: { status: 'False', message: 'BarFoo' } });
@@ -59,7 +62,7 @@ describe('grouping pairs', () => {
     );
   });
   it('skipps inventory without resource', () => {
-    const result = groupPairs([MOCK_INVENTORY_PROVIDERS.openshift[0].object as ProviderResource], {
+    const result = groupPairs([MOCK_INVENTORY_PROVIDERS.openshift[0].object as V1beta1Provider], {
       openshift: [MOCK_INVENTORY_PROVIDERS.openshift[1]],
       ovirt: [],
       openstack: [],
@@ -72,7 +75,7 @@ describe('grouping pairs', () => {
   });
   it('skipps items without UID', () => {
     const provider = MOCK_INVENTORY_PROVIDERS.openshift[0];
-    const k8sNoUid: ProviderResource = {
+    const k8sNoUid: V1beta1Provider = {
       ...provider.object,
       metadata: { ...(provider.object.metadata as ObjectMetadata), uid: undefined },
     };
@@ -88,7 +91,7 @@ describe('grouping pairs', () => {
   it('groups into pairs', () => {
     const provider = MOCK_INVENTORY_PROVIDERS.openshift[0];
     expect(
-      groupPairs([provider.object as ProviderResource], {
+      groupPairs([provider.object as V1beta1Provider], {
         openshift: [provider],
         ovirt: [],
         openstack: [],
@@ -105,7 +108,7 @@ describe('merging k8s Provider with inventory Provider', () => {
 
   test('standard mock data', () => {
     const merged = mergeData(
-      groupPairs(MOCK_CLUSTER_PROVIDERS as ProviderResource[], MOCK_INVENTORY_PROVIDERS),
+      groupPairs(MOCK_CLUSTER_PROVIDERS as V1beta1Provider[], MOCK_INVENTORY_PROVIDERS),
     );
     expect(JSON.parse(JSON.stringify(merged))).toEqual(MERGED_MOCK_DATA);
   });

--- a/packages/forklift-console-plugin/src/modules/Providers/data.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/data.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import * as C from 'src/utils/constants';
 import { useProviders } from 'src/utils/fetch';
 import { groupVersionKindForObj } from 'src/utils/resources';
-import { Condition, ProviderResource } from 'src/utils/types';
 
 import { useInventoryProvidersQuery } from '@kubev2v/legacy/queries';
 import {
@@ -12,6 +11,7 @@ import {
   IRHVProvider,
   IVMwareProvider,
 } from '@kubev2v/legacy/queries/types';
+import { V1beta1Provider, V1beta1ProviderStatusConditions } from '@kubev2v/types';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 const conditionState = (state: string) =>
@@ -64,9 +64,9 @@ export interface MergedProvider {
 type FlattenedInventory = Partial<IVMwareProvider & IRHVProvider & IOpenShiftProvider>;
 
 export const groupPairs = (
-  resources: ProviderResource[],
+  resources: V1beta1Provider[],
   inventory: IProvidersByType,
-): [ProviderResource, FlattenedInventory][] => {
+): [V1beta1Provider, FlattenedInventory][] => {
   const uid2inventory: { [key: string]: FlattenedInventory } = Object.fromEntries(
     Object.values(inventory)
       .flat()
@@ -76,20 +76,20 @@ export const groupPairs = (
 
   return resources
     .filter(Boolean)
-    .map((resource): [string, ProviderResource] => [resource?.metadata?.uid, resource])
+    .map((resource): [string, V1beta1Provider] => [resource?.metadata?.uid, resource])
     .filter(([uid, resource]) => uid && resource)
-    .map(([uid, resource]): [ProviderResource, FlattenedInventory] => [
+    .map(([uid, resource]): [V1beta1Provider, FlattenedInventory] => [
       resource,
       uid2inventory[uid] ?? {},
     ]);
 };
 
-export const mergeData = (pairs: [ProviderResource, FlattenedInventory][]) =>
+export const mergeData = (pairs: [V1beta1Provider, FlattenedInventory][]) =>
   pairs
     .map(
       ([resource, inventory]): [
-        ProviderResource,
-        ProviderResource,
+        V1beta1Provider,
+        V1beta1Provider,
         K8sGroupVersionKind,
         FlattenedInventory,
         SupportedConditions,
@@ -164,7 +164,7 @@ export const mergeData = (pairs: [ProviderResource, FlattenedInventory][]) =>
       }),
     );
 
-export const toSupportedConditions = (conditions: Condition[]) =>
+export const toSupportedConditions = (conditions: V1beta1ProviderStatusConditions[]) =>
   conditions.reduce(
     (acc: SupportedConditions, { type, status, message }) => ({
       ...acc,

--- a/packages/forklift-console-plugin/src/utils/fetch.ts
+++ b/packages/forklift-console-plugin/src/utils/fetch.ts
@@ -3,7 +3,6 @@ import {
   MigrationResource,
   NetworkMapResource,
   PlanResource,
-  ProviderResource,
   StorageMapResource,
 } from 'src/utils/types';
 
@@ -14,6 +13,7 @@ import {
 import { MOCK_MIGRATIONS } from '@kubev2v/legacy/queries/mocks/migrations.mock';
 import { MOCK_PLANS } from '@kubev2v/legacy/queries/mocks/plans.mock';
 import { MOCK_CLUSTER_PROVIDERS } from '@kubev2v/legacy/queries/mocks/providers.mock';
+import { V1beta1Provider } from '@kubev2v/types';
 import {
   K8sGroupVersionKind,
   K8sResourceCommon,
@@ -45,14 +45,14 @@ function createRealK8sWatchResourceHook<T>(kind: string) {
   };
 }
 
-const useMockProviders = ({ name }: WatchK8sResource): WatchK8sResult<ProviderResource[]> => {
-  const mockData: ProviderResource[] = useMemo(
+const useMockProviders = ({ name }: WatchK8sResource): WatchK8sResult<V1beta1Provider[]> => {
+  const mockData: V1beta1Provider[] = useMemo(
     () =>
       !name
-        ? (MOCK_CLUSTER_PROVIDERS as ProviderResource[])
+        ? (MOCK_CLUSTER_PROVIDERS as V1beta1Provider[])
         : (MOCK_CLUSTER_PROVIDERS?.filter(
             (provider) => provider?.metadata?.name === name,
-          ) as ProviderResource[]),
+          ) as V1beta1Provider[]),
     [name],
   );
   return [mockData, true, false];
@@ -60,7 +60,7 @@ const useMockProviders = ({ name }: WatchK8sResource): WatchK8sResult<ProviderRe
 
 export const useProviders = IS_MOCK
   ? useMockProviders
-  : createRealK8sWatchResourceHook<ProviderResource>('Provider');
+  : createRealK8sWatchResourceHook<V1beta1Provider>('Provider');
 
 const useMockPlans = ({ name }: WatchK8sResource): WatchK8sResult<PlanResource[]> => {
   const mockData: PlanResource[] = useMemo(

--- a/packages/forklift-console-plugin/src/utils/resources.ts
+++ b/packages/forklift-console-plugin/src/utils/resources.ts
@@ -1,9 +1,9 @@
-import { CLUSTER_API_VERSION } from '@kubev2v/legacy/common/constants';
 import { hasCondition } from '@kubev2v/legacy/common/helpers';
 import { IStatusCondition } from '@kubev2v/legacy/queries/types';
+import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { K8sResourceCommon, ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
 
-import { ProviderRef, ProviderResource } from './types';
+import { ProviderRef } from './types';
 
 /**
  * Get reference group version kind string forgroup version kind strings
@@ -46,14 +46,8 @@ export const referenceForObj = (obj: K8sResourceCommon) => {
  */
 export const resolveProviderRef = (
   { name, namespace }: ObjectReference,
-  providers: ProviderResource[],
+  providers: V1beta1Provider[],
 ): ProviderRef => {
-  // fallback is required if provider reference inside plan is obsolete/out-of-synch
-  const fallbackProvider: Partial<ProviderResource> = {
-    apiVersion: CLUSTER_API_VERSION,
-    kind: 'Provider',
-  };
-
   const provider = providers.find(
     (p) => p.metadata?.namespace === namespace && p.metadata?.name === name,
   );
@@ -61,7 +55,7 @@ export const resolveProviderRef = (
   return {
     resolved: !!provider,
     name,
-    gvk: groupVersionKindForObj(provider ?? fallbackProvider),
+    gvk: provider ? groupVersionKindForObj(provider) : ProviderModelGroupVersionKind,
     ready: hasCondition((provider?.status?.conditions ?? []) as IStatusCondition[], 'Ready'),
   };
 };

--- a/packages/forklift-console-plugin/src/utils/types.ts
+++ b/packages/forklift-console-plugin/src/utils/types.ts
@@ -18,20 +18,6 @@ export type Condition = {
   reason?: string;
 };
 
-export type ProviderResource = {
-  spec?: {
-    type: string;
-    url?: string;
-    secret?: {
-      name: string;
-      namespace: string;
-    };
-  };
-  status?: {
-    conditions?: Condition[];
-  };
-} & K8sResourceCommon;
-
 export type PlanResource = IPlan & K8sResourceCommon;
 
 export type MigrationResource = IMigration & K8sResourceCommon;

--- a/packages/types/src/models/index.ts
+++ b/packages/types/src/models/index.ts
@@ -19,4 +19,5 @@ export * from './V1beta1NetworkMap';
 export * from './V1beta1OvirtVolumePopulator';
 export * from './V1beta1Plan';
 export * from './V1beta1Provider';
+export * from './V1beta1ProviderStatusConditions';
 export * from './V1beta1StorageMap';


### PR DESCRIPTION
@yaacov 
Auto-generated `V1beta1Provider` should be a drop-in replacement for manually created `ProviderResource` interface.
~~Currently the tests are failing due to a  change in gvk resolving code: in the new version gvk is hardcoded to auto-generated `ProviderModelGroupVersionKind`. In the previous (and in the legacy) this was read from the resource.~~
edit: we continue to resolve gvk based on resource and use `ProviderModelGroupVersionKind` only as fallback.