### PR TITLE
Trim filter when comparing with target value

### DIFF
--- a/packages/common/src/components/Filter/matchers.ts
+++ b/packages/common/src/components/Filter/matchers.ts
@@ -34,11 +34,11 @@ export const createMatcher =
       .every(Boolean);
 
 /**
- * The value is accepted if it contains the filter as substring.
+ * The value is accepted if it contains the trimmed filter as substring.
  */
 export const freetextMatcher = {
   filterType: 'freetext',
-  matchValue: (value: string) => (filter: string) => value?.includes(filter),
+  matchValue: (value: string) => (filter: string) => value?.includes(filter?.trim()),
 };
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Mappings/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Mappings/NetworkMappingsPage.tsx
@@ -126,7 +126,7 @@ const targetNetworkMatcher: ValueMatcher = {
   matchValue: (networks: Network[]) => (filter: string) =>
     networks.some((net) => {
       const name = net?.type === 'pod' ? 'pod' : net?.name ?? '';
-      return name.includes(filter?.toLocaleLowerCase());
+      return name.includes(filter?.trim()?.toLocaleLowerCase());
     }),
 };
 

--- a/packages/forklift-console-plugin/src/modules/Mappings/StorageMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Mappings/StorageMappingsPage.tsx
@@ -92,7 +92,7 @@ const PageMemo = React.memo(Page);
 const targetStorageMatcher: ValueMatcher = {
   filterType: 'targetStorage',
   matchValue: (storages: Storage[]) => (filter: string) =>
-    storages?.some((storage) => storage?.name?.includes(filter) ?? false),
+    storages?.some((storage) => storage?.name?.includes(filter?.trim()) ?? false),
 };
 
 export default StorageMappingsPage;


### PR DESCRIPTION
Fixes #233  and #232 

`FreetextFilter` component allows to enter spaces. This may be intended and needed in some scenarios but also leads to incorrect results if white chars are pasted by accident.
The solution is provided in the matcher layer. The matcher is trimming the filter before comparison. 
Advantages of this approach:
1. easy overriding if needed - see how `targetStorage` uses `FreetextFilter` with [custom matcher](https://github.com/kubev2v/forklift-console-plugin/blob/18743706bb6cfe9cf143a6dd9213435acec15701/packages/forklift-console-plugin/src/modules/Mappings/StorageMappingsPage.tsx#L84)
2. automatic support for filters from URL
3. no extra logic in the filter component to maintain "trimmed" state

Side effect of this approach is that user can enter filters that will be consider duplicate i.e. `foo   ` and  `    foo` will be considered the same.