### PR TITLE
check for valid ip before sending it to Netmask

### DIFF
--- a/packages/legacy/src/Providers/components/VMwareProviderHostsTable/helpers.ts
+++ b/packages/legacy/src/Providers/components/VMwareProviderHostsTable/helpers.ts
@@ -17,6 +17,7 @@ export const findSelectedNetworkAdapter = (
 ): IHostNetworkAdapter | null => {
   const managementNetwork =
     host.networkAdapters.find((adapter) =>
+      host.managementServerIp &&
       new Netmask(adapter.ipAddress, adapter.subnetMask).contains(host.managementServerIp)
     ) || null;
   if (!hostConfig) return managementNetwork;


### PR DESCRIPTION
Issue:
Using forkliftci vcsim server the `managementServerIp` is empty, this will crash the hosts page,

FIx:
test for empty  `managementServerIp` , and return that it's it does not match without using `Netmask` to test it.

Screeshots:
Before:
![dont-crash-on-empty-ip-crash](https://user-images.githubusercontent.com/2181522/220902827-5cad8092-0499-43d2-aad8-16df70d07e5f.png)

After:
![dont-crash-on-empty-ip](https://user-images.githubusercontent.com/2181522/220902871-d86c1d91-0418-4f9d-9d1d-7371c6d2698e.png)

