### PR TITLE
Hide debugging menu items

### DIFF
--- a/packages/forklift-console-plugin/plugin-extensions.ts
+++ b/packages/forklift-console-plugin/plugin-extensions.ts
@@ -1,9 +1,7 @@
 import type { EncodedExtension } from '@openshift/dynamic-plugin-sdk';
 import type { NavSection } from '@openshift-console/dynamic-plugin-sdk';
 
-import { extensions as hookExtensions } from './src/modules/Hooks/dynamic-plugin';
 import { extensions as mappingExtensions } from './src/modules/Mappings/dynamic-plugin';
-import { extensions as migrationExtensions } from './src/modules/Migrations/dynamic-plugin';
 import { extensions as planExtensions } from './src/modules/Plans/dynamic-plugin';
 import { extensions as providerExtensions } from './src/modules/Providers/dynamic-plugin';
 
@@ -24,19 +22,6 @@ const extensions: EncodedExtension[] = [
   ...providerExtensions,
   ...planExtensions,
   ...mappingExtensions,
-
-  {
-    type: 'console.navigation/separator',
-    properties: {
-      perspective: 'admin',
-      section: 'migration',
-      insertAfter: 'storageMappings',
-      id: 'forklift-utilities-seperator',
-    },
-  },
-
-  ...migrationExtensions,
-  ...hookExtensions,
 ];
 
 export default extensions;


### PR DESCRIPTION
Issue:
In #208 I added debugging menu items to help development team and end users identify and debug issues with forklift,
A concern was raised that
a. layman users may see problems with our resources that we want to hide from none power-users.
b. debugging power is missing some functionality like:
    i. filtering by resource status.
    ii. restart migrations,
    iii. disable creating of migrations without plan
    
Fix:
Hide debugging menu items untils:
a. resource handling is better (e.g. we will auto remove unused migrations)
b. missing functionality is added to the migrations list page (actions, filters)

Screenshot:
After:
![without-debug-menu-items](https://user-images.githubusercontent.com/2181522/220905752-655882d1-e607-4610-b7a7-cca6a3192c74.png)

Before:
![with-debug-menu-items](https://user-images.githubusercontent.com/2181522/220905732-8ef28085-c8d9-44d4-84eb-6e13e621de3d.png)



