### PR TITLE
Enable `insecureSkipVerify` handling for ovirt providers

### DIFF
--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -147,8 +147,7 @@ const useAddProviderFormState = (
     }),
     ovirt: useFormState({
       ...sourceProviderFields,
-      // TODO: Enable once ovirt support is ready
-      // insecureSkipVerify,
+      insecureSkipVerify,
       caCert: useFormField('', yup.string().label('CA certificate').required()),
       caCertFilename: useFormField('', yup.string()),
     }),

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/helpers.ts
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/helpers.ts
@@ -47,7 +47,6 @@ export const useAddEditProviderPrefillEffect = (
         const secret = secretQuery.data;
         const { fields } = forms[providerType];
 
-        // TODO: prefill namespace from the provider?
         fields.providerType.prefill(providerType);
         fields.name.prefill(providerBeingEdited.metadata.name);
 
@@ -70,12 +69,11 @@ export const useAddEditProviderPrefillEffect = (
           ovirtFields.password.prefill(atob(secret?.data.password || ''));
           ovirtFields.hostname.prefill(ovirtUrlToHostname(spec.url || ''));
           ovirtFields.caCert.prefill(atob(secret?.data.cacert || ''));
-          // TODO: Enable once ovirt support is ready
-          // ovirtFields.insecureSkipVerify.prefill(
-          //   secret?.data.insecureSkipVerify
-          //     ? stringToBoolean(atob(secret?.data.insecureSkipVerify))
-          //     : false
-          // );
+          ovirtFields.insecureSkipVerify.prefill(
+            secret?.data.insecureSkipVerify
+              ? stringToBoolean(atob(secret?.data.insecureSkipVerify))
+              : false
+          );
         }
         if (providerType === 'openstack') {
           const openstackFields = forms.openstack.fields;

--- a/packages/legacy/src/client/helpers.ts
+++ b/packages/legacy/src/client/helpers.ts
@@ -116,8 +116,7 @@ export function convertFormValuesToSecret(
       user: btoa(rhvValues.username),
       password: btoa(rhvValues.password),
       cacert: btoa(rhvValues.caCert),
-      // TODO: Enable once ovirt support is ready
-      // insecureSkipVerify: btoa(booleanToString(rhvValues.insecureSkipVerify) ?? ''),
+      insecureSkipVerify: btoa(booleanToString(rhvValues.insecureSkipVerify) ?? ''),
     };
   }
   if (values.providerType === 'openstack') {


### PR DESCRIPTION
Use the same field processing as vmware to enable `insecureSkipVerify` handling for ovirt providers.

Follow up #215

Adding ovirt provider:
![screenshot-localhost_9000-2023 02 17-17_48_59](https://user-images.githubusercontent.com/3985964/221657490-a3c2cd98-a98f-4740-ae8b-484eda804267.png)

