### PR TITLE
Skip default values when editing invalid mappings

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Mappings/__tests__/__snapshots__/MappingRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Mappings/__tests__/__snapshots__/MappingRow.test.tsx.snap
@@ -474,22 +474,11 @@ exports[`NetworkMap rows vcenter3-invalid-network-map 1`] = `
           class=""
           data-label="Source provider"
         >
-          <span>
-            <svg
-              aria-hidden="true"
-              fill="#C9190B"
-              height="1em"
-              role="img"
-              style="vertical-align: -0.125em;"
-              viewBox="0 0 512 512"
-              width="1em"
-            >
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-              />
-            </svg>
-             unknown-provider
-          </span>
+          <div
+            class="ResourceLink_mock"
+          >
+            name: vcenter-1, gvk: forklift.konveyor.io~v1beta1~Provider, ns: konveyor-forklift
+          </div>
         </td>
         <td
           class=""
@@ -611,7 +600,7 @@ exports[`NetworkMap rows vcenter3-invalid-network-map 1`] = `
 </DocumentFragment>
 `;
 
-exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
+exports[`NetworkMap rows vcenter4-invalid-network-map 1`] = `
 <DocumentFragment>
   <table>
     <tbody>
@@ -631,6 +620,211 @@ exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
             aria-labelledby="simple-node0 expand-toggle0"
             class="pf-c-button pf-m-plain"
             data-ouia-component-id="OUIA-Generated-Button-plain-4"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe="true"
+            id="expand-toggle0"
+            type="button"
+          >
+            <div
+              class="pf-c-table__toggle-icon"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <td
+          class=""
+          data-label="Name"
+        >
+          <div
+            class="ResourceLink_mock"
+          >
+            name: vcenter4-invalid-network-map, gvk: forklift.konveyor.io~v1beta1~NetworkMap, ns: konveyor-forklift
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Namespace"
+        >
+          <div
+            class="ResourceLink_mock"
+          >
+            name: konveyor-forklift, gvk: ~~, ns: undefined
+          </div>
+        </td>
+        <td
+          class=""
+          data-label="Source provider"
+        >
+          <span>
+            <svg
+              aria-hidden="true"
+              fill="#C9190B"
+              height="1em"
+              role="img"
+              style="vertical-align: -0.125em;"
+              viewBox="0 0 512 512"
+              width="1em"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              />
+            </svg>
+             unknown-provider
+          </span>
+        </td>
+        <td
+          class=""
+          data-label="Target provider"
+        >
+          <div
+            class="ResourceLink_mock"
+          >
+            name: ocpv-1, gvk: forklift.konveyor.io~v1beta1~Provider, ns: konveyor-forklift
+          </div>
+        </td>
+        <td
+          class="pf-c-table__compound-expansion-toggle"
+          data-label="From"
+        >
+          <button
+            aria-expanded="false"
+            class="pf-c-table__button"
+            type="button"
+          >
+            <span
+              class="pf-c-table__text"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 1088 1024"
+                width="1em"
+              >
+                <path
+                  d="M574,320 L574,448 L896,448 C931.332514,448.033078 959.966922,476.667486 960,512 L960,512 L960,640 L1024,640 C1059.33251,640.033078 1087.96692,668.667486 1088,704 L1088,704 L1088,896 C1087.96692,931.332514 1059.33251,959.966922 1024,960 L1024,960 L832,960 C796.667486,959.966922 768.033078,931.332514 768,896 L768,896 L768,704 C768.033078,668.667486 796.667486,640.033078 832,640 L832,640 L896,640 L896,512 L574,512 L574,640 L639,640 C674.332514,640.033078 702.966922,668.667486 703,704 L703,704 L703,896 C702.966922,931.332514 674.332514,959.966922 639,960 L639,960 L447,960 C411.667486,959.966922 383.033078,931.332514 383,896 L383,896 L383,704 C383.033078,668.667486 411.667486,640.033078 447,640 L447,640 L510,640 L510,512 L192,512 L192,640 L256,640 C291.332514,640.033078 319.966922,668.667486 320,704 L320,704 L320,896 C319.966922,931.332514 291.332514,959.966922 256,960 L256,960 L64,960 C28.6674863,959.966922 0.0330777378,931.332514 0,896 L0,896 L0,704 C0.0330777378,668.667486 28.6674863,640.033078 64,640 L64,640 L128,640 L128,512 C128.033078,476.667486 156.667486,448.033078 192,448 L192,448 L510,448 L510,320 L574,320 Z M1024,64 L1024,256 L64,256 L64,64 L1024,64 Z M704,192 L960.5,192 L960.5,128 L704,128 L704,192 Z"
+                />
+              </svg>
+               1
+            </span>
+          </button>
+        </td>
+        <td
+          class="pf-c-table__compound-expansion-toggle"
+          data-label="To"
+        >
+          <button
+            aria-expanded="false"
+            class="pf-c-table__button"
+            type="button"
+          >
+            <span
+              class="pf-c-table__text"
+            >
+              <span
+                class="forklift-table__flex-labels-with-gaps"
+              >
+                <span
+                  class="pf-c-label pf-m-blue"
+                >
+                  <span
+                    class="pf-c-label__content"
+                  >
+                    openshift-migration/ocp-network-3
+                  </span>
+                </span>
+              </span>
+            </span>
+          </button>
+        </td>
+        <td
+          class=""
+          data-label=""
+        >
+          <div
+            class="pf-c-dropdown pf-m-align-right"
+            data-ouia-component-id="OUIA-Generated-Dropdown-4"
+            data-ouia-component-type="PF4/Dropdown"
+            data-ouia-safe="true"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="false"
+              aria-label="Actions"
+              class="pf-c-dropdown__toggle pf-m-plain"
+              id="pf-dropdown-toggle-id-7"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 192 512"
+                width="1em"
+              >
+                <path
+                  d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                />
+              </svg>
+            </button>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="pf-c-table__expandable-row"
+        data-ouia-component-id="OUIA-Generated-TableRow-8"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+        hidden=""
+      >
+        <td
+          class="pf-m-no-padding"
+          colspan="7"
+          data-label="Mapping graph"
+        />
+      </tr>
+    </tbody>
+  </table>
+</DocumentFragment>
+`;
+
+exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
+<DocumentFragment>
+  <table>
+    <tbody>
+      <tr
+        class=""
+        data-ouia-component-id="OUIA-Generated-TableRow-9"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe="true"
+      >
+        <td
+          class="pf-c-table__toggle"
+        >
+          <button
+            aria-disabled="false"
+            aria-expanded="false"
+            aria-label="Details"
+            aria-labelledby="simple-node0 expand-toggle0"
+            class="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-5"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             id="expand-toggle0"
@@ -758,7 +952,7 @@ exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
         >
           <div
             class="pf-c-dropdown pf-m-align-right"
-            data-ouia-component-id="OUIA-Generated-Dropdown-4"
+            data-ouia-component-id="OUIA-Generated-Dropdown-5"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
@@ -767,7 +961,7 @@ exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
               aria-haspopup="false"
               aria-label="Actions"
               class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-7"
+              id="pf-dropdown-toggle-id-9"
               type="button"
             >
               <svg
@@ -789,7 +983,7 @@ exports[`StorageMap rows vcenter1-datastore-to-ocpv-storageclass1 1`] = `
       </tr>
       <tr
         class="pf-c-table__expandable-row"
-        data-ouia-component-id="OUIA-Generated-TableRow-8"
+        data-ouia-component-id="OUIA-Generated-TableRow-10"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
         hidden=""
@@ -811,7 +1005,7 @@ exports[`StorageMap rows vcenter1-invalid-storage-mapping 1`] = `
     <tbody>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-11"
+        data-ouia-component-id="OUIA-Generated-TableRow-13"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -824,7 +1018,7 @@ exports[`StorageMap rows vcenter1-invalid-storage-mapping 1`] = `
             aria-label="Details"
             aria-labelledby="simple-node0 expand-toggle0"
             class="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-6"
+            data-ouia-component-id="OUIA-Generated-Button-plain-7"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             id="expand-toggle0"
@@ -952,7 +1146,7 @@ exports[`StorageMap rows vcenter1-invalid-storage-mapping 1`] = `
         >
           <div
             class="pf-c-dropdown pf-m-align-right"
-            data-ouia-component-id="OUIA-Generated-Dropdown-6"
+            data-ouia-component-id="OUIA-Generated-Dropdown-7"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
@@ -961,7 +1155,7 @@ exports[`StorageMap rows vcenter1-invalid-storage-mapping 1`] = `
               aria-haspopup="false"
               aria-label="Actions"
               class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-11"
+              id="pf-dropdown-toggle-id-13"
               type="button"
             >
               <svg
@@ -983,7 +1177,7 @@ exports[`StorageMap rows vcenter1-invalid-storage-mapping 1`] = `
       </tr>
       <tr
         class="pf-c-table__expandable-row"
-        data-ouia-component-id="OUIA-Generated-TableRow-12"
+        data-ouia-component-id="OUIA-Generated-TableRow-14"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
         hidden=""
@@ -1005,7 +1199,7 @@ exports[`StorageMap rows vcenter3-datastore-to-ocpv-storageclass2 1`] = `
     <tbody>
       <tr
         class=""
-        data-ouia-component-id="OUIA-Generated-TableRow-9"
+        data-ouia-component-id="OUIA-Generated-TableRow-11"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
       >
@@ -1018,7 +1212,7 @@ exports[`StorageMap rows vcenter3-datastore-to-ocpv-storageclass2 1`] = `
             aria-label="Details"
             aria-labelledby="simple-node0 expand-toggle0"
             class="pf-c-button pf-m-plain"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
+            data-ouia-component-id="OUIA-Generated-Button-plain-6"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             id="expand-toggle0"
@@ -1146,7 +1340,7 @@ exports[`StorageMap rows vcenter3-datastore-to-ocpv-storageclass2 1`] = `
         >
           <div
             class="pf-c-dropdown pf-m-align-right"
-            data-ouia-component-id="OUIA-Generated-Dropdown-5"
+            data-ouia-component-id="OUIA-Generated-Dropdown-6"
             data-ouia-component-type="PF4/Dropdown"
             data-ouia-safe="true"
           >
@@ -1155,7 +1349,7 @@ exports[`StorageMap rows vcenter3-datastore-to-ocpv-storageclass2 1`] = `
               aria-haspopup="false"
               aria-label="Actions"
               class="pf-c-dropdown__toggle pf-m-plain"
-              id="pf-dropdown-toggle-id-9"
+              id="pf-dropdown-toggle-id-11"
               type="button"
             >
               <svg
@@ -1177,7 +1371,7 @@ exports[`StorageMap rows vcenter3-datastore-to-ocpv-storageclass2 1`] = `
       </tr>
       <tr
         class="pf-c-table__expandable-row"
-        data-ouia-component-id="OUIA-Generated-TableRow-10"
+        data-ouia-component-id="OUIA-Generated-TableRow-12"
         data-ouia-component-type="PF4/TableRow"
         data-ouia-safe="true"
         hidden=""

--- a/packages/forklift-console-plugin/src/modules/Mappings/__tests__/mergedNetworkData.json
+++ b/packages/forklift-console-plugin/src/modules/Mappings/__tests__/mergedNetworkData.json
@@ -281,20 +281,20 @@
                         "namespace": "openshift-migration"
                     },
                     "source": {
-                        "name": "unknown-provider",
-                        "namespace": "unknown-ns"
+                        "name": "vcenter-1",
+                        "namespace": "openshift-migration"
                     }
                 }
             }
         },
-        "source": "unknown-provider",
+        "source": "vcenter-1",
         "sourceGvk": {
             "group": "forklift.konveyor.io",
             "kind": "Provider",
             "version": "v1beta1"
         },
-        "sourceReady": false,
-        "sourceResolved": false,
+        "sourceReady": true,
+        "sourceResolved": true,
         "target": "ocpv-1",
         "targetGvk": {
             "group": "forklift.konveyor.io",
@@ -311,5 +311,87 @@
                 "type": "multus"
             }
         ]
+    },
+    {
+        "name": "vcenter4-invalid-network-map",
+        "namespace": "konveyor-forklift",
+        "template": true,
+        "gvk": {
+            "group": "forklift.konveyor.io",
+            "version": "v1beta1",
+            "kind": "NetworkMap"
+        },
+        "source": "unknown-provider",
+        "sourceGvk": {
+            "group": "forklift.konveyor.io",
+            "kind": "Provider",
+            "version": "v1beta1"
+        },
+        "sourceReady": false,
+        "sourceResolved": false,
+        "target": "ocpv-1",
+        "targetGvk": {
+            "group": "forklift.konveyor.io",
+            "kind": "Provider",
+            "version": "v1beta1"
+        },
+        "targetResolved": true,
+        "targetReady": true,
+        "from": [
+            [
+                {
+                    "name": "ocp-network-3",
+                    "namespace": "openshift-migration",
+                    "type": "multus"
+                },
+                [
+                    {
+                        "id": "2"
+                    }
+                ]
+            ]
+        ],
+        "to": [
+            {
+                "name": "ocp-network-3",
+                "namespace": "openshift-migration",
+                "type": "multus"
+            }
+        ],
+        "object": {
+            "apiVersion": "forklift.konveyor.io/v1beta1",
+            "kind": "NetworkMap",
+            "metadata": {
+                "name": "vcenter4-invalid-network-map",
+                "namespace": "konveyor-forklift",
+                "annotations": {
+                    "forklift.konveyor.io/shared": "true"
+                }
+            },
+            "spec": {
+                "provider": {
+                    "source": {
+                        "namespace": "unknown-ns",
+                        "name": "unknown-provider"
+                    },
+                    "destination": {
+                        "name": "ocpv-1",
+                        "namespace": "openshift-migration"
+                    }
+                },
+                "map": [
+                    {
+                        "source": {
+                            "id": "2"
+                        },
+                        "destination": {
+                            "name": "ocp-network-3",
+                            "namespace": "openshift-migration",
+                            "type": "multus"
+                        }
+                    }
+                ]
+            }
+        }
     }
 ]

--- a/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
+++ b/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFormField, useFormState, ValidatedTextInput } from '@migtools/lib-ui';
-import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema } from './MappingBuilder';
+import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema, getDefaultTarget } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';
 import {
   MappingType,
@@ -74,7 +74,7 @@ const useMappingFormState = (
       yup.mixed<IOpenShiftProvider>().label('Target provider').required()
     ),
     builderItems: useFormField<IMappingBuilderItem[]>(
-      [{ source: null, target: null }],
+      [],
       mappingBuilderItemsSchema
     ),
   });
@@ -121,7 +121,7 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
   // If you change providers, reset the mapping selections.
   React.useEffect(() => {
     if (isDonePrefilling) {
-      form.fields.builderItems.setValue([{ source: null, target: null }]);
+      form.fields.builderItems.setValue([]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.values.sourceProvider, form.values.targetProvider]);
@@ -249,7 +249,8 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
                     sourceProviderType={form.values.sourceProvider?.type || 'vsphere'}
                     availableSources={mappingResourceQueries.availableSources}
                     availableTargets={mappingResourceQueries.availableTargets}
-                    builderItems={form.values.builderItems}
+                    builderItems={form.values.builderItems.length ? 
+                      form.values.builderItems : [{source: null, target: getDefaultTarget(mappingResourceQueries.availableTargets, mappingType)}]}
                     setBuilderItems={form.fields.builderItems.setValue}
                   />
                 </ResolvedQueries>

--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -4,7 +4,7 @@ import { Button, TextContent, Text, Grid, GridItem, Bullseye, Flex } from '@patt
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
-import { MappingType, MappingSource, MappingTarget } from 'legacy/src/queries/types';
+import { MappingType, MappingSource, MappingTarget, POD_NETWORK, IAnnotatedStorageClass } from 'legacy/src/queries/types';
 import { LineArrow } from 'legacy/src/common/components/LineArrow';
 import { MappingSourceSelect } from './MappingSourceSelect';
 import { MappingTargetSelect } from './MappingTargetSelect';
@@ -39,6 +39,9 @@ interface IMappingBuilderProps {
   isWizardMode?: boolean;
 }
 
+export const getDefaultTarget = (availableTargets:MappingTarget[], mappingType: MappingType) => 
+  mappingType === MappingType.Network ? POD_NETWORK : availableTargets.find((target) => (target as IAnnotatedStorageClass).uiMeta.isDefault) || null
+
 export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
   mappingType,
   sourceProviderType,
@@ -50,7 +53,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
 }: IMappingBuilderProps) => {
   const reset = () => setBuilderItems([{ source: null, target: null }]);
   const isReset = builderItems.length === 1 && !builderItems[0].source && !builderItems[0].target;
-  const addEmptyItem = () => setBuilderItems([...builderItems, { source: null, target: null }]);
+  const addEmptyItem = () => setBuilderItems([...builderItems, { source: null, target: getDefaultTarget(availableTargets, mappingType) }]);
   const removeItem = (itemIndex: number) => {
     if (builderItems.length > 1) {
       setBuilderItems(builderItems.filter((_item, index) => index !== itemIndex));

--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -9,7 +9,6 @@ import {
   IOpenShiftNetwork,
   MappingTarget,
   MappingType,
-  POD_NETWORK,
 } from 'legacy/src/queries/types';
 import { IMappingBuilderItem } from './MappingBuilder';
 import { getMappingTargetName } from '../MappingDetailView/helpers';
@@ -41,22 +40,6 @@ export const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectPr
     },
     [builderItems, itemIndex, setBuilderItems]
   );
-
-  React.useEffect(() => {
-    if (!builderItems[itemIndex].target) {
-      let defaultTarget: MappingTarget | null = null;
-      if (mappingType === MappingType.Network) {
-        defaultTarget = POD_NETWORK;
-      } else if (mappingType === MappingType.Storage) {
-        defaultTarget =
-          availableTargets.find((target) => (target as IAnnotatedStorageClass).uiMeta.isDefault) ||
-          null;
-      }
-      if (defaultTarget) {
-        setTarget(defaultTarget);
-      }
-    }
-  }, [availableTargets, builderItems, itemIndex, mappingType, setTarget]);
 
   const targetOptions: OptionWithValue<MappingTarget>[] = availableTargets.map((target) => {
     let name = getMappingTargetName(target, mappingType);

--- a/packages/legacy/src/queries/mocks/mappings.mock.ts
+++ b/packages/legacy/src/queries/mocks/mappings.mock.ts
@@ -212,7 +212,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
-  const invalidNetworkMapping: INetworkMapping = {
+  const invalidNetworkMappingDueToNetwork: INetworkMapping = {
     apiVersion: CLUSTER_API_VERSION,
     kind: 'NetworkMap',
     metadata: {
@@ -222,7 +222,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     spec: {
       provider: {
-        source: {namespace: 'unknown-ns', name: 'unknown-provider'},
+        source: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.vsphere[0]),
         destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
       },
       map: [
@@ -240,10 +240,38 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
   };
 
+  const invalidNetworkMappingDueToProvider: INetworkMapping = {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'NetworkMap',
+    metadata: {
+      name: 'vcenter4-invalid-network-map',
+      namespace: ENV.NAMESPACE,
+      annotations: { 'forklift.konveyor.io/shared': 'true' },
+    },
+    spec: {
+      provider: {
+        source: {namespace: 'unknown-ns', name: 'unknown-provider'},
+        destination: nameAndNamespace(MOCK_INVENTORY_PROVIDERS.openshift[0]),
+      },
+      map: [
+        {
+          source: {
+            id: MOCK_VMWARE_NETWORKS[1].id,
+          },
+          destination: {
+            ...nameAndNamespace(MOCK_OPENSHIFT_NETWORKS[2]),
+            type: 'multus',
+          },
+        },
+      ],
+    },
+  };
+
   MOCK_NETWORK_MAPPINGS = [
     networkMapping1,
     networkMapping1WithOwner,
     networkMapping2,
-    invalidNetworkMapping,
+    invalidNetworkMappingDueToNetwork,
+    invalidNetworkMappingDueToProvider
   ];
 }


### PR DESCRIPTION
Depends on https://github.com/kubev2v/forklift-console-plugin/pull/242
    
Standalone UI blocked editing if the target network was invalid.
Currently this limitation was removed. The edit dialog treats mapping
with invalid/missing target as empty/new mapping and assigns default
value to empty target slot.

The fix is to assign default value only in following cases:
1. no items/rows in the mapping - initial state for a new mapping
2. adding a new mapping item/row - triggered by the user
