### PR TITLE
Use openstack tree/project api endpoint

### DIFF
--- a/packages/legacy/src/queries/mocks/tree.mock.ts
+++ b/packages/legacy/src/queries/mocks/tree.mock.ts
@@ -1,4 +1,4 @@
-import { IInventoryHostTree, IVMwareFolderTree } from '../types/tree.types';
+import { IInventoryHostTree, IOpenstackFolderTree, IVMwareFolderTree } from '../types/tree.types';
 
 export let MOCK_VMWARE_HOST_TREE: IInventoryHostTree = {
   kind: '',
@@ -13,6 +13,12 @@ export let MOCK_RHV_HOST_TREE: IInventoryHostTree = {
 };
 
 export let MOCK_VMWARE_VM_TREE: IVMwareFolderTree = {
+  kind: '',
+  object: null,
+  children: null,
+};
+
+export let MOCK_OPENSTACK_HOST_TREE: IOpenstackFolderTree = {
   kind: '',
   object: null,
   children: null,
@@ -393,6 +399,58 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         ],
       },
     ],
+  };
+
+  MOCK_OPENSTACK_HOST_TREE = {
+    'kind':'',
+    'object':null,
+    'children':
+    [
+      {
+        'kind':'Project',
+        'object': {
+          'id':'863df1446a134ec88581998d98912ff3',
+          'revision':1,
+          'path':'admin',
+          'name':'admin',
+          'selfLink':'providers/openstack/a3714338-7b7b-4b2f-a646-c3a6b69a1ed7/projects/863df1446a134ec88581998d98912ff3',
+          'is_domain':false,
+          'description':'Bootstrap project for initializing the cloud.',
+          'domain_id':'default',
+          'enabled':true,
+          'parent_id':'default'
+        },
+        'children': [
+          {
+            'kind':'VM',
+            'object': {
+              'id':'231efc19-af42-47e3-ad13-eb6da01f2316',
+              'revision':1,
+              'path':'admin/cirros',
+              'name':'cirros',
+              'selfLink':'providers/openstack/a3714338-7b7b-4b2f-a646-c3a6b69a1ed7/vms/231efc19-af42-47e3-ad13-eb6da01f2316'
+            },
+            'children':null
+          }
+        ]
+      },
+      {
+        'kind':'Project',
+        'object': {
+          'id':'e4cd61a02dba448abc1db1b4462c6f38',
+          'revision':1,
+          'path':'services',
+          'name':'services',
+          'selfLink':'providers/openstack/a3714338-7b7b-4b2f-a646-c3a6b69a1ed7/projects/e4cd61a02dba448abc1db1b4462c6f38',
+          'is_domain':false,
+          'description':'',
+          'domain_id':'default',
+          'enabled':true,
+          'parent_id':'default'
+        },
+        'children':null
+      }
+    ]
   };
 
   MOCK_VMWARE_VM_TREE = {

--- a/packages/legacy/src/queries/types/tree.types.ts
+++ b/packages/legacy/src/queries/types/tree.types.ts
@@ -8,6 +8,13 @@ export interface ICommonTreeObject {
   variant?: 'ComputeResource';
   name: string;
   selfLink: string;
+  revision?: number;
+  path?: string;
+  is_domain?: boolean;
+  description?: string;
+  domain_id?: string;
+  enabled?: boolean;
+  parent_id?: string;
 }
 
 interface ICommonTree {
@@ -18,7 +25,7 @@ interface ICommonTree {
 
 // TODO we should rename this to IClusterHostTree and use the cluster naming everywhere
 export interface IInventoryHostTree extends ICommonTree {
-  kind: '' | 'Datacenter' | 'DataCenter' | 'Cluster' | 'Folder' | 'Host' | 'VM';
+  kind: '' | 'Datacenter' | 'DataCenter' | 'Cluster' | 'Project' | 'Folder' | 'Host' | 'VM';
   children: IInventoryHostTree[] | null;
 }
 
@@ -27,4 +34,9 @@ export interface IVMwareFolderTree extends ICommonTree {
   children: IVMwareFolderTree[] | null;
 }
 
-export type InventoryTree = IInventoryHostTree | IVMwareFolderTree;
+export interface IOpenstackFolderTree extends ICommonTree {
+  kind: '' | 'Project' | 'VM';
+  children: IOpenstackFolderTree[] | null;
+}
+
+export type InventoryTree = IInventoryHostTree | IVMwareFolderTree | IOpenstackFolderTree;


### PR DESCRIPTION
When creating a plan with openstack source we will use a `/tree/projects` endpoint to show a tree of virtual machines.

This PR adds a call to this new api endpoint.

Screenshot:
![os-plan](https://user-images.githubusercontent.com/2181522/222235917-8a4a765f-4122-435f-9afa-cdf79dab06bd.gif)
