### PR TITLE
Validate certificate fields on providers modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "jsonc-parser": "^3.2.0",
+        "jsrsasign": "^10.6.1",
         "prettier": "^2.7.1",
         "prettier-stylelint": "^0.4.2",
         "rollup-plugin-analyzer": "^4.0.0",
@@ -45,7 +46,8 @@
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.8.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "yup": "^0.32.11"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10059,6 +10061,14 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsrsasign": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
+      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
+      "funding": {
+        "url": "https://github.com/kjur/jsrsasign#donations"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.3",
       "dev": true,
@@ -17834,7 +17844,8 @@
     },
     "node_modules/yup": {
       "version": "0.32.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/lodash": "^4.14.175",
@@ -17924,12 +17935,14 @@
         "classnames": "2.x",
         "dayjs": "^1.11.5",
         "file-saver": "1.3.x",
+        "jsrsasign": "^10.6.1",
         "netmask": "^2.0.2",
         "react": "^17.0.1",
         "react-query": "^3.39.2",
         "react-router": "5.2.0",
         "react-router-dom": "5.2.0",
-        "react-syntax-highlighter": "^15.5.0"
+        "react-syntax-highlighter": "^15.5.0",
+        "yup": "^0.32.11"
       }
     },
     "packages/types": {
@@ -24647,6 +24660,11 @@
         "universalify": "^2.0.0"
       }
     },
+    "jsrsasign": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
+      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw=="
+    },
     "jsx-ast-utils": {
       "version": "3.3.3",
       "dev": true,
@@ -29746,6 +29764,8 @@
     },
     "yup": {
       "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@types/lodash": "^4.14.175",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "jsonc-parser": "^3.2.0",
+    "jsrsasign": "^10.6.1",
     "prettier": "^2.7.1",
     "prettier-stylelint": "^0.4.2",
     "rollup-plugin-analyzer": "^4.0.0",
@@ -64,6 +65,7 @@
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "yup": "^0.32.11"
   }
 }

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -67,12 +67,14 @@
     "classnames": "2.x",
     "dayjs": "^1.11.5",
     "file-saver": "1.3.x",
+    "jsrsasign": "^10.6.1",
     "netmask": "^2.0.2",
     "react": "^17.0.1",
     "react-query": "^3.39.2",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
-    "react-syntax-highlighter": "^15.5.0"
+    "react-syntax-highlighter": "^15.5.0",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@types/ejs": "^3.0.6",

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -30,6 +30,7 @@ import {
   PROVIDER_TYPE_NAMES,
   urlSchema,
   usernameSchema,
+  x509PemSchema,
 } from 'legacy/src/common/constants';
 import { usePausedPollingEffect } from 'legacy/src/common/context';
 import {
@@ -137,7 +138,6 @@ const useAddProviderFormState = (
   };
 
   const insecureSkipVerify = useFormField(false, yup.boolean().label('skip server SSL certificate verification'));
-  const caCertFildSchema = yup.string().label('CA certificate');
 
   return {
     vsphere: useFormState({
@@ -149,7 +149,7 @@ const useAddProviderFormState = (
     ovirt: useFormState({
       ...sourceProviderFields,
       insecureSkipVerify,
-      caCert: useFormField('', insecureSkipVerify.value ? caCertFildSchema : caCertFildSchema.required()),
+      caCert: useFormField('', insecureSkipVerify.value ? x509PemSchema : x509PemSchema.required()),
       caCertFilename: useFormField('', yup.string()),
     }),
     openstack: useFormState({
@@ -161,7 +161,7 @@ const useAddProviderFormState = (
       projectName: useFormField('', yup.string().label('Project').required()),
       region: useFormField('', yup.string().label('Region').required()),
       insecureSkipVerify,
-      caCertIfSecure: useFormField('', caCertFildSchema),
+      caCertIfSecure: useFormField('', x509PemSchema),
       caCertFilenameIfSecure: useFormField('', yup.string()),
     }),
     openshift: useFormState({

--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import { X509 } from 'jsrsasign';
 import { BrandType, IEnvVars } from './types';
 
 /**
@@ -150,6 +151,26 @@ export const usernameSchema = yup
     message: ({ label }) => `${label} must not contain spaces`,
     excludeEmptyString: true,
   });
+
+export const x509PemSchema = yup
+  .string()
+  .label('PEM encoded X.509 certificate')
+  .trim()
+  .test(
+    'pem-x509-certificate',
+    'The certificate is not a valid PEM encoded X.509 certificate',
+    (value): boolean | yup.ValidationError => {
+      if (!value) return false;
+
+      try {
+        const cert = new X509();
+        cert.readCertPEM(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+  );
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const noop = () => {};


### PR DESCRIPTION
Add a yup schema to validate certificate input fields.  The schema uses the `jsrsasign` package to parse the certificate value.  As long as the value can be parsed as a cert, it is considered valid.

Details:
  - Add packages `yup` explicitly to the monorepo (as dev) and legacy (as peer) projects: - `yup` for input validation and to make the dependency explicit - `jsrsasign` for cert parsing

  - Add yup schema `x509PemSchema` to do a basic sanity check of certificate input fields

  - Use `x509PemSchema` in `AddEditProviderModal`

Resolves: #226

Modal with a valid certificate:
![screenshot-localhost_9000-2023 03 01-19_08_42](https://user-images.githubusercontent.com/3985964/222295997-e223e93e-0b89-46f5-86b3-c3b1c602b0f3.png)

Modal with an invalid certificate (obviously wrong):
![screenshot-localhost_9000-2023 03 01-19_09_11](https://user-images.githubusercontent.com/3985964/222296232-62a0d6db-c1f3-4c16-8fee-b972a29f57c7.png)


Modal with an invalid certificate (non-obvious wrong):
![screenshot-localhost_9000-2023 03 01-19_10_28](https://user-images.githubusercontent.com/3985964/222296167-b14fa823-e0ea-4070-ba9c-91e25b6077c4.png)


