### PR TITLE
Remove jsrsasign and yap from global devdeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "jsonc-parser": "^3.2.0",
-        "jsrsasign": "^10.6.1",
         "prettier": "^2.7.1",
         "prettier-stylelint": "^0.4.2",
         "rollup-plugin-analyzer": "^4.0.0",
@@ -46,8 +45,7 @@
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.8.1",
-        "typescript": "^4.7.4",
-        "yup": "^0.32.11"
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10065,6 +10063,7 @@
       "version": "10.6.1",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
       "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/kjur/jsrsasign#donations"
       }
@@ -24663,7 +24662,8 @@
     "jsrsasign": {
       "version": "10.6.1",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.6.1.tgz",
-      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw=="
+      "integrity": "sha512-emiQ05haY9CRj1Ho/LiuCqr/+8RgJuWdiHYNglIg2Qjfz0n+pnUq9I2QHplXuOMO2EnAW1oCGC1++aU5VoWSlw==",
+      "peer": true
     },
     "jsx-ast-utils": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "jsonc-parser": "^3.2.0",
-    "jsrsasign": "^10.6.1",
     "prettier": "^2.7.1",
     "prettier-stylelint": "^0.4.2",
     "rollup-plugin-analyzer": "^4.0.0",
@@ -65,7 +64,6 @@
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.4",
-    "yup": "^0.32.11"
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
 jsrsasign and yap are depenedencies of the legacy packages
https://github.com/kubev2v/forklift-console-plugin/blob/main/packages/legacy/package.json#L70

a. they are not part of the root package dependencies
b. they are used on runtime, they are not dev dependencies