### PR TITLE
Don't block provider form if caCert is missing

### DIFF
--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -160,8 +160,7 @@ export const x509PemSchema = yup
     'pem-x509-certificate',
     'The certificate is not a valid PEM encoded X.509 certificate',
     (value): boolean | yup.ValidationError => {
-      if (!value) return false;
-
+      if (!value) return true;
       try {
         const cert = new X509();
         cert.readCertPEM(value);


### PR DESCRIPTION
Currently we use yup `test`, to verify if cacert field is not empty, we should use yup `required` for that.

This PR, changes the behavior of the cacert test to not fail on empty, and use `required` instead.

Screenshot:
Before:
![blocking](https://user-images.githubusercontent.com/2181522/222391296-360a6d4a-682e-4e17-be22-5d10f74be5ea.gif)

After:
![none-blocking](https://user-images.githubusercontent.com/2181522/222390617-cef1cc26-ed47-4117-be73-9fb4e282db94.gif)
 