### PR TITLE
Allow creating arbitrary mappings in the Plan Wizard

### DIFF
--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -36,7 +36,6 @@ interface IMappingBuilderProps {
   availableTargets: MappingTarget[];
   builderItems: IMappingBuilderItem[];
   setBuilderItems: (groups: IMappingBuilderItem[]) => void;
-  isWizardMode?: boolean;
 }
 
 export const getDefaultTarget = (availableTargets:MappingTarget[], mappingType: MappingType) => 
@@ -49,7 +48,6 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
   availableTargets,
   builderItems,
   setBuilderItems,
-  isWizardMode = false,
 }: IMappingBuilderProps) => {
   const reset = () => setBuilderItems([{ source: null, target: null }]);
   const isReset = builderItems.length === 1 && !builderItems[0].source && !builderItems[0].target;
@@ -64,21 +62,12 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
 
   let instructionText = '';
   if (mappingType === MappingType.Network) {
-    if (isWizardMode) {
-      instructionText = 'Select target networks.';
-    } else {
-      instructionText = 'Map source and target networks.';
-    }
-    instructionText = `${instructionText} The OpenShift pod network is the default target network. You can select a different target network from the network list.`;
+    instructionText = `Map source and target networks. The OpenShift pod network is the default target network. You can select a different target network from the network list.`;
   }
   if (mappingType === MappingType.Storage) {
-    if (isWizardMode) {
-      instructionText = 'Select target storage classes.';
-    } else {
-      instructionText = `Map source ${getStorageTitle(
-        sourceProviderType
-      )} to target storage classes.`;
-    }
+    instructionText = `Map source ${getStorageTitle(
+      sourceProviderType
+    )} to target storage classes.`;
   }
 
   return (
@@ -99,7 +88,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                     </span>
                   </label>
                 </GridItem>
-                <GridItem span={isWizardMode ? 2 : 1} />
+                <GridItem span={1} />
                 <GridItem span={5} className={spacing.pbSm}>
                   <label className="pf-c-form__label">
                     <span className="pf-c-form__label-text">
@@ -107,11 +96,11 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                     </span>
                   </label>
                 </GridItem>
-                {isWizardMode ? null : <GridItem span={1} />}
+                <GridItem span={1} />
               </>
             ) : null}
             <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
-              {isWizardMode && item.source ? (
+              {item.source ? (
                 <Bullseye style={{ justifyContent: 'left' }} className={spacing.plSm}>
                   <TextContent>
                     <TruncatedText>{item.source.name}</TruncatedText>
@@ -140,7 +129,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 />
               )}
             </GridItem>
-            <GridItem span={isWizardMode ? 2 : 1}>
+            <GridItem span={1}>
               <Bullseye>
                 <LineArrow />
               </Bullseye>
@@ -160,55 +149,49 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 />
               </Bullseye>
             </GridItem>
-            {isWizardMode ? null : (
-              <GridItem span={1}>
-                <Bullseye>
-                  <Button
-                    variant="plain"
-                    aria-label="Remove mapping"
-                    onClick={() => removeItem(itemIndex)}
-                    isDisabled={isReset}
-                  >
-                    <TrashIcon />
-                  </Button>
-                </Bullseye>
-              </GridItem>
-            )}
+            <GridItem span={1}>
+              <Bullseye>
+                <Button
+                  variant="plain"
+                  aria-label="Remove mapping"
+                  onClick={() => removeItem(itemIndex)}
+                  isDisabled={isReset}
+                >
+                  <TrashIcon />
+                </Button>
+              </Bullseye>
+            </GridItem>
           </Grid>
         );
       })}
-      {isWizardMode ? null : (
-        <Flex
-          justifyContent={{ default: 'justifyContentCenter' }}
-          spaceItems={{ default: 'spaceItemsMd' }}
-        >
-          {builderItems.every((item) => item.source && item.target) ? (
-            <ConditionalTooltip
-              isTooltipEnabled={builderItems.length === availableSources.length}
-              content={`All source ${
-                mappingType === MappingType.Network
-                  ? 'networks'
-                  : getStorageTitle(sourceProviderType)
-              } have been mapped.`}
-              position="bottom"
-            >
-              <div>
-                <Button
-                  isDisabled={builderItems.length === availableSources.length}
-                  variant="secondary"
-                  icon={<PlusCircleIcon />}
-                  onClick={addEmptyItem}
-                >
-                  Add
-                </Button>
-              </div>
-            </ConditionalTooltip>
-          ) : null}
-          <Button variant="secondary" onClick={reset} isDisabled={isReset}>
-            Remove all
-          </Button>
-        </Flex>
-      )}
+      <Flex
+        justifyContent={{ default: 'justifyContentCenter' }}
+        spaceItems={{ default: 'spaceItemsMd' }}
+      >
+        {builderItems.every((item) => item.source && item.target) ? (
+          <ConditionalTooltip
+            isTooltipEnabled={builderItems.length === availableSources.length}
+            content={`All source ${
+              mappingType === MappingType.Network ? 'networks' : getStorageTitle(sourceProviderType)
+            } have been mapped.`}
+            position="bottom"
+          >
+            <div>
+              <Button
+                isDisabled={builderItems.length === availableSources.length}
+                variant="secondary"
+                icon={<PlusCircleIcon />}
+                onClick={addEmptyItem}
+              >
+                Add
+              </Button>
+            </div>
+          </ConditionalTooltip>
+        ) : null}
+        <Button variant="secondary" onClick={reset} isDisabled={isReset}>
+          Remove all
+        </Button>
+      </Flex>
     </>
   );
 };

--- a/packages/legacy/src/Plans/components/Wizard/MappingForm.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/MappingForm.tsx
@@ -14,6 +14,7 @@ import {
   SelectGroup,
   SelectOptionObject,
   Divider,
+  Alert,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { ValidatedTextInput } from '@migtools/lib-ui';
@@ -216,6 +217,15 @@ export const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
       ]}
     >
       <Form>
+        {form.values.isPrefilled && form.values.filteredOutItemCount > 0 && (
+          <Alert isInline variant="warning" title="Unresolved mappings">
+            {`${form.values.filteredOutItemCount} ${mappingType.toLocaleLowerCase()} ${
+              form.values.filteredOutItemCount > 1
+                ? 'mappings could not be resolved based on available configuration and are skipped below.'
+                : 'mapping could not be resolved based on availableconfiguration and is skipped below.'
+            }`}
+          </Alert>
+        )}
         {!form.values.isPrefilled ? (
           <TextContent>
             <Text component="p">
@@ -293,12 +303,11 @@ export const MappingForm: React.FunctionComponent<IMappingFormProps> = ({
                 availableTargets={filteredAvailableTargets}
                 builderItems={form.values.builderItems}
                 setBuilderItems={form.fields.builderItems.setValue}
-                isWizardMode
               />
               {form.values.isCreateMappingSelected || form.values.isPrefilled || hasAddedItems ? (
                 <>
                   <Checkbox
-                    label="Save mapping to use again"
+                    label="Save current mapping as a template"
                     aria-label="save mapping checkbox"
                     id="save-mapping-check"
                     isChecked={form.values.isSaveNewMapping}

--- a/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
@@ -72,6 +72,7 @@ const useMappingFormState = (mappingsQuery: UseQueryResult<IKubeList<Mapping>>) 
     isCreateMappingSelected: useFormField(false, yup.boolean().required()),
     selectedExistingMapping: useFormField<Mapping | null>(null, yup.mixed<Mapping | null>()),
     builderItems: useFormField<IMappingBuilderItem[]>([], mappingBuilderItemsSchema),
+    filteredOutItemCount: useFormField(0, yup.number().optional()),
     isSaveNewMapping,
     newMappingName: useFormField(
       '',

--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -678,41 +678,47 @@ export const usePlanWizardPrefillEffect = (
 
       forms.selectVMs.fields.selectedVMIds.prefill(selectedVMs.map((vm) => vm.id));
 
-      forms.networkMapping.fields.builderItems.prefill(
-        getBuilderItemsWithMissingSources(
-          getBuilderItemsFromMappingItems(
-            networkMapping?.spec.map || [],
-            MappingType.Network,
-            networkMappingResourceQueries.availableSources,
-            networkMappingResourceQueries.availableTargets
-          ),
-          networkMappingResourceQueries,
-          selectedVMs,
+      const inputNetworkItems = networkMapping?.spec.map || [];
+      const filteredNetworkItems = getBuilderItemsWithMissingSources(
+        getBuilderItemsFromMappingItems(
+          inputNetworkItems,
           MappingType.Network,
-          sourceProvider?.type || 'vsphere',
-          false,
-          nicProfilesQuery?.data || [],
-          disksQuery?.data || []
-        )
+          networkMappingResourceQueries.availableSources,
+          networkMappingResourceQueries.availableTargets
+        ),
+        networkMappingResourceQueries,
+        selectedVMs,
+        MappingType.Network,
+        sourceProvider?.type || 'vsphere',
+        false,
+        nicProfilesQuery?.data || [],
+        disksQuery?.data || []
+      );
+      forms.networkMapping.fields.builderItems.prefill(filteredNetworkItems);
+      forms.networkMapping.fields.filteredOutItemCount.prefill(
+        inputNetworkItems.length - filteredNetworkItems.length
       );
       forms.networkMapping.fields.isPrefilled.prefill(true);
 
-      forms.storageMapping.fields.builderItems.prefill(
-        getBuilderItemsWithMissingSources(
-          getBuilderItemsFromMappingItems(
-            storageMapping?.spec.map || [],
-            MappingType.Storage,
-            storageMappingResourceQueries.availableSources,
-            storageMappingResourceQueries.availableTargets
-          ),
-          storageMappingResourceQueries,
-          selectedVMs,
+      const inputStorageItems = storageMapping?.spec.map || [];
+      const filteredStorageItems = getBuilderItemsWithMissingSources(
+        getBuilderItemsFromMappingItems(
+          inputStorageItems,
           MappingType.Storage,
-          sourceProvider?.type || 'vsphere',
-          false,
-          nicProfilesQuery?.data || [],
-          disksQuery?.data || []
-        )
+          storageMappingResourceQueries.availableSources,
+          storageMappingResourceQueries.availableTargets
+        ),
+        storageMappingResourceQueries,
+        selectedVMs,
+        MappingType.Storage,
+        sourceProvider?.type || 'vsphere',
+        false,
+        nicProfilesQuery?.data || [],
+        disksQuery?.data || []
+      );
+      forms.storageMapping.fields.builderItems.prefill(filteredStorageItems);
+      forms.storageMapping.fields.filteredOutItemCount.prefill(
+        inputStorageItems.length - filteredStorageItems.length
       );
       forms.storageMapping.fields.isPrefilled.prefill(true);
 


### PR DESCRIPTION
Before mappings were created based on network/storage resources
required by the VM. However some VMs have no nics/diska or the resources
are incorrectly linked/defined.

By default mappings in the edit/duplicate flow are filtered to remove:
1. invalid source/target (no longer in the inventory)
2. not required by the current VM configuration
This may confuse the user as not all items visible in yaml are shown in
the UI.

Changes:
1. allow editing/removing/adding mappings in the wizard
2. change the wording in the Network/Storage step to better explain
   that every time a new mapping is created (based on the template).
3. add a warning that some mapping items were filtered out - applies to
   edit/duplicate actions



### Example 1
#### Mapping used to create the plan has 3 items
![Screenshot from 2023-03-03 20-23-35](https://user-images.githubusercontent.com/64194103/222811540-57add0c3-4053-4df3-b72b-59729dbc2eb5.png)
### Edit action filters out 2 of them
![Screenshot from 2023-03-03 20-24-11](https://user-images.githubusercontent.com/64194103/222811818-af6f315d-bec5-4446-8051-0b959f03e11d.png)

### Example 2

####  All 3 network items filtered out (before this PR the wizard would be blocked)

![Screenshot from 2023-03-03 20-25-20](https://user-images.githubusercontent.com/64194103/222812106-0c58ef2c-a7a3-4735-b093-a5eb1fb67207.png)

#### All 6 storage items filtered out

![Screenshot from 2023-03-03 20-25-31](https://user-images.githubusercontent.com/64194103/222812302-4ce47586-d7fb-4b65-a4b8-392975b543bb.png)

### Example 3

#### Different wording used for single item being filtered out

![Screenshot from 2023-03-03 19-57-02](https://user-images.githubusercontent.com/64194103/222812433-f6ee12d9-3bda-46de-862b-b34461b1d12f.png)
