### PR TITLE
Mark some Plans related legacy component as @deprecated

### DIFF
--- a/packages/legacy/src/Plans/PlansPage.tsx
+++ b/packages/legacy/src/Plans/PlansPage.tsx
@@ -22,6 +22,9 @@ import { CreatePlanButton } from './components/CreatePlanButton';
 import { ResolvedQueries } from 'legacy/src/common/components/ResolvedQuery';
 import { ENV, PROVIDER_TYPE_NAMES } from 'legacy/src/common/constants';
 
+/**
+ * @deprecated See packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+ */
 export const PlansPage: React.FunctionComponent = () => {
   const namespace = ENV.DEFAULT_NAMESPACE;
   const sufficientProvidersQuery = useHasSufficientProvidersQuery();

--- a/packages/legacy/src/Plans/components/PlansTable.tsx
+++ b/packages/legacy/src/Plans/components/PlansTable.tsx
@@ -73,6 +73,9 @@ interface IPlansTableProps {
   plans: IPlan[];
 }
 
+/**
+ * @deprecated See packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+ */
 export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
   plans,
 }: IPlansTableProps) => {


### PR DESCRIPTION
Although all *legacy* package components are technically deprecated, mark a few Plans related components as officially deprecated since they are not currently in use.