### PR TITLE
Read identity columns visibility from parent

### DIFF
--- a/packages/common/src/components/TableView/ManageColumnsToolbar.tsx
+++ b/packages/common/src/components/TableView/ManageColumnsToolbar.tsx
@@ -171,7 +171,10 @@ const ManageColumns = ({
                       <DataListCheck
                         aria-labelledby={`draggable-${id}`}
                         name={id}
-                        checked={isVisible}
+                        checked={
+                          // visibility for identity columns (namespace) is governed by parent component
+                          isIdentity ? columns.find((c) => c.id === id)?.isVisible : isVisible
+                        }
                         isDisabled={isIdentity}
                         onChange={(value) => onSelect(id, value)}
                         otherControls


### PR DESCRIPTION
By design, the visibility of an identity column cannot be changed using ManageColumns dialog. However we cannot assume it's constant: the parent component is free to hide/show any column.