### PR TITLE
Make table cell progress bar use PF small variant

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -20,6 +20,7 @@ import {
   Label,
   Progress,
   ProgressMeasureLocation,
+  ProgressSize,
   Truncate,
 } from '@patternfly/react-core';
 import { ArchiveIcon, VirtualMachineIcon } from '@patternfly/react-icons';
@@ -78,6 +79,7 @@ const StatusCell = ({
           valueText={t('{{vmDone}} of {{vmCount}} VMs migrated', { vmDone, vmCount })}
           variant={variant}
           measureLocation={ProgressMeasureLocation.top}
+          size={ProgressSize.sm}
         />
       </Link>
     );

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
@@ -92,14 +92,14 @@ exports[`Plan rows plantest-01 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-1"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress"
+              class="pf-c-progress pf-m-sm"
               id="progress_for_plantest-01_in_openshift-migration"
             >
               <div
@@ -509,14 +509,14 @@ exports[`Plan rows plantest-03 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-3"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress pf-m-danger"
+              class="pf-c-progress pf-m-danger pf-m-sm"
               id="progress_for_plantest-03_in_openshift-migration"
             >
               <div
@@ -747,14 +747,14 @@ exports[`Plan rows plantest-04 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-4"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress pf-m-success"
+              class="pf-c-progress pf-m-success pf-m-sm"
               id="progress_for_plantest-04_in_openshift-migration"
             >
               <div
@@ -1755,14 +1755,14 @@ exports[`Plan rows plantest-09 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-9"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress"
+              class="pf-c-progress pf-m-sm"
               id="progress_for_plantest-09_in_openshift-migration"
             >
               <div
@@ -1962,14 +1962,14 @@ exports[`Plan rows plantest-10 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-10"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress pf-m-danger"
+              class="pf-c-progress pf-m-danger pf-m-sm"
               id="progress_for_plantest-10_in_openshift-migration"
             >
               <div
@@ -2200,14 +2200,14 @@ exports[`Plan rows plantest-11 1`] = `
         >
           <button
             aria-disabled="false"
-            class="pf-c-button pf-m-link clickable-progress-bar"
+            class="pf-c-button pf-m-link forklift-table__status-cell-progress"
             data-ouia-component-id="OUIA-Generated-Button-link-11"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe="true"
             type="button"
           >
             <div
-              class="pf-c-progress pf-m-warning"
+              class="pf-c-progress pf-m-warning pf-m-sm"
               id="progress_for_plantest-11_in_openshift-migration"
             >
               <div

--- a/packages/forklift-console-plugin/src/modules/Plans/styles.css
+++ b/packages/forklift-console-plugin/src/modules/Plans/styles.css
@@ -1,8 +1,12 @@
-.clickable-progress-bar {
+.forklift-table__status-cell-progress {
   margin: calc(0px - var(--pf-global--spacer--form-element))
     calc(0px - var(--pf-global--spacer--md));
   width: 100%;
   text-align: left;
+}
+
+.forklift-table__status-cell-progress div {
+  grid-gap: var(--pf-global--spacer--xs);
 }
 
 .forklift-table__flex-cell {

--- a/packages/legacy/src/Plans/components/PlanStatusNavLink.tsx
+++ b/packages/legacy/src/Plans/components/PlanStatusNavLink.tsx
@@ -25,7 +25,7 @@ export const PlanNameNavLink = ({
       variant="link"
       onClick={() => history.push(`${PATH_PREFIX}/plans/${name}`)}
       isInline={isInline}
-      className={!isInline ? 'clickable-progress-bar' : ''}
+      className={!isInline ? 'forklift-table__status-cell-progress' : ''}
     >
       {children}
     </Button>

--- a/packages/legacy/src/Plans/components/PlansTable.css
+++ b/packages/legacy/src/Plans/components/PlansTable.css
@@ -23,7 +23,7 @@
   padding-left: var(--pf-global--spacer--xl);
 }
 
-.pf-c-table.plans-table button.clickable-progress-bar {
+.pf-c-table.plans-table button.forklift-table__status-cell-progress {
   margin: calc(0px - var(--pf-global--spacer--form-element))
     calc(0px - var(--pf-global--spacer--md));
   width: 100%;


### PR DESCRIPTION
Issue:
In plans list we show the progress using normal size progress, the table cell height is effected.

Fix:
Use the small progress variant from PF, the height increase of the cell is lessened.

  - [x] use small progress variant
  - [x] update progress css class name to use BEM convention

Screenshot:
Before:
![regular-progress](https://user-images.githubusercontent.com/2181522/223962935-37a4c401-8a2f-4b0c-bed7-1314fcdf897c.png)

After:
![xsmall-progress](https://user-images.githubusercontent.com/2181522/223962956-489f75c6-1da2-421f-a1b5-cdab651208d6.png)

