### PR TITLE
Re-design Providers table page status column and tooltips

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -62,7 +62,6 @@
   "NetworkMaps": "NetworkMaps",
   "NetworkMaps for virtualization": "NetworkMaps for virtualization",
   "Networks": "Networks",
-  "No information": "No information",
   "No providers have been defined.": "No providers have been defined.",
   "Not Ready": "Not Ready",
   "OpenStack": "OpenStack",

--- a/packages/forklift-console-plugin/src/modules/Providers/data.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/data.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import * as C from 'src/utils/constants';
 import { useProviders } from 'src/utils/fetch';
 import { groupVersionKindForObj } from 'src/utils/resources';
-import { ProviderStatus } from 'src/utils/types';
+import { ProviderPhase } from 'src/utils/types';
 
 import { useInventoryProvidersQuery } from '@kubev2v/legacy/queries';
 import {
@@ -55,7 +55,7 @@ export interface MergedProvider {
   [C.VM_COUNT]: number;
   [C.NETWORK_COUNT]: number;
   [C.STORAGE_COUNT]: number;
-  [C.PHASE]: ProviderStatus;
+  [C.PHASE]: ProviderPhase;
   [C.OWNER_REFERENCES]: OwnerReference[];
   [C.IS_OWNED_BY_CONTROLLER]: boolean;
   positiveConditions: PositiveConditions;
@@ -175,7 +175,7 @@ export const mergeData = (pairs: [V1beta1Provider, FlattenedInventory][]) =>
         },
         object: provider as IProviderObject,
         selfLink,
-        phase: phase as ProviderStatus,
+        phase: phase as ProviderPhase,
         isOwnedByController: !!ownerReferences.find((ref) => ref.kind === 'ForkliftController'),
       }),
     );

--- a/packages/forklift-console-plugin/src/utils/enums.ts
+++ b/packages/forklift-console-plugin/src/utils/enums.ts
@@ -2,7 +2,7 @@ import { K8sConditionStatus } from '@kubev2v/common/components/types';
 import { PlanState, ProviderType } from '@kubev2v/legacy/common/constants';
 import { PlanType } from '@kubev2v/legacy/queries/types';
 
-import { ProviderStatus } from './types';
+import { ProviderPhase } from './types';
 
 export const PROVIDERS: Record<ProviderType, (t: (k: string) => string) => string> = {
   vsphere: (t) => t('VMware'),
@@ -17,7 +17,7 @@ export const CONDITIONS: Record<K8sConditionStatus, (t: (k: string) => string) =
   Unknown: (t) => t('Unknown'),
 };
 
-export const PROVIDER_STATUS: Record<ProviderStatus, (t: (k: string) => string) => string> = {
+export const PROVIDER_STATUS: Record<ProviderPhase, (t: (k: string) => string) => string> = {
   Ready: (t) => t('Ready'),
   ConnectionFailed: (t) => t('Connection Failed'),
   Staging: (t) => t('Staging'),

--- a/packages/forklift-console-plugin/src/utils/types.ts
+++ b/packages/forklift-console-plugin/src/utils/types.ts
@@ -37,11 +37,11 @@ export interface ProviderRef {
   resolved: boolean;
 }
 
-export const ProviderStatusValues = [
+export const ProviderPhaseValues = [
   'ValidationFailed',
   'ConnectionFailed',
   'Ready',
   'Staging',
   'Unknown',
 ] as const;
-export type ProviderStatus = (typeof ProviderStatusValues)[number];
+export type ProviderPhase = (typeof ProviderPhaseValues)[number];


### PR DESCRIPTION
Fixes: #247 

Change the logic and icons for the Providers Status column in Providers list table:
1. Change icons to Patternfly for displaying a visible longer condition messages in providers status tooltip  - fixing #247
2. Remove the Positive/Negative State mapping.
3. Avoid displaying a Button and a Tooltip in case of no condition message existed for a status.

## Screenshots:

![image](https://user-images.githubusercontent.com/18169498/224163564-076a5e92-b159-48c9-b144-2dc0ee6c3364.png)

![image](https://user-images.githubusercontent.com/18169498/224165377-5182c9c1-9b62-4590-9082-79af5df88452.png)

![image](https://user-images.githubusercontent.com/18169498/224165529-99255638-2360-45d8-acac-552a10b7059e.png)

#
#
### A followup enhancement:
Render the condition message text to look the same as in yaml file (i.e. text/html format) 

