### PR TITLE
Fixes reviews from add-jsonpath-support-i

### DIFF
--- a/packages/common/src/components/Filter/AttributeValueFilter.tsx
+++ b/packages/common/src/components/Filter/AttributeValueFilter.tsx
@@ -12,9 +12,14 @@ import {
 import { FilterFromDef } from './FilterFromDef';
 import { MetaFilterProps } from './types';
 
-const toSelectOption = (id: string, label: string): SelectOptionObject => ({
+interface IdOption extends SelectOptionObject {
+  id: string;
+}
+
+const toSelectOption = (id: string, label: string): IdOption => ({
+  id,
   toString: () => label,
-  compareTo: (o) => o.id === id,
+  compareTo: (other: IdOption): boolean => id === other?.id,
 });
 
 /**
@@ -33,7 +38,7 @@ export const AttributeValueFilter = ({
   const [expanded, setExpanded] = useState(false);
 
   const selectOptionToFilter = (selectedId) =>
-    fieldFilters.find(({ resourceFieldID }) => resourceFieldID === selectedId) ?? currentFilter;
+    fieldFilters.find(({ resourceFieldId }) => resourceFieldId === selectedId) ?? currentFilter;
 
   const onFilterTypeSelect = (event, value, isPlaceholder) => {
     if (!isPlaceholder) {
@@ -52,26 +57,26 @@ export const AttributeValueFilter = ({
           variant={SelectVariant.single}
           aria-label={'Select Filter'}
           selections={
-            currentFilter && toSelectOption(currentFilter.resourceFieldID, currentFilter.label)
+            currentFilter && toSelectOption(currentFilter.resourceFieldId, currentFilter.label)
           }
         >
-          {fieldFilters.map(({ resourceFieldID, label }) => (
-            <SelectOption key={resourceFieldID} value={toSelectOption(resourceFieldID, label)} />
+          {fieldFilters.map(({ resourceFieldId, label }) => (
+            <SelectOption key={resourceFieldId} value={toSelectOption(resourceFieldId, label)} />
           ))}
         </Select>
       </ToolbarItem>
 
-      {fieldFilters.map(({ resourceFieldID, label, filterDef }) => (
+      {fieldFilters.map(({ resourceFieldId, label, filterDef }) => (
         <FilterFromDef
-          key={resourceFieldID}
+          key={resourceFieldId}
           {...{
-            resourceFieldID,
+            resourceFieldId,
             label,
             filterDef,
             onFilterUpdate,
             selectedFilters,
             FilterType: supportedFilterTypes[filterDef.type],
-            showFilter: currentFilter?.resourceFieldID === resourceFieldID,
+            showFilter: currentFilter?.resourceFieldId === resourceFieldId,
           }}
         />
       ))}

--- a/packages/common/src/components/Filter/FilterFromDef.tsx
+++ b/packages/common/src/components/Filter/FilterFromDef.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { FilterDef, FilterTypeProps, GlobalFilters } from './types';
 
 interface FilterFromDefProps {
-  resourceFieldID: string;
+  resourceFieldId: string;
   label: string;
   filterDef: FilterDef;
   selectedFilters: GlobalFilters;
@@ -13,7 +13,7 @@ interface FilterFromDefProps {
 }
 
 export const FilterFromDef = ({
-  resourceFieldID: id,
+  resourceFieldId: id,
   label,
   filterDef: def,
   selectedFilters,
@@ -34,7 +34,7 @@ export const FilterFromDef = ({
         }
         placeholderLabel={def.toPlaceholderLabel}
         selectedFilters={selectedFilters[id] ?? []}
-        title={def?.label ?? label}
+        title={def?.fieldLabel ?? label}
         showFilter={showFilter}
         supportedValues={def.values}
         supportedGroups={def.groups}

--- a/packages/common/src/components/Filter/FilterGroup.tsx
+++ b/packages/common/src/components/Filter/FilterGroup.tsx
@@ -18,11 +18,11 @@ export const FilterGroup = ({
   supportedFilterTypes = {},
 }: MetaFilterProps) => (
   <ToolbarGroup variant="filter-group">
-    {fieldFilters.map(({ resourceFieldID, label, filterDef }) => (
+    {fieldFilters.map(({ resourceFieldId, label, filterDef }) => (
       <FilterFromDef
-        key={resourceFieldID}
+        key={resourceFieldId}
         {...{
-          resourceFieldID,
+          resourceFieldId,
           label,
           filterDef,
           onFilterUpdate,

--- a/packages/common/src/components/Filter/GroupedEnumFilter.tsx
+++ b/packages/common/src/components/Filter/GroupedEnumFilter.tsx
@@ -64,7 +64,7 @@ export const GroupedEnumFilter = ({
   // put the IDs needed for compareTo (although not part of the interface)
   const toSelectOption = ({ id, groupId, label }): SelectOptionObject =>
     ({
-      toString: label,
+      toString: () => label,
       id,
       groupId,
       compareTo: (option) => option.id === id && option.groupId === groupId,

--- a/packages/common/src/components/Filter/__tests__/matchers.test.ts
+++ b/packages/common/src/components/Filter/__tests__/matchers.test.ts
@@ -14,7 +14,7 @@ const matchFreetext = (
     ...freetextMatcher,
     resourceFields: [
       {
-        resourceFieldID: NAME,
+        resourceFieldId: NAME,
         label: NAME,
         filter,
       },
@@ -72,7 +72,7 @@ const matchBothFieldsFreetext = () =>
     },
     [
       {
-        resourceFieldID: NAME,
+        resourceFieldId: NAME,
         label: NAME,
         filter: {
           type: 'freetext',
@@ -80,7 +80,7 @@ const matchBothFieldsFreetext = () =>
         },
       },
       {
-        resourceFieldID: NAMESPACE,
+        resourceFieldId: NAMESPACE,
         label: NAMESPACE,
         filter: {
           type: 'freetext',

--- a/packages/common/src/components/Filter/__tests__/useUrlFilters.test.tsx
+++ b/packages/common/src/components/Filter/__tests__/useUrlFilters.test.tsx
@@ -32,7 +32,7 @@ describe('parse filters from the URL on initialization', () => {
         },
       } = renderHook(() =>
         useUrlFilters({
-          fields: [{ resourceFieldID: NAME, label: NAME }],
+          fields: [{ resourceFieldId: NAME, label: NAME }],
         }),
       );
       expect(selectedFilters[NAME]).toStrictEqual(output);
@@ -47,7 +47,7 @@ describe('parse filters from the URL on initialization', () => {
       },
     } = renderHook(() =>
       useUrlFilters({
-        fields: [{ resourceFieldID: NAME, label: NAME }],
+        fields: [{ resourceFieldId: NAME, label: NAME }],
       }),
     );
     expect(Object.entries(selectedFilters).length).toStrictEqual(0);
@@ -61,7 +61,7 @@ describe('parse filters from the URL on initialization', () => {
       },
     } = renderHook(() =>
       useUrlFilters({
-        fields: [{ resourceFieldID: NAME, label: NAME }],
+        fields: [{ resourceFieldId: NAME, label: NAME }],
         filterPrefix: 'bar',
       }),
     );
@@ -82,7 +82,7 @@ describe('display currrently selected filters in the URL', () => {
       },
     } = renderHook(() =>
       useUrlFilters({
-        fields: [{ resourceFieldID: NAME, label: NAME }],
+        fields: [{ resourceFieldId: NAME, label: NAME }],
       }),
     );
     act(() => setSelectedFilters({ [NAME]: update }));

--- a/packages/common/src/components/Filter/helpers.ts
+++ b/packages/common/src/components/Filter/helpers.ts
@@ -3,10 +3,10 @@ import { ResourceField } from '../types';
 import { FieldFilter } from './types';
 
 export const toFieldFilter = ({
-  resourceFieldID,
+  resourceFieldId,
   label,
   filter: filterDef,
-}: ResourceField): FieldFilter => ({ resourceFieldID, label, filterDef });
+}: ResourceField): FieldFilter => ({ resourceFieldId, label, filterDef });
 
 export const fromI18nEnum = (i18nEnum: { [k: string]: string }) =>
   Object.entries(i18nEnum).map(([type, label]) => ({ id: type, label }));

--- a/packages/common/src/components/Filter/matchers.ts
+++ b/packages/common/src/components/Filter/matchers.ts
@@ -9,22 +9,22 @@ import { ValueMatcher } from './types';
  * definition struct.
  *
  * @param resourceData is a struct holding all the data needed to render a resource
- * @param resourceFieldID is the field id, in the resourceFields
+ * @param resourceFieldId is the field id, in the resourceFields
  * @param resourceFields the resourceData fields table
  * @returns the value of the fields based on the field jsonPath
  */
 export const getResourceFieldValue = (
   resourceData: unknown,
-  resourceFieldID: string,
+  resourceFieldId: string,
   resourceFields: ResourceField[],
 ) => {
-  const field = resourceFields.find((f) => f.resourceFieldID === resourceFieldID);
+  const field = resourceFields.find((f) => f.resourceFieldId === resourceFieldId);
   if (typeof resourceData !== 'object' || !field) {
     return undefined;
   }
 
   if (!field.jsonPath) {
-    return resourceData?.[resourceFieldID];
+    return resourceData?.[resourceFieldId];
   }
 
   switch (typeof field.jsonPath) {
@@ -61,14 +61,14 @@ export const createMatcher =
     resourceFields
       .filter(({ filter }) => filter?.type === filterType)
       .filter(
-        ({ resourceFieldID, filter }) =>
-          (selectedFilters[resourceFieldID] && selectedFilters[resourceFieldID]?.length) ||
+        ({ resourceFieldId, filter }) =>
+          (selectedFilters[resourceFieldId] && selectedFilters[resourceFieldId]?.length) ||
           filter?.defaultValues,
       )
-      .map(({ resourceFieldID, filter }) => ({
-        value: getResourceFieldValue(resourceData, resourceFieldID, resourceFields),
-        filters: selectedFilters[resourceFieldID]?.length
-          ? selectedFilters[resourceFieldID]
+      .map(({ resourceFieldId, filter }) => ({
+        value: getResourceFieldValue(resourceData, resourceFieldId, resourceFields),
+        filters: selectedFilters[resourceFieldId]?.length
+          ? selectedFilters[resourceFieldId]
           : filter?.defaultValues,
       }))
       .map(({ value, filters }) => filters.some(matchValue(value)))

--- a/packages/common/src/components/Filter/types.ts
+++ b/packages/common/src/components/Filter/types.ts
@@ -13,7 +13,7 @@ export interface FilterDef {
   type: string;
   toPlaceholderLabel: string;
   values?: EnumValue[];
-  label?: string;
+  fieldLabel?: string;
   primary?: boolean;
   standalone?: boolean;
   groups?: EnumGroup[];
@@ -56,7 +56,7 @@ export interface FilterTypeProps {
  * Field ID to filter defintion mapping.
  */
 export type FieldFilter = {
-  resourceFieldID: string;
+  resourceFieldId: string;
   label: string;
   filterDef: FilterDef;
 };

--- a/packages/common/src/components/Filter/useUrlFilters.ts
+++ b/packages/common/src/components/Filter/useUrlFilters.ts
@@ -38,15 +38,15 @@ export const useUrlFilters = ({
   const [selectedFilters, setSelectedFilters] = useState(() =>
     Object.fromEntries(
       fields
-        .map(({ resourceFieldID }) => ({
-          resourceFieldID,
+        .map(({ resourceFieldId }) => ({
+          resourceFieldId,
           // discard any corrupted filters i.e. partially copy-pasted
-          params: safeParse(searchParams[`${filterPrefix}${resourceFieldID}`]),
+          params: safeParse(searchParams[`${filterPrefix}${resourceFieldId}`]),
         }))
         // discard filters with invalid structure (basic validation)
         // each filter should validate if values make sense (i.e. enum values in range)
         .filter(({ params }) => Array.isArray(params) && params.length)
-        .map(({ resourceFieldID, params }) => [resourceFieldID, params]),
+        .map(({ resourceFieldId, params }) => [resourceFieldId, params]),
     ),
   );
   const setStateAndUrl = useMemo(
@@ -55,9 +55,9 @@ export const useUrlFilters = ({
       updateSearchParams(
         Object.fromEntries(
           fields
-            .map(({ resourceFieldID }) => ({ resourceFieldID, filters: filters[resourceFieldID] }))
-            .map(({ resourceFieldID, filters }) => [
-              resourceFieldID,
+            .map(({ resourceFieldId }) => ({ resourceFieldId, filters: filters[resourceFieldId] }))
+            .map(({ resourceFieldId, filters }) => [
+              resourceFieldId,
               Array.isArray(filters) && filters.length ? JSON.stringify(filters) : undefined,
             ]),
         ),

--- a/packages/common/src/components/StandardPage/__tests__/StandardPage.test.tsx
+++ b/packages/common/src/components/StandardPage/__tests__/StandardPage.test.tsx
@@ -12,9 +12,9 @@ afterEach(cleanup);
 function SimpleRow<T>({ resourceFields, resourceData }: RowProps<T>) {
   return (
     <Tr ouiaId={undefined} ouiaSafe={undefined}>
-      {resourceFields.map(({ resourceFieldID, label }) => (
-        <Td key={resourceFieldID} dataLabel={label}>
-          {String(resourceData[resourceFieldID] ?? '')}
+      {resourceFields.map(({ resourceFieldId, label }) => (
+        <Td key={resourceFieldId} dataLabel={label}>
+          {String(resourceData[resourceFieldId] ?? '')}
         </Td>
       ))}
     </Tr>
@@ -32,7 +32,7 @@ test('empty result set returned, no filters ', async () => {
       dataSource={dataSource}
       fieldsMetadata={[
         {
-          resourceFieldID: NAME,
+          resourceFieldId: NAME,
           label: 'Name',
         },
       ]}
@@ -59,7 +59,7 @@ test('single entry returned, both filters ', async () => {
       dataSource={dataSource}
       fieldsMetadata={[
         {
-          resourceFieldID: NAME,
+          resourceFieldId: NAME,
           label: 'Name',
           isIdentity: true,
           isVisible: true,
@@ -70,7 +70,7 @@ test('single entry returned, both filters ', async () => {
           },
         },
         {
-          resourceFieldID: NAMESPACE,
+          resourceFieldId: NAMESPACE,
           label: 'Namespace',
           isIdentity: true,
           isVisible: true,

--- a/packages/common/src/components/StandardPage/__tests__/useFields.test.tsx
+++ b/packages/common/src/components/StandardPage/__tests__/useFields.test.tsx
@@ -12,8 +12,8 @@ describe('manage fields', () => {
       result: {
         current: [fields],
       },
-    } = renderHook(() => useFields(undefined, [{ resourceFieldID: NAME, label: '' }]));
-    expect(fields).toMatchObject([{ resourceFieldID: NAME, isVisible: false }]);
+    } = renderHook(() => useFields(undefined, [{ resourceFieldId: NAME, label: '' }]));
+    expect(fields).toMatchObject([{ resourceFieldId: NAME, isVisible: false }]);
   });
   it('enables namespace column visibility if no namespace is chosen', () => {
     const {
@@ -22,13 +22,13 @@ describe('manage fields', () => {
       },
     } = renderHook(() =>
       useFields(undefined, [
-        { resourceFieldID: NAME, label: '', isVisible: true },
-        { resourceFieldID: NAMESPACE, label: '', isVisible: false },
+        { resourceFieldId: NAME, label: '', isVisible: true },
+        { resourceFieldId: NAMESPACE, label: '', isVisible: false },
       ]),
     );
     expect(fields).toMatchObject([
-      { resourceFieldID: NAME, isVisible: true },
-      { resourceFieldID: NAMESPACE, isVisible: true },
+      { resourceFieldId: NAME, isVisible: true },
+      { resourceFieldId: NAMESPACE, isVisible: true },
     ]);
   });
   it('disables namespace column visibility if a namespace is chosen', () => {
@@ -38,13 +38,13 @@ describe('manage fields', () => {
       },
     } = renderHook(() =>
       useFields('some_namespace', [
-        { resourceFieldID: NAME, label: '', isVisible: true },
-        { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+        { resourceFieldId: NAME, label: '', isVisible: true },
+        { resourceFieldId: NAMESPACE, label: '', isVisible: true },
       ]),
     );
     expect(fields).toMatchObject([
-      { resourceFieldID: NAME, isVisible: true },
-      { resourceFieldID: NAMESPACE, isVisible: false },
+      { resourceFieldId: NAME, isVisible: true },
+      { resourceFieldId: NAMESPACE, isVisible: false },
     ]);
   });
 });
@@ -59,13 +59,13 @@ describe('initialize fields from user settings', () => {
       useFields(
         undefined,
         [
-          { resourceFieldID: NAME, label: '', isVisible: true },
-          { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+          { resourceFieldId: NAME, label: '', isVisible: true },
+          { resourceFieldId: NAMESPACE, label: '', isVisible: true },
         ],
         {
           data: [
-            { resourceFieldID: NAMESPACE, isVisible: true },
-            { resourceFieldID: NAME, isVisible: true },
+            { resourceFieldId: NAMESPACE, isVisible: true },
+            { resourceFieldId: NAME, isVisible: true },
           ],
           save: () => undefined,
           clear: () => undefined,
@@ -73,8 +73,8 @@ describe('initialize fields from user settings', () => {
       ),
     );
     expect(fields).toMatchObject([
-      { resourceFieldID: NAMESPACE, isVisible: true },
-      { resourceFieldID: NAME, isVisible: true },
+      { resourceFieldId: NAMESPACE, isVisible: true },
+      { resourceFieldId: NAME, isVisible: true },
     ]);
   });
 
@@ -87,13 +87,13 @@ describe('initialize fields from user settings', () => {
       useFields(
         'some-namespace',
         [
-          { resourceFieldID: NAME, label: '', isVisible: true, isIdentity: true },
-          { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+          { resourceFieldId: NAME, label: '', isVisible: true, isIdentity: true },
+          { resourceFieldId: NAMESPACE, label: '', isVisible: true },
         ],
         {
           data: [
-            { resourceFieldID: NAME, isVisible: false },
-            { resourceFieldID: NAMESPACE, isVisible: false },
+            { resourceFieldId: NAME, isVisible: false },
+            { resourceFieldId: NAMESPACE, isVisible: false },
           ],
           save: () => undefined,
           clear: () => undefined,
@@ -101,8 +101,8 @@ describe('initialize fields from user settings', () => {
       ),
     );
     expect(fields).toMatchObject([
-      { resourceFieldID: NAME, isVisible: true },
-      { resourceFieldID: NAMESPACE, isVisible: false },
+      { resourceFieldId: NAME, isVisible: true },
+      { resourceFieldId: NAMESPACE, isVisible: false },
     ]);
   });
   it('filters out duplicated and unsupported fields', () => {
@@ -114,14 +114,14 @@ describe('initialize fields from user settings', () => {
       useFields(
         undefined,
         [
-          { resourceFieldID: NAME, label: '', isVisible: true },
-          { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+          { resourceFieldId: NAME, label: '', isVisible: true },
+          { resourceFieldId: NAMESPACE, label: '', isVisible: true },
         ],
         {
           data: [
-            { resourceFieldID: NAME, isVisible: false },
-            { resourceFieldID: NAME, isVisible: true },
-            { resourceFieldID: 'foo', isVisible: false },
+            { resourceFieldId: NAME, isVisible: false },
+            { resourceFieldId: NAME, isVisible: true },
+            { resourceFieldId: 'foo', isVisible: false },
           ],
           save: () => undefined,
           clear: () => undefined,
@@ -129,8 +129,8 @@ describe('initialize fields from user settings', () => {
       ),
     );
     expect(fields).toMatchObject([
-      { resourceFieldID: NAME, isVisible: false },
-      { resourceFieldID: NAMESPACE, isVisible: true },
+      { resourceFieldId: NAME, isVisible: false },
+      { resourceFieldId: NAMESPACE, isVisible: true },
     ]);
   });
 });
@@ -146,21 +146,21 @@ describe('saves fields to user settings', () => {
       useFields(
         undefined,
         [
-          { resourceFieldID: NAME, label: '', isVisible: true },
-          { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+          { resourceFieldId: NAME, label: '', isVisible: true },
+          { resourceFieldId: NAMESPACE, label: '', isVisible: true },
         ],
         { data: [], save: saveSettings, clear: () => undefined },
       ),
     );
     act(() =>
       setFields([
-        { resourceFieldID: NAMESPACE, label: '', isVisible: true },
-        { resourceFieldID: NAME, label: '', isVisible: false },
+        { resourceFieldId: NAMESPACE, label: '', isVisible: true },
+        { resourceFieldId: NAME, label: '', isVisible: false },
       ]),
     );
     expect(saveSettings).toBeCalledWith([
-      { resourceFieldID: NAMESPACE, isVisible: true },
-      { resourceFieldID: NAME, isVisible: false },
+      { resourceFieldId: NAMESPACE, isVisible: true },
+      { resourceFieldId: NAME, isVisible: false },
     ]);
   });
   it('clears settings if equal to defaults)', () => {
@@ -173,16 +173,16 @@ describe('saves fields to user settings', () => {
       useFields(
         undefined,
         [
-          { resourceFieldID: NAME, label: '', isVisible: true },
-          { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+          { resourceFieldId: NAME, label: '', isVisible: true },
+          { resourceFieldId: NAMESPACE, label: '', isVisible: true },
         ],
         { data: [], save: () => undefined, clear: clearSettings },
       ),
     );
     act(() =>
       setFields([
-        { resourceFieldID: NAME, label: '', isVisible: true },
-        { resourceFieldID: NAMESPACE, label: '', isVisible: true },
+        { resourceFieldId: NAME, label: '', isVisible: true },
+        { resourceFieldId: NAMESPACE, label: '', isVisible: true },
       ]),
     );
     expect(clearSettings).toBeCalled();

--- a/packages/common/src/components/StandardPage/types.ts
+++ b/packages/common/src/components/StandardPage/types.ts
@@ -4,8 +4,8 @@ export interface UserSettings {
 }
 
 export interface FieldSettings {
-  data: { resourceFieldID: string; isVisible?: boolean }[];
-  save: (fields: { resourceFieldID: string; isVisible?: boolean }[]) => void;
+  data: { resourceFieldId: string; isVisible?: boolean }[];
+  save: (fields: { resourceFieldId: string; isVisible?: boolean }[]) => void;
   clear: () => void;
 }
 

--- a/packages/common/src/components/StandardPage/useFields.tsx
+++ b/packages/common/src/components/StandardPage/useFields.tsx
@@ -12,7 +12,7 @@ const sameOrderAndVisibility = (a: ResourceField[], b: ResourceField[]): boolean
 
   for (let i = 0; i < a.length; i++) {
     if (
-      a[i]?.resourceFieldID !== b[i]?.resourceFieldID ||
+      a[i]?.resourceFieldId !== b[i]?.resourceFieldId ||
       Boolean(a[i]?.isVisible) !== Boolean(b[i]?.isVisible)
     ) {
       return false;
@@ -47,10 +47,10 @@ export const useFields = (
 
   const [fields, setFields] = useState<ResourceField[]>(() => {
     const supportedIds: { [id: string]: ResourceField } = defaultFields.reduce(
-      (acc, it) => ({ ...acc, [it.resourceFieldID]: it }),
+      (acc, it) => ({ ...acc, [it.resourceFieldId]: it }),
       {},
     );
-    const savedIds = new Set(fieldsFromSettings.map(({ resourceFieldID }) => resourceFieldID));
+    const savedIds = new Set(fieldsFromSettings.map(({ resourceFieldId }) => resourceFieldId));
     // used to detect duplicates
     const idsToBeVisited = new Set(savedIds);
 
@@ -58,26 +58,26 @@ export const useFields = (
       // put fields saved via user settings (if any)
       ...fieldsFromSettings
         // ignore duplicates:ID is removed from the helper map on the first visit
-        .filter((it) => idsToBeVisited.delete(it.resourceFieldID))
+        .filter((it) => idsToBeVisited.delete(it.resourceFieldId))
         // ignore unsupported fields
-        .filter(({ resourceFieldID }) => supportedIds[resourceFieldID])
-        .map(({ resourceFieldID, isVisible }) => ({
-          ...supportedIds[resourceFieldID],
+        .filter(({ resourceFieldId }) => supportedIds[resourceFieldId])
+        .map(({ resourceFieldId, isVisible }) => ({
+          ...supportedIds[resourceFieldId],
           // keep the invariant that identity resourceFields are always visible
-          isVisible: isVisible || supportedIds[resourceFieldID].isIdentity,
+          isVisible: isVisible || supportedIds[resourceFieldId].isIdentity,
         })),
       // put all remaining fields (all fields if there are no settings)
       ...defaultFields
-        .filter(({ resourceFieldID }) => !savedIds.has(resourceFieldID))
+        .filter(({ resourceFieldId }) => !savedIds.has(resourceFieldId))
         .map((it) => ({ ...it })),
     ];
   });
   const namespaceAwareFields: ResourceField[] = useMemo(
     () =>
-      fields.map(({ resourceFieldID, isVisible = false, ...rest }) => ({
-        resourceFieldID,
+      fields.map(({ resourceFieldId, isVisible = false, ...rest }) => ({
+        resourceFieldId,
         ...rest,
-        isVisible: resourceFieldID === NAMESPACE ? !currentNamespace : isVisible,
+        isVisible: resourceFieldId === NAMESPACE ? !currentNamespace : isVisible,
       })),
     [currentNamespace, fields],
   );
@@ -90,7 +90,7 @@ export const useFields = (
         clearSettings();
       } else {
         saveFieldsInSettings(
-          fields.map(({ resourceFieldID, isVisible }) => ({ resourceFieldID, isVisible })),
+          fields.map(({ resourceFieldId, isVisible }) => ({ resourceFieldId, isVisible })),
         );
       }
     },

--- a/packages/common/src/components/StandardPage/userSettings.ts
+++ b/packages/common/src/components/StandardPage/userSettings.ts
@@ -23,9 +23,9 @@ const saveRestOrRemoveKey = (key: string, { rest }: { [k: string]: { [n: string]
   }
 };
 
-const toField = ({ resourceFieldID, isVisible }) => ({ resourceFieldID, isVisible });
+const toField = ({ resourceFieldId, isVisible }) => ({ resourceFieldId, isVisible });
 
-const sanitizeFields = (fields: unknown): { resourceFieldID: string; isVisible?: boolean }[] =>
+const sanitizeFields = (fields: unknown): { resourceFieldId: string; isVisible?: boolean }[] =>
   Array.isArray(fields)
     ? fields
         // array should contain objects
@@ -33,7 +33,7 @@ const sanitizeFields = (fields: unknown): { resourceFieldID: string; isVisible?:
         // cherry-pick desired props
         .map(toField)
         // verify that ID is string
-        .filter(({ resourceFieldID }) => resourceFieldID && typeof resourceFieldID === 'string')
+        .filter(({ resourceFieldId }) => resourceFieldId && typeof resourceFieldId === 'string')
     : [];
 
 /**

--- a/packages/common/src/components/TableView/DefaultHeader.tsx
+++ b/packages/common/src/components/TableView/DefaultHeader.tsx
@@ -12,9 +12,9 @@ export const DefaultHeader = ({
 }: TableViewHeaderProps) => {
   return (
     <>
-      {visibleColumns.map(({ resourceFieldID, label, sortable }, columnIndex) => (
+      {visibleColumns.map(({ resourceFieldId, label, sortable }, columnIndex) => (
         <Th
-          key={resourceFieldID}
+          key={resourceFieldId}
           sort={
             sortable &&
             buildSort({

--- a/packages/common/src/components/TableView/ManageColumnsToolbar.tsx
+++ b/packages/common/src/components/TableView/ManageColumnsToolbar.tsx
@@ -102,7 +102,7 @@ const ManageColumns = ({
       return false;
     }
     const base = editedColumns.filter(
-      ({ resourceFieldID: id }) => id !== draggedItem?.resourceFieldID,
+      ({ resourceFieldId: id }) => id !== draggedItem?.resourceFieldId,
     );
     setEditedColumns([
       ...base.slice(0, dest.index),
@@ -113,10 +113,10 @@ const ManageColumns = ({
   };
   const onSelect = (updatedId: string, updatedValue: boolean): void => {
     setEditedColumns(
-      editedColumns.map(({ resourceFieldID, isVisible, ...rest }) => ({
-        resourceFieldID,
+      editedColumns.map(({ resourceFieldId, isVisible, ...rest }) => ({
+        resourceFieldId,
         ...rest,
-        isVisible: resourceFieldID === updatedId ? updatedValue : isVisible,
+        isVisible: resourceFieldId === updatedId ? updatedValue : isVisible,
       })),
     );
   };
@@ -161,7 +161,7 @@ const ManageColumns = ({
             id="table-column-management"
             isCompact
           >
-            {editedColumns.map(({ resourceFieldID: id, isVisible, isIdentity, label }) => (
+            {editedColumns.map(({ resourceFieldId: id, isVisible, isIdentity, label }) => (
               <Draggable key={id} hasNoWrapper>
                 <DataListItem aria-labelledby={`draggable-${id}`} ref={React.createRef()}>
                   <DataListItemRow>
@@ -176,7 +176,7 @@ const ManageColumns = ({
                         checked={
                           // visibility for identity resourceFields (namespace) is governed by parent component
                           isIdentity
-                            ? resourceFields.find((c) => c.resourceFieldID === id)?.isVisible
+                            ? resourceFields.find((c) => c.resourceFieldId === id)?.isVisible
                             : isVisible
                         }
                         isDisabled={isIdentity}

--- a/packages/common/src/components/TableView/TableView.tsx
+++ b/packages/common/src/components/TableView/TableView.tsx
@@ -29,7 +29,7 @@ export function TableView<T>({
   Header,
 }: TableViewProps<T>) {
   const hasChildren = children.filter(Boolean).length > 0;
-  const columnSignature = visibleColumns.map(({ resourceFieldID: id }) => id).join();
+  const columnSignature = visibleColumns.map(({ resourceFieldId: id }) => id).join();
   return (
     <TableComposable aria-label={ariaLabel} variant="compact" isStickyHeader>
       <Thead>

--- a/packages/common/src/components/TableView/__tests__/sort.test.ts
+++ b/packages/common/src/components/TableView/__tests__/sort.test.ts
@@ -17,7 +17,7 @@ describe('compareWith compareFn factory', () => {
   it('works without custom compareFn', () => {
     expect(
       compareWith(
-        { resourceFieldID: NAME, isAsc: true, label: NAME },
+        { resourceFieldId: NAME, isAsc: true, label: NAME },
         'en',
         undefined,
       )({ name: 'name_a' }, { name: 'name_b' }),
@@ -27,7 +27,7 @@ describe('compareWith compareFn factory', () => {
   it('works for nullish entities', () => {
     expect(
       compareWith(
-        { resourceFieldID: NAME, isAsc: true, label: NAME },
+        { resourceFieldId: NAME, isAsc: true, label: NAME },
         'en',
         undefined,
       )(null, undefined),
@@ -37,7 +37,7 @@ describe('compareWith compareFn factory', () => {
   it('treats all values equal if sortType is not defined', () => {
     expect(
       compareWith(
-        { resourceFieldID: undefined, isAsc: false, label: undefined },
+        { resourceFieldId: undefined, isAsc: false, label: undefined },
         'en',
         undefined,
       )('a', 'b'),
@@ -47,7 +47,7 @@ describe('compareWith compareFn factory', () => {
   it('reverts sorting order based on sortType.isAsc', () => {
     expect(
       compareWith(
-        { resourceFieldID: NAME, isAsc: false, label: NAME },
+        { resourceFieldId: NAME, isAsc: false, label: NAME },
         'en',
         undefined,
       )({ name: 'name_a' }, { name: 'name_b' }),
@@ -57,7 +57,7 @@ describe('compareWith compareFn factory', () => {
   it('uses custom field compareFn if provided', () => {
     expect(
       compareWith(
-        { resourceFieldID: NAME, isAsc: true, label: NAME },
+        { resourceFieldId: NAME, isAsc: true, label: NAME },
         'en',
         (a, b) => a.localeCompare(b), // no numeric
       )({ name: 'a10' }, { name: 'a5' }),
@@ -66,15 +66,15 @@ describe('compareWith compareFn factory', () => {
 });
 
 describe('buildSort factory', () => {
-  const NameColumn = { resourceFieldID: NAME, label: NAME };
-  const NamespaceColumn = { resourceFieldID: NAMESPACE, label: NAMESPACE };
+  const NameColumn = { resourceFieldId: NAME, label: NAME };
+  const NamespaceColumn = { resourceFieldId: NAMESPACE, label: NAMESPACE };
   it('sorts ascending', () => {
     const setActiveSort = jest.fn();
     const { sortBy, onSort, columnIndex } = buildSort({
       columnIndex: 0,
       resourceFields: [NameColumn, NamespaceColumn],
       activeSort: {
-        resourceFieldID: NAME,
+        resourceFieldId: NAME,
         isAsc: true,
         label: NAME,
       },
@@ -85,7 +85,7 @@ describe('buildSort factory', () => {
     onSort(undefined, 1, SortByDirection.asc, undefined);
     expect(setActiveSort).toBeCalledWith({
       isAsc: true,
-      resourceFieldID: NAMESPACE,
+      resourceFieldId: NAMESPACE,
       label: NamespaceColumn.label,
     });
   });
@@ -96,7 +96,7 @@ describe('buildSort factory', () => {
       columnIndex: 1,
       resourceFields: [NameColumn, NamespaceColumn],
       activeSort: {
-        resourceFieldID: NAME,
+        resourceFieldId: NAME,
         isAsc: false,
         label: NAME,
       },
@@ -107,7 +107,7 @@ describe('buildSort factory', () => {
     onSort(undefined, 1, SortByDirection.desc, undefined);
     expect(setActiveSort).toBeCalledWith({
       isAsc: false,
-      resourceFieldID: NAMESPACE,
+      resourceFieldId: NAMESPACE,
       label: NamespaceColumn.label,
     });
   });
@@ -118,7 +118,7 @@ describe('buildSort factory', () => {
       columnIndex: 1,
       resourceFields: [NameColumn, NamespaceColumn],
       activeSort: {
-        resourceFieldID: undefined,
+        resourceFieldId: undefined,
         isAsc: undefined,
         label: undefined,
       },
@@ -133,7 +133,7 @@ describe('buildSort factory', () => {
       columnIndex: 1,
       resourceFields: [NameColumn, NamespaceColumn],
       activeSort: {
-        resourceFieldID: NAME,
+        resourceFieldId: NAME,
         isAsc: false,
         label: NAME,
       },

--- a/packages/common/src/components/TableView/__tests__/useSort.test.tsx
+++ b/packages/common/src/components/TableView/__tests__/useSort.test.tsx
@@ -7,16 +7,16 @@ import { useSort } from '../sort';
 afterEach(cleanup);
 
 describe('useSort hook', () => {
-  const NameColumn = { resourceFieldID: NAME, label: NAME, isIdentity: true };
+  const NameColumn = { resourceFieldId: NAME, label: NAME, isIdentity: true };
   it('uses first identity column as default sort', () => {
     const {
       result: {
         current: [activeSort],
       },
-    } = renderHook(() => useSort([{ resourceFieldID: 'Foo', label: '' }, NameColumn]));
+    } = renderHook(() => useSort([{ resourceFieldId: 'Foo', label: '' }, NameColumn]));
 
     expect(activeSort).toMatchObject({
-      resourceFieldID: NAME,
+      resourceFieldId: NAME,
       label: NameColumn.label,
       isAsc: false,
     });
@@ -27,10 +27,10 @@ describe('useSort hook', () => {
       result: {
         current: [activeSort],
       },
-    } = renderHook(() => useSort([{ resourceFieldID: 'Foo', label: undefined }]));
+    } = renderHook(() => useSort([{ resourceFieldId: 'Foo', label: undefined }]));
 
     expect(activeSort).toMatchObject({
-      resourceFieldID: 'Foo',
+      resourceFieldId: 'Foo',
       label: undefined,
       isAsc: false,
     });
@@ -44,7 +44,7 @@ describe('useSort hook', () => {
     } = renderHook(() => useSort([]));
 
     expect(activeSort).toMatchObject({
-      resourceFieldID: undefined,
+      resourceFieldId: undefined,
       label: undefined,
       isAsc: false,
     });

--- a/packages/common/src/components/TableView/sort.ts
+++ b/packages/common/src/components/TableView/sort.ts
@@ -32,13 +32,13 @@ export function compareWith(
   fieldComparator: (a, b, locale: string) => number,
 ): (a, b) => number {
   return (a, b) => {
-    if (!currentSort?.resourceFieldID) {
+    if (!currentSort?.resourceFieldId) {
       return 0;
     }
     const compareFn = fieldComparator ?? universalComparator;
     const compareValue = compareFn(
-      a?.[currentSort.resourceFieldID],
-      b?.[currentSort.resourceFieldID],
+      a?.[currentSort.resourceFieldId],
+      b?.[currentSort.resourceFieldId],
       locale ?? 'en',
     );
     return currentSort.isAsc ? compareValue : -compareValue;
@@ -65,7 +65,7 @@ export const useSort = (
 
   const [activeSort, setActiveSort] = useState<SortType>({
     isAsc: false,
-    resourceFieldID: firstField?.resourceFieldID,
+    resourceFieldId: firstField?.resourceFieldId,
     label: firstField?.label,
   });
 
@@ -74,7 +74,7 @@ export const useSort = (
       compareWith(
         activeSort,
         i18n.resolvedLanguage,
-        fields.find((field) => field.resourceFieldID === activeSort.resourceFieldID)?.compareFn,
+        fields.find((field) => field.resourceFieldId === activeSort.resourceFieldId)?.compareFn,
       ),
     [fields, activeSort],
   );
@@ -100,15 +100,15 @@ export const buildSort = ({
   sortBy: {
     index:
       resourceFields.find(
-        ({ resourceFieldID }) => resourceFieldID === activeSort.resourceFieldID,
+        ({ resourceFieldId }) => resourceFieldId === activeSort.resourceFieldId,
       ) &&
       resourceFields.findIndex(
-        ({ resourceFieldID }) => resourceFieldID === activeSort.resourceFieldID,
+        ({ resourceFieldId }) => resourceFieldId === activeSort.resourceFieldId,
       ),
     direction: activeSort.isAsc ? 'asc' : 'desc',
   },
   onSort: (_event, index, direction) => {
-    resourceFields[index]?.resourceFieldID &&
+    resourceFields[index]?.resourceFieldId &&
       setActiveSort({
         isAsc: direction === 'asc',
         ...resourceFields[index],

--- a/packages/common/src/components/types.ts
+++ b/packages/common/src/components/types.ts
@@ -1,16 +1,16 @@
 import { FilterDef } from './Filter/types';
 
-type OpenAPIjsonPath = string | ((resourceData: unknown) => unknown);
+type OpenApiJsonPath = string | ((resourceData: unknown) => unknown);
 
 export interface SortType {
   isAsc: boolean;
-  resourceFieldID: string;
+  resourceFieldId: string;
   label: string;
 }
 
 export interface ResourceField {
-  resourceFieldID: string;
-  jsonPath?: OpenAPIjsonPath;
+  resourceFieldId: string;
+  jsonPath?: OpenApiJsonPath;
   label: string;
   // visiblity status, can change in time
   isVisible?: boolean;

--- a/packages/common/src/polyfills/console-dynamic-plugin-sdk/extensions/console-types.ts
+++ b/packages/common/src/polyfills/console-dynamic-plugin-sdk/extensions/console-types.ts
@@ -317,7 +317,7 @@ export type TableColumn<D> = ICell & {
 
 export type RowProps<D, R extends any = {}> = {
   obj: D;
-  resourceData: R;
+  rowData: R;
   activeColumnIDs: Set<string>;
 };
 
@@ -326,7 +326,7 @@ type VirtualizedTableProps<D, R extends any = {}> = {
   unfilteredData: D[];
   loaded: boolean;
   loadError: any;
-  resourceFields: TableColumn<D>[];
+  columns: TableColumn<D>[];
   Row: React.ComponentType<RowProps<D, R>>;
   NoDataEmptyMsg?: React.ComponentType<{}>;
   EmptyMsg?: React.ComponentType<{}>;
@@ -335,7 +335,7 @@ type VirtualizedTableProps<D, R extends any = {}> = {
   label?: string;
   'aria-label'?: string;
   gridBreakPoint?: TableGridBreakpoint;
-  resourceData?: R;
+  rowData?: R;
 };
 
 export type VirtualizedTableFC = <D, R extends any = {}>(
@@ -349,11 +349,11 @@ export type TableDataProps = {
 };
 
 export type UseActiveColumns = <D = any>({
-  resourceFields,
+  columns,
   showNamespaceOverride,
   columnManagementID,
 }: {
-  resourceFields: TableColumn<D>[];
+  columns: TableColumn<D>[];
   showNamespaceOverride: boolean;
   columnManagementID: string;
 }) => [TableColumn<D>[], boolean];
@@ -419,7 +419,7 @@ export type RowFilter<R = any> = RowMatchFilter<R> | RowReducerFilter<R>;
 
 export type ColumnLayout = {
   id: string;
-  resourceFields: ManagedColumn[];
+  columns: ManagedColumn[];
   selectedColumns: Set<string>;
   showNamespaceOverride?: boolean;
   type: string;

--- a/packages/forklift-console-plugin/src/components/mappings/MappingPage.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/MappingPage.tsx
@@ -65,13 +65,13 @@ const byName = {
 
 export const commonFieldsMetadata: ResourceField[] = [
   {
-    resourceFieldID: C.NAME,
+    resourceFieldId: C.NAME,
     label: 'Name',
     ...byName,
     isIdentity: true,
   },
   {
-    resourceFieldID: C.NAMESPACE,
+    resourceFieldId: C.NAMESPACE,
     label: 'Namespace',
     isVisible: true,
     isIdentity: true,
@@ -82,18 +82,18 @@ export const commonFieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.SOURCE,
+    resourceFieldId: C.SOURCE,
     label: 'Source provider',
     ...byName,
   },
   {
-    resourceFieldID: C.TARGET,
+    resourceFieldId: C.TARGET,
     label: 'Target provider',
     ...byName,
   },
 
   {
-    resourceFieldID: C.FROM,
+    resourceFieldId: C.FROM,
     label: 'From',
     isVisible: true,
     sortable: false,

--- a/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
@@ -113,21 +113,21 @@ function MappingRow<T extends CommonMapping>({
             onToggle: toggleExpand,
           }}
         />
-        {resourceFields.map(({ resourceFieldID, label }) => {
-          const Cell = cellCreator[resourceFieldID] ?? TextCell;
+        {resourceFields.map(({ resourceFieldId, label }) => {
+          const Cell = cellCreator[resourceFieldId] ?? TextCell;
           return (
             <Td
-              key={resourceFieldID}
+              key={resourceFieldId}
               dataLabel={label}
               compoundExpand={
-                resourceFieldID === C.FROM || resourceFieldID === C.TO
+                resourceFieldId === C.FROM || resourceFieldId === C.TO
                   ? { isExpanded: isRowExpanded, onToggle: toggleExpand }
                   : undefined
               }
             >
               <Cell
                 value={String(
-                  getResourceFieldValue(resourceData, resourceFieldID, resourceFields) ?? '',
+                  getResourceFieldValue(resourceData, resourceFieldId, resourceFields) ?? '',
                 )}
                 resourceData={resourceData}
                 t={t}

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
@@ -24,7 +24,7 @@ import NetworkMappingRow from './NetworkMappingRow';
 export const fieldsMetadata: ResourceField[] = [
   ...commonFieldsMetadata,
   {
-    resourceFieldID: C.TO,
+    resourceFieldId: C.TO,
     label: 'To',
     isVisible: true,
     filter: {
@@ -34,7 +34,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: false,
   },
   {
-    resourceFieldID: C.ACTIONS,
+    resourceFieldId: C.ACTIONS,
     label: '',
     isAction: true,
     isVisible: true,

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -186,9 +186,9 @@ const PlanRow = ({ resourceFields, resourceData, currentNamespace }: RowProps<Fl
   const primaryAction = getButtonState(resourceData.status);
   return (
     <Tr>
-      {resourceFields.map(({ resourceFieldID, label }) => {
-        const Cell = cellCreator[resourceFieldID] ?? TextCell;
-        return resourceFieldID === C.DESCRIPTION ? (
+      {resourceFields.map(({ resourceFieldId, label }) => {
+        const Cell = cellCreator[resourceFieldId] ?? TextCell;
+        return resourceFieldId === C.DESCRIPTION ? (
           [
             <Td key={`${C.DESCRIPTION}_large`} visibility={['hidden', 'visibleOnMd']} width={20}>
               <Truncate content={resourceData.description ?? ''} />
@@ -198,10 +198,10 @@ const PlanRow = ({ resourceFields, resourceData, currentNamespace }: RowProps<Fl
             </Td>,
           ]
         ) : (
-          <Td key={resourceFieldID} dataLabel={label}>
+          <Td key={resourceFieldId} dataLabel={label}>
             <Cell
               value={String(
-                getResourceFieldValue(resourceData, resourceFieldID, resourceFields) ?? '',
+                getResourceFieldValue(resourceData, resourceFieldId, resourceFields) ?? '',
               )}
               resourceData={resourceData}
               primaryAction={primaryAction}

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -19,7 +19,7 @@ import PlanRow from './PlanRow';
 
 export const fieldsMetadata: ResourceField[] = [
   {
-    resourceFieldID: C.NAME,
+    resourceFieldId: C.NAME,
     label: 'Name',
     isVisible: true,
     isIdentity: true,
@@ -30,7 +30,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.NAMESPACE,
+    resourceFieldId: C.NAMESPACE,
     label: 'Namespace',
     isVisible: true,
     isIdentity: true,
@@ -41,7 +41,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.SOURCE,
+    resourceFieldId: C.SOURCE,
     label: 'Source provider',
     isVisible: true,
     filter: {
@@ -51,7 +51,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.TARGET,
+    resourceFieldId: C.TARGET,
     label: 'Target provider',
     isVisible: true,
     filter: {
@@ -61,13 +61,13 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.VM_COUNT,
+    resourceFieldId: C.VM_COUNT,
     label: 'VMs',
     isVisible: true,
     sortable: true,
   },
   {
-    resourceFieldID: C.STATUS,
+    resourceFieldId: C.STATUS,
     label: 'Status',
     isVisible: true,
     filter: {
@@ -80,19 +80,19 @@ export const fieldsMetadata: ResourceField[] = [
   },
 
   {
-    resourceFieldID: C.DESCRIPTION,
+    resourceFieldId: C.DESCRIPTION,
     label: 'Description',
     isVisible: true,
   },
   {
-    resourceFieldID: C.ACTIONS,
+    resourceFieldId: C.ACTIONS,
     label: '',
     isAction: true,
     isVisible: true,
     sortable: false,
   },
   {
-    resourceFieldID: C.ARCHIVED,
+    resourceFieldId: C.ARCHIVED,
     label: 'Archived',
     isHidden: true,
     filter: {

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
@@ -191,17 +191,17 @@ const ProviderRow = ({
   const { t } = useTranslation();
   return (
     <Tr>
-      {resourceFields.map(({ resourceFieldID, label }) => (
-        <Td key={resourceFieldID} dataLabel={label}>
-          {cellCreator?.[resourceFieldID]?.({
-            value: getResourceFieldValue(resourceData, resourceFieldID, resourceFields),
+      {resourceFields.map(({ resourceFieldId, label }) => (
+        <Td key={resourceFieldId} dataLabel={label}>
+          {cellCreator?.[resourceFieldId]?.({
+            value: getResourceFieldValue(resourceData, resourceFieldId, resourceFields),
             resourceData,
             t,
             currentNamespace,
           }) ?? (
             <TextCell
               value={String(
-                getResourceFieldValue(resourceData, resourceFieldID, resourceFields) ?? '',
+                getResourceFieldValue(resourceData, resourceFieldId, resourceFields) ?? '',
               )}
             />
           )}

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -24,7 +24,7 @@ import ProviderRow from './ProviderRow';
 
 export const fieldsMetadata: ResourceField[] = [
   {
-    resourceFieldID: C.NAME,
+    resourceFieldId: C.NAME,
     label: 'Name',
     isVisible: true,
     isIdentity: true, // Name is sufficient ID when Namespace is pre-selected
@@ -35,7 +35,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.NAMESPACE,
+    resourceFieldId: C.NAMESPACE,
     label: 'Namespace',
     isVisible: true,
     isIdentity: true,
@@ -46,7 +46,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.PHASE,
+    resourceFieldId: C.PHASE,
     label: 'Status',
     isVisible: true,
     filter: {
@@ -58,7 +58,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.URL,
+    resourceFieldId: C.URL,
     label: 'Endpoint',
     isVisible: true,
     filter: {
@@ -68,7 +68,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.TYPE,
+    resourceFieldId: C.TYPE,
     label: 'Type',
     isVisible: true,
     filter: {
@@ -88,37 +88,37 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: true,
   },
   {
-    resourceFieldID: C.VM_COUNT,
+    resourceFieldId: C.VM_COUNT,
     label: 'VMs',
     isVisible: true,
     sortable: true,
   },
   {
-    resourceFieldID: C.NETWORK_COUNT,
+    resourceFieldId: C.NETWORK_COUNT,
     label: 'Networks',
     isVisible: true,
     sortable: true,
   },
   {
-    resourceFieldID: C.CLUSTER_COUNT,
+    resourceFieldId: C.CLUSTER_COUNT,
     label: 'Clusters',
     isVisible: false,
     sortable: true,
   },
   {
-    resourceFieldID: C.HOST_COUNT,
+    resourceFieldId: C.HOST_COUNT,
     label: 'Hosts',
     isVisible: true,
     sortable: true,
   },
   {
-    resourceFieldID: C.STORAGE_COUNT,
+    resourceFieldId: C.STORAGE_COUNT,
     label: 'Storage',
     isVisible: false,
     sortable: true,
   },
   {
-    resourceFieldID: C.ACTIONS,
+    resourceFieldId: C.ACTIONS,
     label: '',
     isAction: true,
     isVisible: true,

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
@@ -24,7 +24,7 @@ import StorageMappingRow from './StorageMappingRow';
 export const fieldsMetadata: ResourceField[] = [
   ...commonFieldsMetadata,
   {
-    resourceFieldID: C.TO,
+    resourceFieldId: C.TO,
     label: 'To',
     isVisible: true,
     filter: {
@@ -34,7 +34,7 @@ export const fieldsMetadata: ResourceField[] = [
     sortable: false,
   },
   {
-    resourceFieldID: C.ACTIONS,
+    resourceFieldId: C.ACTIONS,
     label: '',
     isVisible: true,
     isAction: true,


### PR DESCRIPTION
Fixes reviews from #279  add-jsonpath-support-i

  - [x] https://github.com/kubev2v/forklift-console-plugin/pull/279#discussion_r1132510098 - missing interface in filter
  - [x] https://github.com/kubev2v/forklift-console-plugin/pull/279#discussion_r1132521404 - `lable` to `fieldLabl`
  - [x] https://github.com/kubev2v/forklift-console-plugin/pull/279#discussion_r1132558259 - revert polyfill changes
  - [x]  https://github.com/kubev2v/forklift-console-plugin/pull/279#discussion_r1132565720 - adopting lower case for abbreviations in variable names ( didn't find documentation supporting either convention , updating as suggested )
 