### PR TITLE
Check at runtime if data to be filtered is an array

### DIFF
--- a/packages/legacy/src/queries/vms.ts
+++ b/packages/legacy/src/queries/vms.ts
@@ -21,7 +21,9 @@ const findVMsInRecord = (record: SourceVMsRecord, keys: string[]) =>
   keys.flatMap((key) => (record[key] ? [record[key]] : []));
 
 export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
-  const sortedVMs = sortByName(vms.filter((vm) => !(vm as IVMwareVM).isTemplate));
+  const sortedVMs = sortByName(
+    (Array.isArray(vms) ? vms : []).filter((vm) => !(vm as IVMwareVM).isTemplate)
+  );
   const vmsById: SourceVMsRecord = {};
   const vmsByName: SourceVMsRecord = {};
   const vmsBySelfLink: SourceVMsRecord = {};


### PR DESCRIPTION
### Recreated with code
```
diff --git a/packages/legacy/src/queries/vms.ts b/packages/legacy/src/queries/vms.ts
index 0198788..c8777c8 100644
--- a/packages/legacy/src/queries/vms.ts
+++ b/packages/legacy/src/queries/vms.ts
@@ -52,7 +52,10 @@ export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
 export const useSourceVMsQuery = (
   provider: SourceInventoryProvider | null
 ): UseQueryResult<IndexedSourceVMs> => {
-  const indexVmsCallback = React.useCallback((data) => indexVMs(data), []);
+  const indexVmsCallback = React.useCallback(
+    (data) => indexVMs('foo' as unknown as SourceVM[]),
+    []
+  );
   let mockVMs: SourceVM[] = [];
   if (provider?.type === 'vsphere') mockVMs = MOCK_VMWARE_VMS;
   if (provider?.type === 'ovirt') mockVMs = MOCK_RHV_VMS;
```

### Before

![Screenshot from 2023-03-10 18-34-42](https://user-images.githubusercontent.com/64194103/224394482-a5161a0d-6fb5-4052-bfea-45f0f69b08fa.png)

### After

![Screenshot from 2023-03-10 18-39-04](https://user-images.githubusercontent.com/64194103/224394590-1d7c2026-bf84-4978-894c-e04f1ee50650.png)
