### PR TITLE
Move the Plans "Get logs" action from the primary action area to the kebab action list

### DIFF
--- a/packages/common/src/polyfills/sdk-shim/index.ts
+++ b/packages/common/src/polyfills/sdk-shim/index.ts
@@ -1,3 +1,8 @@
 export { withModalProvider } from './withModalProvider';
-export { ActionService, useModal } from '../console-dynamic-plugin-sdk'
+export {
+  Action,
+  ActionService,
+  ActionServiceProviderProps,
+  useModal
+} from '../console-dynamic-plugin-sdk'
 export { ActionServiceProvider } from '../console-shared/components/actions'

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -6,7 +6,6 @@ import { PLAN_TYPE } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 
 import { RowProps } from '@kubev2v/common/components/TableView';
-import { MustGatherBtn } from '@kubev2v/legacy/common/components/MustGatherBtn';
 import { StatusCondition } from '@kubev2v/legacy/common/components/StatusCondition';
 import { PATH_PREFIX } from '@kubev2v/legacy/common/constants';
 import {
@@ -102,13 +101,6 @@ const Actions = ({ primaryAction, resourceData, currentNamespace }: CellProps) =
     >
       {primaryAction && (
         <FlexItem align={{ default: 'alignRight' }}>
-          {primaryAction === 'MustGather' && (
-            <MustGatherBtn
-              type="plan"
-              isCompleted={!!resourceData.migrationCompleted}
-              displayName={resourceData.name}
-            />
-          )}
           {primaryAction === 'ScheduledCutover' && (
             <ScheduledCutoverTime cutover={resourceData.latestMigration?.cutover} />
           )}
@@ -125,11 +117,9 @@ const Actions = ({ primaryAction, resourceData, currentNamespace }: CellProps) =
       {(primaryAction || !isBeingStarted) && (
         <FlexItem align={{ default: 'alignRight' }}>
           <PlanActions
-            {...{
-              resourceData: resourceData,
-              ignoreList: primaryAction ? [primaryAction] : [],
-              namespace: currentNamespace,
-            }}
+            resourceData={resourceData}
+            namespace={currentNamespace}
+            ignoreList={primaryAction && primaryAction !== 'MustGather' ? [primaryAction] : []}
           />
         </FlexItem>
       )}

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -9,7 +9,10 @@ import { RowProps } from '@kubev2v/common/components/TableView';
 import { MustGatherBtn } from '@kubev2v/legacy/common/components/MustGatherBtn';
 import { StatusCondition } from '@kubev2v/legacy/common/components/StatusCondition';
 import { PATH_PREFIX } from '@kubev2v/legacy/common/constants';
-import { getButtonState, getMigStatusState } from '@kubev2v/legacy/Plans/components/helpers';
+import {
+  getMigStatusState,
+  getPrimaryActionFromPlanState,
+} from '@kubev2v/legacy/Plans/components/helpers';
 import { MigrateOrCutoverButton } from '@kubev2v/legacy/Plans/components/MigrateOrCutoverButton';
 import { PlanNameNavLink as Link } from '@kubev2v/legacy/Plans/components/PlanStatusNavLink';
 import { ScheduledCutoverTime } from '@kubev2v/legacy/Plans/components/ScheduledCutoverTime';
@@ -183,7 +186,7 @@ const cellCreator: Record<string, (props: CellProps) => JSX.Element> = {
 };
 
 const PlanRow = ({ resourceFields, resourceData, currentNamespace }: RowProps<FlatPlan>) => {
-  const primaryAction = getButtonState(resourceData.status);
+  const primaryAction = getPrimaryActionFromPlanState(resourceData.status);
   return (
     <Tr>
       {resourceFields.map(({ resourceFieldId, label }) => {

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
@@ -602,18 +602,7 @@ exports[`Plan rows plantest-03 1`] = `
           >
             <div
               class="pf-m-align-right"
-            >
-              <button
-                aria-disabled="true"
-                class="pf-c-button pf-m-secondary pf-m-aria-disabled pf-m-progress"
-                data-ouia-component-id="OUIA-Generated-Button-secondary-1"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                Get logs
-              </button>
-            </div>
+            />
             <div
               class="pf-m-align-right"
             >
@@ -840,18 +829,7 @@ exports[`Plan rows plantest-04 1`] = `
           >
             <div
               class="pf-m-align-right"
-            >
-              <button
-                aria-disabled="true"
-                class="pf-c-button pf-m-secondary pf-m-aria-disabled pf-m-progress"
-                data-ouia-component-id="OUIA-Generated-Button-secondary-2"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                Get logs
-              </button>
-            </div>
+            />
             <div
               class="pf-m-align-right"
             >
@@ -1035,18 +1013,7 @@ exports[`Plan rows plantest-05 1`] = `
           >
             <div
               class="pf-m-align-right"
-            >
-              <button
-                aria-disabled="true"
-                class="pf-c-button pf-m-secondary pf-m-aria-disabled pf-m-progress"
-                data-ouia-component-id="OUIA-Generated-Button-secondary-3"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                Get logs
-              </button>
-            </div>
+            />
             <div
               class="pf-m-align-right"
             >
@@ -2055,18 +2022,7 @@ exports[`Plan rows plantest-10 1`] = `
           >
             <div
               class="pf-m-align-right"
-            >
-              <button
-                aria-disabled="true"
-                class="pf-c-button pf-m-secondary pf-m-aria-disabled pf-m-progress"
-                data-ouia-component-id="OUIA-Generated-Button-secondary-4"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                Get logs
-              </button>
-            </div>
+            />
             <div
               class="pf-m-align-right"
             >
@@ -2293,18 +2249,7 @@ exports[`Plan rows plantest-11 1`] = `
           >
             <div
               class="pf-m-align-right"
-            >
-              <button
-                aria-disabled="true"
-                class="pf-c-button pf-m-secondary pf-m-aria-disabled pf-m-progress"
-                data-ouia-component-id="OUIA-Generated-Button-secondary-5"
-                data-ouia-component-type="PF4/Button"
-                data-ouia-safe="true"
-                type="button"
-              >
-                Get logs
-              </button>
-            </div>
+            />
             <div
               class="pf-m-align-right"
             >

--- a/packages/legacy/src/Plans/components/PlansTable.tsx
+++ b/packages/legacy/src/Plans/components/PlansTable.tsx
@@ -55,7 +55,7 @@ import './PlansTable.css';
 import {
   getPlanStatusTitle,
   getPlanState,
-  getButtonState,
+  getPrimaryActionFromPlanState,
   getMigStatusState,
   canBeRestarted,
 } from './helpers';
@@ -226,7 +226,7 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
 
     const planState = getPlanState(plan, latestMigration, migrationsQuery.data?.items);
     const canRestart = canBeRestarted(planState);
-    const buttonType = getButtonState(planState);
+    const buttonType = getPrimaryActionFromPlanState(planState);
     const { title, variant } = getMigStatusState(planState, isWarmPlan);
 
     const { statusValue = 0, statusMessage = '' } = ratioVMs(plan);

--- a/packages/legacy/src/Plans/components/helpers.ts
+++ b/packages/legacy/src/Plans/components/helpers.ts
@@ -93,7 +93,7 @@ export const canBeRestarted = (planState: PlanState | null) => {
   );
 };
 
-export const getButtonState = (state: PlanState | null): PlanActionButtonType | null => {
+export const getPrimaryActionFromPlanState = (state: PlanState | null): PlanActionButtonType | null => {
   let type: PlanActionButtonType | null;
 
   switch (true) {


### PR DESCRIPTION
The "Download logs" and "Get logs" plan action has been moved from a primary action button to the kebab menu actions list.  The label used, its disabled status, tooltip text and action handlers are all the same as previous.

This solves points a and b in issue #122 

A few permutations of the current "Get logs" action:

![Screenshot from 2023-03-10 14-31-04](https://user-images.githubusercontent.com/3985964/224411020-b9001fcd-1a15-49dc-b59d-4668503e147b.png)

![Screenshot from 2023-03-10 14-32-24](https://user-images.githubusercontent.com/3985964/224411037-50a61a50-6747-4415-9ff5-042f77bd6b4c.png)

![Screenshot from 2023-03-10 14-32-55](https://user-images.githubusercontent.com/3985964/224411053-aecc7bde-8d1f-4215-b73e-a7bff156c407.png)

Summary of changes:
  - fixed not-disabled state tooltip rendering in ActionServiceDropdown
  - export additional types from the console shim layer so they can be used to make the code easier to reason about
  - renamed a helper button to be more descriptive
  - where it made sense, add explicit types and jsdoc to describe component structure, relationships and data flow