### PR TITLE
Add namespace to plan nav link

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -52,28 +52,48 @@ const StatusCell = ({
   const { title, variant } = getMigStatusState(status, isWarmPlan);
 
   if (status === 'Archiving') {
-    return <Link name={name}>{t('Archiving')}</Link>;
+    return (
+      <Link name={name} namespace={namespace}>
+        {t('Archiving')}
+      </Link>
+    );
   } else if (status === 'Archived') {
     return (
-      <Link name={name}>
+      <Link name={name} namespace={namespace}>
         <ArchiveIcon /> {t('Archived')}
       </Link>
     );
   } else if (isBeingStarted && !isWarmPlan) {
-    return <Link name={name}>{t('Running - preparing for migration')}</Link>;
+    return (
+      <Link name={name} namespace={namespace}>
+        {t('Running - preparing for migration')}
+      </Link>
+    );
   } else if (isBeingStarted && isWarmPlan) {
-    return <Link name={name}>{t('Running - preparing for incremental data copies')}</Link>;
+    return (
+      <Link name={name} namespace={namespace}>
+        {t('Running - preparing for incremental data copies')}
+      </Link>
+    );
   } else if (status === 'Unknown') {
     return <StatusIcon status="Warning" label="Unknown" />;
   } else if (status === 'NotStarted-Ready' || status === 'NotStarted-NotReady') {
     return <StatusCondition status={object.status} />;
   } else if (status === 'Copying' || status === 'Copying-CutoverScheduled') {
-    return <Link name={name}>{t('Running - performing incremental data copies')}</Link>;
+    return (
+      <Link name={name} namespace={namespace}>
+        {t('Running - performing incremental data copies')}
+      </Link>
+    );
   } else if (status === 'StartingCutover') {
-    return <Link name={name}>{t('Running - preparing for cutover')}</Link>;
+    return (
+      <Link name={name} namespace={namespace}>
+        {t('Running - preparing for cutover')}
+      </Link>
+    );
   } else {
     return (
-      <Link name={name} isInline={false}>
+      <Link name={name} namespace={namespace} isInline={false}>
         <Progress
           id={`progress_for_${name}_in_${namespace}`}
           title={title}

--- a/packages/legacy/src/Plans/components/PlanStatusNavLink.tsx
+++ b/packages/legacy/src/Plans/components/PlanStatusNavLink.tsx
@@ -12,10 +12,12 @@ interface IPlanStatusNavLinkProps {
 
 export const PlanNameNavLink = ({
   name,
+  namespace,
   isInline = true,
   children,
 }: {
   name: string;
+  namespace: string,
   isInline?: boolean;
   children: React.ReactNode;
 }) => {
@@ -23,7 +25,7 @@ export const PlanNameNavLink = ({
   return (
     <Button
       variant="link"
-      onClick={() => history.push(`${PATH_PREFIX}/plans/${name}`)}
+      onClick={() => history.push(`${PATH_PREFIX}/plans/ns/${namespace}/${name}`)}
       isInline={isInline}
       className={!isInline ? 'forklift-table__status-cell-progress' : ''}
     >
@@ -37,7 +39,7 @@ export const PlanStatusNavLink: React.FunctionComponent<IPlanStatusNavLinkProps>
   isInline = true,
   children,
 }) => (
-  <PlanNameNavLink name={plan.metadata.name} isInline={isInline}>
+  <PlanNameNavLink name={plan.metadata.name} namespace={plan.metadata.namespace} isInline={isInline}>
     {children}
   </PlanNameNavLink>
 );


### PR DESCRIPTION
Issue:
The link navigation item links to "all namespace" instead of the plans unique namespace.

Fix:
Add namespace to the navigation link

Screenshot:
Before, link to "http://localhost:9000/mtv/plans/plantest-11":
![Screenshot from 2023-03-12 12-39-36](https://user-images.githubusercontent.com/2181522/224539534-1bda8407-83de-4acc-b563-256f93cdba7e.png)

After, link to "http://localhost:9000/mtv/plans/ns/openshift-migration/plantest-11"
![Screenshot from 2023-03-12 12-38-54](https://user-images.githubusercontent.com/2181522/224539570-c857bcef-26c5-4001-8a44-7c949ef1dc3d.png)

