### PR TITLE
Require namespace for routed sub-pages

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -129,7 +129,6 @@ const Actions = ({ primaryAction, resourceData, currentNamespace }: CellProps) =
               plan={resourceData.object}
               buttonType={primaryAction}
               isBeingStarted={isBeingStarted}
-              currentNamespace={currentNamespace}
             />
           )}
         </FlexItem>
@@ -189,7 +188,7 @@ const cellCreator: Record<string, (props: CellProps) => JSX.Element> = {
   [C.STATUS]: StatusCell,
   [C.ACTIONS]: Actions,
   [C.VM_COUNT]: ({ value, resourceData }: CellProps) => (
-    <RouterLink to={`${PATH_PREFIX}/plans/${resourceData.name}`}>
+    <RouterLink to={`${PATH_PREFIX}/plans/ns/${resourceData.namespace}/${resourceData.name}`}>
       <VirtualMachineIcon /> {value}
     </RouterLink>
   ),

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/__snapshots__/PlanRow.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Plan rows plantest-01 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-01"
+            href="/mtv/plans/ns/openshift-migration/plantest-01"
           >
             <svg
               aria-hidden="true"
@@ -275,7 +275,7 @@ exports[`Plan rows plantest-02 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-02"
+            href="/mtv/plans/ns/openshift-migration/plantest-02"
           >
             <svg
               aria-hidden="true"
@@ -485,7 +485,7 @@ exports[`Plan rows plantest-03 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-03"
+            href="/mtv/plans/ns/openshift-migration/plantest-03"
           >
             <svg
               aria-hidden="true"
@@ -712,7 +712,7 @@ exports[`Plan rows plantest-04 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-04"
+            href="/mtv/plans/ns/openshift-migration/plantest-04"
           >
             <svg
               aria-hidden="true"
@@ -939,7 +939,7 @@ exports[`Plan rows plantest-05 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-05"
+            href="/mtv/plans/ns/openshift-migration/plantest-05"
           >
             <svg
               aria-hidden="true"
@@ -1123,7 +1123,7 @@ exports[`Plan rows plantest-06 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-06"
+            href="/mtv/plans/ns/openshift-migration/plantest-06"
           >
             <svg
               aria-hidden="true"
@@ -1333,7 +1333,7 @@ exports[`Plan rows plantest-07 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-07"
+            href="/mtv/plans/ns/openshift-migration/plantest-07"
           >
             <svg
               aria-hidden="true"
@@ -1515,7 +1515,7 @@ exports[`Plan rows plantest-08 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-08"
+            href="/mtv/plans/ns/openshift-migration/plantest-08"
           >
             <svg
               aria-hidden="true"
@@ -1698,7 +1698,7 @@ exports[`Plan rows plantest-09 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-09"
+            href="/mtv/plans/ns/openshift-migration/plantest-09"
           >
             <svg
               aria-hidden="true"
@@ -1905,7 +1905,7 @@ exports[`Plan rows plantest-10 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-10"
+            href="/mtv/plans/ns/openshift-migration/plantest-10"
           >
             <svg
               aria-hidden="true"
@@ -2132,7 +2132,7 @@ exports[`Plan rows plantest-11 1`] = `
           data-label="VMs"
         >
           <a
-            href="/mtv/plans/plantest-11"
+            href="/mtv/plans/ns/openshift-migration/plantest-11"
           >
             <svg
               aria-hidden="true"

--- a/packages/forklift-console-plugin/src/modules/Plans/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/dynamic-plugin.ts
@@ -50,7 +50,7 @@ export const extensions: EncodedExtension[] = [
       component: {
         $codeRef: 'PlanWizard',
       },
-      path: ['/mtv/plans/ns/:ns/create', '/mtv/plans/create'],
+      path: ['/mtv/plans/ns/:ns/create'],
       exact: false,
     },
   } as EncodedExtension<RoutePage>,
@@ -61,12 +61,7 @@ export const extensions: EncodedExtension[] = [
       component: {
         $codeRef: 'PlanWizard',
       },
-      path: [
-        '/mtv/plans/ns/:ns/:planName/edit',
-        '/mtv/plans/:planName/edit',
-        '/mtv/plans/ns/:ns/:planName/duplicate',
-        '/mtv/plans/:planName/duplicate',
-      ],
+      path: ['/mtv/plans/ns/:ns/:planName/edit', '/mtv/plans/ns/:ns/:planName/duplicate'],
       exact: false,
     },
   } as EncodedExtension<RoutePage>,
@@ -77,7 +72,7 @@ export const extensions: EncodedExtension[] = [
       component: {
         $codeRef: 'VMMigrationDetails',
       },
-      path: ['/mtv/plans/ns/:ns/:planName', '/mtv/plans/:planName'],
+      path: ['/mtv/plans/ns/:ns/:planName'],
       exact: false,
     },
   } as EncodedExtension<RoutePage>,

--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -62,12 +62,9 @@ export const useFlatPlanActions: ExtensionHook<
   {
     /** Resource the actions will act upon. */
     resourceData: FlatPlan;
-
-    /** The entity's namespace. */
-    namespace: string;
   }
-> = ({ resourceData: plan, namespace }) => {
-  const { migrationStarted, migrationCompleted, archived: isPlanArchived, name } = plan;
+> = ({ resourceData: plan }) => {
+  const { migrationStarted, migrationCompleted, archived: isPlanArchived, name, namespace } = plan;
   const isPlanStarted = !!migrationStarted;
   const { t } = useTranslation();
   const launchModal = useModal();
@@ -186,9 +183,7 @@ export const useFlatPlanActions: ExtensionHook<
     () => ({
       id: 'edit',
       cta: {
-        href: namespace
-          ? `${PATH_PREFIX}/plans/ns/${namespace}/${name}/edit`
-          : `${PATH_PREFIX}/plans/${name}/edit`,
+        href: `${PATH_PREFIX}/plans/ns/${namespace}/${name}/edit`,
       },
       label: t('Edit'),
       disabled: editingDisabled,
@@ -216,9 +211,7 @@ export const useFlatPlanActions: ExtensionHook<
     () => ({
       id: 'duplicate',
       cta: {
-        href: namespace
-          ? `${PATH_PREFIX}/plans/ns/${namespace}/${name}/duplicate`
-          : `${PATH_PREFIX}/plans/${name}/duplicate`,
+        href: `${PATH_PREFIX}/plans/ns/${namespace}/${name}/duplicate`,
       },
       label: t('Duplicate'),
       disabled: !areProvidersReady,

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
@@ -17,14 +17,8 @@ export const HostCell: React.FC<CellProps> = ({ resourceData, resourceFields }) 
 
   return (
     <>
-      {phase === 'Ready' && hostCount && type === 'vsphere' ? (
-        <Link
-          to={
-            namespace
-              ? `${PATH_PREFIX}/providers/vsphere/ns/${namespace}/${name}`
-              : `${PATH_PREFIX}/providers/vsphere/${name}`
-          }
-        >
+      {phase === 'Ready' && hostCount && type === 'vsphere' && name && namespace ? (
+        <Link to={`${PATH_PREFIX}/providers/vsphere/ns/${namespace}/${name}`}>
           <TextWithIcon icon={<OutlinedHddIcon />} label={hostCount} />
         </Link>
       ) : (

--- a/packages/forklift-console-plugin/src/modules/Providers/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/dynamic-plugin.ts
@@ -49,7 +49,7 @@ export const extensions: EncodedExtension[] = [
       component: {
         $codeRef: 'HostsPage',
       },
-      path: ['/mtv/providers/vsphere/ns/:ns/:providerName', '/mtv/providers/vsphere/:providerName'],
+      path: ['/mtv/providers/vsphere/ns/:ns/:providerName'],
       exact: false,
     },
   } as EncodedExtension<RoutePage>,

--- a/packages/legacy/src/Plans/components/CreatePlanButton.tsx
+++ b/packages/legacy/src/Plans/components/CreatePlanButton.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonProps } from '@patternfly/react-core';
 import { ConditionalTooltip } from 'legacy/src/common/components/ConditionalTooltip';
 import { useHasSufficientProvidersQuery } from 'legacy/src/queries';
 import { useHistory } from 'react-router-dom';
-import { PATH_PREFIX } from 'legacy/src/common/constants';
+import { ENV, PATH_PREFIX } from 'legacy/src/common/constants';
 
 interface ICreatePlanButtonProps {
   variant?: ButtonProps['variant'];
@@ -24,11 +24,7 @@ export const CreatePlanButton: React.FunctionComponent<ICreatePlanButtonProps> =
     >
       <Button
         onClick={() =>
-          history.push(
-            namespace
-              ? `${PATH_PREFIX}/plans/ns/${namespace}/create`
-              : `${PATH_PREFIX}/plans/create`
-          )
+          history.push(`${PATH_PREFIX}/plans/ns/${namespace || ENV.DEFAULT_NAMESPACE}/create`)
         }
         isAriaDisabled={!hasSufficientProviders}
         variant={variant}

--- a/packages/legacy/src/Plans/components/MigrateOrCutoverButton.tsx
+++ b/packages/legacy/src/Plans/components/MigrateOrCutoverButton.tsx
@@ -13,24 +13,18 @@ interface IMigrateOrCutoverButtonProps {
   plan: IPlan;
   buttonType: PlanActionButtonType;
   isBeingStarted: boolean;
-  currentNamespace?: string;
 }
 
 export const MigrateOrCutoverButton: React.FunctionComponent<IMigrateOrCutoverButtonProps> = ({
   plan,
   buttonType,
   isBeingStarted,
-  currentNamespace,
 }: IMigrateOrCutoverButtonProps) => {
   const history = useHistory();
   const [isConfirmModalOpen, toggleConfirmModal] = React.useReducer((isOpen) => !isOpen, false);
   const onMigrationStarted = () => {
     toggleConfirmModal();
-    history.push(
-      currentNamespace
-        ? `${PATH_PREFIX}/plans/ns/${currentNamespace}/${plan.metadata.name}`
-        : `${PATH_PREFIX}/plans/${plan.metadata.name}`
-    );
+    history.push(`${PATH_PREFIX}/plans/ns/${plan.metadata.namespace}/${plan.metadata.name}`);
   };
   const createMigrationMutation = useCreateMigrationMutation(
     plan.metadata.namespace,

--- a/packages/legacy/src/Plans/components/PlanActionsDropdown.tsx
+++ b/packages/legacy/src/Plans/components/PlanActionsDropdown.tsx
@@ -48,7 +48,7 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
   const history = useHistory();
   const onMigrationStarted = (migration: IMigration) => {
     toggleRestartModal();
-    history.push(`${PATH_PREFIX}/plans/${migration.spec.plan.name}`);
+    history.push(`${PATH_PREFIX}/plans/ns/${migration.spec.plan.namespace}/${migration.spec.plan.name}`);
   };
   const createMigrationMutation = useCreateMigrationMutation(namespace, onMigrationStarted);
   const setCutoverMutation = useSetCutoverMutation(namespace);
@@ -105,7 +105,7 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
               isDisabled={isPlanStarted || !areProvidersReady || isPlanArchived || isPlanGathering}
               onClick={() => {
                 setKebabIsOpen(false);
-                history.push(`${PATH_PREFIX}/plans/${plan.metadata.name}/edit`);
+                history.push(`${PATH_PREFIX}/plans/ns/${plan.metadata.namespace}/${plan.metadata.name}/edit`);
               }}
             >
               Edit
@@ -120,7 +120,7 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
               isDisabled={!areProvidersReady}
               onClick={() => {
                 setKebabIsOpen(false);
-                history.push(`${PATH_PREFIX}/plans/${plan.metadata.name}/duplicate`);
+                history.push(`${PATH_PREFIX}/plans/ns/${plan.metadata.namespace}/${plan.metadata.name}/duplicate`);
               }}
             >
               Duplicate

--- a/packages/legacy/src/Plans/components/PlansTable.tsx
+++ b/packages/legacy/src/Plans/components/PlansTable.tsx
@@ -246,7 +246,7 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
         {
           title: (
             <>
-              <Link to={`${PATH_PREFIX}/plans/${plan.metadata.name}`}>{plan.metadata.name}</Link>
+              <Link to={`${PATH_PREFIX}/plans/ns/${plan.metadata.namespace}/${plan.metadata.name}`}>{plan.metadata.name}</Link>
               <Flex>
                 <Text component="small">{plan.spec.description}</Text>
               </Flex>

--- a/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
+++ b/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
@@ -92,11 +92,10 @@ export type VMMigrationDetailsProps = {
 };
 
 export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps> = ({ match }) => {
-  const currentNamespace = match?.params?.ns;
-  const plansQuery = usePlansQuery(currentNamespace);
+  const resourceNamespace = match?.params?.ns;
+  const plansQuery = usePlansQuery(resourceNamespace);
   const plan = plansQuery.data?.items.find((item) => item.metadata.name === match?.params.planName);
   const planStarted = !!plan?.status?.migration?.started;
-  const effectiveNamespace = plan?.metadata?.namespace || currentNamespace;
 
   const providersQuery = useInventoryProvidersQuery();
   const { sourceProvider } = findProvidersByRefs(plan?.spec.provider || null, providersQuery);
@@ -107,7 +106,7 @@ export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps
     return nameFromInventory || vmStatus.name;
   };
 
-  const migrationsQuery = useMigrationsQuery(effectiveNamespace);
+  const migrationsQuery = useMigrationsQuery(resourceNamespace);
   const latestMigration = findLatestMigration(plan || null, migrationsQuery.data?.items || null);
   const planState = getPlanState(plan || null, latestMigration, migrationsQuery.data?.items);
   const isShowingPrecopyView =
@@ -235,7 +234,7 @@ export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps
 
   const [isCancelModalOpen, toggleCancelModal] = React.useReducer((isOpen) => !isOpen, false);
 
-  const cancelVMsMutation = useCancelVMsMutation(plan || null, effectiveNamespace, () => {
+  const cancelVMsMutation = useCancelVMsMutation(plan || null, resourceNamespace, () => {
     toggleCancelModal();
     setSelectedItems([]);
   });
@@ -355,7 +354,7 @@ export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps
       <PageSection variant="light">
         <Breadcrumb className={`${spacing.mbLg} ${spacing.prLg}`}>
           <BreadcrumbItem>
-            <ResourceLink kind={PLANS_REFERENCE} hideIcon displayName="Migration plans" />
+            <ResourceLink kind={PLANS_REFERENCE} namespace={resourceNamespace} hideIcon displayName="Migration plans" />
           </BreadcrumbItem>
           <BreadcrumbItem>{match?.params.planName}</BreadcrumbItem>
         </Breadcrumb>

--- a/packages/legacy/src/Providers/HostsPage.tsx
+++ b/packages/legacy/src/Providers/HostsPage.tsx
@@ -17,7 +17,7 @@ import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-i
 import { useHostsQuery, useInventoryProvidersQuery } from 'legacy/src/queries';
 import { IVMwareProvider } from 'legacy/src/queries/types';
 import { ResolvedQueries } from 'legacy/src/common/components/ResolvedQuery';
-import { PROVIDERS_REFERENCE, PROVIDER_TYPE_NAMES } from 'legacy/src/common/constants';
+import { ENV, PROVIDERS_REFERENCE, PROVIDER_TYPE_NAMES } from 'legacy/src/common/constants';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
 export interface IHostsMatchParams {
@@ -30,9 +30,12 @@ export const HostsPage: React.FunctionComponent<RouteComponentProps<IHostsMatchP
   match,
 }) => {
   const providersQuery = useInventoryProvidersQuery();
+  const providerNamespace = match?.params?.ns || ENV.DEFAULT_NAMESPACE;
+  const providerName = match?.params.providerName || '';
   const provider =
-    providersQuery.data?.vsphere.find((provider) => provider.name === match?.params.providerName) ||
-    null;
+    providersQuery.data?.vsphere.find(
+      (provider) => provider.name === providerName && provider.namespace === providerNamespace
+    ) || null;
 
   const hostsQuery = useHostsQuery(provider);
 
@@ -45,13 +48,13 @@ export const HostsPage: React.FunctionComponent<RouteComponentProps<IHostsMatchP
               <BreadcrumbItem>
                 <ResourceLink
                   kind={PROVIDERS_REFERENCE}
-                  namespace={match?.params?.ns}
+                  namespace={providerNamespace}
                   hideIcon
                   displayName="Providers"
                 />
               </BreadcrumbItem>
               <BreadcrumbItem>{PROVIDER_TYPE_NAMES.vsphere}</BreadcrumbItem>
-              <BreadcrumbItem>{match?.params.providerName}</BreadcrumbItem>
+              <BreadcrumbItem>{providerName}</BreadcrumbItem>
               <BreadcrumbItem isActive>Hosts</BreadcrumbItem>
             </Breadcrumb>
           </LevelItem>
@@ -68,7 +71,7 @@ export const HostsPage: React.FunctionComponent<RouteComponentProps<IHostsMatchP
           errorTitles={['Cannot load hosts', 'Cannot load providers']}
           errorsInline={false}
         >
-          {!match?.params?.providerName ? (
+          {!providerName ? (
             <Alert variant="danger" title="No matching host found" />
           ) : !hostsQuery.data ? null : hostsQuery?.data?.length === 0 ? (
             <EmptyState className={spacing.my_2xl}>

--- a/packages/legacy/src/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
+++ b/packages/legacy/src/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
@@ -165,7 +165,7 @@ export const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTable
             );
             return {
               title: hasCondition(provider.status?.conditions || [], 'Ready') ? (
-                <Link to={`${PATH_PREFIX}/providers/vsphere/${provider.metadata.name}`}>
+                <Link to={`${PATH_PREFIX}/providers/vsphere/ns/${provider.metadata.namespace}/${provider.metadata.name}`}>
                   {hostCountWithIcon}
                 </Link>
               ) : (


### PR DESCRIPTION
Fix problem with name collisions between resources from different
namespaces.

Before, the namespace provided via the URL referred to workspace
namespace (chosen by the user). This allowed to pass that value to
legacy code which is not aware of console global state (which namespace
is part of).
After the fix, the namespace always refers to the resource namespace.
If the namespace is unknown (create operation in All Namespaces view)
then the ENV.DEFAULT_NAMESPACE is used.

Side effect of this fix is that the previous workspace namespace is
no longer preserved. Example:
1. choose 'All Namespaces' on Plans list screen
2. enter create plan screen
3. cancel create action
4. the namespace on Plans list screen is now 'konveyor-forklift'
   (or other defined at compile time using ENV.DEFAULT_NAMESPACE)