### PR TITLE
Enable URL and token fields to be non mandatory for KuveVirt

### DIFF
--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -107,7 +107,9 @@ export const dnsLabelNameSchema = yup
 
 export const urlSchema = yup.string().test('is-valid-url', 'Must be a valid URL', (value) => {
   try {
-    new URL(value as string);
+    if (value) {
+      new URL(value as string);
+    }
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
Fixes: #272 

The following fields can now be non mandatory for KubeVirt, valid only if they are **both** left empty:

- URL

- Service account token

In such a case when they both fields are empty, the default cluster KubeVirt provider (same as used for the managed host one) is used.

### ScreenShots
![image](https://user-images.githubusercontent.com/18169498/224985053-832a883f-1477-4d0b-a247-dcd546ca3182.png)

![image](https://user-images.githubusercontent.com/18169498/224985150-17b96e05-1db0-4514-b23d-e4f5822d1a71.png)
![image](https://user-images.githubusercontent.com/18169498/224985305-b83e47c5-1d5c-4c3a-a578-d2307314eda8.png)
