### PR TITLE
Port Console's LoadingBox component

### DIFF
--- a/packages/common/src/components/LoadingDots.tsx
+++ b/packages/common/src/components/LoadingDots.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export interface LoadingDotsProps {
+  delayInMs?: number;
+}
+
+/**
+ *  Port of the LoadingBox component from the console.
+ *  Note that the component uses directly the CSS from the Console.
+ *
+ *  This components addresses following problems:
+ *  1. flickering due to different spinners used by the Console and by the plugin. Solved by using the same component.
+ *  2. loading state (which results in flickering) when user enters for the second time an extension page (although data is cached). Solved by using a delay.
+ *
+ * @see https://github.com/openshift/console/blob/52cf627de2e8e4164176fc49edbea9c8a5ed4c92/frontend/public/components/utils/status-box.tsx#L70
+ */
+export const LoadingDots = ({ delayInMs = 500 }: LoadingDotsProps) => {
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const [showDots, setShowDots] = useState(false);
+  useEffect(() => {
+    timerRef.current = setTimeout(() => setShowDots(true), delayInMs);
+    return () => clearTimeout(timerRef.current);
+  });
+
+  if (!showDots) {
+    return null;
+  }
+
+  return (
+    <div className="cos-status-box cos-status-box--loading loading-box loading-box__loading">
+      <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
+        <div className="co-m-loader-dot__one" />
+        <div className="co-m-loader-dot__two" />
+        <div className="co-m-loader-dot__three" />
+      </div>
+    </div>
+  );
+};

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
@@ -8,9 +8,9 @@ import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { FreetextFilter, ValueMatcher } from '@kubev2v/common/components/Filter';
+import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
 import withQueryClient from '@kubev2v/common/components/QueryClientHoc';
 import {
-  Loading,
   loadUserSettings,
   StandardPage,
   UserSettings,
@@ -82,7 +82,7 @@ const Page = ({
   const loadedDataIsEmpty = isLoadSuccess && !isLoadError && (data?.length ?? 0) === 0;
 
   if (isLoading) {
-    return <Loading />;
+    return <LoadingDots />;
   }
 
   if (loadedDataIsEmpty) {

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -5,8 +5,8 @@ import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { EnumToTuple } from '@kubev2v/common/components/Filter/helpers';
+import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
 import {
-  Loading,
   loadUserSettings,
   StandardPage,
   UserSettings,
@@ -141,7 +141,7 @@ const Page = ({
   const loadedDataIsEmpty = isLoadSuccess && !isLoadError && (data?.length ?? 0) === 0;
 
   if (isLoading) {
-    return <Loading />;
+    return <LoadingDots />;
   }
 
   if (loadedDataIsEmpty) {

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -5,8 +5,8 @@ import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { EnumToTuple } from '@kubev2v/common/components/Filter/helpers';
+import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
 import {
-  Loading,
   loadUserSettings,
   StandardPage,
   UserSettings,
@@ -166,7 +166,7 @@ const Page: React.FC<{
   const loadedDataIsEmpty = isLoadSuccess && !isLoadError && (data?.length ?? 0) === 0;
 
   if (isLoading) {
-    return <Loading />;
+    return <LoadingDots />;
   }
 
   if (loadedDataIsEmpty) {

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
@@ -9,8 +9,8 @@ import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { FreetextFilter, ValueMatcher } from '@kubev2v/common/components/Filter';
+import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
 import {
-  Loading,
   loadUserSettings,
   StandardPage,
   StandardPageProps,
@@ -74,7 +74,7 @@ const Page = ({
   const loadedDataIsEmpty = isLoadSuccess && !isLoadError && (data?.length ?? 0) === 0;
 
   if (isLoading) {
-    return <Loading />;
+    return <LoadingDots />;
   }
 
   if (loadedDataIsEmpty) {


### PR DESCRIPTION
 Port Console's LoadingBox component

Addresses following problems:
1. flickering due to different spinners used by the Console and
   by the plugin. Solved by using the same component.
2. loading state (which results in flickering) when the user enters
   for the second time an extension page (although data is cached).
   Solved by using a delay.

Note that the component uses the CSS directly  from the Console.

Reference-Url: https://github.com/openshift/console/blob/52cf627de2e8e4164176fc49edbea9c8a5ed4c92/frontend/public/components/utils/status-box.tsx#L70
Signed-off-by: Radoslaw Szwajkowski <rszwajko@redhat.com>
