### PR TITLE
Make inventory data optional on the Provider screen

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
@@ -33,24 +33,27 @@ const cellCreator: Record<string, React.FC<CellProps>> = {
   [C.ACTIONS]: ({ resourceData: resourceData }: CellProps) => (
     <ProviderActions resourceData={resourceData} />
   ),
-  [C.NETWORK_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) => (
-    <TextWithIcon
-      icon={<NetworkIcon />}
-      label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
-    />
-  ),
-  [C.STORAGE_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) => (
-    <TextWithIcon
-      icon={<DatabaseIcon />}
-      label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
-    />
-  ),
-  [C.VM_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) => (
-    <TextWithIcon
-      icon={<VirtualMachineIcon />}
-      label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
-    />
-  ),
+  [C.NETWORK_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) =>
+    !!resourceData.inventory?.name && (
+      <TextWithIcon
+        icon={<NetworkIcon />}
+        label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
+      />
+    ),
+  [C.STORAGE_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) =>
+    !!resourceData.inventory?.name && (
+      <TextWithIcon
+        icon={<DatabaseIcon />}
+        label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
+      />
+    ),
+  [C.VM_COUNT]: ({ resourceData, resourceFieldId, resourceFields }: CellProps) =>
+    !!resourceData.inventory?.name && (
+      <TextWithIcon
+        icon={<VirtualMachineIcon />}
+        label={getResourceFieldValue(resourceData, resourceFieldId, resourceFields)}
+      />
+    ),
   [C.HOST_COUNT]: HostCell,
 };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
@@ -15,6 +15,10 @@ export const HostCell: React.FC<CellProps> = ({ resourceData, resourceFields }) 
   const type = getResourceFieldValue(resourceData, C.TYPE, resourceFields);
   const hostCount = getResourceFieldValue(resourceData, C.HOST_COUNT, resourceFields);
 
+  if (!resourceData.inventory?.name) {
+    return null;
+  }
+
   return (
     <>
       {phase === 'Ready' && hostCount && type === 'vsphere' && name && namespace ? (

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -154,7 +154,7 @@ const ProvidersPage: React.FC<ResourceConsolePageProps> = ({ namespace }) => {
 ProvidersPage.displayName = 'ProvidersPage';
 
 const Page: React.FC<{
-  dataSource: [MergedProvider[], boolean, unknown, unknown, unknown];
+  dataSource: [MergedProvider[], boolean, unknown];
   namespace: string;
   title: string;
   userSettings: UserSettings;

--- a/packages/forklift-console-plugin/src/modules/Providers/data.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/data.ts
@@ -24,7 +24,7 @@ export type GetFlatDataFn = {
     inventory,
   }: {
     providers: V1beta1Provider[];
-    inventory: IProvidersByType;
+    inventory?: IProvidersByType;
   }): MergedProvider[];
 };
 export const getFlatData: GetFlatDataFn = ({ providers, inventory }) => {
@@ -73,25 +73,13 @@ export const useHasSufficientProviders = (namespace?: string) => {
   return hasSufficientProviders;
 };
 
-export const useProvidersWithInventory = ({
-  namespace,
-}): [MergedProvider[], boolean, unknown, unknown, unknown] => {
+export const useProvidersWithInventory = ({ namespace }): [MergedProvider[], boolean, unknown] => {
   const [providers, providersLoaded, providersError] = useProviders({
     namespace,
   });
-  const {
-    data: inventory,
-    isSuccess: inventoryLoaded,
-    isError: inventoryError,
-  } = useInventoryProvidersQuery();
+  const { data: inventory, isError } = useInventoryProvidersQuery();
 
-  const flatData = getFlatData({ providers, inventory });
+  const flatData = getFlatData({ providers, inventory: isError ? undefined : inventory });
 
-  return [
-    flatData,
-    providersLoaded && inventoryLoaded,
-    providersError || inventoryError,
-    { providers, providersLoaded, providersError },
-    { inventory, inventoryLoaded, inventoryError },
-  ];
+  return [flatData, providersLoaded, providersError];
 };


### PR DESCRIPTION
Inventory data adds extra information to the Provider resource. The screen is functional also without this information.

Changes:
1. display empty cells if inventory is not available - applies to individual providers missing but also to the whole service not available
2. skip inventory data  if the inventory query failed - in such case all providers will be displayed without inventory.