### PR TITLE
Provide JSON content type for must-gather payload

### DIFF
--- a/packages/legacy/src/queries/mustGather.ts
+++ b/packages/legacy/src/queries/mustGather.ts
@@ -16,7 +16,10 @@ export const useMustGatherMutation = (
   const result = useMockableMutation<IMustGatherResponse>(
     async (options) => {
       return new Promise((res, rej) => {
-        consoleFetchJSON(getMustGatherApiUrl(url), 'POST', { body: JSON.stringify(options) })
+        consoleFetchJSON(getMustGatherApiUrl(url), 'POST', {
+          body: JSON.stringify(options),
+          headers: { 'Content-Type': 'application/json' },
+        })
           .then((mustGatherData) => {
             res(mustGatherData.json());
           })


### PR DESCRIPTION
Bind function used by triggerGathering method chooses deserialization strategy based on the content type.

Reference-Url: https://github.com/kubev2v/forklift-must-gather-api/blob/c28f9b6a0bc64950903e7e2b8af4c907e868dda9/pkg/must-gather-api.go#L68