### PR TITLE
Plan Wizard, Create - Upgrade handling for ovirt/RHV source providers

### DIFF
--- a/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
+++ b/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
@@ -220,7 +220,8 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
                   <ProviderSelect
                     providerRole="source"
                     field={form.fields.sourceProvider}
-                    notReadyTooltipPosition="right"
+                    onProviderSelect={form.fields.sourceProvider.setValue}
+                    tooltipPosition="right"
                     menuAppendTo="parent"
                     maxHeight="40vh"
                     namespace={namespace}
@@ -230,6 +231,7 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
                   <ProviderSelect
                     providerRole="target"
                     field={form.fields.targetProvider}
+                    onProviderSelect={form.fields.targetProvider.setValue}
                     menuAppendTo="parent"
                     maxHeight="40vh"
                     namespace={namespace}
@@ -249,7 +251,7 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
                     sourceProviderType={form.values.sourceProvider?.type || 'vsphere'}
                     availableSources={mappingResourceQueries.availableSources}
                     availableTargets={mappingResourceQueries.availableTargets}
-                    builderItems={form.values.builderItems.length ? 
+                    builderItems={form.values.builderItems.length ?
                       form.values.builderItems : [{source: null, target: getDefaultTarget(mappingResourceQueries.availableTargets, mappingType)}]}
                     setBuilderItems={form.fields.builderItems.setValue}
                   />

--- a/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
@@ -385,7 +385,12 @@ export const PlanWizard: React.FunctionComponent<RouteComponentProps<{ ns: strin
       name: 'Type',
       component: (
         <WizardStepContainer title="Migration type">
-          <TypeForm form={forms.type} selectedVMs={selectedVMs} />
+          <TypeForm
+            form={forms.type}
+            sourceProvider={forms.general.values.sourceProvider}
+            selectedVMs={selectedVMs}
+            namespace={prefillPlanNamespace}
+          />
         </WizardStepContainer>
       ),
       enableNext: forms.type.isValid,

--- a/packages/legacy/src/queries/secrets.ts
+++ b/packages/legacy/src/queries/secrets.ts
@@ -1,10 +1,12 @@
+import { useCallback, useMemo } from 'react';
 import { createSecretResource } from 'legacy/src/client/helpers';
 import { usePollingContext } from 'legacy/src/common/context';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { UseQueryResult } from 'react-query';
-import { useMockableQuery } from './helpers';
+import { mockKubeList, useMockableQuery } from './helpers';
 import { MOCK_SECRET_INSECURE, MOCK_SECRET_SECURE } from './mocks/secrets.mock';
-import { ISecret } from './types';
+import { IMetaObjectMeta, IProviderObject, ISecret } from './types';
+import { IKubeList } from '../client/types';
 
 export const useSecretQuery = (
   secretName: string | null,
@@ -13,11 +15,51 @@ export const useSecretQuery = (
   const secretResource = createSecretResource(namespace);
   return useMockableQuery<ISecret>(
     {
-      queryKey: ['secrets', secretName],
+      queryKey: ['secret', secretName],
       queryFn: async () => await consoleFetchJSON(secretResource.namedPath(secretName)),
       refetchInterval: usePollingContext().refetchInterval,
       enabled: !!secretName,
     },
-    secretName ==='secure' ? MOCK_SECRET_SECURE : MOCK_SECRET_INSECURE
+    secretName === 'secure' ? MOCK_SECRET_SECURE : MOCK_SECRET_INSECURE
   );
+};
+
+export const useSecretsQuery = (
+  secretNames: string[] | null,
+  namespace: string,
+): UseQueryResult<IKubeList<ISecret>> => {
+  const filterList = useCallback(
+    (data: IKubeList<ISecret>): IKubeList<ISecret> =>
+      !secretNames || secretNames.length == 0
+        ? data
+        : ({
+          ...data,
+          items: data.items.filter((d) => secretNames.includes((d.metadata as IMetaObjectMeta)?.name)),
+        }),
+    [secretNames]
+  );
+
+  const secretResource = createSecretResource(namespace);
+  return useMockableQuery<IKubeList<ISecret>>(
+    {
+      queryKey: ['secrets', secretNames],
+      queryFn: async () => await consoleFetchJSON(secretResource.listPath()),
+      refetchInterval: usePollingContext().refetchInterval,
+      enabled: !!secretNames && secretNames.length > 0,
+      select: filterList,
+    },
+    mockKubeList([MOCK_SECRET_SECURE, MOCK_SECRET_INSECURE], 'SecretList')
+  );
+};
+
+export const useSecretsForProvidersQuery = (
+  providersQuery: UseQueryResult<IKubeList<IProviderObject>>,
+  namespace: string,
+): UseQueryResult<IKubeList<ISecret>> => {
+  const providerSecretNames: string[] = useMemo(() =>
+    providersQuery.data?.items?.map((provider) => provider.spec?.secret?.name ?? '').filter(Boolean) ?? [],
+    [providersQuery.data]
+  );
+
+  return useSecretsQuery(providerSecretNames, namespace);
 };


### PR DESCRIPTION
Enhance plan wizard to be source provider `insecureSkipVerify` aware

## Summary
In the create mode of the plan wizard, consider if the selected source provider is an ovirt type with insecureSkipVerify true. If it is ovirt+insecure then:
  1. Only allow selection of a local target provider
  2. Only allow cold migrations

Fixes: #320

## Change Details
  Secret queries:
    - add ability to query for the secrets that belong to the providers found in a cluster providers query

  `GeneralForm`:
    - keeps track of if the currently selected source provider is ovirt+insecure
    - disable a remote provider and enable a tooltip if a remote is not currently allowed
    - if the source provider is changed from ovirt/secure to ovirt/insecure and the target provider is not a local target, clear the target provider to force reselection

  `ProviderSelect`:
    - convert to a fully controlled component via the onProviderSelect
    - add flag providerAllowRemote to block selection of some providers
    - render the conditional tooltip as a List so multiple reasons can be nicely displayed

  `TypeForm`:
    - when the source provider is ovirt+insecure, disable the warm migration option and show an alert box to indicate why warm is not available
  - Add ability to query for the secrets that belong to the providers found in a cluster providers query

## Screen Shots

Creating a plan, ovirt insecure skip verify source provider, don't allow selection of remote target:
![image](https://user-images.githubusercontent.com/3985964/227087630-8720f18c-5e51-4d83-b7c0-507fc13844c5.png)

Creating a plan, ovirt insecure skip verify source provider, on the type of migration step:
![image](https://user-images.githubusercontent.com/3985964/227087962-fdc4890b-be7b-42b8-8884-40f1b4ab3556.png)


## Pending work
Additional work is needed to completely cover #320:
  - [x] Add a conditional tooltip to `ProviderSelect`'s `renderOption()` function to cover the case when `providerRole = 'target'` and `providerAllowRemote=false`.
  - [x] Make sure the calculation of `isLocalTargetRequired` in `GeneralForm` for the target provider is correct.
  - [x] Fixup the `TypeForm` to prevent selecting warm migrations

## Future work
  - Add mock data for ovirt+insecure provider with matching secret and unit test changes
  - Address plan wizard in edit mode if the plan already has an incompatible target for the source