### PR TITLE
Add NotificationContextProvider required by MustGatherModal

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/PlansWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansWrapper.tsx
@@ -3,15 +3,20 @@ import { ResourceConsolePageProps } from 'src/utils/types';
 
 import withQueryClient from '@kubev2v/common/components/QueryClientHoc';
 import { withModalProvider } from '@kubev2v/common/polyfills/sdk-shim';
-import { MustGatherContextProvider } from '@kubev2v/legacy/common/context';
+import {
+  MustGatherContextProvider,
+  NotificationContextProvider,
+} from '@kubev2v/legacy/common/context';
 
 import PlansPage from './PlansPage';
 
 const PlansWrapper = withQueryClient(
   withModalProvider((props: ResourceConsolePageProps) => (
-    <MustGatherContextProvider>
-      <PlansPage {...props} />
-    </MustGatherContextProvider>
+    <NotificationContextProvider>
+      <MustGatherContextProvider>
+        <PlansPage {...props} />
+      </MustGatherContextProvider>
+    </NotificationContextProvider>
   )),
 );
 PlansWrapper.displayName = 'PlansWrapper';

--- a/packages/forklift-console-plugin/src/modules/Plans/VMMigrationDetailsWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/VMMigrationDetailsWrapper.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 
 import withQueryClient from '@kubev2v/common/components/QueryClientHoc';
 import { withModalProvider } from '@kubev2v/common/polyfills/sdk-shim';
-import { MustGatherContextProvider } from '@kubev2v/legacy/common/context';
+import {
+  MustGatherContextProvider,
+  NotificationContextProvider,
+} from '@kubev2v/legacy/common/context';
 import {
   VMMigrationDetails,
   VMMigrationDetailsProps,
@@ -10,9 +13,11 @@ import {
 
 const VMMigrationDetailsWrapper = withQueryClient(
   withModalProvider((props: VMMigrationDetailsProps) => (
-    <MustGatherContextProvider>
-      <VMMigrationDetails match={props.match} />
-    </MustGatherContextProvider>
+    <NotificationContextProvider>
+      <MustGatherContextProvider>
+        <VMMigrationDetails match={props.match} />
+      </MustGatherContextProvider>
+    </NotificationContextProvider>
   )),
 );
 VMMigrationDetailsWrapper.displayName = 'VMMigrationDetailsWrapper';

--- a/packages/legacy/src/queries/mustGather.ts
+++ b/packages/legacy/src/queries/mustGather.ts
@@ -16,7 +16,10 @@ export const useMustGatherMutation = (
   const result = useMockableMutation<IMustGatherResponse>(
     async (options) => {
       return new Promise((res, rej) => {
-        consoleFetchJSON(getMustGatherApiUrl(url), 'POST', { body: JSON.stringify(options) })
+        consoleFetchJSON(getMustGatherApiUrl(url), 'POST', {
+          body: JSON.stringify(options),
+          headers: { 'Content-Type': 'application/json' },
+        })
           .then((mustGatherData) => {
             res(mustGatherData.json());
           })


### PR DESCRIPTION
Issue:
the "get logs" action is using `MustGatherModal` that requires the `NotificationContext`

FIx:
add the context using a provider, in pages that use this modal