### PR TITLE
Use stream saver instead of file saver for must gather gzip files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16794,6 +16794,17 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/streamsaver": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/streamsaver/-/streamsaver-2.0.6.tgz",
+      "integrity": "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        }
+      ]
+    },
     "node_modules/streamx": {
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.13.2.tgz",
@@ -19884,7 +19895,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@migtools/lib-ui": "^8.4.1",
-        "jsonpath": "^1.1.1"
+        "jsonpath": "^1.1.1",
+        "streamsaver": "^2.0.6"
       },
       "devDependencies": {
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.8",
@@ -21262,6 +21274,7 @@
         "jsonpath": "^1.1.1",
         "mini-svg-data-uri": "^1.4.4",
         "react-linkify": "^1.0.0-alpha",
+        "streamsaver": "^2.0.6",
         "style-loader": "^3.3.1",
         "terser-webpack-plugin": "^5.3.6",
         "ts-loader": "^9.3.1",
@@ -33043,6 +33056,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "streamsaver": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/streamsaver/-/streamsaver-2.0.6.tgz",
+      "integrity": "sha512-LK4e7TfCV8HzuM0PKXuVUfKyCB1FtT9L0EGxsFk5Up8njj0bXK8pJM9+Wq2Nya7/jslmCQwRK39LFm55h7NBTw=="
     },
     "streamx": {
       "version": "2.13.2",

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@migtools/lib-ui": "^8.4.1",
-    "jsonpath": "^1.1.1"
+    "jsonpath": "^1.1.1",
+    "streamsaver": "^2.0.6"
   },
   "peerDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "0.0.18",


### PR DESCRIPTION
Issue:
Response for a must gather file may be big, currently we assume using blob is good enough for most cases.
But on some cases it fails

Fix:
Read the response as a stream.

Screenshot:
After:
[Screencast from 2023-03-19 14-57-32.webm](https://user-images.githubusercontent.com/2181522/226176896-52a76ac5-1e45-41d6-a5a3-ebbfbd2c47c1.webm)

Before:
[Screencast from 2023-03-19 15-01-30.webm](https://user-images.githubusercontent.com/2181522/226176908-b0ca9dd4-d304-4b37-9ffc-342e031ff89e.webm)

 