### PR TITLE
Add uid to the must-gather custom name

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -79,7 +79,9 @@ export const useFlatPlanActions: ExtensionHook<
     fetchMustGatherResult,
     notifyDownloadFailed,
   } = React.useContext(MustGatherContext);
-  const mustGather = latestAssociatedMustGather(withNs(plan.name, 'plan'));
+  const mustGather = latestAssociatedMustGather(
+    withNs(plan.name, plan?.object?.metadata?.uid || '', 'plan'),
+  );
   const cutoverMutation = useSetCutoverMutation(plan.namespace);
 
   const isPlanGathering = mustGather?.status === 'inprogress' || mustGather?.status === 'new';
@@ -149,7 +151,7 @@ export const useFlatPlanActions: ExtensionHook<
             : mustGather?.status === 'new'
             ? 'Must gather queued for execution.'
             : mustGather?.status === 'error'
-            ? `Cannot complete must gather for ${withoutNs(mustGather?.['custom-name'], 'plan')}`
+            ? `Cannot complete must gather for ${withoutNs(mustGather?.['custom-name'])}`
             : !mustGathersQuery?.isSuccess
             ? 'Cannot reach must gather service.'
             : !migrationCompleted
@@ -161,6 +163,7 @@ export const useFlatPlanActions: ExtensionHook<
           setMustGatherModalOpen(true);
           setActiveMustGather({
             type: 'plan',
+            planUid: plan?.object?.metadata?.uid || '',
             displayName: name,
             status: 'new',
           });

--- a/packages/legacy/src/Plans/components/PlanActionsDropdown.tsx
+++ b/packages/legacy/src/Plans/components/PlanActionsDropdown.tsx
@@ -41,7 +41,7 @@ export const PlanActionsDropdown: React.FunctionComponent<IPlansActionDropdownPr
   const namespace = plan.metadata.namespace;
   const { withNs, latestAssociatedMustGather } = React.useContext(MustGatherContext);
 
-  const mustGather = latestAssociatedMustGather(withNs(plan.metadata.name, 'plan'));
+  const mustGather = latestAssociatedMustGather(withNs(plan.metadata.name, plan?.metadata?.uid || '', 'plan'));
 
   const isPlanGathering = mustGather?.status === 'inprogress' || mustGather?.status === 'new';
 

--- a/packages/legacy/src/Plans/components/PlansTable.tsx
+++ b/packages/legacy/src/Plans/components/PlansTable.tsx
@@ -303,6 +303,7 @@ export const PlansTable: React.FunctionComponent<IPlansTableProps> = ({
                 {buttonType === 'MustGather' ? (
                   <MustGatherBtn
                     type="plan"
+                    planUid={plan?.metadata?.uid || ''}
                     isCompleted={!!plan.status?.migration?.completed}
                     displayName={plan.metadata.name}
                   />

--- a/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
+++ b/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
@@ -325,6 +325,7 @@ export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps
           title: (
             <MustGatherBtn
               type="vm"
+              planUid={plan?.metadata?.uid || ''}
               isCompleted={!!vmStatus.completed}
               displayName={getVMName(vmStatus)}
             />

--- a/packages/legacy/src/common/components/MustGatherBtn.tsx
+++ b/packages/legacy/src/common/components/MustGatherBtn.tsx
@@ -5,12 +5,14 @@ import { MustGatherContext } from 'legacy/src/common/context';
 
 interface IMustGatherBtn {
   displayName: string;
+  planUid: string;
   type: 'plan' | 'vm';
   isCompleted?: boolean;
 }
 
 export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({
   displayName,
+  planUid,
   type,
   isCompleted,
 }) => {
@@ -26,7 +28,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({
     notifyDownloadFailed,
   } = React.useContext(MustGatherContext);
 
-  const namespacedName = withNs(displayName, type);
+  const namespacedName = withNs(displayName, planUid, type);
   const mustGather = latestAssociatedMustGather(namespacedName);
 
   return mustGather?.status === 'completed' && mustGather?.['archive-name'] ? (
@@ -64,7 +66,7 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({
           : mustGather?.status === 'new'
           ? `Must gather queued for execution.`
           : mustGather?.status === 'error'
-          ? `Cannot complete must gather for ${withoutNs(mustGather?.['custom-name'], type)}`
+          ? `Cannot complete must gather for ${withoutNs(mustGather?.['custom-name'])}`
           : `Collects the current ${
               type === 'plan' ? 'migration plan' : 'VM migration'
             } logs and creates a tar archive file for download.`
@@ -87,7 +89,8 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({
           setMustGatherModalOpen(true);
           setActiveMustGather({
             type,
-            displayName: displayName,
+            displayName,
+            planUid,
             status: 'new',
           });
         }}

--- a/packages/legacy/src/common/components/MustGatherModal.tsx
+++ b/packages/legacy/src/common/components/MustGatherModal.tsx
@@ -43,8 +43,8 @@ export const MustGatherModal: React.FunctionComponent = () => {
     handleMustGatherError
   );
 
-  const handleMustGatherRequest = ({ displayName, type }: MustGatherObjType) => {
-    const namespacedName = withNs(displayName, type);
+  const handleMustGatherRequest = ({ displayName, planUid, type }: MustGatherObjType) => {
+    const namespacedName = withNs(displayName, planUid, type);
     registerMustGather.mutate({
       'custom-name': namespacedName,
       command:

--- a/packages/legacy/src/common/components/MustGatherWatcher.tsx
+++ b/packages/legacy/src/common/components/MustGatherWatcher.tsx
@@ -24,7 +24,7 @@ export const MustGatherWatcher: React.FunctionComponent<IMustGatherWatcherProps>
 
   React.useEffect(() => {
     const type = data?.command.toLowerCase().includes('plan') ? 'plan' : 'vm';
-    const unprefixedName = data && withoutNs(data['custom-name'], type);
+    const unprefixedName = data && withoutNs(data['custom-name']);
     if (
       data?.status === 'completed' ||
       completedPreviously ||


### PR DESCRIPTION
Fixes: #332 #333 

Issue:
Currently we only use the resource name and type to identify a must gather record.

  - If we have two migrated vms with the same name, the must-gather `record-id` will be the same, even if it belongs to a different plan.
  - if we delete and then create a new plan with the same name, the must-gather `record-id` will be the same for both plans.

Suggested fix:
  - [x] Add the plan uid to each custom-name created by the `must-gather-api` pod
  - [x] Use the plan uid when searching for a resource must-gather record

Screenshot:
After:
[after-uid-fix.webm](https://user-images.githubusercontent.com/2181522/226299874-1ab7a712-eb17-4673-b4c1-c8f7e0e464a7.webm)

Before:
[before-fix.webm](https://user-images.githubusercontent.com/2181522/226299919-91d559de-9bc3-466c-91f7-a11800ee727c.webm)

 
