### PR TITLE
Add missing tmp dir

### DIFF
--- a/ci/configure/openshift.sh
+++ b/ci/configure/openshift.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -ex
+mkdir -p $(pwd)/tmp
 
 export BRIDGE_K8S_AUTH="bearer-token"
 export BRIDGE_USER_AUTH="disabled"


### PR DESCRIPTION
ci scripts use `./tmp` directory.

this PR creats this dir, so scripts that use it, will not fail