### PR TITLE
Open kind port 30088

### DIFF
--- a/ci/deploy-cluster.sh
+++ b/ci/deploy-cluster.sh
@@ -46,6 +46,8 @@ nodes:
   extraPortMappings:
   - containerPort: 30080
     hostPort: 30080
+  - containerPort: 30088
+    hostPort: 30088
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]


### PR DESCRIPTION
in #353 I closed most ports used for development because the are not needed for the new e2e tests, port 30088 is used for inventory, and is very useful, adding it back for ease of local development. 