### PR TITLE
Use openstack volumeType in plan wizard storageMap step

### DIFF
--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -383,12 +383,6 @@ export const filterSourcesBySelectedVMs = (
   nicProfiles: INicProfile[],
   disks: IDisk[]
 ): MappingSource[] => {
-  // Openstack store the volume ID not the volume types,
-  // disable filtering for openstack volumes.
-  if (sourceProviderType === 'openstack' && mappingType === MappingType.Storage) {
-    return availableSources;
-  }
-
   const sourceIds: (string | undefined)[] = Array.from(
     new Set(
       selectedVMs.flatMap((vm) => {
@@ -418,6 +412,13 @@ export const filterSourcesBySelectedVMs = (
             );
             const storageDomainIds = vmDisks.map((disk) => disk?.storageDomain);
             return storageDomainIds;
+          }
+          if (sourceProviderType === 'openstack') {
+            const vmDisks = (vm as IOpenStackVM).attachedVolumes.map((av) =>
+              disks.find((disk) => disk.id === av.ID)
+            );
+            const volumeTypeIds = vmDisks.map((disk) => disk?.volumeType);
+            return volumeTypeIds;
           }
         }
         return [];

--- a/packages/legacy/src/queries/disks.ts
+++ b/packages/legacy/src/queries/disks.ts
@@ -11,18 +11,24 @@ export interface IDisk {
   revision: number;
   selfLink: string;
   // properties available with ?detail=1
-  storageDomain: string;
+  storageDomain?: string;
+  volumeType?: string;
 }
 
 export const useDisksQuery = (
   provider: SourceInventoryProvider | null
 ): UseQueryResult<IDisk[]> => {
+  const quaryParams = {
+    ovirt: 'disks?detail=1',
+    openstack: 'volumes?detail=1',
+  };
+
   return useMockableQuery<IDisk[], unknown>(
     {
       queryKey: ['disks', provider?.selfLink],
       queryFn: async () =>
-        await consoleFetchJSON(getInventoryApiUrl(`${provider?.selfLink || ''}/disks?detail=1`)),
-      enabled: !!provider && provider.type === 'ovirt',
+        await consoleFetchJSON(getInventoryApiUrl(`${provider?.selfLink || ''}/${quaryParams[provider?.type] || ''}`)),
+      enabled: !!provider && Object.keys(quaryParams).includes(provider.type),
       refetchInterval: usePollingContext().refetchInterval,
     },
     MOCK_DISKS


### PR DESCRIPTION
In #343 I ignored the openstack storage type because it did not have the voluemType, only the volumeID.

Issue:
When ignoring the volumeType, all volumeTypes are accepted, this only work when you use all the volumeTypes.

Fix:
Get the volumeTypes using a separate API request, and match volume to volumeType to the volumeID you get in the first API call.

Screenshots:
Before:
![openstack-before](https://user-images.githubusercontent.com/2181522/227866809-5ae74fd6-ad68-4c38-90ca-2c4a959c888b.png)

After:
![openstack-after](https://user-images.githubusercontent.com/2181522/227866854-c954b401-69e0-4ca3-b592-59307f1f67f2.png)

