### PR TITLE
Change "output only" fields from disabled text input to output only

### DIFF
--- a/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
+++ b/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
@@ -9,9 +9,10 @@ import {
   Stack,
   Flex,
   FormGroup,
-  TextInput,
+  Popover,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { useFormField, useFormState, ValidatedTextInput } from '@migtools/lib-ui';
 import { MappingBuilder, IMappingBuilderItem, mappingBuilderItemsSchema, getDefaultTarget } from './MappingBuilder';
 import { getMappingFromBuilderItems } from './MappingBuilder/helpers';
@@ -197,25 +198,60 @@ export const AddEditMappingModal: React.FunctionComponent<IAddEditMappingModalPr
             <>
               <Grid hasGutter className={spacing.mbMd}>
                 <GridItem md={6}>
-                  <FormGroup label="Namespace (default to migration operator namespace)" fieldId="mapping-namespace">
-                    <TextInput
+                  <FormGroup
+                    label="Namespace"
+                    fieldId="mapping-namespace"
+                    labelIcon={(
+                      <Popover
+                        bodyContent={
+                          <div>
+                            The default is the migration operator namespace.
+                          </div>
+                        }
+                      >
+                        <Button
+                          variant="plain"
+                          aria-label="More info for Mapping resource namespace field"
+                          onClick={(e) => e.preventDefault()}
+                          aria-describedby="mapping-namespace"
+                          className="pf-c-form__group-label-help"
+                        >
+                         <HelpIcon noVerticalAlign />
+                        </Button>
+                      </Popover>
+                    )}
+                  >
+                    <div
                       id="mapping-namespace"
-                      aria-label="Mapping namespace"
-                      value={namespace}
-                      isDisabled={true}
-                    />
+                      style={{ paddingLeft: 8, fontSize: 16}}
+                    >
+                      { namespace }
+                    </div>
                   </FormGroup>
                 </GridItem>
+
                 <GridItem md={6} className={spacing.mbMd}>
-                  <ValidatedTextInput
-                    field={form.fields.name}
-                    isRequired
-                    fieldId="mapping-name"
-                    inputProps={{
-                      isDisabled: !!mappingBeingEdited,
-                    }}
-                  />
+                  {!!!mappingBeingEdited ? (
+                    <ValidatedTextInput
+                      field={form.fields.name}
+                      isRequired
+                      fieldId="mapping-name"
+                    />
+                  ) :
+                    <FormGroup
+                      label="Name"
+                      fieldId="name"
+                    >
+                      <div
+                        id="mapping-name"
+                        style={{ paddingLeft: 8, fontSize: 16}}
+                      >
+                        { form.fields.name.value }
+                      </div>
+                    </FormGroup>
+                  }
                 </GridItem>
+
                 <GridItem md={6}>
                   <ProviderSelect
                     providerRole="source"

--- a/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
@@ -11,7 +11,6 @@ import {
   Title,
   Button,
   Popover,
-  TextInput,
 } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { getFormGroupProps, ValidatedTextInput } from '@migtools/lib-ui';
@@ -122,20 +121,58 @@ export const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
         <Title headingLevel="h2" size="md">
           Give your plan a name and a description
         </Title>
-        <FormGroup label="Plan resource namespace (default to migration operator namespace)" fieldId="formgroup-plan-namespace">
-          <TextInput
-            id="plan-namespace"
-            aria-label="Plan Namespace"
-            value={namespace}
-            isDisabled={true}
-          />
+        <FormGroup
+          label="Plan resource namespace"
+          fieldId="plan-namespace"
+
+          labelIcon={(
+            <Popover
+              bodyContent={
+                <div>
+                  The default is the migration operator namespace.
+                </div>
+              }
+            >
+              <Button
+                variant="plain"
+                aria-label="More info for plan resource namespace field"
+                onClick={(e) => e.preventDefault()}
+                aria-describedby="plan-namespace"
+                className="pf-c-form__group-label-help"
+              >
+                <HelpIcon noVerticalAlign />
+              </Button>
+            </Popover>
+          )}
+        >
+          <div
+                id="plan-namespace"
+                style={{ paddingLeft: 8, fontSize: 16}}
+              >
+                { namespace }
+          </div>
         </FormGroup>
-        <ValidatedTextInput
-          field={form.fields.planName}
-          isRequired
-          fieldId="plan-name"
-          inputProps={{ isDisabled: wizardMode === 'edit' }}
-        />
+
+        {wizardMode !== 'edit' ? (
+          <ValidatedTextInput
+            field={form.fields.planName}
+            isRequired
+            fieldId="plan-name"
+          />
+        ) :
+          <FormGroup
+            label="Plan name"
+            fieldId="plan-name"
+          >
+            <div
+              id="plan-name"
+              style={{ paddingLeft: 8, fontSize: 16}}
+            >
+              { form.fields.planName.value }
+            </div>
+          </FormGroup>
+        }
+        
         <ValidatedTextInput
           component={TextArea}
           field={form.fields.planDescription}

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   Popover,
   FileUpload,
-  TextInput,
   Checkbox,
   Hint,
 } from '@patternfly/react-core';
@@ -303,15 +302,34 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
         ) : (
           <Form>
             <FormGroup
-              label="Provider resource namespace (default to migration operator namespace)"
-              fieldId="plan-namespace"
+              label="Provider resource namespace"
+              fieldId="provider-namespace"
+              labelIcon={(
+                <Popover
+                  bodyContent={
+                    <div>
+                      The default is the migration operator namespace.
+                    </div>
+                  }
+                >
+                  <Button
+                    variant="plain"
+                    aria-label="More info for Provider resource namespace field"
+                    onClick={(e) => e.preventDefault()}
+                    aria-describedby="provider-namespace"
+                    className="pf-c-form__group-label-help"
+                  >
+                    <HelpIcon noVerticalAlign />
+                  </Button>
+                </Popover>
+              )}
             >
-              <TextInput
-                id="plan-namespace"
-                aria-label="Plan Namespace"
-                value={prefillNamespace}
-                isDisabled={true}
-              />
+              <div
+                id="provider-namespace"
+                style={{ paddingLeft: 8, fontSize: 16}}
+              >
+                { prefillNamespace }
+              </div>
             </FormGroup>
 
             <FormGroup
@@ -320,36 +338,57 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
               fieldId="provider-type"
               {...getFormGroupProps(providerTypeField)}
             >
-              <SimpleSelect
-                id="provider-type"
-                aria-label="Provider type"
-                options={PROVIDER_TYPE_OPTIONS}
-                value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
-                onChange={(selection) => {
-                  providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
-                  providerTypeField.setIsTouched(true);
-                }}
-                placeholderText="Select a provider type..."
-                isDisabled={!!providerBeingEdited}
-                menuAppendTo="parent"
-                maxHeight="40vh"
-              />
+              {!!!providerBeingEdited ? (
+                <SimpleSelect
+                  id="provider-type"
+                  aria-label="Provider type"
+                  options={PROVIDER_TYPE_OPTIONS}
+                  value={[PROVIDER_TYPE_OPTIONS.find((option) => option.value === providerType)]}
+                  onChange={(selection) => {
+                    providerTypeField.setValue((selection as OptionWithValue<ProviderType>).value);
+                    providerTypeField.setIsTouched(true);
+                  }}
+                  placeholderText="Select a provider type..."
+                  menuAppendTo="parent"
+                  maxHeight="40vh"
+                />
+              ) :
+                <div
+                  id="provider-type"
+                  style={{ paddingLeft: 8, fontSize: 16}}
+                >
+                  { providerType }
+                </div>
+              }
             </FormGroup>
 
             {providerType ? (
               <>
                 {fields?.name ? (
-                  <ValidatedTextInput
-                    field={forms[providerType].fields.name}
-                    isRequired
-                    fieldId="name"
-                    inputProps={{
-                      isDisabled: !!providerBeingEdited,
-                    }}
-                    formGroupProps={{
-                      helperText: 'User specified name to display in the list of providers',
-                    }}
-                  />
+                  <>
+                    {!!!providerBeingEdited ? (
+                      <ValidatedTextInput
+                        field={forms[providerType].fields.name}
+                        isRequired
+                        fieldId="name"
+                        formGroupProps={{
+                          helperText: 'User specified name to display in the list of providers',
+                        }}
+                      />
+                    ) :
+                      <FormGroup
+                        label="Name"
+                        fieldId="name"
+                      >
+                        <div
+                          id="name"
+                          style={{ paddingLeft: 8, fontSize: 16}}
+                        >
+                          { forms[providerType].fields.name.value }
+                        </div>
+                      </FormGroup>
+                    }
+                  </>
                 ) : null}
 
                 {fields?.openstackUrl ? (


### PR DESCRIPTION
Fixes: #227 

For all "output only" fiels within dialogs and a wizard, change their type from disabled input text/SimpleSelect to output label fields so that it will be more clear that those fields are not editable.

This change affects the following fields:
1. Create Provider - 'Provider resource namespace'.
2. Edit Provider -  'Provider resource namespace', 'Type', 'Name'.
3. Create Network/Storage mapping - 'Namespace'.
4. Edit Network/Storage mapping - 'Namespace', 'Name'.
5. Create Plan - 'Plan resource namespace'.
6. Edit Plan - 'Plan resource namespace', 'Plan name'.

## Screenshots:

## **Provider dialog**
![image](https://user-images.githubusercontent.com/18169498/228022940-f5130e26-803c-4408-9ecb-514c9397915d.png)
![image](https://user-images.githubusercontent.com/18169498/228023186-41919e63-fd5d-42a8-9dab-ac71074d983c.png)
##
##



### **Mapping dialog**
![image](https://user-images.githubusercontent.com/18169498/228023321-5ca72a26-d029-456f-983d-177f8a337e49.png)
##
##



### **Plan dialog**
![image](https://user-images.githubusercontent.com/18169498/228023495-0deb9924-001f-4722-8773-ad942f9a1d6d.png)
