### PR TITLE
Make forkliftci a sub module in our ci directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ci/forkliftci"]
+	path = ci/forkliftci
+	url = https://github.com/kubev2v/forkliftci.git

--- a/ci/README.forkliftci.md
+++ b/ci/README.forkliftci.md
@@ -1,0 +1,92 @@
+# forkliftci
+
+Git forkliftci submodule - the forkliftci repository is linked as a submodule for easy usage.
+
+forkliftci is the backend forklift tools for creating and deploying forklift cluster infrastructure and running integration tests against it.
+
+Ref: https://github.com/kubev2v/forkliftci
+
+## Git submodule
+
+forkliftci is a submodule, it's not part of the forklift-console-plugin code,
+to get the code, use git `submodule` commands.
+
+``` bash
+# when cloning the project use recurse-submodules
+git clone --recurse-submodules https://github.com/chaconinc/MainProject
+
+# When updating to latest version
+git submodule update --init --recursive
+```
+
+## Usage
+
+``` bash
+# Once - create a local nfs server
+# NOTE - run only once to create a server
+#        require root permissions and create a server running on the local machine
+sudo bash ./ci/forkliftci/cluster/providers/openstack/install_nfs.sh
+
+# build a cluster with kubevirt-forklift and a set of demo providers using forkliftci
+bash ./ci/deploy-all.sh --with-all-providers
+
+# You can also install selected providers
+#    --with-ovirt-provider, --with-vmware-provider, --with-openstack-provider
+bash ./ci/deploy-all.sh --with-ovirt-provider
+```
+
+# Providers info
+
+## Ovirt
+
+``` bash
+OVIRT_USERNAME=admin@internal
+OVIRT_PASSWORD=123456
+OVIRT_URL=https://fakeovirt.konveyor-forklift.svc.cluster.local:30001/ovirt-engine/api
+```
+
+```
+-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIUeHhXLiJJpaIld4tY7I5f8m7RjtwwDQYJKoZIhvcNAQEL
+BQAwQjELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0eTEcMBoGA1UE
+CgwTRGVmYXVsdCBDb21wYW55IEx0ZDAeFw0yMjExMDEwOTQ5NDNaFw0zMjEwMjkw
+OTQ5NDNaMIGCMQswCQYDVQQGEwJYWDEVMBMGA1UEBwwMRGVmYXVsdCBDaXR5MRww
+GgYDVQQKDBNEZWZhdWx0IENvbXBhbnkgTHRkMT4wPAYDVQQDDDVmYWtlb3ZpcnQu
+a29udmV5b3ItZm9ya2xpZnQsaW1hZ2Vpby5rb252ZXlvci1mb3JrbGlmdDCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALffxVPN+Lin21wDbPnFc1weibfD
+mHqcXfzIMHaaHvV3MA3IXe5q3kmJlt1zc1ds4ydoaYRcJeNpuA7Fr4PdATHVqxZB
+jC9m+wB/A16BgT69VPmnDWuzmkkn+NM8JdBRv+xOFJs1P9ndMFtHgSK1o/+sGpGj
+aVuuZbOd4drG8bhYWKWhxHTDkFjGe9C82G6XY1Qk2gB2f5EA30uo/sSLYur69HiK
+HSs7r+RAaES7wlM7Nz4Hrf4XAI2qcdHNI1T5ZpDXkZNpgC6l/9m5FIUjeVzHqf0g
+MzCIPTBwjp4zJOMIQ21D4cXm2Zi/nlrM60IfAd7DZX2WqBCaUjELDHFTFUECAwEA
+AaNkMGIwQQYDVR0RBDowOIIbZmFrZW92aXJ0LmtvbnZleW9yLWZvcmtsaWZ0ghlp
+bWFnZWlvLmtvbnZleW9yLWZvcmtsaWZ0MB0GA1UdDgQWBBSoSoPKSAo3U0bDo/0U
+hgAceY4ZgTANBgkqhkiG9w0BAQsFAAOCAQEAB4B7DCipsCxRYq8t0+a1IUYCcWbs
+AI40GhRg2k6/p4gP2WU/v6TRpQ3HuxY2Tty3IdezMBZzeW2NgQBxt/Eo9cfWTs/5
+yX7kICzQvrOabTgF84EcCeRlP+It9xjfWWG4adEyv0XETjYUG85rBW7ud8n6dOMY
+cOgdOcJ1VvqDAfAF1uDYOIpEdqESrnqTxj+qewlBpBv2Y8m8na+AL9Sy6rdkV90e
+xKfiJG/OQNJEzgpK1XUSh/Eg3gEnrpuA+jWxShOL0zJFbMQDA0oxv6wnBxLIZXpQ
+8dDsiipGN6HDZUpzxHGFDDPB7xtCFGjyLBXCLegh+31XnZ7w6AzY3mIBYw==
+-----END CERTIFICATE-----
+```
+
+## vmWare
+
+``` bash
+VMWARE_USER=administrator@vsphere.local
+VMWARE_PASSWORD=123456
+VMWARE_URL=https://vcsim.konveyor-forklift.svc.cluster.local:8989/sdk
+VDDK_IMAGE=quay.io/kubev2v/vddk-test-vmdk
+VMWARE_FINGERPRINT=52:6C:4E:88:1D:78:AE:12:1C:F3:BB:6C:5B:F4:E2:82:86:A7:08:AF
+```
+
+## Openstack
+
+``` bash
+OPENSTACK_USERNAME=admin
+OPENSTACK_PASSWORD='12e2f14739194a6c'
+OPENSTACK_REGION_NAME=RegionOne
+OPENSTACK_AUTH_URL=http://packstack.konveyor-forklift.svc.cluster.local:5000/v3
+OPENSTACK_PROJECT_NAME=admin
+OPENSTACK_USER_DOMAIN_NAME=Default
+```

--- a/ci/deploy-all-providers.sh
+++ b/ci/deploy-all-providers.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+script_dir=$(dirname "$0")
+
+echo ""
+echo "Install mock providers"
+echo "======================"
+
+# Setup NFS 
+# Uncomment for install NFS one time (requires sudo)
+# ${script_dir}/forkliftci/cluster/providers/openstack/install_nfs.sh
+
+export NFS_IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{ print $7 }' | head -1)
+export NFS_SHARE="/home/nfsshare"
+
+bash ${script_dir}/deploy-ovirt-provider.sh
+bash ${script_dir}/deploy-vmware-provider.sh
+bash ${script_dir}/deploy-openstack-provider.sh

--- a/ci/deploy-all.sh
+++ b/ci/deploy-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-script_dir=$(dirname "$0")
+script_dir=$(realpath $(dirname "$0"))
 
 export K8S_TIMEOUT="365s"
 
@@ -51,6 +51,25 @@ bash ${script_dir}/deploy-kubevirt.sh
 
 # Install forklift
 bash ${script_dir}/deploy-forklift.sh
+
+# Install mock providers
+if [[ $@ == *'--with-all-providers'* ]]; then
+  # make the submodule the current working direcotry for running the script
+  (cd ${script_dir}/forkliftci && bash ${script_dir}/deploy-providers.sh)
+fi
+
+if [[ $@ == *'--with-ovirt-provider'* ]]; then
+  # make the submodule the current working direcotry for running the script
+  (cd ${script_dir}/forkliftci && bash ${script_dir}/deploy-ovirt-provider.sh)
+fi
+if [[ $@ == *'--with-vmware-provider'* ]]; then
+  # make the submodule the current working direcotry for running the script
+  (cd ${script_dir}/forkliftci && bash ${script_dir}/deploy-vmware-provider.sh)
+fi
+if [[ $@ == *'--with-openstack-provider'* ]]; then
+  # make the submodule the current working direcotry for running the script
+  (cd ${script_dir}/forkliftci && bash ${script_dir}/deploy-openstack-provider.sh)
+fi
 
 # Print some help
 # ---------------

--- a/ci/deploy-openstack-provider.sh
+++ b/ci/deploy-openstack-provider.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+script_dir=$(dirname "$0")
+
+echo ""
+echo "Install mock providers"
+echo "======================"
+
+# Setup NFS 
+# Uncomment for install NFS one time (requires sudo)
+# ${script_dir}/forkliftci/cluster/providers/openstack/install_nfs.sh
+
+export NFS_IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{ print $7 }' | head -1)
+export NFS_SHARE="/home/nfsshare"
+
+# Deploy packstack + test-vm
+bash ${script_dir}/forkliftci/cluster/providers/openstack/setup.sh
+bash ${script_dir}/forkliftci/cluster/providers/openstack/create_test_vms.sh

--- a/ci/deploy-ovirt-provider.sh
+++ b/ci/deploy-ovirt-provider.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+script_dir=$(dirname "$0")
+
+echo ""
+echo "Install mock providers"
+echo "======================"
+
+# Setup NFS 
+# Uncomment for install NFS one time (requires sudo)
+# ${script_dir}/forkliftci/cluster/providers/openstack/install_nfs.sh
+
+export NFS_IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{ print $7 }' | head -1)
+export NFS_SHARE="/home/nfsshare"
+
+# Deploy mock ovirt provider
+bash ${script_dir}/forkliftci/cluster/providers/ovirt/setup.sh

--- a/ci/deploy-vmware-provider.sh
+++ b/ci/deploy-vmware-provider.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+script_dir=$(dirname "$0")
+
+echo ""
+echo "Install mock providers"
+echo "======================"
+
+# Setup NFS 
+# Uncomment for install NFS one time (requires sudo)
+# ${script_dir}/forkliftci/cluster/providers/openstack/install_nfs.sh
+
+export NFS_IP_ADDRESS=$(ip route get 8.8.8.8 | awk '{ print $7 }' | head -1)
+export NFS_SHARE="/home/nfsshare"
+
+# Deploy mock vmware provider
+bash ${script_dir}/forkliftci/cluster/providers/vmware/setup.sh


### PR DESCRIPTION
Issue:
When a developer is tasked with improving an existing provider, they need to interact with a real provider, mocks may not provide data for new features.

The solution is to get access to real providers, that is not always possible, and may be hard for a new developer in the project, this PR adds an option to auto deploy providers a developer can interact with.

`forklift-console-plugin` repository share ci scripts with `forkliftci`, some scripts for development and ci environment
are the same while others differ, the UI deploy Openshift console and UI plugin, while it does not need the latest
back-end builds.

This PR adds `forkliftci` as sub module in `forklift-console-plugin` so we can use the scripts useful for UI development.
We will deploy CI environment containing UI console and  plugin using the scripts from the UI repository.
We will deploy a development environment with mock providers using forkliftci as submodule.

  - [x] Build development environment with OKD console - using ui scripts
  - [x] Build CI environment with OKD console - using ui scripts
  - [x] Optionally build development environment with mock providers - using forkliftci scripts

Screenshot:
![forkliftci-on-kind-env](https://user-images.githubusercontent.com/2181522/228528937-45be8c78-d3e5-4613-90c8-9cc8a8207af1.png)
