### PR TITLE
Rename fields labels of the Provider dialog

### DIFF
--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -58,22 +58,22 @@ const PROVIDER_TYPE_OPTIONS = PROVIDER_TYPES.map((type) => ({
   value: type,
 })) as OptionWithValue<ProviderType>[];
 
-const oVirtLabelPrefix = process.env.BRAND_TYPE === 'RedHat' ? 'RHV Manager' : 'oVirt Engine';
+const oVirtLabelPrefix = process.env.BRAND_TYPE === 'RedHat' ? 'RHV Manager' : 'oVirt';
 const vmwareLabelPrefix = 'vCenter';
-const openStackLabelPrefix = 'OpenStack Identity (Keystone)';
-const getLabelName = (type: 'hostname' | 'URL' | 'username' | 'pwd', prefix?: string) => {
+const openStackLabelPrefix = 'OpenStack';
+const getLabelName = (type: 'ovirt-hostname' | 'hostname' | 'username' | 'pwd', prefix?: string) => {
   let label = '';
   switch (type) {
-    case 'hostname': {
-      label = prefix ? `${prefix} host name or IP address` : 'Host name or IP address';
+    case 'ovirt-hostname': {
+      label = prefix ? `${prefix} Engine server hostname or IP address` : 'Hostname or IP address';
       break;
     }
-    case 'URL': {
-      label = prefix ? `${prefix} URL` : 'URL';
+    case 'hostname': {
+      label = prefix ? `${prefix} server hostname or IP address` : 'Hostname or IP address';
       break;
     }
     case 'username': {
-      label = prefix ? `${prefix} user name` : 'User name';
+      label = prefix ? `${prefix} username` : 'Username';
       break;
     }
     case 'pwd': {
@@ -112,7 +112,7 @@ const useAddProviderFormState = (
     providerType: providerTypeField,
     name: useFormField(
       '',
-      getProviderNameSchema(clusterProvidersQuery, providerBeingEdited).label('Name').required()
+      getProviderNameSchema(clusterProvidersQuery, providerBeingEdited).label('Provider name').required()
     ),
   };
 
@@ -120,7 +120,7 @@ const useAddProviderFormState = (
     ...commonProviderFields,
     hostname: useFormField(
       '',
-      hostnameSchema.label(getLabelName('hostname', brandPrefix(providerTypeField.value)))
+      hostnameSchema.label(getLabelName((isOvirt(providerTypeField.value) ? 'ovirt-hostname' : 'hostname'), brandPrefix(providerTypeField.value)))
     ),
     username: useFormField(
       '',
@@ -157,7 +157,7 @@ const useAddProviderFormState = (
     }),
     openstack: useFormState({
       ...commonProviderFields,
-      openstackUrl: useFormField('', urlSchema.required().label(getLabelName('URL', brandPrefix(providerTypeField.value)))),
+      openstackUrl: useFormField('', urlSchema.label('OpenStack Identity server URL').required()),
       username: useFormField('', usernameSchema.required().label(getLabelName('username', brandPrefix(providerTypeField.value)))),
       password: useFormField('', yup.string().max(256).label(getLabelName('pwd', brandPrefix(providerTypeField.value))).required()),
       domainName: useFormField('', yup.string().label('Domain').required()),
@@ -170,7 +170,7 @@ const useAddProviderFormState = (
     }),
     openshift: useFormState({
       ...commonProviderFields,
-      openshiftUrl: useFormField('', urlSchema.label('URL')),
+      openshiftUrl: useFormField('', urlSchema.label('Kubernetes API server URL')),
       saToken: useFormField('', yup.string().label('Service account token')),
     }),
   };
@@ -323,7 +323,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
         ) : (
           <Form>
             <FormGroup
-              label="Provider resource namespace"
+              label="Provider namespace"
               fieldId="provider-namespace"
               labelIcon={(
                 <Popover
@@ -354,7 +354,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
             </FormGroup>
 
             <FormGroup
-              label="Type"
+              label="Provider type"
               isRequired
               fieldId="provider-type"
               {...getFormGroupProps(providerTypeField)}
@@ -398,7 +398,7 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       />
                     ) :
                       <FormGroup
-                        label="Name"
+                        label="Provider name"
                         fieldId="name"
                       >
                         <div

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/__tests__/AddEditProviderModal.test.tsx
@@ -59,10 +59,10 @@ describe('<AddEditProviderModal />', () => {
     const caCertField = screen.getByLabelText(/^File upload/);
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
-      name: /oVirt Engine host name or IP address/i,
+      name: /oVirt Engine server hostname or IP address/i,
     });
-    const username = screen.getByRole('textbox', { name: /oVirt Engine user name/i });
-    const password = screen.getByLabelText(/^oVirt Engine password/);
+    const username = screen.getByRole('textbox', { name: /oVirt username/i });
+    const password = screen.getByLabelText(/^oVirt password/);
     await waitFor(() => {
       userEvent.type(name, 'providername');
       userEvent.type(hostname, 'host.example.com');
@@ -100,9 +100,9 @@ describe('<AddEditProviderModal />', () => {
 
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
-      name: /vCenter host name or IP address/i,
+      name: /vCenter server hostname or IP address/i,
     });
-    const username = screen.getByRole('textbox', { name: /vCenter user name/i });
+    const username = screen.getByRole('textbox', { name: /vCenter username/i });
     const password = screen.getByLabelText(/^vCenter password/);
 
     userEvent.type(name, 'providername');
@@ -156,9 +156,9 @@ describe('<AddEditProviderModal />', () => {
 
     const name = screen.getByRole('textbox', { name: /Name/ });
     const hostname = screen.getByRole('textbox', {
-      name: /vCenter host name or IP address/i,
+      name: /vCenter server hostname or IP address/i,
     });
-    const username = screen.getByRole('textbox', { name: /vCenter user name/i });
+    const username = screen.getByRole('textbox', { name: /vCenter username/i });
     const password = screen.getByLabelText(/^vCenter password/);
 
     await waitFor(() => {


### PR DESCRIPTION
Fixes: #246 

For keeping the consistency among all provider types, rename the fields for the Create/Edit Provider dialogs to use one naming convention and field order as follows:

**[all: vmWare, oVirt, OpenStack, KubeVirt]**
Provider namespace
Provider type
Provider name

**[vmWare]**
vCenter server hostname or IP address
vCenter username
vCenter password

VDDK init image

Skip certificate validation (if checked, the provider's certificate won't be validated)
SHA-1 fingerprint

**[oVirt]**
oVirt Engine server hostname or IP address
oVirt username
oVirt password

Skip certificate validation (if checked, the provider's certificate won't be validated)
CA certificate

**[Openstack]**
OpenStack Identity server URL
OpenStack username
OpenStack password

Domain
Project
Region

Skip certificate validation (if checked, the provider's certificate won't be validated)
CA certificate

**[kubevirt]**
Kubernetes API server URL

Service account token

