### PR TITLE
Self-hosted plugin setup for development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.8.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.7.4",
+        "webpack-merge": "^5.8.0"
       }
     },
     "../config": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "NODE_ENV=production npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
     "start": "npm run build -w @kubev2v/webpack -w @kubev2v/types && npm run start -w @kubev2v/forklift-console-plugin",
     "start:mock": "npm run start -w @kubev2v/mocks -- ",
+    "start:proxy": "npm run start -w @kubev2v/forklift-console-plugin -- -c webpack.proxy.config.ts",
     "i18n": "npm run i18n -w @kubev2v/forklift-console-plugin",
     "lint": "npm run lint -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
     "lint:fix": "npm run lint:fix -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
@@ -71,6 +72,7 @@
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.8.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "webpack-merge": "^5.8.0"
   }
 }

--- a/packages/forklift-console-plugin/webpack.proxy.config.ts
+++ b/packages/forklift-console-plugin/webpack.proxy.config.ts
@@ -1,0 +1,45 @@
+/* eslint-env node */
+
+import { type Configuration as WebpackConfiguration } from 'webpack';
+import { type Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
+import { merge } from 'webpack-merge';
+
+import baseConfig from './webpack.config';
+
+/**
+ * Run the forklift plugin as an overlay on top of an existing Console UI.
+ * The requirement is that the plugin is already installed in the Console.
+ * Key points:
+ * 1. Console UI is accessed via webpack dev server proxy with all the paths unchanged
+ * 2. local plugin is served via public path (see base config) which is the same as the URL used by the Console
+ * 3. when the Console loads the plugin(by URL) the local version is used
+ */
+const config: WebpackConfiguration & {
+  devServer: WebpackDevServerConfiguration;
+} = {
+  devServer: {
+    port: 9000,
+    // hot reload doesn't work with the Console (the plugin needs to be re-loaded)
+    hot: false,
+    webSocketServer: {
+      options: {
+        //prevents conflicts with web sockets from the app
+        port: 9001,
+        // just to differentiate WebPack sockets
+        path: '/webpackWebSockets',
+      },
+    },
+    proxy: [
+      {
+        // proxy also the root URL ('/')
+        context: () => true,
+        target: process.env.CONSOLE_URL || 'http://localhost:30080/',
+        ws: true,
+        changeOrigin: true,
+        secure: false,
+      },
+    ],
+  },
+};
+
+export default merge(baseConfig, config);


### PR DESCRIPTION
Current version:
```
 Run the Forklift plugin as an overlay on top of an existing Console UI.
 The requirement is that the plugin is already installed in the Console.
 Key points:
 1. Console UI is accessed via webpack dev server proxy with all the paths unchanged
 2. local plugin is served via public path (see base config) which is the same as the URL used by the Console
 3. when the Console loads the plugin(by URL) the local version is used```
```
Previous versions:
1.  [V1](https://github.com/rszwajko/forklift-console-plugin/tree/selfhosted) 
     1. pros: no overlay is used (the plugin is consumed by the Console via bridge)
     2. cons: the Console bridge is required
2. [V2](https://github.com/rszwajko/forklift-console-plugin/tree/selfhostedV2_early)
     1. pros: no bridge 
     2. cons: no mocks, part of the main webpack config
3. [V3](https://github.com/rszwajko/forklift-console-plugin/tree/selfhostedV3) 
     1. pros: no bridge, mocks injected via proxy (no connection to the plugin code)
     2. cons: part of the main webpack config
  
