### PR TITLE
Fix dev server for fedora with kind

### DIFF
--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -7,6 +7,8 @@ source ${script_dir}/configure/openshift.sh
 CONSOLE_CONTAINER_NAME=okd-console
 
 PLUGIN_NAME="forklift-console-plugin"
+PLUGIN_URL=${PLUGIN_URL:-"http://localhost:9001"}
+CONTAINER_NETWORK_TYPE=${CONTAINER_NETWORK_TYPE:-"host"}
 CONSOLE_IMAGE=${CONSOLE_IMAGE:-"quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:-9000}
 INVENTORY_SERVER_HOST=${INVENTORY_SERVER_HOST:-"http://localhost:30088"}
@@ -34,7 +36,9 @@ fi
 # Configure bridge for our plugin (console container to plugin dev server on container host)
 #      When the container network is type host, localhost == container host
 #      When the container network is default, host.containers.internal == container host
-BRIDGE_PLUGINS="${PLUGIN_NAME}=http://host.containers.internal:9001"
+#
+# NOTE: When running KinD we should use host network type because KinD only listen on localhost.
+BRIDGE_PLUGINS="${PLUGIN_NAME}=${PLUGIN_URL}"
 BRIDGE_PLUGIN_PROXY=$(cat << END | jq -c .
 {"services":[
     {
@@ -53,6 +57,13 @@ END
 
 # export all variables with the prefix "BRIDGE_"...
 export $(compgen -v | grep '^BRIDGE_')
+
+# mount tmp dir if available
+if [[ -d "$(pwd)/tmp" ]]; then
+    mount_tmp_dir_flag="-v $(pwd)/tmp:/mnt/config:Z"
+else
+    mount_tmp_dir_flag=""
+fi
 
 # run the console container
 echo "
@@ -73,7 +84,8 @@ $(echo ${BRIDGE_PLUGIN_PROXY} | jq .)
 podman run \
     --pull=${PULL_POLICY} \
     --rm \
-    -v $(pwd)/tmp:/mnt/config:Z \
+    ${mount_tmp_dir_flag} \
+    --network=${CONTAINER_NETWORK_TYPE} \
     --publish=${CONSOLE_PORT}:${CONSOLE_PORT} \
     --name=${CONSOLE_CONTAINER_NAME} \
     --env "BRIDGE_*" \

--- a/packages/forklift-console-plugin/webpack.config.ts
+++ b/packages/forklift-console-plugin/webpack.config.ts
@@ -88,8 +88,6 @@ const config: WebpackConfiguration & {
     static: './dist',
     host: 'localhost',
     port: 9001,
-    // Allow bridge running in a container to connect to the plugin dev server.
-    allowedHosts: 'all',
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',


### PR DESCRIPTION
Our current ci setup will not play nice with local KinD API server.

Issues:
A. in #388 we set the webpack dev server `host`, but we didn't change the  `allowedHosts: 'all'`.
when the webpack devserver listen to 'all' hosts `allowedHosts: 'all'`, bypassing the `host` setings [1]
It makes sense to allow only `localhost` by default, we shuld remove the `allowedHosts` settings.  

B. in #394 we changed the console network type from `host` to `default`.
when running the console we use the `default` container network, we will query the k8s server from a different IP, currently our KinD server only listen to `127.0.01`, when using KinD k8s API server we need to use `host` container network.

C. in #394 we refactored the creation of the `tmp` directory only when runnin in auth mode/
when running the console we always try to mount the `tmp dir`, but it is only set if we run with `oauth` settings. we should only mount this dir if it exist.

Fixes:
  - [x] remove `allowedHosts: 'all'` from webpack server
  - [x] use `host` container network for console, so it will play nice when running with `KinD`
  - [x] mount `tmp` only if exist.

[1] https://webpack.js.org/configuration/dev-server/#devserverallowedhosts
 