### PR TITLE
Add clean scripts to mock package

### DIFF
--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -6,6 +6,8 @@
   "license": "Apache-2.0",
   "main": "./src/server.ts",
   "scripts": {
+    "clean": "rm -rf ./dist && rm -rf ./coverage",
+    "clean:all": "npm run clean && rm -rf ./node_modules",
     "build": "rm -rf ./dist && tsc",
     "start": "npx ts-node .",
     "lint": "eslint . ",


### PR DESCRIPTION
Issue:
when running `npm run clean[:all]` from the root directory, we get warnings that this scripts are not defined for the mock package.

Fix:
add stub `clean` scripts to the mock package