### PR TITLE
Remove check for kind cli tool

### DIFF
--- a/ci/deploy-all.sh
+++ b/ci/deploy-all.sh
@@ -17,26 +17,6 @@ if ! [ -x "$(command -v podman)" ]; then
 fi
 echo "Found: podman"
 
-# Check for kind cmd
-# ------------------
-
-echo "Check for kind"
-echo "==============="
-
-if ! [ -x "$(command -v kind)" ]; then
-  echo "Error: can't find 'kind' command line utility, exit"
-  echo "  see: https://sigs.k8s.io/kind for more information"
-  exit 1
-fi
-echo "Found $(which kind)"
-
-if ! [ -x "$(command -v kubectl)" ]; then
-  echo "Error: can't find 'kubectl' command line utility, exit"
-  echo "  see: https://kubernetes.io/docs/tasks/tools/#kubectl for more information"
-  exit 1
-fi
-echo "Found $(which kubectl)"
-
 # Install cluster
 # ---------------
 

--- a/ci/install-kubectl.sh
+++ b/ci/install-kubectl.sh
@@ -17,4 +17,4 @@ curl --silent -LO "https://dl.k8s.io/$KUBECTL_VERSION/bin/linux/amd64/kubectl.sh
 echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
 
 # install
-install kubectl /usr/local/bin/kubectl
+sudo install kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
Issue:
When running the `install all` script we test for `kind`cli tool, but we don't need to, when creating a cluster we will install it if it's missing

Fix:
  - [x] remove test for `kind` because we will install it if it's missing
  - [x] add `sudo`  when installing kubectl, because we may run this script as none root user
