### PR TITLE
In mocks, install mockServiceWorker.js as a `postinstall` action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ openapitools.json
 
 cypress/videos
 ci/yaml/openapi.yaml
+
+**/mockServiceWorker.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -22328,6 +22328,7 @@
     "packages/mocks": {
       "name": "@kubev2v/mocks",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mswjs/http-middleware": "^0.8.0",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "main": "./src/server.ts",
   "scripts": {
+    "postinstall": "npx msw init ./generated --save",
     "clean": "rm -rf ./dist && rm -rf ./coverage",
     "clean:all": "npm run clean && rm -rf ./node_modules",
     "build": "rm -rf ./dist && tsc",
@@ -23,5 +24,8 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.1"
+  },
+  "msw": {
+    "workerDirectory": "generated"
   }
 }


### PR DESCRIPTION
Since MSW requires a static js to work, there are 2 common ways to handle the file:

  - First is to generate the file and commit it to the repo in the normal way.  Various linters and code check services don't like some of the code provided.  So storing the js in git is less attractive.

  - The second way to handle the file is to ignore it from the repo and use a `postinstall` script to add it after `npm install` runs. This is a common code generation point.  This way is preferred to keep library code out of our repo.


We choose the second way.