### PR TITLE
Add folder generated/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+generated/
 tmp/
 yarn-error.log
 openapitools.json


### PR DESCRIPTION
It seems that  adding the moc service worker alone is not enough -> https://github.com/kubev2v/forklift-console-plugin/blob/87cac3b9a801cb848793a14c62da45c4eaa9914c/.gitignore#L11