### PR TITLE
Fix import paths used for monorepo packages

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/mappingActions.tsx
@@ -1,7 +1,7 @@
-import { MappingType } from 'legacy/src/queries/types';
 import { useMappingActions } from 'src/components/mappings/mappingActions';
 
 import { withActionServiceContext } from '@kubev2v/common/components/ActionServiceDropdown';
+import { MappingType } from '@kubev2v/legacy/queries/types';
 
 import { FlatNetworkMapping } from './dataForNetwork';
 

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { MustGatherModal } from 'legacy/src/common/components/MustGatherModal';
 import StandardPage from 'src/components/page/StandardPage';
 import * as C from 'src/utils/constants';
 import { PLAN_STATUS_FILTER } from 'src/utils/enums';
@@ -10,6 +9,7 @@ import { EnumToTuple } from '@kubev2v/common/components/FilterGroup';
 import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
 import { loadUserSettings, UserSettings } from '@kubev2v/common/components/Page';
 import { ResourceFieldFactory } from '@kubev2v/common/utils/types';
+import { MustGatherModal } from '@kubev2v/legacy/common/components/MustGatherModal';
 import { CreatePlanButton } from '@kubev2v/legacy/Plans/components/CreatePlanButton';
 
 import { FlatPlan, useFlatPlans } from './data';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { MappingType } from 'legacy/src/queries/types';
 import ForkliftEmptyState from 'src/components/empty-states/ForkliftEmptyState';
 import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { AddMappingButton } from 'src/components/mappings/MappingPage';
@@ -11,6 +10,7 @@ import { useTranslation } from 'src/utils/i18n';
 import { ExternalLink } from '@kubev2v/common/components/ExternalLink';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
 import { createK8sPath } from '@kubev2v/legacy/queries/helpers';
+import { MappingType } from '@kubev2v/legacy/queries/types';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 
 import { useHasSufficientProviders } from '../Providers/data';


### PR DESCRIPTION
Some files in `forklift-console-plugin` were using the wrong import paths to reference other packages in the monorepo.  The reason they still worked was the extra paths references needed in the plugin's `tsconfig.json` to handle the path references in the legacy and common packages.

The ultimate goal is to be able to remove the need for config kludges like this (tsconfig.json path references across projects) and have each package be directly consumable.