### PR TITLE
Add `.eslintignore` to project root for vscode support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
The eslint extension in vscode were still running eslint on all `dist/` folders in the workspace projects.  Centrally locating `.eslintignore` in the project root makes the ignores apply nicely for `npm run lint` and for vscode.

If you ever look at the transpiled or packaged code under `dist/`, this tweak will make life nicer.