### PR TITLE
Add `sonar-project.properties` to test code is considered test code

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+#
+# Include all of the source directories, but exclude test and mock code
+#
+sonar.sources = ./
+sonar.exclusions = ./**/__tests__/**/*, ./**/*.test.tsx, ./**/__mocks__/**/*, ./**/*.mock.ts
+
+#
+# Include all of the test and mock code
+#
+sonar.tests = ./
+sonar.test.inclusions = ./**/__tests__/**/*, ./**/*.test.tsx, ./**/__mocks__/**/*, ./**/*.mock.ts


### PR DESCRIPTION
See https://docs.sonarcloud.io/advanced-setup/analysis-scope/#initial-scope for how the inclusions and exclusions are figured.  From that page:

  > Why is test code scoped separately?
  >
  > Test and non-test code are distinguished because different analysis
  > tules are applied to each category; the two categories have different
  > metrics.
  >
  > Additionally, test code does not counts toward your lines of code
  > (LOC) usage in paid SonarCloud accounts and does not count toward
  > coverage (you don’t have to test your test code).

The goal is to have test code considered test code.  Would be nice to have mock data ignored.