### PR TITLE
Set of fixes for #411

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.8.1",
+        "tsc-alias": "^1.8.6",
         "typescript": "^4.7.4",
         "webpack-merge": "^5.8.0"
       }
@@ -14230,6 +14231,19 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
@@ -15368,6 +15382,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/plimit-lit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.5.0.tgz",
+      "integrity": "sha512-Eb/MqCb1Iv/ok4m1FqIXqvUKPISufcjZ605hl3KM/n8GaX8zfhtgdLwZU3vKjuHGh2O9Rjog/bHTq8ofIShdng==",
+      "dev": true,
+      "dependencies": {
+        "queue-lit": "^1.5.0"
       }
     },
     "node_modules/popper.js": {
@@ -17149,6 +17172,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.0.tgz",
+      "integrity": "sha512-IslToJ4eiCEE9xwMzq3viOO5nH8sUWUCwoElrhNMozzr9IIt2qqvB4I+uHu/zJTQVqc9R5DFwok4ijNK1pU3fA==",
       "dev": true
     },
     "node_modules/queue-microtask": {
@@ -20894,6 +20923,23 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.6.tgz",
+      "integrity": "sha512-vq+i6VpE83IeMsSJVcFN03ZBofADhr8/gIJXjxpbnTRfN/MFXy0+SBaKG2o7p95QqXBGkeG98HYz3IkOOveFbg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.2.tgz",
@@ -22596,6 +22642,7 @@
         "streamsaver": "^2.0.6"
       },
       "devDependencies": {
+        "@kubev2v/mocks": "*",
         "@kubev2v/types": "*",
         "@kubev2v/webpack": "*",
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.9",
@@ -24468,6 +24515,7 @@
       "requires": {
         "@kubev2v/common": "*",
         "@kubev2v/legacy": "*",
+        "@kubev2v/mocks": "*",
         "@kubev2v/types": "*",
         "@kubev2v/webpack": "*",
         "@migtools/lib-ui": "^8.4.1",
@@ -33773,6 +33821,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
+    "mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true
+    },
     "nano-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
@@ -34664,6 +34718,15 @@
             "p-limit": "^2.2.0"
           }
         }
+      }
+    },
+    "plimit-lit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.5.0.tgz",
+      "integrity": "sha512-Eb/MqCb1Iv/ok4m1FqIXqvUKPISufcjZ605hl3KM/n8GaX8zfhtgdLwZU3vKjuHGh2O9Rjog/bHTq8ofIShdng==",
+      "dev": true,
+      "requires": {
+        "queue-lit": "^1.5.0"
       }
     },
     "popper.js": {
@@ -36047,6 +36110,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "queue-lit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.0.tgz",
+      "integrity": "sha512-IslToJ4eiCEE9xwMzq3viOO5nH8sUWUCwoElrhNMozzr9IIt2qqvB4I+uHu/zJTQVqc9R5DFwok4ijNK1pU3fA==",
       "dev": true
     },
     "queue-microtask": {
@@ -38936,6 +39005,20 @@
           "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
           "dev": true
         }
+      }
+    },
+    "tsc-alias": {
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.6.tgz",
+      "integrity": "sha512-vq+i6VpE83IeMsSJVcFN03ZBofADhr8/gIJXjxpbnTRfN/MFXy0+SBaKG2o7p95QqXBGkeG98HYz3IkOOveFbg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
       }
     },
     "tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "clean": "rimraf ./dist ./coverage && npm run clean -ws",
     "clean:all": "npm run clean -- ./node_modules ./tmp && npm run clean:all -ws",
     "build": "NODE_ENV=production npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
-    "build:dev": "npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common && npm run build:dev -w @kubev2v/forklift-console-plugin",
-    "start": "npm run build -w @kubev2v/webpack -w @kubev2v/types && npm run start -w @kubev2v/forklift-console-plugin",
+    "build:depenencies": "npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common",
+    "build:dev": "npm run build:depenencies && npm run build:dev -w @kubev2v/forklift-console-plugin",
+    "start": "npm run build:depenencies && npm run start -w @kubev2v/forklift-console-plugin",
     "start:mock": "npm run start -w @kubev2v/mocks -- ",
     "start:proxy": "npm run start -w @kubev2v/forklift-console-plugin -- -c webpack.proxy.config.ts",
     "i18n": "npm run i18n -w @kubev2v/forklift-console-plugin",
@@ -73,6 +74,7 @@
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.8.1",
+    "tsc-alias": "^1.8.6",
     "typescript": "^4.7.4",
     "webpack-merge": "^5.8.0"
   }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,24 +12,24 @@
     "./dist/*"
   ],
   "exports": {
-    "./components/*": "./dist/src/components/*",
-    "./hooks/*": "./dist/src/hooks/*",
-    "./polyfills/*": "./dist/src/polyfills/*",
-    "./utils/*": "./dist/src/utils/*"
+    "./components/*": "./dist/components/*",
+    "./hooks/*": "./dist/hooks/*",
+    "./polyfills/*": "./dist/polyfills/*",
+    "./utils/*": "./dist/utils/*"
   },
   "typesVersions": {
     "*": {
       "components/*": [
-        "dist/src/components/*"
+        "dist/components/*"
       ],
       "hooks/*": [
-        "dist/src/hooks/*"
+        "dist/hooks/*"
       ],
       "polyfills/*": [
-        "dist/src/polyfills/*"
+        "dist/polyfills/*"
       ],
       "utils/*": [
-        "dist/src/utils/*"
+        "dist/utils/*"
       ]
     }
   },
@@ -37,8 +37,8 @@
     "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules",
     "build": "npm run clean && npm run compile && npm run copy:css",
-    "compile": "tsc --build --verbose",
-    "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/src",
+    "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
+    "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",
     "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "test": "TZ=UTC jest",

--- a/packages/common/src/components/ActionServiceDropdown/ActionServiceDropdown.tsx
+++ b/packages/common/src/components/ActionServiceDropdown/ActionServiceDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { useHistory } from 'react-router';
-import { type ActionService, ActionServiceProvider } from 'common/src/polyfills/sdk-shim';
+import { ActionService, ActionServiceProvider } from 'common/src/polyfills/sdk-shim';
 
 import { Dropdown, DropdownItem, DropdownToggle, KebabToggle } from '@patternfly/react-core';
 

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*"],
+  "include": ["./src/**/*"],
 
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "composite": true,
 
     "paths": {

--- a/packages/forklift-console-plugin/jest.config.ts
+++ b/packages/forklift-console-plugin/jest.config.ts
@@ -5,20 +5,24 @@ import type { Config } from '@jest/types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { compilerOptions } = require('./tsconfig.json');
 
+const moduleNameMapper = {
+  '\\.(css|less|scss|svg)$': '<rootDir>/src/__mocks__/dummy.ts',
+  '@console/*': '<rootDir>/src/__mocks__/dummy.ts',
+  '@openshift-console/*': '<rootDir>/src/__mocks__/dummy.ts',
+  'react-i18next': '<rootDir>/src/__mocks__/react-i18next.ts',
+  'legacy/src/(.*)$': '<rootDir>/../legacy/src/$1', // remove when using rollup
+  'common/src/(.*)$': '<rootDir>/../common/src/$1', // remove when using rollup
+  ...pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
+};
+
 // Sync object
 export const config: Config.InitialOptions = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['<rootDir>/src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
-  moduleNameMapper: {
-    '\\.(css|less|scss|svg)$': '<rootDir>/src/__mocks__/dummy.ts',
-    '@console/*': '<rootDir>/src/__mocks__/dummy.ts',
-    '@openshift-console/*': '<rootDir>/src/__mocks__/dummy.ts',
-    'react-i18next': '<rootDir>/src/__mocks__/react-i18next.ts',
-    ...pathsToModuleNameMapper(compilerOptions.paths, {
-      prefix: '<rootDir>/',
-    }),
-  },
+  moduleNameMapper,
   modulePaths: ['<rootDir>'],
   roots: ['<rootDir>/src'],
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx'],

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -35,6 +35,7 @@
     "react-router-dom": "5.2.0"
   },
   "devDependencies": {
+    "@kubev2v/mocks": "*",
     "@kubev2v/types": "*",
     "@kubev2v/webpack": "*",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.9",

--- a/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
+++ b/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { ManageColumnsModal, ManageColumnsToolbarItem } from 'common/src/components/TableView';
-import { ResourceField } from 'common/src/utils/types';
 import { useTranslation } from 'src/utils/i18n';
+
+import { ManageColumnsModal, ManageColumnsToolbarItem } from '@kubev2v/common/components/TableView';
+import { ResourceField } from '@kubev2v/common/utils/types';
 
 export interface ManageColumnsToolbarProps {
   /** Read only. State maintained by parent component. */

--- a/packages/forklift-console-plugin/src/modules/Providers/__tests__/ProviderRow.test.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/__tests__/ProviderRow.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
+
 import {
   MOCK_CLUSTER_PROVIDERS,
   MOCK_INVENTORY_PROVIDERS,
-} from 'legacy/src/queries/mocks/providers.mock';
-
+} from '@kubev2v/legacy/queries/mocks/providers.mock';
 import { V1beta1Provider } from '@kubev2v/types';
 import { cleanup, render } from '@testing-library/react';
 

--- a/packages/forklift-console-plugin/tsconfig.json
+++ b/packages/forklift-console-plugin/tsconfig.json
@@ -1,22 +1,25 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*", "*.ts"],
+  "include": ["./src/**/*", "./plugin-metadata.ts", "./plugin-extensions.ts"],
 
   "compilerOptions": {
-    "outDir": "dist",
-    "declarationDir": "dist/types",
+    "outDir": "./dist",
 
     "paths": {
       "src/*": ["./src/*"],
 
-      "common/src/*": ["../common/src/*"],
-      "legacy/src/*": ["../legacy/src/*"]
+      "@kubev2v/legacy/*": ["../legacy/src/*"],
+      "@kubev2v/common/*": ["../common/src/*"],
+      "@kubev2v/mocks/*": ["../mocks/src/*"],
+      "@kubev2v/webpack": ["../webpack/src"],
+      "@kubev2v/types": ["../types/src"]
     }
   },
 
   "references": [
     { "path": "../common" },
+    { "path": "../types" },
     { "path": "../legacy" }
   ]
 }

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -12,40 +12,40 @@
     "./dist/*"
   ],
   "exports": {
-    "./client/*": "./dist/src/client/*",
-    "./common/*": "./dist/src/common/*",
-    "./Mappings/*": "./dist/src/Mappings/*",
-    "./Plans/*": "./dist/src/Plans/*",
-    "./Providers/*": "./dist/src/Providers/*",
-    "./queries": "./dist/src/queries",
-    "./queries/*": "./dist/src/queries/*",
-    "./utils/*": "./dist/src/utils/*"
+    "./client/*": "./dist/client/*",
+    "./common/*": "./dist/common/*",
+    "./Mappings/*": "./dist/Mappings/*",
+    "./Plans/*": "./dist/Plans/*",
+    "./Providers/*": "./dist/Providers/*",
+    "./queries": "./dist/queries",
+    "./queries/*": "./dist/queries/*",
+    "./utils/*": "./dist/utils/*"
   },
   "typesVersions": {
     "*": {
       "client/*": [
-        "dist/src/client/*"
+        "dist/client/*"
       ],
       "common/*": [
-        "dist/src/common/*"
+        "dist/common/*"
       ],
       "Mappings/*": [
-        "dist/src/Mappings/*"
+        "dist/Mappings/*"
       ],
       "Plans/*": [
-        "dist/src/Plans/*"
+        "dist/Plans/*"
       ],
       "Providers/*": [
-        "dist/src/Providers/*"
+        "dist/Providers/*"
       ],
       "queries": [
-        "dist/src/queries"
+        "dist/queries"
       ],
       "queries/*": [
-        "dist/src/queries/*"
+        "dist/queries/*"
       ],
       "utils/*": [
-        "dist/src/utils/*"
+        "dist/utils/*"
       ]
     }
   },
@@ -53,8 +53,8 @@
     "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules",
     "build": "npm run clean && npm run compile && npm run copy:css",
-    "compile": "tsc --build --verbose",
-    "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/src",
+    "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
+    "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "echo 'this package is untested'; exit 0"

--- a/packages/legacy/tsconfig.json
+++ b/packages/legacy/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*"],
+  "include": ["./src/**/*"],
 
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "composite": true,
 
     "paths": {

--- a/packages/mocks/tsconfig.json
+++ b/packages/mocks/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*"],
+  "include": ["./src/**/*"],
 
   "compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,8 +11,8 @@
   "files": [
     "./dist/*"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rimraf ./dist ./coverage",
     "clean:all": "npm run clean -- ./node_modules",

--- a/packages/types/rollup.config.js
+++ b/packages/types/rollup.config.js
@@ -2,4 +2,4 @@ import { tsLibConfig } from '../../config/rollup-configs';
 
 import pkg from './package.json';
 
-export default tsLibConfig(pkg, 'src/index.ts');
+export default tsLibConfig(pkg, './src/index.ts');

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*"],
+  "include": ["./src/**/*"],
 
   "compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "dist"
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
   }
 }

--- a/packages/webpack/tsconfig.json
+++ b/packages/webpack/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../config/tsconfig.base.json",
 
-  "include": ["src/**/*"],
+  "include": ["./src/**/*"],
 
   "compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   }
 }


### PR DESCRIPTION
In #411 we introduced some tsconfig refactoring and left the tests broken, this PR fixes this issues.

  - [x] always import from packages, e.g. `from '@kubev2v/...`
  - [x] build into `dist` dir instead of `dist/src`
  - [x] use `./src` and `./dist` convention instead of `src` and `dist`
  - [x] compile with relative paths using `tsc-alias`
  - [x] add temporary mapping for jest, fixes using vanilla tsc for building the packages    
