### PR TITLE
Clean up scripts in `package.json` files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "stylelint-config-prettier": "^9.0.3",
         "stylelint-config-standard": "^26.0.0",
         "ts-jest": "^28.0.7",
-        "ts-node": "^10.8.1",
+        "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.6",
         "typescript": "^4.7.4",
         "webpack-merge": "^5.8.0"

--- a/package.json
+++ b/package.json
@@ -7,22 +7,23 @@
   "workspaces": [
     "packages/*"
   ],
+  "config": {
+    "libs": "-w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/mocks"
+  },
   "scripts": {
     "clean": "rimraf ./dist ./coverage && npm run clean -ws",
     "clean:all": "npm run clean && npm run clean:all -ws && rimraf ./node_modules ./tmp ",
-    "build": "NODE_ENV=production npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
-    "build:dependencies": "npm run build -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common",
-    "build:dev": "npm run build:dependencies && npm run build:dev -w @kubev2v/forklift-console-plugin",
-    "start": "npm run build:dependencies && npm run start -w @kubev2v/forklift-console-plugin",
-    "start:mock": "npm run start -w @kubev2v/mocks -- ",
-    "start:proxy": "npm run start -w @kubev2v/forklift-console-plugin -- -c webpack.proxy.config.ts",
+    "build": "NODE_ENV=production npm run build $npm_package_config_libs -w @kubev2v/forklift-console-plugin",
+    "build:dev": "npm run build $npm_package_config_libs && npm run build:dev -w @kubev2v/forklift-console-plugin",
+    "start": "npm run build $npm_package_config_libs && npm run start -w @kubev2v/forklift-console-plugin",
+    "start:overlay-proxy": "npm run build $npm_package_config_libs && npm run start -w @kubev2v/forklift-console-plugin -- -c webpack.proxy.config.ts",
     "i18n": "npm run i18n -w @kubev2v/forklift-console-plugin",
-    "lint": "npm run lint -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
-    "lint:fix": "npm run lint:fix -w @kubev2v/webpack -w @kubev2v/types -w @kubev2v/legacy -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
+    "lint": "npm run lint -ws --if-present",
+    "lint:fix": "npm run lint:fix -ws --if-present",
     "test:i18n": "bash ./ci/test-i18n.sh",
-    "test": "npm run test -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
-    "test:coverage": "npm run test:coverage -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
-    "test:updateSnapshot": "npm run test:updateSnapshot -w @kubev2v/common -w @kubev2v/forklift-console-plugin",
+    "test": "npm run test -ws --if-present",
+    "test:coverage": "npm run test:coverage -ws --if-present",
+    "test:updateSnapshot": "npm run test:updateSnapshot -ws --if-present",
     "test:e2e": "cypress run --config-file config/cypress.config.ts --browser chrome --headed",
     "console": "bash ./ci/start-console.sh",
     "console:oauth": "bash ./ci/start-console.sh --auth",
@@ -73,7 +74,7 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^26.0.0",
     "ts-jest": "^28.0.7",
-    "ts-node": "^10.8.1",
+    "ts-node": "^10.9.1",
     "tsc-alias": "^1.8.6",
     "typescript": "^4.7.4",
     "webpack-merge": "^5.8.0"

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./dist ./coverage",
     "clean:all": "npm run clean -- ./node_modules",
     "i18n": "i18next \"./src/**/*.{js,jsx,ts,tsx}\" [-oc] -c ./i18next-parser.config.mjs",
-    "build": "NODE_ENV=production webpack",
+    "build": "npm run clean && NODE_ENV=production webpack",
     "build:dev": "webpack --progress",
     "start": "webpack serve",
     "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -56,8 +56,7 @@
     "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
     "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "test": "echo 'this package is untested'; exit 0"
+    "lint:fix": "eslint . --fix"
   },
   "peerDependencies": {
     "@migtools/lib-ui": "^8.4.1",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -6,10 +6,12 @@
   "license": "Apache-2.0",
   "main": "./src/index.ts",
   "scripts": {
-    "postinstall": "npx msw init ./generated --save",
+    "postinstall": "msw init ./generated --save",
     "clean": "rimraf ./dist ./coverage",
     "clean:all": "npm run clean -- ./node_modules",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && npm run compile && npm run copy",
+    "compile": "tsc --build --verbose",
+    "copy": "copyfiles -u 1 ./generated/** ./dist",
     "lint": "eslint . ",
     "lint:fix": "eslint . --fix"
   },

--- a/packages/mocks/src/index.ts
+++ b/packages/mocks/src/index.ts
@@ -1,2 +1,2 @@
-export * from './browser';
-export * from './cluster-proxy-server/handlers';
+// stub for future work
+export const stub = 'stub';

--- a/packages/mocks/tsconfig.json
+++ b/packages/mocks/tsconfig.json
@@ -5,6 +5,7 @@
 
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
 }


### PR DESCRIPTION
  - use `$npm_config_***` references to repeat long strings

  - use `-ws --if-present` in root package.json to easily apply the script across every workspace package

  - don't `npx` in a package.json script, it isn't needed

  - stub out the **mocks** package as a `composite: true` package