### PR TITLE
When cleaning all also clean rollup cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ cypress/videos
 ci/yaml/openapi.yaml
 
 **/mockServiceWorker.js
+
+.rollup.cache

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && npm run compile && npm run copy:css",
     "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
     "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rimraf ./dist ./coverage",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "i18n": "i18next \"./src/**/*.{js,jsx,ts,tsx}\" [-oc] -c ./i18next-parser.config.mjs",
     "build": "npm run clean && NODE_ENV=production webpack",
     "build:dev": "webpack --progress",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "postinstall": "msw init ./generated --save",
     "clean": "rimraf ./dist ./coverage",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && npm run compile && npm run copy",
     "compile": "tsc --build --verbose",
     "copy": "copyfiles -u 1 ./generated/** ./dist",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rimraf ./dist ./coverage",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && npx rollup -c --bundleConfigAsCjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -15,7 +15,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rimraf ./dist ./coverage",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && tsc",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
Issue:
when running build. rollup creates a tmp cache we do not clean up.

Fix:
add the rollup cache to the `clean:all` script