### PR TITLE
Mock data and handlers for Provider and Inventory queries

### DIFF
--- a/packages/mocks/src/console-handlers/index.ts
+++ b/packages/mocks/src/console-handlers/index.ts
@@ -1,0 +1,8 @@
+import { type RestHandler } from 'msw';
+
+import { handlers as providersHandlers } from './providers';
+
+/**
+ * All of the mock REST providers defined and available for use.
+ */
+export const allHandlers: RestHandler[] = [...providersHandlers];

--- a/packages/mocks/src/console-handlers/providers.ts
+++ b/packages/mocks/src/console-handlers/providers.ts
@@ -1,0 +1,74 @@
+import { rest, RestHandler } from 'msw';
+
+import { createResource, ForkliftResourceKind } from '@kubev2v/legacy/client/helpers';
+import { IKubeList } from '@kubev2v/legacy/client/types';
+import { CLUSTER_API_VERSION } from '@kubev2v/legacy/common/constants';
+import { IProviderObject } from '@kubev2v/legacy/queries/types';
+
+import { MOCK_INVENTORY_PROVIDERS } from '../mocks/providers.mock';
+
+import { fancyCaptureUrl } from './util';
+
+const mockClusterProviders = (namespace?: string): IKubeList<IProviderObject> => {
+  const items = Object.values(MOCK_INVENTORY_PROVIDERS)
+    .flat()
+    .filter((provider) => (namespace ? provider.namespace === namespace : true))
+    .map((provider) => provider.object);
+
+  return {
+    apiVersion: CLUSTER_API_VERSION,
+    kind: 'Providers',
+    metadata: {
+      continue: '',
+      resourceVersion: '',
+      selfLink: '/foo/list/selfLink',
+    },
+    items,
+  };
+};
+
+// these ultimately rely on @migtools/lib-ui for path generation
+const providerClusterResource = createResource(ForkliftResourceKind.Provider, '');
+
+const providerNamespacedResource = createResource(ForkliftResourceKind.Provider, ':namespace');
+
+const getInventoryApiUrl = (relativePath?: string): string =>
+  `/api/proxy/plugin/forklift-console-plugin/forklift-inventory/${relativePath || ''}`;
+
+/**
+ * These handler paths should be from the perspective of the plugin running on console.
+ *
+ * The intention is to have handlers for every providers based query and mutation
+ * present in `packages/legacy/src/queries/providers.ts`.
+ */
+export const handlers: RestHandler[] = [
+  // support `useClusterProvidersQuery` (cluster and namespaced)
+  rest.get(providerClusterResource.listPath(), (req, res, ctx) => {
+    console.log(...fancyCaptureUrl(req.url));
+    return res(ctx.json(mockClusterProviders()));
+  }),
+
+  rest.get(providerNamespacedResource.listPath(), (req, res, ctx) => {
+    console.log(...fancyCaptureUrl(req.url));
+    const { namespace } = req.params;
+    const _namespace = Array.isArray(namespace) ? namespace[0] : namespace;
+    return res(ctx.json(mockClusterProviders(_namespace)));
+  }),
+
+  // support `useInventoryProvidersQuery`
+  rest.get(getInventoryApiUrl('providers'), (req, res, ctx) => {
+    const detail = req.url.searchParams.get('detail');
+    console.log(...fancyCaptureUrl(req.url), `detail=${detail}`);
+    return res(ctx.json(MOCK_INVENTORY_PROVIDERS));
+  }),
+
+  // TODO: support `useCreateProviderMutation`
+
+  // TODO: support `usePatchProviderMutation`
+
+  // TODO: support `useDeleteProviderMutation`
+
+  // TODO: support `useHasSufficientProvidersQuery`
+
+  // TODO: support `useOCPMigrationNetworkMutation`
+];

--- a/packages/mocks/src/console-handlers/util.ts
+++ b/packages/mocks/src/console-handlers/util.ts
@@ -1,0 +1,10 @@
+/**
+ * Setup pretty printing to browser console of a URL and other data.
+ */
+export const fancyCaptureUrl = (url, ...rest) => [
+  '%cmock-plugin capture%c \u{1f440} %s',
+  'font-weight: bold; color: darkred',
+  'font-weight: inherit; color: inherit',
+  url,
+  ...rest,
+];

--- a/packages/mocks/src/mocks/providers.mock.ts
+++ b/packages/mocks/src/mocks/providers.mock.ts
@@ -1,0 +1,438 @@
+import {
+  ICommonProvider,
+  IOpenShiftProvider,
+  IOpenStackProvider,
+  IProviderObject,
+  IRHVProvider,
+  IVMwareProvider,
+} from '@kubev2v/legacy/queries/types';
+
+const providerStatusReadyFields: IProviderObject = {
+  status: {
+    conditions: [
+      {
+        category: 'Required',
+        lastTransitionTime: '2021-03-18T21:01:10Z',
+        message: 'Connection test, succeeded.',
+        reason: 'Tested',
+        status: 'True',
+        type: 'ConnectionTestSucceeded',
+      },
+      {
+        category: 'Advisory',
+        lastTransitionTime: '2021-02-08T19:36:55Z',
+        message: 'Validation has been completed.',
+        reason: 'Completed',
+        status: 'True',
+        type: 'Validated',
+      },
+      {
+        category: 'Required',
+        lastTransitionTime: '2021-03-23T16:58:23Z',
+        message: 'The inventory has been loaded.',
+        reason: 'Completed',
+        status: 'True',
+        type: 'InventoryCreated',
+      },
+      {
+        category: 'Required',
+        lastTransitionTime: '2021-03-23T16:58:23Z',
+        message: 'The provider is ready.',
+        status: 'True',
+        type: 'Ready',
+      },
+    ],
+    phase: 'Ready',
+  },
+  metadata: undefined,
+  spec: {
+    type: 'vsphere',
+    url: '',
+    secret: undefined,
+    settings: {
+      vddkInitImage: '',
+    },
+  },
+  apiVersion: '',
+  kind: '',
+};
+
+const vmwareProvider1: IVMwareProvider = {
+  uid: 'mock-uid-vcenter-1',
+  namespace: 'openshift-migration',
+  name: 'vcenter-1',
+  selfLink: '/foo/vmwareprovider/1',
+  type: 'vsphere',
+  object: {
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    kind: 'Provider',
+    metadata: {
+      name: 'vcenter-1',
+      namespace: 'openshift-migration',
+      selfLink: '/foo/bar',
+      uid: 'mock-uid-vcenter-1',
+      creationTimestamp: '2020-08-21T18:36:41.468Z',
+    },
+    spec: {
+      type: 'vsphere',
+      url: 'https://vcenter.v2v.bos.redhat.com/sdk',
+      secret: {
+        namespace: 'openshift-migration',
+        name: 'boston',
+      },
+      settings: {
+        vddkInitImage: 'quay.io/username/vddk',
+      },
+    },
+    status: {
+      ...providerStatusReadyFields.status,
+    },
+  },
+  clusterCount: 2,
+  hostCount: 2,
+  vmCount: 41,
+  networkCount: 8,
+  datastoreCount: 3,
+};
+
+const vmwareProvider2: IVMwareProvider = {
+  ...vmwareProvider1,
+  uid: 'mock-uid-vcenter-2',
+  name: 'vcenter-2',
+  selfLink: '/foo/vmwareprovider/2',
+  object: {
+    ...vmwareProvider1.object,
+    metadata: {
+      ...vmwareProvider1.object.metadata,
+      name: 'vcenter-2',
+      uid: 'mock-uid-vcenter-2',
+      creationTimestamp: '2020-08-22T18:36:41.468Z',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'URLNotValid',
+          status: 'True',
+          category: 'Critical',
+          message: 'The provider is not responding.',
+          lastTransitionTime: '2020-08-21T18:36:41.468Z',
+          reason: '',
+        },
+      ],
+      phase: 'ConnectionFailed',
+    },
+  },
+};
+
+const vmwareProvider3: IVMwareProvider = {
+  ...vmwareProvider1,
+  uid: 'mock-uid-vcenter-3',
+  name: 'vcenter-3',
+  selfLink: '/foo/vmwareprovider/3',
+  object: {
+    ...vmwareProvider1.object,
+    metadata: {
+      ...vmwareProvider1.object.metadata,
+      name: 'vcenter-3',
+      uid: 'mock-uid-vcenter-3',
+      creationTimestamp: '2020-08-23T18:36:41.468Z',
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Required',
+          lastTransitionTime: '2021-03-18T21:01:10Z',
+          message: 'Connection test, succeeded.',
+          reason: 'Tested',
+          status: 'True',
+          type: 'ConnectionTestSucceeded',
+        },
+        {
+          category: 'Advisory',
+          lastTransitionTime: '2021-02-08T19:36:55Z',
+          message: 'Validation has been completed.',
+          reason: 'Completed',
+          status: 'True',
+          type: 'Validated',
+        },
+        {
+          category: 'Advisory',
+          lastTransitionTime: '2021-03-23T16:58:23Z',
+          message: 'Loading the inventory.',
+          reason: 'Started',
+          status: 'True',
+          type: 'LoadInventory',
+        },
+      ],
+      phase: 'Staging',
+    },
+  },
+};
+
+const rhvProvider1: IRHVProvider = {
+  uid: 'mock-uid-rhv-1',
+  namespace: 'konveyor-forklift',
+  name: 'rhv-1',
+  selfLink: 'providers/ovirt/foo1',
+  type: 'ovirt',
+  object: {
+    kind: 'Provider',
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    metadata: {
+      name: 'rhv-1',
+      namespace: 'konveyor-forklift',
+      selfLink:
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/konveyor-forklift/providers/rhv-1/status',
+      uid: 'mock-uid-rhv-1',
+      creationTimestamp: '2021-05-06T13:35:06Z',
+      annotations: {
+        'kubectl.kubernetes.io/last-applied-configuration':
+          '{"apiVersion":"forklift.konveyor.io/v1beta1","kind":"Provider","metadata":{"annotations":{},"name":"rhv","namespace":"konveyor-forklift"},"spec":{"secret":{"name":"rhv","namespace":"konveyor-forklift"},"type":"ovirt","url":"https://rhvm.v2v.bos.redhat.com/ovirt-engine/api"}}\n',
+      },
+    },
+    spec: {
+      type: 'ovirt',
+      url: 'https://rhvm.v2v.bos.redhat.com/ovirt-engine/api',
+      secret: { namespace: 'konveyor-forklift', name: 'rhv' },
+    },
+    status: {
+      ...providerStatusReadyFields.status,
+    },
+  },
+  datacenterCount: 1,
+  clusterCount: 2,
+  hostCount: 4,
+  vmCount: 36,
+  networkCount: 15,
+  storageDomainCount: 9,
+};
+
+const rhvProvider1i: IRHVProvider = {
+  ...rhvProvider1,
+  uid: 'mock-uid-rhv-1i',
+  name: 'rhv-1-insecure',
+  selfLink: 'providers/ovirt/foo1i',
+  object: {
+    ...rhvProvider1.object,
+    metadata: {
+      ...rhvProvider1.object.metadata,
+      name: 'rhv-1-insecure',
+      uid: 'mock-uid-rhv-1i',
+    },
+    spec: {
+      ...rhvProvider1.object.spec,
+      secret: { namespace: 'konveyor-forklift', name: 'mock-insecure' },
+    },
+    // TODO different mocked status?
+  },
+};
+
+const rhvProvider2: IRHVProvider = {
+  ...rhvProvider1,
+  uid: 'mock-uid-rhv-2',
+  name: 'rhv-2',
+  selfLink: 'providers/ovirt/foo2',
+  object: {
+    ...rhvProvider1.object,
+    metadata: {
+      ...rhvProvider1.object.metadata,
+      name: 'rhv-2',
+      uid: 'mock-uid-rhv-2',
+    },
+    // TODO different mocked status?
+  },
+};
+
+const rhvProvider3: IRHVProvider = {
+  ...rhvProvider1,
+  uid: 'mock-uid-rhv-3',
+  name: 'rhv-3',
+  selfLink: 'providers/ovirt/foo3',
+  object: {
+    ...rhvProvider1.object,
+    metadata: {
+      ...rhvProvider1.object.metadata,
+      name: 'rhv-3',
+      uid: 'mock-uid-rhv-3',
+    },
+    // TODO different mocked status?
+  },
+};
+
+const openstackProvider1: IOpenStackProvider = {
+  uid: 'mock-uid-openstack-1',
+  namespace: 'konveyor-forklift',
+  name: 'openstack-insecure-1',
+  selfLink: 'providers/openstack/foo1',
+  type: 'openstack',
+  object: {
+    kind: 'Provider',
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    metadata: {
+      name: 'openstack-insecure-1',
+      namespace: 'konveyor-forklift',
+      selfLink:
+        '/apis/forklift.konveyor.io/v1beta1/namespaces/konveyor-forklift/providers/openstack/status',
+      uid: 'mock-uid-openstack-1',
+      creationTimestamp: '2023-02-20T11:53:06Z',
+      annotations: {
+        'kubectl.kubernetes.io/last-applied-configuration':
+          '{"apiVersion":"forklift.konveyor.io/v1beta1","kind":"Provider","metadata":{"annotations":{},"name":"openstack","namespace":"konveyor-forklift"},"spec":{"secret":{"name":"openstack","namespace":"konveyor-forklift"},"type":"openstack","url":"https://v2v.com:5000/v3"}}\n',
+      },
+    },
+    spec: {
+      type: 'openstack',
+      url: 'https://v2v.com:5000/v3',
+      secret: { namespace: 'konveyor-forklift', name: 'insecure' },
+    },
+    status: {
+      ...providerStatusReadyFields.status,
+    },
+  },
+  clusterCount: 0, // TODO need to remove when refactoring since there is no such counter for openStack, i.e. This field won't return from a real server
+  hostCount: 0, // TODO need to remove when refactoring since there is no such counter for openStack, i.e. This field won't return from a real server
+  regionCount: 1,
+  projectCount: 1,
+  vmCount: 3,
+  imageCount: 1,
+  volumeCount: 5,
+  volumeTypeCount: 2,
+  networkCount: 3,
+};
+
+const openstackProvider2: IOpenStackProvider = {
+  ...openstackProvider1,
+  uid: 'mock-uid-openstack-2',
+  name: 'openstack-secure-2',
+  selfLink: 'providers/openstack/foo2',
+  object: {
+    ...openstackProvider1.object,
+    metadata: {
+      ...openstackProvider1.object.metadata,
+      name: 'openstack-secure-2',
+      uid: 'mock-uid-openstack-2',
+    },
+    spec: {
+      type: 'openstack',
+      url: 'https://packstack.com:5000/v3',
+      secret: { namespace: 'konveyor-forklift', name: 'secure' },
+    },
+  },
+};
+
+const openshiftProvider1: IOpenShiftProvider = {
+  uid: 'mock-uid-ocpv-1',
+  namespace: 'openshift-migration',
+  name: 'ocpv-1',
+  selfLink: '/foo/openshiftprovider/1',
+  type: 'openshift',
+  object: {
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    kind: 'Provider',
+    metadata: {
+      name: 'ocpv-1',
+      namespace: 'openshift-migration',
+      selfLink: '/foo/bar',
+      uid: 'mock-uid-ocpv-1',
+      creationTimestamp: '2020-08-21T18:36:41.468Z',
+      annotations: {
+        'forklift.konveyor.io/defaultTransferNetwork': 'ocp-network-3',
+      },
+    },
+    spec: {
+      type: 'openshift',
+      url: 'https://my_OCPv_url',
+      secret: {
+        namespace: 'openshift-migration',
+        name: 'boston',
+      },
+    },
+    status: {
+      ...providerStatusReadyFields.status,
+    },
+  },
+  vmCount: 26,
+  networkCount: 8,
+};
+
+const openshiftProvider2: IOpenShiftProvider = {
+  ...openshiftProvider1,
+  uid: 'mock-uid-ocpv-2',
+  name: 'ocpv-2',
+  selfLink: '/foo/openshiftprovider/2',
+  object: {
+    ...openshiftProvider1.object,
+    metadata: {
+      ...openshiftProvider1.object.metadata,
+      name: 'ocpv-2',
+      uid: 'mock-uid-ocpv-2',
+    },
+    status: {
+      conditions: [
+        {
+          type: 'URLNotValid',
+          status: 'True',
+          category: 'Critical',
+          message: 'The provider is not responding.',
+          lastTransitionTime: '2020-08-21T18:36:41.468Z',
+          reason: '',
+        },
+      ],
+      phase: 'ConnectionFailed',
+    },
+  },
+};
+
+const openshiftProvider3: IOpenShiftProvider = {
+  ...openshiftProvider1,
+  uid: 'mock-uid-ocpv-3',
+  name: 'ocpv-3',
+  selfLink: '/foo/openshiftprovider/3',
+  object: {
+    ...openshiftProvider1.object,
+    metadata: {
+      ...openshiftProvider1.object.metadata,
+      name: 'ocpv-3',
+      uid: 'mock-uid-ocpv-3',
+    },
+    spec: {
+      ...openshiftProvider1.object.spec,
+      url: '',
+    },
+  },
+};
+
+const openshiftProvider4: IOpenShiftProvider = {
+  ...openshiftProvider1,
+  uid: 'mock-uid-host',
+  name: 'host',
+  selfLink: '/foo/openshiftprovider/3',
+  object: {
+    ...openshiftProvider1.object,
+    metadata: {
+      ...openshiftProvider1.object.metadata,
+      name: 'host',
+      uid: 'mock-uid-host',
+      ownerReferences: [
+        {
+          apiVersion: 'forklift.konveyor.io/v1beta1',
+          kind: 'ForkliftController',
+          name: 'forklift-controller',
+          namespace: 'openshift-migration',
+          uid: '2d0a80a3-94a7-4fe5-b0cb-225cf5e24eac',
+        },
+      ],
+    },
+    spec: {
+      ...openshiftProvider1.object.spec,
+      url: '',
+    },
+  },
+};
+
+export const MOCK_INVENTORY_PROVIDERS: Record<string, ICommonProvider[]> = {
+  vsphere: [vmwareProvider1, vmwareProvider2, vmwareProvider3],
+  ovirt: [rhvProvider1, rhvProvider1i, rhvProvider2, rhvProvider3],
+  openstack: [openstackProvider1, openstackProvider2],
+  openshift: [openshiftProvider1, openshiftProvider2, openshiftProvider3, openshiftProvider4],
+};


### PR DESCRIPTION
This change was created in support of #392 as a way to have "real mocks" to verify functionality.

Summary of changes:
  - Mock data ported from `legacy` package to the `mocks` package.
  - Removed any `DATA_MODE` handling.
  - Drop `useMockableQuery` from MSW handler covered provider queries

Handlers created using the mock data for endpoints:
  - Provider cluster resources
  - Provider namespaced resources
  - Provider inventory list

**Note:** The MSW mocks only cover http/rest requests.  The current console watch APIs go over WebSockets.  Those calls cannot currently be mocked (or blocked).

**Note 2:** To step around meaningless SonarCloud security errors, any mock data with `http:` URLs were changed to `https:` URLs.

