### PR TITLE
Clean up `tsconfig.tsbuildinfo` and rollup cache

### DIFF
--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -5,7 +5,7 @@
   "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "rimraf ./dist ./coverage",
+    "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "i18n": "i18next \"./src/**/*.{js,jsx,ts,tsx}\" [-oc] -c ./i18next-parser.config.mjs",
     "build": "npm run clean && NODE_ENV=production webpack",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
-    "clean:all": "npm run clean -- ./node_modules",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && npm run compile && npm run copy:css",
     "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
     "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -7,7 +7,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "postinstall": "msw init ./generated --save",
-    "clean": "rimraf ./dist ./coverage",
+    "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && npm run compile && npm run copy",
     "compile": "tsc --build --verbose",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,9 +14,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist ./coverage",
+    "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
-    "build": "npm run clean && npx rollup -c --bundleConfigAsCjs",
+    "build": "npm run clean && rollup -c --bundleConfigAsCjs",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -14,7 +14,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist ./coverage",
+    "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "build": "npm run clean && tsc",
     "lint": "eslint .",


### PR DESCRIPTION
Make sure all packages clean up the build generated files that we use.  Some were missing.  Keeping the clean consistent between packages makes it easier to have full clean coverage everywhere.

Without this, the follow will fail:
```sh
npm install
npm run build
npm run clean:all
npm install
npm run build
```