### PR TITLE
Set the StorageMaps source title for OpenStack

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -55,7 +55,7 @@
   "Managed provider cannot be edited": "Managed provider cannot be edited",
   "Manged mappings can not be deleted": "Manged mappings can not be deleted",
   "Manged mappings can not be edited": "Manged mappings can not be edited",
-  "Map source datastores or storage domains and networks to target storage classes and networks.": "Map source datastores or storage domains and networks to target storage classes and networks.",
+  "Map source datastores or storage domains or volume types and networks to target storage classes and networks.": "Map source datastores or storage domains or volume types and networks to target storage classes and networks.",
   "Mapping graph": "Mapping graph",
   "Migrating virtualization workloads is a multi-step process:": "Migrating virtualization workloads is a multi-step process:",
   "Migration network maps are used to map network interfaces between source and target virtualization providers, at least one source and one target provider must be available in order to create a migration storage map, <2>Learn more</2>.": "Migration network maps are used to map network interfaces between source and target virtualization providers, at least one source and one target provider must be available in order to create a migration storage map, <2>Learn more</2>.",

--- a/packages/forklift-console-plugin/src/modules/Providers/EmptyStateProviders.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/EmptyStateProviders.tsx
@@ -34,7 +34,7 @@ const EmptyStateProviders: React.FC<{ namespace: string }> = ({ namespace }) => 
             <TextListItem>{t('Add source and target providers for the migration.')}</TextListItem>
             <TextListItem>
               {t(
-                'Map source datastores or storage domains and networks to target storage classes and networks.',
+                'Map source datastores or storage domains or volume types and networks to target storage classes and networks.',
               )}
             </TextListItem>
             <TextListItem>

--- a/packages/legacy/src/Mappings/Mappings.tsx
+++ b/packages/legacy/src/Mappings/Mappings.tsx
@@ -50,7 +50,7 @@ export const Mappings: React.FunctionComponent<IMappingsProps> = ({
           <EmptyStateBody>
             {mappingType === MappingType.Network
               ? 'Map source provider networks to target provider networks.'
-              : 'Map source provider datastores or storage domains to target provider storage classes.'}
+              : 'Map source provider datastores or storage domains or volume types to target provider storage classes.'}
           </EmptyStateBody>
           <CreateMappingButton onClick={toggleModalAndResetEdit} />
         </EmptyState>

--- a/packages/legacy/src/common/helpers.ts
+++ b/packages/legacy/src/common/helpers.ts
@@ -206,6 +206,7 @@ export const isProviderLocalTarget = (provider: IProviderObject): boolean =>
 export const getStorageTitle = (sourceProviderType: ProviderType, cap = false): string => {
   if (sourceProviderType === 'vsphere') return `${cap ? 'D' : 'd'}atastores`;
   if (sourceProviderType === 'ovirt') return `${cap ? 'S' : 's'}torage domains`;
+  if (sourceProviderType === 'openstack') return `${cap ? 'V' : 'v'}olume types`;
   return '';
 };
 


### PR DESCRIPTION
Fixes: #404 
Set the StorageMaps source title, in case the source provider type is OpenStack, to 'Source volume types'.

In addition, add volume types mapping for empty state messages, for keeping code persistence.