### PR TITLE
Make getmockdata generic

### DIFF
--- a/packages/mocks/src/__tests__/getMockData.test.ts
+++ b/packages/mocks/src/__tests__/getMockData.test.ts
@@ -1,3 +1,5 @@
+import { ProvidersInventory } from '@kubev2v/types';
+
 import { getMockData, MockDataRequestParameters, MockResponse } from '../getMockData';
 
 describe('getMockData', () => {
@@ -23,5 +25,15 @@ describe('getMockData', () => {
     const response: MockResponse | null = getMockData(requestParameters);
 
     expect(response).toBeNull();
+  });
+
+  it('should return the correct type', () => {
+    const requestParameters: MockDataRequestParameters = {
+      pathname: '/api/proxy/plugin/forklift-console-plugin/forklift-inventory/providers',
+    };
+
+    const response = getMockData<ProvidersInventory>(requestParameters);
+
+    expect(response.body.openshift[0].type).toBe('openshift');
   });
 });

--- a/packages/mocks/src/getMockData.ts
+++ b/packages/mocks/src/getMockData.ts
@@ -12,24 +12,25 @@ const mockData: Record<string, object> = {
 /**
  * Get a mock response for a given request and path parameters.
  *
+ * @template T - The expected type of the response body (defaults to `object`)
  * @param {Object} param0 - The object containing the request parameters
  * @param {string} param0.pathname - The incoming request pathname to match against the mock handlers
- * @param {string} param0.method - An optional string, the incoming request method to match against the mock handlers
- * @param {PathParams} param0.params - An optional object containing the path parameters of the request
- * @returns {MockResponse | null} A mock response or null if no mock handler is found
+ * @param {string} [param0.method] - An optional string, the incoming request method to match against the mock handlers
+ * @param {PathParams} [param0.params] - An optional object containing the path parameters of the request
+ * @returns {MockResponse<T> | null} A mock response or null if no mock handler is found
  */
-export const getMockData = ({ pathname }: MockDataRequestParameters): MockResponse | null => {
+export const getMockData = <T = object>({
+  pathname,
+}: MockDataRequestParameters): MockResponse<T> | null => {
+  // Dynamic handlers, using custom logic.
+
   // Add your mock handlers here, e.g.:
   // if (method === 'GET' && pathname === '/api/some-resource' && params['details'] === '1') {
   //   return mockResponse;
   // }
 
-  // Dynamic handlers, using custom logic.
-
-  // ...
-
   // Static handlers, using mockData.
-  const data = mockData[pathname] || null;
+  const data = (mockData[pathname] as T) || null;
   if (data) {
     return {
       statusCode: 200,

--- a/packages/mocks/src/getMockData.ts
+++ b/packages/mocks/src/getMockData.ts
@@ -49,7 +49,7 @@ export const getMockData = <T = object>({
  */
 export interface MockResponse<T = object> {
   statusCode: number;
-  body: T | string | null;
+  body: T;
 }
 
 /**


### PR DESCRIPTION
Issue:
Currently `getMockData` always return an object, but it may be useful to return a specific type, e.g. k8s type, or inventory.

Fix:
Add a generic type to the method.

Example:
``` ts
const requestParameters: MockDataRequestParameters = {
    pathname: '/api/proxy/plugin/forklift-console-plugin/forklift-inventory/providers',
};
const response = getMockData<ProvidersInventory>(requestParameters);

// response is now of type ProvidersInventory
// run tests with response.body.openshift[0] ...
```