### PR TITLE
Revert get mock data generic

### DIFF
--- a/packages/mocks/src/__tests__/getMockData.test.ts
+++ b/packages/mocks/src/__tests__/getMockData.test.ts
@@ -1,5 +1,3 @@
-import { ProvidersInventory } from '@kubev2v/types';
-
 import { getMockData, MockDataRequestParameters, MockResponse } from '../getMockData';
 
 describe('getMockData', () => {
@@ -25,15 +23,5 @@ describe('getMockData', () => {
     const response: MockResponse | null = getMockData(requestParameters);
 
     expect(response).toBeNull();
-  });
-
-  it('should return the correct type', () => {
-    const requestParameters: MockDataRequestParameters = {
-      pathname: '/api/proxy/plugin/forklift-console-plugin/forklift-inventory/providers',
-    };
-
-    const response = getMockData<ProvidersInventory>(requestParameters);
-
-    expect(response.body.openshift[0].type).toBe('openshift');
   });
 });

--- a/packages/mocks/src/getMockData.ts
+++ b/packages/mocks/src/getMockData.ts
@@ -12,16 +12,13 @@ const mockData: Record<string, object> = {
 /**
  * Get a mock response for a given request and path parameters.
  *
- * @template T - The expected type of the response body (defaults to `object`)
  * @param {Object} param0 - The object containing the request parameters
  * @param {string} param0.pathname - The incoming request pathname to match against the mock handlers
  * @param {string} [param0.method] - An optional string, the incoming request method to match against the mock handlers
  * @param {PathParams} [param0.params] - An optional object containing the path parameters of the request
- * @returns {MockResponse<T> | null} A mock response or null if no mock handler is found
+ * @returns {MockResponse | null} A mock response or null if no mock handler is found
  */
-export const getMockData = <T = object>({
-  pathname,
-}: MockDataRequestParameters): MockResponse<T> | null => {
+export const getMockData = ({ pathname }: MockDataRequestParameters): MockResponse | null => {
   // Dynamic handlers, using custom logic.
 
   // Add your mock handlers here, e.g.:
@@ -30,7 +27,7 @@ export const getMockData = <T = object>({
   // }
 
   // Static handlers, using mockData.
-  const data = (mockData[pathname] as T) || null;
+  const data = mockData[pathname];
   if (data) {
     return {
       statusCode: 200,
@@ -45,11 +42,11 @@ export const getMockData = <T = object>({
  * Interface representing a mock response.
  *
  * @property statusCode - The HTTP status code of the mock response
- * @property body - The response body, which can be an object or a string
+ * @property body - The response body as object
  */
-export interface MockResponse<T = object> {
+export interface MockResponse {
   statusCode: number;
-  body: T;
+  body: object | null;
 }
 
 /**


### PR DESCRIPTION
Issue:
In https://github.com/kubev2v/forklift-console-plugin/pull/435 I made the `getMockData` method generic,
@rszwajko raised a concern that making this method generic may encourage abuse of the generics [1].

Fix:
Removing the generics

[1] https://github.com/kubev2v/forklift-console-plugin/pull/435#discussion_r1184967403