### PR TITLE
Use data source = msw form msw mocking

### DIFF
--- a/packages/forklift-console-plugin/src/mock-console-extension/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/mock-console-extension/dynamic-plugin.ts
@@ -17,9 +17,9 @@ const _extensions: EncodedExtension[] = [
 ];
 
 /**
- * The plugin will be configured only if the DATA_SOURCE is 'mock'.
+ * The plugin will be configured only if the DATA_SOURCE is 'msw'.
  */
-const isDataSourceMock = process.env.DATA_SOURCE === 'mock';
+const isDataSourceMock = process.env.DATA_SOURCE === 'msw';
 
 export const exposedModules = isDataSourceMock ? _exposedModules : {};
 export const extensions = isDataSourceMock ? _extensions : [];


### PR DESCRIPTION
Issue:
while development of the new mock package it makes sense to run them in parallel, e.g. once running only the legacy mocking, and once running only the msw mocking.

Fix:
Use different DATA_SOURCE keys for each

Example:
``` bash
# run the plugin using the legacy mocking system
DATA_SOURCE=mock npm start
``` 

``` bash
# run the plugin using the msw mocking system
DATA_SOURCE=msw npm start
``` 