### PR TITLE
Add readme to the mock extension

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-generated/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules/
 dist/
 coverage/
-generated/
 tmp/
 yarn-error.log
 openapitools.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -20868,7 +20868,6 @@
     "packages/forklift-console-plugin": {
       "name": "@kubev2v/forklift-console-plugin",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@kubev2v/common": "*",

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -5,13 +5,12 @@
   "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
   "license": "Apache-2.0",
   "scripts": {
-    "postinstall": "msw init ./generated --save",
     "clean": "rimraf ./dist ./coverage tsconfig.tsbuildinfo",
-    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache ./generated",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
     "i18n": "i18next \"./src/**/*.{js,jsx,ts,tsx}\" [-oc] -c ./i18next-parser.config.mjs",
     "build": "NODE_ENV=production webpack",
     "build:dev": "webpack --progress",
-    "start": "webpack serve",
+    "start": "msw init ./dist --save; webpack serve",
     "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "test": "TZ=UTC jest",
@@ -58,6 +57,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "msw": {
-    "workerDirectory": "generated"
+    "workerDirectory": "dist"
   }
 }

--- a/packages/forklift-console-plugin/src/mock-console-extension/README.md
+++ b/packages/forklift-console-plugin/src/mock-console-extension/README.md
@@ -1,0 +1,72 @@
+# Mock console extention
+
+This extention implements MSW browser worker as an OpenShift console plugin extnetion.
+
+The extention sets up mock data as external to the query code using MockServerWorker
+(MSW). This configuration allows the query code to have minimal knowledge of if the
+plugin is running on mock data. Production builds will not need to include mock data.
+
+Ref: [https://mswjs.io/docs/getting-started/integrate/browser](https://mswjs.io)
+
+## Openshift web console extention
+
+The extention uses a `console.context-provider` console extension point
+to inject the mock service worker very close to the start up of console.
+The MSW worker is only setup once. The setup handler is logged to the
+console before the context provider is done running.
+
+## Run the extention
+To run the plugin in dev mode with mock data, set the env variable `DATA_SOURCE=msw` and 
+use the same command to start the dev server:
+
+```sh
+# set the DATA_SOURCE enviorment variable and run the command that starts your plugin
+DATA_SOURCE=msw npm start
+```
+
+## Setting the REST mock data
+
+Mock data is fetched in the file `setupBrowserWorker.tsx`.
+In your code change the method `setupBrowserWorker` to get your mock data.
+
+``` ts
+// Implement your own getMockData to return an object containing the http return code, and the answer object
+// 
+// forklift-console-plugin implements getMockData method that mock data, the method gets
+// the pathname, method and params, and returns the http code and bode,
+// in your plugin, implement your own getMockData method.
+// for exampel:
+// ... if ( pathname == '/api/msg' )
+// ... response = { statusCode: 200, body: { "msg": "hello world" }}
+const mockResponse = getMockData({
+    pathname: req.url.pathname,
+    method: req.method,
+    params: req.params,
+});
+```
+
+## Setting up the extention in your plugin
+
+Create the `mockServiceWorker.js` file and push it in to the `dist` directory before starting
+the development server.
+
+``` bash
+msw init ./dist --save; npm start
+```
+
+Add the `Service-Worker-Allowed` http header to your plugin webpack config `devServer`
+``` ts
+'Service-Worker-Allowed': '/',
+```
+
+Add the mock console extention `exposedModules` and `extensions` to your plugin extentions file.
+
+## Openshift forklift console plugin extension specifics
+
+  - webpack dev server setup to serve MSW's `mockServerWorker.ts`
+  - webpack dev server adds response header `Service-Worker-Allowed`
+    with the value `/`.  Setting the header to `/` allows MSW to
+    scope to `/` and mock ALL calls.
+  - `forklift-console-plugin` has new extension `mock-console-extension`
+    and it's `dynamic-plugin.ts` is sensitive to the `DATA_SOURCE`
+    environment variable.

--- a/packages/forklift-console-plugin/webpack.config.ts
+++ b/packages/forklift-console-plugin/webpack.config.ts
@@ -84,7 +84,7 @@ const config: WebpackConfiguration & {
     ],
   },
   devServer: {
-    static: ['./dist', './generated'],
+    static: ['./dist'],
     host: 'localhost',
     port: 9001,
     headers: {


### PR DESCRIPTION
Issue:
The mock extension requires some documentation to help users set it up an maintain it.

This PR, simplify the extension setup by following more closely the MSW documentation and add a README file to help users understand the setup process of the extension into a new plugin.

  - [x] init the MSW server into the public directory (`./dist`) instead of `.generated`, to follow the documentation.
  - [x] removed unused msw  section in the package definition.
  - [x] add a readme to explain the extension integration process.  


