### PR TITLE
Add some more mock data

### DIFF
--- a/packages/mocks/src/data/migrations.K8s.json
+++ b/packages/mocks/src/data/migrations.K8s.json
@@ -1,0 +1,796 @@
+{
+    "apiVersion": "forklift.konveyor.io/v1beta1",
+    "items": [
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Migration",
+        "metadata": {
+          "creationTimestamp": "2023-04-19T10:27:59Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:plan": {}
+                }
+              },
+              "manager": "OpenAPI-Generator",
+              "operation": "Update",
+              "time": "2023-04-19T10:27:59Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:completed": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:started": {},
+                  "f:vms": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-19T10:33:17Z"
+            }
+          ],
+          "name": "bkhizgiy-migration",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "469079126",
+          "uid": "70c78fd6-2c40-4776-830f-10de451edcd0"
+        },
+        "spec": {
+          "plan": {
+            "name": "bkhizgiy-plan",
+            "namespace": "openshift-mtv"
+          }
+        },
+        "status": {
+          "completed": "2023-04-19T10:33:17Z",
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-19T10:27:59Z",
+              "message": "The migration is ready.",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-19T10:33:17Z",
+              "message": "The migration has SUCCEEDED.",
+              "status": "True",
+              "type": "Succeeded"
+            }
+          ],
+          "observedGeneration": 1,
+          "started": "2023-04-19T10:28:06Z",
+          "vms": [
+            {
+              "completed": "2023-04-19T10:32:46Z",
+              "conditions": [
+                {
+                  "category": "Advisory",
+                  "durable": true,
+                  "lastTransitionTime": "2023-04-19T10:32:46Z",
+                  "message": "The VM migration has SUCCEEDED.",
+                  "status": "True",
+                  "type": "Succeeded"
+                }
+              ],
+              "id": "d56af2fb-e3fa-4553-b5e5-f9101c95344d",
+              "name": "bkhizgiy-mtv-1",
+              "phase": "Completed",
+              "pipeline": [
+                {
+                  "completed": "2023-04-19T10:28:52Z",
+                  "description": "Initialize migration.",
+                  "name": "Initialize",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-19T10:28:06Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "completed": "2023-04-19T10:32:36Z",
+                  "description": "Transfer disks.",
+                  "name": "DiskTransfer",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 25600,
+                    "total": 25600
+                  },
+                  "started": "2023-04-19T10:29:04Z",
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "completed": "2023-04-19T10:32:36Z",
+                      "name": "82f13654-9968-4e26-8323-df7b2f54d374",
+                      "progress": {
+                        "completed": 25600,
+                        "total": 25600
+                      },
+                      "started": "2023-04-19T10:32:36Z"
+                    }
+                  ]
+                },
+                {
+                  "completed": "2023-04-19T10:32:46Z",
+                  "description": "Create VM.",
+                  "name": "VirtualMachineCreation",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-19T10:32:46Z"
+                }
+              ],
+              "restorePowerState": "Off",
+              "started": "2023-04-19T10:28:06Z"
+            },
+            {
+              "completed": "2023-04-19T10:33:16Z",
+              "conditions": [
+                {
+                  "category": "Advisory",
+                  "durable": true,
+                  "lastTransitionTime": "2023-04-19T10:33:16Z",
+                  "message": "The VM migration has SUCCEEDED.",
+                  "status": "True",
+                  "type": "Succeeded"
+                }
+              ],
+              "id": "2b17d6a4-c267-4c9f-b90b-b123b38addc2",
+              "name": "bkhizgiy-mtv-2",
+              "phase": "Completed",
+              "pipeline": [
+                {
+                  "completed": "2023-04-19T10:29:04Z",
+                  "description": "Initialize migration.",
+                  "name": "Initialize",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-19T10:28:18Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "completed": "2023-04-19T10:33:06Z",
+                  "description": "Transfer disks.",
+                  "name": "DiskTransfer",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 25600,
+                    "total": 25600
+                  },
+                  "started": "2023-04-19T10:29:14Z",
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "completed": "2023-04-19T10:33:06Z",
+                      "name": "6b3683e6-b36e-4ae1-81c0-0f9cd39d8741",
+                      "progress": {
+                        "completed": 25600,
+                        "total": 25600
+                      },
+                      "started": "2023-04-19T10:33:06Z"
+                    }
+                  ]
+                },
+                {
+                  "completed": "2023-04-19T10:33:16Z",
+                  "description": "Create VM.",
+                  "name": "VirtualMachineCreation",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-19T10:33:16Z"
+                }
+              ],
+              "restorePowerState": "Off",
+              "started": "2023-04-19T10:28:18Z"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Migration",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T11:40:15Z",
+          "generation": 2,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:started": {},
+                  "f:vms": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:40:23Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"006a5208-9a55-47ff-9916-ea3823a0ac34\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:cancel": {},
+                  "f:plan": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:43:28Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan-1680781215417",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "copy-of-mnecas-test-plan",
+              "uid": "006a5208-9a55-47ff-9916-ea3823a0ac34"
+            }
+          ],
+          "resourceVersion": "481802717",
+          "uid": "a29c5339-ec9d-444a-b6b2-b049e7dce3eb"
+        },
+        "spec": {
+          "cancel": [
+            {
+              "id": "vm-35512",
+              "name": "tg-mini-no-selinux-kernel"
+            }
+          ],
+          "plan": {
+            "name": "copy-of-mnecas-test-plan",
+            "namespace": "openshift-mtv"
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-06T11:43:52Z",
+              "message": "The plan execution has been CANCELED.",
+              "status": "True",
+              "type": "Canceled"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The migration is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 2,
+          "started": "2023-04-06T11:40:23Z",
+          "vms": [
+            {
+              "conditions": [
+                {
+                  "category": "Advisory",
+                  "durable": true,
+                  "lastTransitionTime": "2023-04-06T11:43:40Z",
+                  "message": "The migration has been canceled.",
+                  "reason": "UserRequested",
+                  "status": "True",
+                  "type": "Canceled"
+                }
+              ],
+              "id": "vm-35512",
+              "name": "tg-mini-no-selinux-kernel",
+              "phase": "Completed",
+              "pipeline": [
+                {
+                  "completed": "2023-04-06T11:41:05Z",
+                  "description": "Initialize migration.",
+                  "name": "Initialize",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-06T11:40:23Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "description": "Allocate disks.",
+                  "name": "DiskAllocation",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 2764
+                  },
+                  "started": "2023-04-06T11:41:14Z",
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "progress": {
+                        "completed": 0,
+                        "total": 2764
+                      }
+                    }
+                  ]
+                },
+                {
+                  "description": "Convert image to kubevirt.",
+                  "name": "ImageConversion",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  }
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "description": "Copy disks.",
+                  "name": "DiskTransferV2v",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 2764
+                  },
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "progress": {
+                        "completed": 0,
+                        "total": 2764
+                      }
+                    }
+                  ]
+                },
+                {
+                  "description": "Create VM.",
+                  "name": "VirtualMachineCreation",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  }
+                }
+              ],
+              "restorePowerState": "Off",
+              "started": "2023-04-06T11:40:23Z"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Migration",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T11:42:40Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"0f59e83d-fa1d-4c94-a4ff-35a4b66077e8\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:plan": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:42:40Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:started": {},
+                  "f:vms": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:42:47Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan-local-1680781360226",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "copy-of-mnecas-test-plan-local",
+              "uid": "0f59e83d-fa1d-4c94-a4ff-35a4b66077e8"
+            }
+          ],
+          "resourceVersion": "481803104",
+          "uid": "a90dae07-d791-4703-bb30-dd7b7351c29c"
+        },
+        "spec": {
+          "plan": {
+            "name": "copy-of-mnecas-test-plan-local",
+            "namespace": "openshift-mtv"
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-27T12:15:06Z",
+              "message": "The migration is RUNNING.",
+              "status": "True",
+              "type": "Running"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:15:06Z",
+              "message": "The migration is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "started": "2023-04-06T11:42:47Z",
+          "vms": [
+            {
+              "id": "vm-35512",
+              "name": "tg-mini-no-selinux-kernel",
+              "phase": "AllocateDisks",
+              "pipeline": [
+                {
+                  "completed": "2023-04-06T11:43:34Z",
+                  "description": "Initialize migration.",
+                  "name": "Initialize",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-06T11:42:47Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "description": "Allocate disks.",
+                  "name": "DiskAllocation",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 2764
+                  },
+                  "started": "2023-04-06T11:43:46Z",
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "progress": {
+                        "completed": 0,
+                        "total": 2764
+                      }
+                    }
+                  ]
+                },
+                {
+                  "description": "Convert image to kubevirt.",
+                  "name": "ImageConversion",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  }
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "description": "Copy disks.",
+                  "name": "DiskTransferV2v",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 2764
+                  },
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "progress": {
+                        "completed": 0,
+                        "total": 2764
+                      }
+                    }
+                  ]
+                },
+                {
+                  "description": "Create VM.",
+                  "name": "VirtualMachineCreation",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  }
+                }
+              ],
+              "restorePowerState": "Off",
+              "started": "2023-04-06T11:42:47Z"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Migration",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T09:40:02Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"7c75032b-94e7-4e31-a5ef-656365048047\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:plan": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T09:40:02Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:completed": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:started": {},
+                  "f:vms": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T09:41:39Z"
+            }
+          ],
+          "name": "mnecas-test-plan-1680774002168",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "mnecas-test-plan",
+              "uid": "7c75032b-94e7-4e31-a5ef-656365048047"
+            }
+          ],
+          "resourceVersion": "448483276",
+          "uid": "c8f040c9-be39-48cc-a6e6-29313a6eb197"
+        },
+        "spec": {
+          "plan": {
+            "name": "mnecas-test-plan",
+            "namespace": "openshift-mtv"
+          }
+        },
+        "status": {
+          "completed": "2023-04-06T09:41:39Z",
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-06T09:40:02Z",
+              "message": "The migration is ready.",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-06T09:41:39Z",
+              "message": "The migration has FAILED.",
+              "status": "True",
+              "type": "Failed"
+            }
+          ],
+          "observedGeneration": 1,
+          "started": "2023-04-06T09:40:11Z",
+          "vms": [
+            {
+              "completed": "2023-04-06T09:41:38Z",
+              "conditions": [
+                {
+                  "category": "Advisory",
+                  "durable": true,
+                  "lastTransitionTime": "2023-04-06T09:41:30Z",
+                  "message": "The VM migration has FAILED.",
+                  "status": "True",
+                  "type": "Failed"
+                }
+              ],
+              "error": {
+                "phase": "ConvertGuest",
+                "reasons": [
+                  "Guest conversion failed. See pod logs for details."
+                ]
+              },
+              "id": "vm-35512",
+              "name": "tg-mini-no-selinux-kernel",
+              "phase": "Completed",
+              "pipeline": [
+                {
+                  "completed": "2023-04-06T09:40:46Z",
+                  "description": "Initialize migration.",
+                  "name": "Initialize",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-06T09:40:10Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "completed": "2023-04-06T09:40:55Z",
+                  "description": "Allocate disks.",
+                  "name": "DiskAllocation",
+                  "phase": "Completed",
+                  "progress": {
+                    "completed": 2764,
+                    "total": 2764
+                  },
+                  "started": "2023-04-06T09:40:55Z",
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "completed": "2023-04-06T09:40:55Z",
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "phase": "Completed",
+                      "progress": {
+                        "completed": 2764,
+                        "total": 2764
+                      },
+                      "reason": "Transfer completed.",
+                      "started": "2023-04-06T09:40:55Z"
+                    }
+                  ]
+                },
+                {
+                  "completed": "2023-04-06T09:41:30Z",
+                  "description": "Convert image to kubevirt.",
+                  "error": {
+                    "phase": "Running",
+                    "reasons": [
+                      "Guest conversion failed. See pod logs for details."
+                    ]
+                  },
+                  "name": "ImageConversion",
+                  "phase": "Running",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  },
+                  "started": "2023-04-06T09:41:03Z"
+                },
+                {
+                  "annotations": {
+                    "unit": "MB"
+                  },
+                  "description": "Copy disks.",
+                  "name": "DiskTransferV2v",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 2764
+                  },
+                  "tasks": [
+                    {
+                      "annotations": {
+                        "unit": "MB"
+                      },
+                      "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                      "progress": {
+                        "completed": 0,
+                        "total": 2764
+                      }
+                    }
+                  ]
+                },
+                {
+                  "description": "Create VM.",
+                  "name": "VirtualMachineCreation",
+                  "phase": "Pending",
+                  "progress": {
+                    "completed": 0,
+                    "total": 1
+                  }
+                }
+              ],
+              "restorePowerState": "Off",
+              "started": "2023-04-06T09:40:10Z"
+            }
+          ]
+        }
+      }
+    ],
+    "kind": "MigrationList",
+    "metadata": {
+      "continue": "",
+      "resourceVersion": "498607863"
+    }
+  }

--- a/packages/mocks/src/data/networkmaps.K8s.json
+++ b/packages/mocks/src/data/networkmaps.K8s.json
@@ -1,0 +1,503 @@
+{
+    "apiVersion": "forklift.konveyor.io/v1beta1",
+    "items": [
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "NetworkMap",
+        "metadata": {
+          "annotations": {
+            "forklift.konveyor.io/shared": "false"
+          },
+          "creationTimestamp": "2023-04-06T11:40:11Z",
+          "generateName": "copy-of-mnecas-test-plan-",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:references": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:40:11Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                  },
+                  "f:generateName": {},
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"006a5208-9a55-47ff-9916-ea3823a0ac34\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:map": {},
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  }
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:40:12Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan-jrf9m",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "copy-of-mnecas-test-plan",
+              "uid": "006a5208-9a55-47ff-9916-ea3823a0ac34"
+            }
+          ],
+          "resourceVersion": "481802693",
+          "uid": "75c6962c-d753-4488-b2ea-cec58bd1cf3d"
+        },
+        "spec": {
+          "map": [
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "network-34001"
+              }
+            }
+          ],
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The network map is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "references": [
+            {
+              "id": "network-34001",
+              "name": "VM Network"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "NetworkMap",
+        "metadata": {
+          "annotations": {
+            "forklift.konveyor.io/shared": "false"
+          },
+          "creationTimestamp": "2023-04-06T11:40:44Z",
+          "generateName": "copy-of-mnecas-test-plan-local-",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                  },
+                  "f:generateName": {},
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"0f59e83d-fa1d-4c94-a4ff-35a4b66077e8\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:map": {},
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  }
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:40:44Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:references": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:40:44Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan-local-jj7pb",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "copy-of-mnecas-test-plan-local",
+              "uid": "0f59e83d-fa1d-4c94-a4ff-35a4b66077e8"
+            }
+          ],
+          "resourceVersion": "481802704",
+          "uid": "3f4efab0-a84c-4a09-90a7-acb51a0f0dce"
+        },
+        "spec": {
+          "map": [
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "network-34001"
+              }
+            }
+          ],
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The network map is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "references": [
+            {
+              "id": "network-34001",
+              "name": "VM Network"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "NetworkMap",
+        "metadata": {
+          "annotations": {
+            "forklift.konveyor.io/shared": "false"
+          },
+          "creationTimestamp": "2023-04-06T09:39:59Z",
+          "generateName": "mnecas-test-plan-",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                  },
+                  "f:generateName": {},
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"7c75032b-94e7-4e31-a5ef-656365048047\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:map": {},
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  }
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T09:39:59Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:references": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T09:39:59Z"
+            }
+          ],
+          "name": "mnecas-test-plan-jpsn4",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "Plan",
+              "name": "mnecas-test-plan",
+              "uid": "7c75032b-94e7-4e31-a5ef-656365048047"
+            }
+          ],
+          "resourceVersion": "481802687",
+          "uid": "04c28829-4ccc-4ffe-9910-be389e448fa2"
+        },
+        "spec": {
+          "map": [
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "network-34001"
+              }
+            }
+          ],
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The network map is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "references": [
+            {
+              "id": "network-34001",
+              "name": "VM Network"
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "NetworkMap",
+        "metadata": {
+          "creationTimestamp": "2023-04-19T10:14:58Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:map": {},
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  }
+                }
+              },
+              "manager": "OpenAPI-Generator",
+              "operation": "Update",
+              "time": "2023-04-19T10:14:58Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:references": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-19T10:25:35Z"
+            }
+          ],
+          "name": "mtv-network-mapping-bella",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802742",
+          "uid": "48bc0731-2273-4481-bddb-559c13cdd131"
+        },
+        "spec": {
+          "map": [
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "3d8f43b8-8f7d-4574-9c45-43cbb58f1414"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "83da1bb4-3423-43d9-a481-87b5513251ee"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "ab9e1e1a-4737-47d6-9eed-a1b129bd068b"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "5ff7f565-3acb-4c89-982e-bd7d800913f2"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "f6649732-e4b9-4f17-ae2b-5c2ca9e31b72"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "dd0b35a2-b36b-4357-bd27-671852d0b9b5"
+              }
+            },
+            {
+              "destination": {
+                "type": "pod"
+              },
+              "source": {
+                "id": "39a33c4c-cac1-4874-aa2b-509b92d2b35d"
+              }
+            }
+          ],
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "mtv-provider-bella",
+              "namespace": "openshift-mtv"
+            }
+          }
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:52Z",
+              "message": "The network map is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "references": [
+            {
+              "id": "3d8f43b8-8f7d-4574-9c45-43cbb58f1414",
+              "name": "OSP_INTERNAL"
+            },
+            {
+              "id": "83da1bb4-3423-43d9-a481-87b5513251ee",
+              "name": "ovirtmgmt"
+            },
+            {
+              "id": "ab9e1e1a-4737-47d6-9eed-a1b129bd068b",
+              "name": "ovirtmgmt"
+            },
+            {
+              "id": "5ff7f565-3acb-4c89-982e-bd7d800913f2",
+              "name": "vlan201"
+            },
+            {
+              "id": "f6649732-e4b9-4f17-ae2b-5c2ca9e31b72",
+              "name": "vlan202"
+            },
+            {
+              "id": "dd0b35a2-b36b-4357-bd27-671852d0b9b5",
+              "name": "vlan203"
+            },
+            {
+              "id": "39a33c4c-cac1-4874-aa2b-509b92d2b35d",
+              "name": "vlan400"
+            }
+          ]
+        }
+      }
+    ],
+    "kind": "NetworkMapList",
+    "metadata": {
+      "continue": "",
+      "resourceVersion": "498626832"
+    }
+  }

--- a/packages/mocks/src/data/plans.K8s.json
+++ b/packages/mocks/src/data/plans.K8s.json
@@ -1,0 +1,1156 @@
+{
+    "apiVersion": "forklift.konveyor.io/v1beta1",
+    "items": [
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Plan",
+        "metadata": {
+          "creationTimestamp": "2023-04-19T10:17:12Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:archived": {},
+                  "f:description": {},
+                  "f:map": {
+                    ".": {},
+                    "f:network": {},
+                    "f:storage": {}
+                  },
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  },
+                  "f:targetNamespace": {},
+                  "f:vms": {},
+                  "f:warm": {}
+                }
+              },
+              "manager": "OpenAPI-Generator",
+              "operation": "Update",
+              "time": "2023-04-19T10:17:12Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:migration": {
+                    ".": {},
+                    "f:completed": {},
+                    "f:history": {},
+                    "f:started": {},
+                    "f:vms": {}
+                  },
+                  "f:observedGeneration": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-19T10:33:17Z"
+            }
+          ],
+          "name": "bkhizgiy-plan",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481803005",
+          "uid": "e81c96b5-e42d-402e-82e6-8a0942eab865"
+        },
+        "spec": {
+          "archived": false,
+          "description": "",
+          "map": {
+            "network": {
+              "name": "mtv-network-mapping-bella",
+              "namespace": "openshift-mtv"
+            },
+            "storage": {
+              "name": "mtv-storage-mapping-bella",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "mtv-provider-bella",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "targetNamespace": "bkhizgiy-project",
+          "vms": [
+            {
+              "hooks": [],
+              "id": "d56af2fb-e3fa-4553-b5e5-f9101c95344d"
+            },
+            {
+              "hooks": [],
+              "id": "2b17d6a4-c267-4c9f-b90b-b123b38addc2"
+            }
+          ],
+          "warm": false
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-19T10:33:17Z",
+              "message": "The plan execution has SUCCEEDED.",
+              "status": "True",
+              "type": "Succeeded"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:15:02Z",
+              "message": "The migration plan is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "migration": {
+            "completed": "2023-04-19T10:33:16Z",
+            "history": [
+              {
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-19T10:33:16Z",
+                    "message": "The plan execution has SUCCEEDED.",
+                    "status": "True",
+                    "type": "Succeeded"
+                  }
+                ],
+                "map": {
+                  "network": {
+                    "generation": 1,
+                    "name": "mtv-network-mapping-bella",
+                    "namespace": "openshift-mtv",
+                    "uid": "48bc0731-2273-4481-bddb-559c13cdd131"
+                  },
+                  "storage": {
+                    "generation": 2,
+                    "name": "mtv-storage-mapping-bella",
+                    "namespace": "openshift-mtv",
+                    "uid": "9fa5fbc5-549c-4e0a-ae70-bec078e5dda6"
+                  }
+                },
+                "migration": {
+                  "generation": 1,
+                  "name": "bkhizgiy-migration",
+                  "namespace": "openshift-mtv",
+                  "uid": "70c78fd6-2c40-4776-830f-10de451edcd0"
+                },
+                "plan": {
+                  "generation": 1,
+                  "name": "bkhizgiy-plan",
+                  "namespace": "openshift-mtv",
+                  "uid": "e81c96b5-e42d-402e-82e6-8a0942eab865"
+                },
+                "provider": {
+                  "destination": {
+                    "generation": 1,
+                    "name": "host",
+                    "namespace": "openshift-mtv",
+                    "uid": "e140d4bc-91b7-48c2-b096-7820c8d20b0d"
+                  },
+                  "source": {
+                    "generation": 1,
+                    "name": "mtv-provider-bella",
+                    "namespace": "openshift-mtv",
+                    "uid": "4864c314-4465-4b5b-8557-00b021e1bb50"
+                  }
+                }
+              }
+            ],
+            "started": "2023-04-19T10:28:06Z",
+            "vms": [
+              {
+                "completed": "2023-04-19T10:32:46Z",
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-19T10:32:46Z",
+                    "message": "The VM migration has SUCCEEDED.",
+                    "status": "True",
+                    "type": "Succeeded"
+                  }
+                ],
+                "id": "d56af2fb-e3fa-4553-b5e5-f9101c95344d",
+                "name": "bkhizgiy-mtv-1",
+                "phase": "Completed",
+                "pipeline": [
+                  {
+                    "completed": "2023-04-19T10:28:52Z",
+                    "description": "Initialize migration.",
+                    "name": "Initialize",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-19T10:28:06Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "completed": "2023-04-19T10:32:36Z",
+                    "description": "Transfer disks.",
+                    "name": "DiskTransfer",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 25600,
+                      "total": 25600
+                    },
+                    "started": "2023-04-19T10:29:04Z",
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "completed": "2023-04-19T10:32:36Z",
+                        "name": "82f13654-9968-4e26-8323-df7b2f54d374",
+                        "progress": {
+                          "completed": 25600,
+                          "total": 25600
+                        },
+                        "started": "2023-04-19T10:32:36Z"
+                      }
+                    ]
+                  },
+                  {
+                    "completed": "2023-04-19T10:32:46Z",
+                    "description": "Create VM.",
+                    "name": "VirtualMachineCreation",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-19T10:32:46Z"
+                  }
+                ],
+                "restorePowerState": "Off",
+                "started": "2023-04-19T10:28:06Z"
+              },
+              {
+                "completed": "2023-04-19T10:33:16Z",
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-19T10:33:16Z",
+                    "message": "The VM migration has SUCCEEDED.",
+                    "status": "True",
+                    "type": "Succeeded"
+                  }
+                ],
+                "id": "2b17d6a4-c267-4c9f-b90b-b123b38addc2",
+                "name": "bkhizgiy-mtv-2",
+                "phase": "Completed",
+                "pipeline": [
+                  {
+                    "completed": "2023-04-19T10:29:04Z",
+                    "description": "Initialize migration.",
+                    "name": "Initialize",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-19T10:28:18Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "completed": "2023-04-19T10:33:06Z",
+                    "description": "Transfer disks.",
+                    "name": "DiskTransfer",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 25600,
+                      "total": 25600
+                    },
+                    "started": "2023-04-19T10:29:14Z",
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "completed": "2023-04-19T10:33:06Z",
+                        "name": "6b3683e6-b36e-4ae1-81c0-0f9cd39d8741",
+                        "progress": {
+                          "completed": 25600,
+                          "total": 25600
+                        },
+                        "started": "2023-04-19T10:33:06Z"
+                      }
+                    ]
+                  },
+                  {
+                    "completed": "2023-04-19T10:33:16Z",
+                    "description": "Create VM.",
+                    "name": "VirtualMachineCreation",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-19T10:33:16Z"
+                  }
+                ],
+                "restorePowerState": "Off",
+                "started": "2023-04-19T10:28:18Z"
+              }
+            ]
+          },
+          "observedGeneration": 1
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Plan",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T11:40:11Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:archived": {},
+                  "f:description": {},
+                  "f:map": {
+                    ".": {},
+                    "f:network": {},
+                    "f:storage": {}
+                  },
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  },
+                  "f:targetNamespace": {},
+                  "f:vms": {},
+                  "f:warm": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:40:11Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:migration": {
+                    ".": {},
+                    "f:completed": {},
+                    "f:history": {},
+                    "f:started": {},
+                    "f:vms": {}
+                  },
+                  "f:observedGeneration": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:43:52Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802712",
+          "uid": "006a5208-9a55-47ff-9916-ea3823a0ac34"
+        },
+        "spec": {
+          "archived": false,
+          "description": "",
+          "map": {
+            "network": {
+              "name": "copy-of-mnecas-test-plan-jrf9m",
+              "namespace": "openshift-mtv"
+            },
+            "storage": {
+              "name": "copy-of-mnecas-test-plan-p4kpn",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "targetNamespace": "mnecas-test",
+          "vms": [
+            {
+              "hooks": [],
+              "id": "vm-35512"
+            }
+          ],
+          "warm": false
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-06T11:43:52Z",
+              "message": "The plan execution has been CANCELED.",
+              "status": "True",
+              "type": "Canceled"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The migration plan is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "migration": {
+            "completed": "2023-04-06T11:43:51Z",
+            "history": [
+              {
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-06T11:43:51Z",
+                    "message": "The plan execution has been CANCELED.",
+                    "status": "True",
+                    "type": "Canceled"
+                  }
+                ],
+                "map": {
+                  "network": {
+                    "generation": 1,
+                    "name": "copy-of-mnecas-test-plan-jrf9m",
+                    "namespace": "openshift-mtv",
+                    "uid": "75c6962c-d753-4488-b2ea-cec58bd1cf3d"
+                  },
+                  "storage": {
+                    "generation": 1,
+                    "name": "copy-of-mnecas-test-plan-p4kpn",
+                    "namespace": "openshift-mtv",
+                    "uid": "7c4532b4-9fcb-497f-bb35-5cd42d6cafcc"
+                  }
+                },
+                "migration": {
+                  "generation": 1,
+                  "name": "copy-of-mnecas-test-plan-1680781215417",
+                  "namespace": "openshift-mtv",
+                  "uid": "a29c5339-ec9d-444a-b6b2-b049e7dce3eb"
+                },
+                "plan": {
+                  "generation": 1,
+                  "name": "copy-of-mnecas-test-plan",
+                  "namespace": "openshift-mtv",
+                  "uid": "006a5208-9a55-47ff-9916-ea3823a0ac34"
+                },
+                "provider": {
+                  "destination": {
+                    "generation": 1,
+                    "name": "host",
+                    "namespace": "openshift-mtv",
+                    "uid": "e140d4bc-91b7-48c2-b096-7820c8d20b0d"
+                  },
+                  "source": {
+                    "generation": 2,
+                    "name": "vmware",
+                    "namespace": "openshift-mtv",
+                    "uid": "1ec8b4c7-028d-4a50-a5a9-3ab07dbd0560"
+                  }
+                }
+              }
+            ],
+            "started": "2023-04-06T11:40:23Z",
+            "vms": [
+              {
+                "completed": "2023-04-06T11:43:51Z",
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-06T11:54:55Z",
+                    "message": "The migration has been canceled.",
+                    "reason": "Modified",
+                    "status": "True",
+                    "type": "Canceled"
+                  }
+                ],
+                "id": "vm-35512",
+                "name": "tg-mini-no-selinux-kernel",
+                "phase": "Completed",
+                "pipeline": [
+                  {
+                    "completed": "2023-04-06T11:41:05Z",
+                    "description": "Initialize migration.",
+                    "name": "Initialize",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-06T11:40:23Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "completed": "2023-04-06T11:43:51Z",
+                    "description": "Allocate disks.",
+                    "name": "DiskAllocation",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 2764
+                    },
+                    "started": "2023-04-06T11:41:14Z",
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "progress": {
+                          "completed": 0,
+                          "total": 2764
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Convert image to kubevirt.",
+                    "name": "ImageConversion",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    }
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "description": "Copy disks.",
+                    "name": "DiskTransferV2v",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 2764
+                    },
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "progress": {
+                          "completed": 0,
+                          "total": 2764
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Create VM.",
+                    "name": "VirtualMachineCreation",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    }
+                  }
+                ],
+                "restorePowerState": "Off",
+                "started": "2023-04-06T11:40:23Z"
+              }
+            ]
+          },
+          "observedGeneration": 1
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Plan",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T11:40:44Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:archived": {},
+                  "f:description": {},
+                  "f:map": {
+                    ".": {},
+                    "f:network": {},
+                    "f:storage": {}
+                  },
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  },
+                  "f:targetNamespace": {},
+                  "f:vms": {},
+                  "f:warm": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T11:40:44Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:migration": {
+                    ".": {},
+                    "f:history": {},
+                    "f:started": {},
+                    "f:vms": {}
+                  },
+                  "f:observedGeneration": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T11:42:47Z"
+            }
+          ],
+          "name": "copy-of-mnecas-test-plan-local",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481803102",
+          "uid": "0f59e83d-fa1d-4c94-a4ff-35a4b66077e8"
+        },
+        "spec": {
+          "archived": false,
+          "description": "",
+          "map": {
+            "network": {
+              "name": "copy-of-mnecas-test-plan-local-jj7pb",
+              "namespace": "openshift-mtv"
+            },
+            "storage": {
+              "name": "copy-of-mnecas-test-plan-local-rb426",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "targetNamespace": "mnecas-test",
+          "vms": [
+            {
+              "hooks": [],
+              "id": "vm-35512"
+            }
+          ],
+          "warm": false
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-06T11:42:47Z",
+              "message": "The plan is EXECUTING.",
+              "status": "True",
+              "type": "Executing"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:15:06Z",
+              "message": "The migration plan is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "migration": {
+            "history": [
+              {
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-06T11:42:47Z",
+                    "message": "The plan is EXECUTING.",
+                    "status": "True",
+                    "type": "Executing"
+                  }
+                ],
+                "map": {
+                  "network": {
+                    "generation": 1,
+                    "name": "copy-of-mnecas-test-plan-local-jj7pb",
+                    "namespace": "openshift-mtv",
+                    "uid": "3f4efab0-a84c-4a09-90a7-acb51a0f0dce"
+                  },
+                  "storage": {
+                    "generation": 1,
+                    "name": "copy-of-mnecas-test-plan-local-rb426",
+                    "namespace": "openshift-mtv",
+                    "uid": "15e1d95f-931c-4a92-89a4-784d1ac28a0f"
+                  }
+                },
+                "migration": {
+                  "generation": 1,
+                  "name": "copy-of-mnecas-test-plan-local-1680781360226",
+                  "namespace": "openshift-mtv",
+                  "uid": "a90dae07-d791-4703-bb30-dd7b7351c29c"
+                },
+                "plan": {
+                  "generation": 1,
+                  "name": "copy-of-mnecas-test-plan-local",
+                  "namespace": "openshift-mtv",
+                  "uid": "0f59e83d-fa1d-4c94-a4ff-35a4b66077e8"
+                },
+                "provider": {
+                  "destination": {
+                    "generation": 1,
+                    "name": "host",
+                    "namespace": "openshift-mtv",
+                    "uid": "e140d4bc-91b7-48c2-b096-7820c8d20b0d"
+                  },
+                  "source": {
+                    "generation": 2,
+                    "name": "vmware",
+                    "namespace": "openshift-mtv",
+                    "uid": "1ec8b4c7-028d-4a50-a5a9-3ab07dbd0560"
+                  }
+                }
+              }
+            ],
+            "started": "2023-04-06T11:42:47Z",
+            "vms": [
+              {
+                "id": "vm-35512",
+                "name": "tg-mini-no-selinux-kernel",
+                "phase": "AllocateDisks",
+                "pipeline": [
+                  {
+                    "completed": "2023-04-06T11:43:34Z",
+                    "description": "Initialize migration.",
+                    "name": "Initialize",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-06T11:42:47Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "description": "Allocate disks.",
+                    "name": "DiskAllocation",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 2764
+                    },
+                    "started": "2023-04-06T11:43:46Z",
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "progress": {
+                          "completed": 0,
+                          "total": 2764
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Convert image to kubevirt.",
+                    "name": "ImageConversion",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    }
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "description": "Copy disks.",
+                    "name": "DiskTransferV2v",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 2764
+                    },
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "progress": {
+                          "completed": 0,
+                          "total": 2764
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Create VM.",
+                    "name": "VirtualMachineCreation",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    }
+                  }
+                ],
+                "restorePowerState": "Off",
+                "started": "2023-04-06T11:42:47Z"
+              }
+            ]
+          },
+          "observedGeneration": 1
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Plan",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T09:39:59Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:archived": {},
+                  "f:description": {},
+                  "f:map": {
+                    ".": {},
+                    "f:network": {},
+                    "f:storage": {}
+                  },
+                  "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                  },
+                  "f:targetNamespace": {},
+                  "f:vms": {},
+                  "f:warm": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T09:39:59Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:migration": {
+                    ".": {},
+                    "f:completed": {},
+                    "f:history": {},
+                    "f:started": {},
+                    "f:vms": {}
+                  },
+                  "f:observedGeneration": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T09:41:39Z"
+            }
+          ],
+          "name": "mnecas-test-plan",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802880",
+          "uid": "7c75032b-94e7-4e31-a5ef-656365048047"
+        },
+        "spec": {
+          "archived": false,
+          "description": "",
+          "map": {
+            "network": {
+              "name": "mnecas-test-plan-jpsn4",
+              "namespace": "openshift-mtv"
+            },
+            "storage": {
+              "name": "mnecas-test-plan-tdpn9",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "provider": {
+            "destination": {
+              "name": "host",
+              "namespace": "openshift-mtv"
+            },
+            "source": {
+              "name": "vmware",
+              "namespace": "openshift-mtv"
+            }
+          },
+          "targetNamespace": "mnecas-test",
+          "vms": [
+            {
+              "hooks": [],
+              "id": "vm-35512"
+            }
+          ],
+          "warm": false
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Advisory",
+              "durable": true,
+              "lastTransitionTime": "2023-04-06T09:41:39Z",
+              "message": "The plan execution has FAILED.",
+              "status": "True",
+              "type": "Failed"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:57Z",
+              "message": "The migration plan is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "migration": {
+            "completed": "2023-04-06T09:41:38Z",
+            "history": [
+              {
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-06T09:41:38Z",
+                    "message": "The plan execution has FAILED.",
+                    "status": "True",
+                    "type": "Failed"
+                  }
+                ],
+                "map": {
+                  "network": {
+                    "generation": 1,
+                    "name": "mnecas-test-plan-jpsn4",
+                    "namespace": "openshift-mtv",
+                    "uid": "04c28829-4ccc-4ffe-9910-be389e448fa2"
+                  },
+                  "storage": {
+                    "generation": 1,
+                    "name": "mnecas-test-plan-tdpn9",
+                    "namespace": "openshift-mtv",
+                    "uid": "917c63fa-3d10-4f26-969c-bd7097b2de1b"
+                  }
+                },
+                "migration": {
+                  "generation": 1,
+                  "name": "mnecas-test-plan-1680774002168",
+                  "namespace": "openshift-mtv",
+                  "uid": "c8f040c9-be39-48cc-a6e6-29313a6eb197"
+                },
+                "plan": {
+                  "generation": 1,
+                  "name": "mnecas-test-plan",
+                  "namespace": "openshift-mtv",
+                  "uid": "7c75032b-94e7-4e31-a5ef-656365048047"
+                },
+                "provider": {
+                  "destination": {
+                    "generation": 1,
+                    "name": "host",
+                    "namespace": "openshift-mtv",
+                    "uid": "e140d4bc-91b7-48c2-b096-7820c8d20b0d"
+                  },
+                  "source": {
+                    "generation": 2,
+                    "name": "vmware",
+                    "namespace": "openshift-mtv",
+                    "uid": "1ec8b4c7-028d-4a50-a5a9-3ab07dbd0560"
+                  }
+                }
+              }
+            ],
+            "started": "2023-04-06T09:40:10Z",
+            "vms": [
+              {
+                "completed": "2023-04-06T09:41:38Z",
+                "conditions": [
+                  {
+                    "category": "Advisory",
+                    "durable": true,
+                    "lastTransitionTime": "2023-04-06T09:41:30Z",
+                    "message": "The VM migration has FAILED.",
+                    "status": "True",
+                    "type": "Failed"
+                  }
+                ],
+                "error": {
+                  "phase": "ConvertGuest",
+                  "reasons": [
+                    "Guest conversion failed. See pod logs for details."
+                  ]
+                },
+                "id": "vm-35512",
+                "name": "tg-mini-no-selinux-kernel",
+                "phase": "Completed",
+                "pipeline": [
+                  {
+                    "completed": "2023-04-06T09:40:46Z",
+                    "description": "Initialize migration.",
+                    "name": "Initialize",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-06T09:40:10Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "completed": "2023-04-06T09:40:55Z",
+                    "description": "Allocate disks.",
+                    "name": "DiskAllocation",
+                    "phase": "Completed",
+                    "progress": {
+                      "completed": 2764,
+                      "total": 2764
+                    },
+                    "started": "2023-04-06T09:40:55Z",
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "completed": "2023-04-06T09:40:55Z",
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "phase": "Completed",
+                        "progress": {
+                          "completed": 2764,
+                          "total": 2764
+                        },
+                        "reason": "Transfer completed.",
+                        "started": "2023-04-06T09:40:55Z"
+                      }
+                    ]
+                  },
+                  {
+                    "completed": "2023-04-06T09:41:30Z",
+                    "description": "Convert image to kubevirt.",
+                    "error": {
+                      "phase": "Running",
+                      "reasons": [
+                        "Guest conversion failed. See pod logs for details."
+                      ]
+                    },
+                    "name": "ImageConversion",
+                    "phase": "Running",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    },
+                    "started": "2023-04-06T09:41:03Z"
+                  },
+                  {
+                    "annotations": {
+                      "unit": "MB"
+                    },
+                    "description": "Copy disks.",
+                    "name": "DiskTransferV2v",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 2764
+                    },
+                    "tasks": [
+                      {
+                        "annotations": {
+                          "unit": "MB"
+                        },
+                        "name": "[v2v_general_porpuse_FC_DC] tg-mini-no-selinux-kernel/tg-mini-no-selinux-kernel.vmdk",
+                        "progress": {
+                          "completed": 0,
+                          "total": 2764
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "description": "Create VM.",
+                    "name": "VirtualMachineCreation",
+                    "phase": "Pending",
+                    "progress": {
+                      "completed": 0,
+                      "total": 1
+                    }
+                  }
+                ],
+                "restorePowerState": "Off",
+                "started": "2023-04-06T09:40:10Z"
+              }
+            ]
+          },
+          "observedGeneration": 1
+        }
+      }
+    ],
+    "kind": "PlanList",
+    "metadata": {
+      "continue": "",
+      "resourceVersion": "498607863"
+    }
+  }

--- a/packages/mocks/src/data/providers.Inventory.json
+++ b/packages/mocks/src/data/providers.Inventory.json
@@ -1,5 +1,4 @@
 {
-    "$schema": "../../../types/schemas/ProvidersInventory.schema.json",
     "openshift": [
         {
             "uid": "c13d9331-b4fc-48d8-9fd0-253d6616428b",

--- a/packages/mocks/src/data/providers.K8s.json
+++ b/packages/mocks/src/data/providers.K8s.json
@@ -1,0 +1,593 @@
+{
+    "apiVersion": "forklift.konveyor.io/v1beta1",
+    "items": [
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "creationTimestamp": "2023-04-03T11:26:12Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"1406869c-22c3-426e-91b9-0d6d2c41a81d\"}": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "OpenAPI-Generator",
+              "operation": "Update",
+              "time": "2023-04-03T11:26:12Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-03T11:27:49Z"
+            }
+          ],
+          "name": "host",
+          "namespace": "openshift-mtv",
+          "ownerReferences": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "kind": "ForkliftController",
+              "name": "forklift-controller-doc",
+              "uid": "1406869c-22c3-426e-91b9-0d6d2c41a81d"
+            }
+          ],
+          "resourceVersion": "481802636",
+          "uid": "e140d4bc-91b7-48c2-b096-7820c8d20b0d"
+        },
+        "spec": {
+          "secret": {},
+          "type": "openshift",
+          "url": ""
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-03T11:27:49Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-03T11:27:49Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:51Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "phase": "Ready"
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "creationTimestamp": "2023-04-19T10:25:21Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "OpenAPI-Generator",
+              "operation": "Update",
+              "time": "2023-04-19T10:25:21Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-19T10:25:22Z"
+            }
+          ],
+          "name": "mtv-provider-bella",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802732",
+          "uid": "4864c314-4465-4b5b-8557-00b021e1bb50"
+        },
+        "spec": {
+          "secret": {
+            "name": "mtv-bkhizgiy",
+            "namespace": "openshift-mtv"
+          },
+          "type": "ovirt",
+          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-19T10:25:22Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-19T10:25:22Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:52Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:52Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "phase": "Ready"
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"forklift.konveyor.io/v1beta1\",\"kind\":\"Provider\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2023-03-30T14:20:37Z\",\"generation\":1,\"name\":\"rhv\",\"namespace\":\"openshift-mtv\"},\"spec\":{\"secret\":{\"name\":\"rhv-zdnst\",\"namespace\":\"demo24\"},\"type\":\"ovirt\",\"url\":\"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api\"}}\n"
+          },
+          "creationTimestamp": "2023-04-03T13:34:48Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:annotations": {
+                    ".": {},
+                    "f:kubectl.kubernetes.io/last-applied-configuration": {}
+                  }
+                },
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "kubectl-client-side-apply",
+              "operation": "Update",
+              "time": "2023-04-03T13:34:48Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-03T13:34:49Z"
+            }
+          ],
+          "name": "rhv",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "493581173",
+          "uid": "130b109c-eec8-4753-82f0-d2ebdaf0f835"
+        },
+        "spec": {
+          "secret": {
+            "name": "rhv-zdnst",
+            "namespace": "demo24"
+          },
+          "type": "ovirt",
+          "url": "https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api"
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Warn",
+              "lastTransitionTime": "2023-04-03T13:34:48Z",
+              "message": "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
+              "reason": "SkipTLSVerification",
+              "status": "True",
+              "type": "ConnectionInsecure"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-05-05T00:28:52Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-05-05T00:28:52Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-05-05T00:28:52Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-05-05T00:28:52Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "phase": "Ready"
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "creationTimestamp": "2023-04-19T09:18:10Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-19T09:18:10Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-19T09:18:13Z"
+            }
+          ],
+          "name": "rhv-lab",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802759",
+          "uid": "42bce1bc-f532-496a-b059-18b1d209269b"
+        },
+        "spec": {
+          "secret": {
+            "name": "rhv-lab-lnslg",
+            "namespace": "openshift-mtv"
+          },
+          "type": "ovirt",
+          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-19T09:18:13Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-19T09:18:13Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:52Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:52Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "phase": "Ready"
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "creationTimestamp": "2023-04-23T10:24:46Z",
+          "generation": 1,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-23T10:24:46Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-23T10:24:48Z"
+            }
+          ],
+          "name": "rhv-lab-pre",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802780",
+          "uid": "0a007b12-7587-4a51-a1a9-550726c71f75"
+        },
+        "spec": {
+          "secret": {
+            "name": "rhv-lab-pre-mlkh2",
+            "namespace": "openshift-mtv"
+          },
+          "type": "ovirt",
+          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-23T10:24:48Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-23T10:24:48Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:53Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:53Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 1,
+          "phase": "Ready"
+        }
+      },
+      {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "Provider",
+        "metadata": {
+          "creationTimestamp": "2023-04-06T08:55:52Z",
+          "generation": 2,
+          "managedFields": [
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:spec": {
+                  ".": {},
+                  "f:secret": {},
+                  "f:settings": {
+                    ".": {},
+                    "f:vddkInitImage": {}
+                  },
+                  "f:type": {},
+                  "f:url": {}
+                }
+              },
+              "manager": "Mozilla",
+              "operation": "Update",
+              "time": "2023-04-06T08:55:52Z"
+            },
+            {
+              "apiVersion": "forklift.konveyor.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:observedGeneration": {},
+                  "f:phase": {}
+                }
+              },
+              "manager": "forklift-controller",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2023-04-06T08:55:53Z"
+            }
+          ],
+          "name": "vmware",
+          "namespace": "openshift-mtv",
+          "resourceVersion": "481802308",
+          "uid": "1ec8b4c7-028d-4a50-a5a9-3ab07dbd0560"
+        },
+        "spec": {
+          "secret": {
+            "name": "vmware-zlls6",
+            "namespace": "openshift-mtv"
+          },
+          "settings": {
+            "vddkInitImage": "quay.io/lrotenbe/vddk:7.0.3"
+          },
+          "type": "vsphere",
+          "url": "https://rhev-node-13.rdu2.scalelab.redhat.com/sdk"
+        },
+        "status": {
+          "conditions": [
+            {
+              "category": "Warn",
+              "lastTransitionTime": "2023-04-06T08:55:52Z",
+              "message": "TLS is susceptible to machine-in-the-middle attacks when certificate verification is skipped.",
+              "reason": "SkipTLSVerification",
+              "status": "True",
+              "type": "ConnectionInsecure"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-06T08:55:53Z",
+              "message": "Connection test, succeeded.",
+              "reason": "Tested",
+              "status": "True",
+              "type": "ConnectionTestSucceeded"
+            },
+            {
+              "category": "Advisory",
+              "lastTransitionTime": "2023-04-06T08:55:53Z",
+              "message": "Validation has been completed.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "Validated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:38Z",
+              "message": "The inventory has been loaded.",
+              "reason": "Completed",
+              "status": "True",
+              "type": "InventoryCreated"
+            },
+            {
+              "category": "Required",
+              "lastTransitionTime": "2023-04-27T12:14:38Z",
+              "message": "The provider is ready.",
+              "status": "True",
+              "type": "Ready"
+            }
+          ],
+          "observedGeneration": 2,
+          "phase": "Ready"
+        }
+      }
+    ],
+    "kind": "ProviderList",
+    "metadata": {
+      "continue": "",
+      "resourceVersion": "498603388"
+    }
+  }

--- a/packages/mocks/src/data/storagemaps.K8s.json
+++ b/packages/mocks/src/data/storagemaps.K8s.json
@@ -1,0 +1,535 @@
+{
+    "apiVersion": "forklift.konveyor.io/v1beta1",
+    "items": [
+        {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "StorageMap",
+        "metadata": {
+            "annotations": {
+            "forklift.konveyor.io/shared": "false"
+            },
+            "creationTimestamp": "2023-04-06T11:40:44Z",
+            "generateName": "copy-of-mnecas-test-plan-local-",
+            "generation": 1,
+            "managedFields": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:metadata": {
+                    "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                    },
+                    "f:generateName": {},
+                    "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"0f59e83d-fa1d-4c94-a4ff-35a4b66077e8\"}": {}
+                    }
+                },
+                "f:spec": {
+                    ".": {},
+                    "f:map": {},
+                    "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                    }
+                }
+                },
+                "manager": "Mozilla",
+                "operation": "Update",
+                "time": "2023-04-06T11:40:44Z"
+            },
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:status": {
+                    ".": {},
+                    "f:conditions": {},
+                    "f:observedGeneration": {},
+                    "f:references": {}
+                }
+                },
+                "manager": "forklift-controller",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2023-04-06T11:40:44Z"
+            }
+            ],
+            "name": "copy-of-mnecas-test-plan-local-rb426",
+            "namespace": "openshift-mtv",
+            "ownerReferences": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "kind": "Plan",
+                "name": "copy-of-mnecas-test-plan-local",
+                "uid": "0f59e83d-fa1d-4c94-a4ff-35a4b66077e8"
+            }
+            ],
+            "resourceVersion": "481802710",
+            "uid": "15e1d95f-931c-4a92-89a4-784d1ac28a0f"
+        },
+        "spec": {
+            "map": [
+            {
+                "destination": {
+                "storageClass": "localblock-sc"
+                },
+                "source": {
+                "id": "datastore-34003"
+                }
+            }
+            ],
+            "provider": {
+            "destination": {
+                "name": "host",
+                "namespace": "openshift-mtv"
+            },
+            "source": {
+                "name": "vmware",
+                "namespace": "openshift-mtv"
+            }
+            }
+        },
+        "status": {
+            "conditions": [
+            {
+                "category": "Required",
+                "lastTransitionTime": "2023-04-27T12:14:51Z",
+                "message": "The storage map is ready.",
+                "status": "True",
+                "type": "Ready"
+            }
+            ],
+            "observedGeneration": 1,
+            "references": [
+            {
+                "id": "datastore-34003",
+                "name": "v2v_general_porpuse_FC_DC"
+            }
+            ]
+        }
+        },
+        {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "StorageMap",
+        "metadata": {
+            "annotations": {
+            "forklift.konveyor.io/shared": "false"
+            },
+            "creationTimestamp": "2023-04-06T11:40:11Z",
+            "generateName": "copy-of-mnecas-test-plan-",
+            "generation": 1,
+            "managedFields": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:status": {
+                    ".": {},
+                    "f:conditions": {},
+                    "f:observedGeneration": {},
+                    "f:references": {}
+                }
+                },
+                "manager": "forklift-controller",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2023-04-06T11:40:11Z"
+            },
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:metadata": {
+                    "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                    },
+                    "f:generateName": {},
+                    "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"006a5208-9a55-47ff-9916-ea3823a0ac34\"}": {}
+                    }
+                },
+                "f:spec": {
+                    ".": {},
+                    "f:map": {},
+                    "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                    }
+                }
+                },
+                "manager": "Mozilla",
+                "operation": "Update",
+                "time": "2023-04-06T11:40:12Z"
+            }
+            ],
+            "name": "copy-of-mnecas-test-plan-p4kpn",
+            "namespace": "openshift-mtv",
+            "ownerReferences": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "kind": "Plan",
+                "name": "copy-of-mnecas-test-plan",
+                "uid": "006a5208-9a55-47ff-9916-ea3823a0ac34"
+            }
+            ],
+            "resourceVersion": "481802698",
+            "uid": "7c4532b4-9fcb-497f-bb35-5cd42d6cafcc"
+        },
+        "spec": {
+            "map": [
+            {
+                "destination": {
+                "storageClass": "openshift-storage.noobaa.io"
+                },
+                "source": {
+                "id": "datastore-34003"
+                }
+            }
+            ],
+            "provider": {
+            "destination": {
+                "name": "host",
+                "namespace": "openshift-mtv"
+            },
+            "source": {
+                "name": "vmware",
+                "namespace": "openshift-mtv"
+            }
+            }
+        },
+        "status": {
+            "conditions": [
+            {
+                "category": "Required",
+                "lastTransitionTime": "2023-04-27T12:14:51Z",
+                "message": "The storage map is ready.",
+                "status": "True",
+                "type": "Ready"
+            }
+            ],
+            "observedGeneration": 1,
+            "references": [
+            {
+                "id": "datastore-34003",
+                "name": "v2v_general_porpuse_FC_DC"
+            }
+            ]
+        }
+        },
+        {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "StorageMap",
+        "metadata": {
+            "annotations": {
+            "forklift.konveyor.io/shared": "false"
+            },
+            "creationTimestamp": "2023-04-06T09:39:59Z",
+            "generateName": "mnecas-test-plan-",
+            "generation": 1,
+            "managedFields": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:metadata": {
+                    "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                    },
+                    "f:generateName": {},
+                    "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"7c75032b-94e7-4e31-a5ef-656365048047\"}": {}
+                    }
+                },
+                "f:spec": {
+                    ".": {},
+                    "f:map": {},
+                    "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                    }
+                }
+                },
+                "manager": "Mozilla",
+                "operation": "Update",
+                "time": "2023-04-06T09:39:59Z"
+            },
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:status": {
+                    ".": {},
+                    "f:conditions": {},
+                    "f:observedGeneration": {},
+                    "f:references": {}
+                }
+                },
+                "manager": "forklift-controller",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2023-04-06T09:39:59Z"
+            }
+            ],
+            "name": "mnecas-test-plan-tdpn9",
+            "namespace": "openshift-mtv",
+            "ownerReferences": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "kind": "Plan",
+                "name": "mnecas-test-plan",
+                "uid": "7c75032b-94e7-4e31-a5ef-656365048047"
+            }
+            ],
+            "resourceVersion": "481802706",
+            "uid": "917c63fa-3d10-4f26-969c-bd7097b2de1b"
+        },
+        "spec": {
+            "map": [
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "datastore-34003"
+                }
+            }
+            ],
+            "provider": {
+            "destination": {
+                "name": "host",
+                "namespace": "openshift-mtv"
+            },
+            "source": {
+                "name": "vmware",
+                "namespace": "openshift-mtv"
+            }
+            }
+        },
+        "status": {
+            "conditions": [
+            {
+                "category": "Required",
+                "lastTransitionTime": "2023-04-27T12:14:51Z",
+                "message": "The storage map is ready.",
+                "status": "True",
+                "type": "Ready"
+            }
+            ],
+            "observedGeneration": 1,
+            "references": [
+            {
+                "id": "datastore-34003",
+                "name": "v2v_general_porpuse_FC_DC"
+            }
+            ]
+        }
+        },
+        {
+        "apiVersion": "forklift.konveyor.io/v1beta1",
+        "kind": "StorageMap",
+        "metadata": {
+            "annotations": {
+            "forklift.konveyor.io/shared": "true"
+            },
+            "creationTimestamp": "2023-04-19T10:14:56Z",
+            "generation": 2,
+            "managedFields": [
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:spec": {
+                    ".": {},
+                    "f:provider": {
+                    ".": {},
+                    "f:destination": {},
+                    "f:source": {}
+                    }
+                }
+                },
+                "manager": "OpenAPI-Generator",
+                "operation": "Update",
+                "time": "2023-04-19T10:14:56Z"
+            },
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:status": {
+                    ".": {},
+                    "f:conditions": {},
+                    "f:observedGeneration": {},
+                    "f:references": {}
+                }
+                },
+                "manager": "forklift-controller",
+                "operation": "Update",
+                "subresource": "status",
+                "time": "2023-04-19T10:25:35Z"
+            },
+            {
+                "apiVersion": "forklift.konveyor.io/v1beta1",
+                "fieldsType": "FieldsV1",
+                "fieldsV1": {
+                "f:metadata": {
+                    "f:annotations": {
+                    ".": {},
+                    "f:forklift.konveyor.io/shared": {}
+                    }
+                },
+                "f:spec": {
+                    "f:map": {}
+                }
+                },
+                "manager": "Mozilla",
+                "operation": "Update",
+                "time": "2023-04-19T10:27:31Z"
+            }
+            ],
+            "name": "mtv-storage-mapping-bella",
+            "namespace": "openshift-mtv",
+            "resourceVersion": "481802745",
+            "uid": "9fa5fbc5-549c-4e0a-ae70-bec078e5dda6"
+        },
+        "spec": {
+            "map": [
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "5a39bb1b-7b15-46c3-bfc0-0765afe19f3b"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "8eb68241-f36f-40bf-aadf-401c53fcd915"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "9c4bbfa7-c57c-4431-8f35-565380171b2d"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "83d6f06b-2bec-4b3c-ba48-872ed54f02b7"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "9911fcf3-1b3b-4e95-9858-d7b7c0ba779e"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "f7b1588c-579d-4a35-9d68-2325ca49a4d1"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "2f5fb606-ee7f-4c46-8e08-b52b62220e70"
+                }
+            },
+            {
+                "destination": {
+                "storageClass": "ocs-storagecluster-ceph-rbd"
+                },
+                "source": {
+                "id": "08e28643-4e89-41ca-ab75-564be2adef81"
+                }
+            }
+            ],
+            "provider": {
+            "destination": {
+                "name": "host",
+                "namespace": "openshift-mtv"
+            },
+            "source": {
+                "name": "mtv-provider-bella",
+                "namespace": "openshift-mtv"
+            }
+            }
+        },
+        "status": {
+            "conditions": [
+            {
+                "category": "Required",
+                "lastTransitionTime": "2023-04-27T12:14:52Z",
+                "message": "The storage map is ready.",
+                "status": "True",
+                "type": "Ready"
+            }
+            ],
+            "observedGeneration": 2,
+            "references": [
+            {
+                "id": "5a39bb1b-7b15-46c3-bfc0-0765afe19f3b",
+                "name": "data-nfs-rdu"
+            },
+            {
+                "id": "8eb68241-f36f-40bf-aadf-401c53fcd915",
+                "name": "data-nfs-tlv2"
+            },
+            {
+                "id": "9c4bbfa7-c57c-4431-8f35-565380171b2d",
+                "name": "export-nfs-rdu"
+            },
+            {
+                "id": "83d6f06b-2bec-4b3c-ba48-872ed54f02b7",
+                "name": "export-nfs-tlv2"
+            },
+            {
+                "id": "9911fcf3-1b3b-4e95-9858-d7b7c0ba779e",
+                "name": "hosted_storage"
+            },
+            {
+                "id": "f7b1588c-579d-4a35-9d68-2325ca49a4d1",
+                "name": "iso-nfs-rdu"
+            },
+            {
+                "id": "2f5fb606-ee7f-4c46-8e08-b52b62220e70",
+                "name": "iso-nfs-tlv2"
+            },
+            {
+                "id": "08e28643-4e89-41ca-ab75-564be2adef81",
+                "name": "vm-leases-tlv2"
+            }
+            ]
+        }
+        }
+    ],
+    "kind": "StorageMapList",
+    "metadata": {
+        "continue": "",
+        "resourceVersion": "498629473"
+    }
+}

--- a/packages/mocks/src/getMockData.ts
+++ b/packages/mocks/src/getMockData.ts
@@ -1,12 +1,26 @@
 import { PathParams } from 'msw';
 
-import * as providers from './data/provider.json';
+import * as migrationsK8s from './data/migrations.K8s.json';
+import * as networkmapsK8s from './data/networkmaps.K8s.json';
+import * as plansK8s from './data/plans.K8s.json';
+import * as providersInventory from './data/providers.Inventory.json';
+import * as providersK8s from './data/providers.K8s.json';
+import * as storagemapsK8s from './data/storagemaps.K8s.json';
 
 /**
  * A mapping of API paths to their corresponding mock data.
  */
 const mockData: Record<string, object> = {
-  '/api/proxy/plugin/forklift-console-plugin/forklift-inventory/providers': providers,
+  '/api/proxy/plugin/forklift-console-plugin/forklift-inventory/providers': providersInventory,
+  '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-mtv/providers':
+    providersK8s,
+  '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-mtv/migrations':
+    migrationsK8s,
+  '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-mtv/plans': plansK8s,
+  '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-mtv/networkmaps':
+    networkmapsK8s,
+  '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/openshift-mtv/storagemaps':
+    storagemapsK8s,
 };
 
 /**


### PR DESCRIPTION
Issue:
Currently we only mock providers inventory, we need more mock data to actually render the list pages

Screenshot:
mocking list pages on namespace "openshift-mtv", ( recording from brq2 cluster )

![Screencast from 2023-05-08 08-45-09 webm](https://user-images.githubusercontent.com/2181522/236743726-b920f6ae-d1e0-421f-9fa2-6f3c3bd969ee.gif)
