### PR TITLE
Add a method to adjust namespace in mock paths

### DIFF
--- a/packages/mocks/src/__tests__/getMockData.test.ts
+++ b/packages/mocks/src/__tests__/getMockData.test.ts
@@ -1,4 +1,9 @@
-import { getMockData, MockDataRequestParameters, MockResponse } from '../getMockData';
+import {
+  getMockData,
+  MockDataRequestParameters,
+  MockResponse,
+  replaceNamespaceInPath,
+} from '../getMockData';
 
 describe('getMockData', () => {
   it('should return the correct mock response when the pathname matches', () => {
@@ -23,5 +28,33 @@ describe('getMockData', () => {
     const response: MockResponse | null = getMockData(requestParameters);
 
     expect(response).toBeNull();
+  });
+});
+
+describe('replaceNamespaceInPath', () => {
+  it('replaces any namespace with the new namespace in the path', () => {
+    const oldPath = '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/old/migrations';
+    const newNamespace = 'new';
+    const expectedPath =
+      '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/new/migrations';
+
+    const actualPath = replaceNamespaceInPath(oldPath, newNamespace);
+    expect(actualPath).toEqual(expectedPath);
+  });
+
+  it('returns the path unchanged if it does not contain a namespace', () => {
+    const path = '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/pods';
+    const newNamespace = 'new';
+
+    const actualPath = replaceNamespaceInPath(path, newNamespace);
+    expect(actualPath).toEqual(path);
+  });
+
+  it('returns the path unchanged if it contains an invalid namespace format', () => {
+    const path = '/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces//migrations';
+    const newNamespace = 'new';
+
+    const actualPath = replaceNamespaceInPath(path, newNamespace);
+    expect(actualPath).toEqual(path);
   });
 });

--- a/packages/mocks/src/data/providers.Inventory.json
+++ b/packages/mocks/src/data/providers.Inventory.json
@@ -295,7 +295,7 @@
                 },
                 "spec": {
                     "type": "openstack",
-                    "url": "https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000/v3",
+                    "url": "https://rhos-d.infra.prod.upshift.rdu2.example.com:13000/v3",
                     "secret": {
                         "namespace": "demo24",
                         "name": "openstack-42xv6"
@@ -362,7 +362,7 @@
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api",
+                    "url": "https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "migration",
                         "name": "rhv-2c28j"
@@ -384,7 +384,7 @@
                             "status": "True",
                             "reason": "Tested",
                             "category": "Critical",
-                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
+                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
                             "lastTransitionTime": "2023-04-29T07:43:56Z"
                         }
                     ],
@@ -418,7 +418,7 @@
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api",
+                    "url": "https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "demo24",
                         "name": "rhv-zdnst"
@@ -440,7 +440,7 @@
                             "status": "True",
                             "reason": "Tested",
                             "category": "Critical",
-                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
+                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
                             "lastTransitionTime": "2023-04-29T07:43:56Z"
                         }
                     ],
@@ -474,7 +474,7 @@
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api",
+                    "url": "https://rhvm.engineering.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "openshift-mtv",
                         "name": "rhv-lab-lnslg"
@@ -545,7 +545,7 @@
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api",
+                    "url": "https://rhvm.engineering.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "openshift-mtv",
                         "name": "mtv-bkhizgiy"
@@ -614,12 +614,12 @@
                     "generation": 1,
                     "creationTimestamp": "2023-04-03T13:34:48Z",
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"forklift.konveyor.io/v1beta1\",\"kind\":\"Provider\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2023-03-30T14:20:37Z\",\"generation\":1,\"name\":\"rhv\",\"namespace\":\"openshift-mtv\"},\"spec\":{\"secret\":{\"name\":\"rhv-zdnst\",\"namespace\":\"demo24\"},\"type\":\"ovirt\",\"url\":\"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api\"}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"forklift.konveyor.io/v1beta1\",\"kind\":\"Provider\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2023-03-30T14:20:37Z\",\"generation\":1,\"name\":\"rhv\",\"namespace\":\"openshift-mtv\"},\"spec\":{\"secret\":{\"name\":\"rhv-zdnst\",\"namespace\":\"demo24\"},\"type\":\"ovirt\",\"url\":\"https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api\"}}\n"
                     }
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api",
+                    "url": "https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "demo24",
                         "name": "rhv-zdnst"
@@ -641,7 +641,7 @@
                             "status": "True",
                             "reason": "Tested",
                             "category": "Critical",
-                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
+                            "message": "Connection test, failed: GET failed. caused by: 'Get \"https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/sso/oauth/token?grant_type=password\u0026password=123456\u0026scope=ovirt-app-api\u0026username=admin%40internal\": dial tcp 10.46.30.10:443: i/o timeout'",
                             "lastTransitionTime": "2023-04-29T07:43:56Z"
                         }
                     ],
@@ -675,7 +675,7 @@
                 },
                 "spec": {
                     "type": "ovirt",
-                    "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api",
+                    "url": "https://rhvm.engineering.example.com/ovirt-engine/api",
                     "secret": {
                         "namespace": "openshift-mtv",
                         "name": "rhv-lab-pre-mlkh2"
@@ -748,7 +748,7 @@
                 },
                 "spec": {
                     "type": "vsphere",
-                    "url": "https://rhev-node-05.rdu2.scalelab.redhat.com/sdk",
+                    "url": "https://rhev-node-05.rdu2.scalelab.example.com/sdk",
                     "secret": {
                         "namespace": "demo24",
                         "name": "vmware-gq7vc"
@@ -773,7 +773,7 @@
                             "status": "True",
                             "reason": "Tested",
                             "category": "Critical",
-                            "message": "Connection test, failed: Post \"https://rhev-node-05.rdu2.scalelab.redhat.com/sdk\": context deadline exceeded",
+                            "message": "Connection test, failed: Post \"https://rhev-node-05.rdu2.scalelab.example.com/sdk\": context deadline exceeded",
                             "lastTransitionTime": "2023-04-30T05:28:35Z"
                         }
                     ],
@@ -809,7 +809,7 @@
                 },
                 "spec": {
                     "type": "vsphere",
-                    "url": "https://rhev-node-13.rdu2.scalelab.redhat.com/sdk",
+                    "url": "https://rhev-node-13.rdu2.scalelab.example.com/sdk",
                     "secret": {
                         "namespace": "openshift-mtv",
                         "name": "vmware-zlls6"
@@ -893,7 +893,7 @@
                 },
                 "spec": {
                     "type": "vsphere",
-                    "url": "https://rhev-node-05.rdu2.scalelab.redhat.com/sdk",
+                    "url": "https://rhev-node-05.rdu2.scalelab.example.com/sdk",
                     "secret": {
                         "namespace": "migration",
                         "name": "vsphere-7t9b2"
@@ -918,7 +918,7 @@
                             "status": "True",
                             "reason": "Tested",
                             "category": "Critical",
-                            "message": "Connection test, failed: Post \"https://rhev-node-05.rdu2.scalelab.redhat.com/sdk\": context deadline exceeded",
+                            "message": "Connection test, failed: Post \"https://rhev-node-05.rdu2.scalelab.example.com/sdk\": context deadline exceeded",
                             "lastTransitionTime": "2023-04-30T05:28:33Z"
                         }
                     ],

--- a/packages/mocks/src/data/providers.K8s.json
+++ b/packages/mocks/src/data/providers.K8s.json
@@ -152,7 +152,7 @@
             "namespace": "openshift-mtv"
           },
           "type": "ovirt",
-          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+          "url": "https://rhvm.engineering.example.com/ovirt-engine/api"
         },
         "status": {
           "conditions": [
@@ -197,7 +197,7 @@
         "kind": "Provider",
         "metadata": {
           "annotations": {
-            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"forklift.konveyor.io/v1beta1\",\"kind\":\"Provider\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2023-03-30T14:20:37Z\",\"generation\":1,\"name\":\"rhv\",\"namespace\":\"openshift-mtv\"},\"spec\":{\"secret\":{\"name\":\"rhv-zdnst\",\"namespace\":\"demo24\"},\"type\":\"ovirt\",\"url\":\"https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api\"}}\n"
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"forklift.konveyor.io/v1beta1\",\"kind\":\"Provider\",\"metadata\":{\"annotations\":{},\"creationTimestamp\":\"2023-03-30T14:20:37Z\",\"generation\":1,\"name\":\"rhv\",\"namespace\":\"openshift-mtv\"},\"spec\":{\"secret\":{\"name\":\"rhv-zdnst\",\"namespace\":\"demo24\"},\"type\":\"ovirt\",\"url\":\"https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api\"}}\n"
           },
           "creationTimestamp": "2023-04-03T13:34:48Z",
           "generation": 1,
@@ -251,7 +251,7 @@
             "namespace": "demo24"
           },
           "type": "ovirt",
-          "url": "https://hosted-engine-08.lab.eng.tlv2.redhat.com/ovirt-engine/api"
+          "url": "https://hosted-engine-08.lab.eng.tlv2.example.com/ovirt-engine/api"
         },
         "status": {
           "conditions": [
@@ -349,7 +349,7 @@
             "namespace": "openshift-mtv"
           },
           "type": "ovirt",
-          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+          "url": "https://rhvm.engineering.example.com/ovirt-engine/api"
         },
         "status": {
           "conditions": [
@@ -439,7 +439,7 @@
             "namespace": "openshift-mtv"
           },
           "type": "ovirt",
-          "url": "https://rhvm.engineering.redhat.com/ovirt-engine/api"
+          "url": "https://rhvm.engineering.example.com/ovirt-engine/api"
         },
         "status": {
           "conditions": [
@@ -536,7 +536,7 @@
             "vddkInitImage": "quay.io/lrotenbe/vddk:7.0.3"
           },
           "type": "vsphere",
-          "url": "https://rhev-node-13.rdu2.scalelab.redhat.com/sdk"
+          "url": "https://rhev-node-13.rdu2.scalelab.example.com/sdk"
         },
         "status": {
           "conditions": [

--- a/packages/mocks/src/getMockData.ts
+++ b/packages/mocks/src/getMockData.ts
@@ -41,7 +41,8 @@ export const getMockData = ({ pathname }: MockDataRequestParameters): MockRespon
   // }
 
   // Static handlers, using mockData.
-  const data = mockData[pathname];
+  const adjustedPathname = replaceNamespaceInPath(pathname, 'openshift-mtv');
+  const data = mockData[adjustedPathname];
   if (data) {
     return {
       statusCode: 200,
@@ -51,6 +52,17 @@ export const getMockData = ({ pathname }: MockDataRequestParameters): MockRespon
 
   return null;
 };
+
+/**
+ * Replaces a namespace string in a Kubernetes path.
+ * @param {string} path - The original Kubernetes path.
+ * @param {string} newNamespace - The replacement namespace.
+ * @returns {string} The modified path with the new namespace.
+ */
+export function replaceNamespaceInPath(path: string, newNamespace: string): string {
+  const namespaceRegex = /\/namespaces\/[^/]+\//g;
+  return path.replace(namespaceRegex, `/namespaces/${newNamespace}/`);
+}
 
 /**
  * Interface representing a mock response.


### PR DESCRIPTION
Issue:
currently the `mockData` keys are set to response to one namespace, this is OK, but in some cases it will be nicer to answer mock data to other namespaces as well.

This PR add a method that allow to update the requested namespace, as a demo it is used here to match the one in `mockData` keys.

Screenshot:
All namespace return the same mock data:
![Screencast from 2023-05-08 09-37-48 webm](https://user-images.githubusercontent.com/2181522/236752384-d20a08b4-f550-4ec3-93df-3380e9f38b38.gif)

