### PR TITLE
Manually bump plugin package version to 2.4.1

### DIFF
--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubev2v/forklift-console-plugin",
-  "version": "0.0.1",
+  "version": "2.4.1",
   "private": true,
   "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
   "license": "Apache-2.0",

--- a/packages/forklift-console-plugin/plugin-metadata.ts
+++ b/packages/forklift-console-plugin/plugin-metadata.ts
@@ -5,10 +5,11 @@ import { exposedModules as networkMapModules } from './src/modules/NetworkMaps/d
 import { exposedModules as planModules } from './src/modules/Plans/dynamic-plugin';
 import { exposedModules as providerModules } from './src/modules/Providers/dynamic-plugin';
 import { exposedModules as storageMapModules } from './src/modules/StorageMaps/dynamic-plugin';
+import pkg from './package.json';
 
 const pluginMetadata: ConsolePluginMetadata = {
   name: process.env.PLUGIN_NAME || 'forklift-console-plugin',
-  version: '0.0.1',
+  version: pkg?.version || '0.0.0',
   displayName: 'OpenShift Console Plugin For Forklift',
   description:
     'Forklift is a suite of migration tools that facilitate the migration of VM workloads to KubeVirt.',


### PR DESCRIPTION
Issue:
The plugin version should match the MTV version, currently we do not bump the plugin package version.
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/440

  - [x] bump the package.json version
  - [x] automate plugin metadata version to match the package version
  - [ ] automate package version to match the branch
  - [ ] update the dev version to 2.5.0 