### PR TITLE
Use process.env.VERSION to set the version number

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -1,6 +1,15 @@
 # Builder container
 FROM registry.access.redhat.com/ubi9/nodejs-16 AS build
 
+# VERSION default value should match the forklift-console-plugin package version
+# The VERSION value can be customize during build by using --build-arg:
+#    podman build \
+#      -t quay.io/kubev2v/forklift-console-plugin \
+#      -f ./build/Containerfile \
+#      --build-arg VERSION=1.2.3 .
+ARG VERSION=2.4.1
+ENV VERSION=${VERSION}
+
 # Copy app source
 COPY . /opt/app-root/src/app
 WORKDIR /opt/app-root/src/app

--- a/ci/deploy-all.sh
+++ b/ci/deploy-all.sh
@@ -78,7 +78,7 @@ echo "==========================================="
 echo ""
 echo "Local registry available on port 5001:    http://localhost:5001/"
 echo "Usage example:"
-echo "  podman build -t localhost:5001/forklift-console-plugin -f ./build/Containerfile"
+echo "  podman build -t localhost:5001/forklift-console-plugin -f ./build/Containerfile ."
 echo "  podman push localhost:5001/forklift-console-plugin --tls-verify=false"
 
 config_path=$(echo ~)/.kube/config

--- a/docs/container-images.md
+++ b/docs/container-images.md
@@ -9,7 +9,7 @@ push it to an image registry.
 
 ```sh
 # build the image and tag it
-podman build -t quay.io/kubev2v/forklift-console-plugin -f ./build/Containerfile
+podman build -t quay.io/kubev2v/forklift-console-plugin -f ./build/Containerfile .
 ```
 
 ### Push the image to a local repository

--- a/packages/forklift-console-plugin/plugin-metadata.ts
+++ b/packages/forklift-console-plugin/plugin-metadata.ts
@@ -9,7 +9,7 @@ import pkg from './package.json';
 
 const pluginMetadata: ConsolePluginMetadata = {
   name: process.env.PLUGIN_NAME || 'forklift-console-plugin',
-  version: pkg?.version || '0.0.0',
+  version: process.env.VERSION || pkg?.version || '0.0.0',
   displayName: 'OpenShift Console Plugin For Forklift',
   description:
     'Forklift is a suite of migration tools that facilitate the migration of VM workloads to KubeVirt.',


### PR DESCRIPTION
Issue:
When building the console pugin image we need to allow to set the plugin metadata version.

Suggested fix:
Use `process.env.VERSION` to set the version number.

Example:
In the build automation user need to set the VERSION env var
``` bash
VERSION=2.3.4 npm run build
```
Building an image:
``` bash
podman build -t quay.io/kubev2v/forklift-console-plugin -f ./build/Containerfile --build-arg VERSION=2.4.5 .
```

In this PR:
  - Allow to use `VERSION` to set the plugin metadata file.
  - Update `Containerfile` to build an image using specific revision

How to test:
  - the generated `plugin-manifest.json` file (after build, found in the plugin `dist` directory) should include the new version
  - or via the UI, go to the plugins page ( overview -> dynamic-plugins -> details )

Screenshot:

![screenshot-console-openshift-console apps mtv rhev lab eng brq2 redhat com-2023 05 09-10_40_17](https://user-images.githubusercontent.com/2181522/237028154-f572ab02-2689-4783-8c20-3030730f447d.png)

Ref:
https://github.com/kubev2v/forklift-console-plugin/issues/440
