### PR TITLE
Refactor webpack config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20803,7 +20803,7 @@
     },
     "packages/forklift-console-plugin": {
       "name": "@kubev2v/forklift-console-plugin",
-      "version": "0.0.1",
+      "version": "2.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubev2v/common": "*",

--- a/packages/forklift-console-plugin/jest.config.ts
+++ b/packages/forklift-console-plugin/jest.config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @cspell/spellchecker */
 import { pathsToModuleNameMapper } from 'ts-jest';
 
 import type { Config } from '@jest/types';
@@ -10,11 +11,16 @@ const moduleNameMapper = {
   '@console/*': '<rootDir>/src/__mocks__/dummy.ts',
   '@openshift-console/*': '<rootDir>/src/__mocks__/dummy.ts',
   'react-i18next': '<rootDir>/src/__mocks__/react-i18next.ts',
-  'legacy/src/(.*)$': '<rootDir>/../legacy/src/$1', // remove when using rollup
-  'common/src/(.*)$': '<rootDir>/../common/src/$1', // remove when using rollup
+
   ...pathsToModuleNameMapper(compilerOptions.paths, {
     prefix: '<rootDir>/',
   }),
+
+  // Mappings for monorepo packages
+  '@kubev2v/legacy/(.*)$': '<rootDir>/../legacy/dist/$1',
+  '@kubev2v/common/(.*)$': '<rootDir>/../common/dist/$1',
+  '@kubev2v/mocks/(.*)$': '<rootDir>/../mocks/dist/$1',
+  '@kubev2v/types/(.*)$': '<rootDir>/../types/dist/$1',
 };
 
 // Sync object

--- a/packages/forklift-console-plugin/tsconfig.json
+++ b/packages/forklift-console-plugin/tsconfig.json
@@ -7,13 +7,7 @@
     "outDir": "./dist",
 
     "paths": {
-      "src/*": ["./src/*"],
-
-      "@kubev2v/legacy/*": ["../legacy/src/*"],
-      "@kubev2v/common/*": ["../common/src/*"],
-      "@kubev2v/mocks/*": ["../mocks/src/*"],
-      "@kubev2v/webpack": ["../webpack/src"],
-      "@kubev2v/types": ["../types/src"]
+      "src/*": ["./src/*"]
     }
   },
 

--- a/packages/forklift-console-plugin/webpack.config.ts
+++ b/packages/forklift-console-plugin/webpack.config.ts
@@ -39,7 +39,7 @@ const config: WebpackConfiguration & {
   module: {
     rules: [
       {
-        test: /\.(jsx?|tsx?)$/,
+        test: /\.(tsx?)$/,
         exclude: /node_modules/,
         use: [
           {
@@ -55,25 +55,21 @@ const config: WebpackConfiguration & {
         use: ['style-loader', 'css-loader'],
       },
       {
-        oneOf: [
-          {
-            test: /\.svg$/,
-            type: 'asset/inline',
-            generator: {
-              dataUrl: (content) => {
-                content = content.toString();
-                return svgToMiniDataURI(content);
-              },
-            },
+        test: /\.svg$/,
+        type: 'asset/inline',
+        generator: {
+          dataUrl: (content) => {
+            content = content.toString();
+            return svgToMiniDataURI(content);
           },
-          {
-            test: /\.(png|jpg|jpeg|gif|svg|woff2?|ttf|eot|otf)(\?.*$|$)/,
-            type: 'asset/resource',
-            generator: {
-              filename: 'assets/[name].[ext]',
-            },
-          },
-        ],
+        },
+      },
+      {
+        test: /\.(png|jpg|jpeg|gif|woff2?|ttf|eot|otf)(\?.*$|$)/,
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[name].[ext]',
+        },
       },
       {
         test: /\.m?js/,


### PR DESCRIPTION
Issues:
  - [x] We currently consume the monorepo packages using two conflicting mechanisms,
    - as required packages in `package.json`
    - as external path in `tsconfig.json`
  - [x] Duplicate rules in `webpack.config.ts`
    - `.js` files where processed by two rules
    - `.svg` files where never processed by `asset/resource` while they did pass the test for this rule.
 
 Fixes:
   - [x] remove the duplicate paths in `tsconfig.json`, once `webpack.config.ts` is fixed, this duplication is not needed anymore.
   - [x] remove the rule duplications in `webpack.config.ts`
 