### PR TITLE
Disable hot reload in webpack dev server

### DIFF
--- a/packages/forklift-console-plugin/webpack.config.ts
+++ b/packages/forklift-console-plugin/webpack.config.ts
@@ -86,6 +86,7 @@ const config: WebpackConfiguration & {
   devServer: {
     static: ['./dist'],
     host: 'localhost',
+    hot: false,
     port: 9001,
     headers: {
       'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
Fixes problems with building the plugin using newer(>1.0.0) versions of @openshift/dynamic-plugin-sdk-webpack library.

Hot reload is not needed as the plugin is consumed by the Console which does not support hot reload of plugins.