### PR TITLE
Add gitCommit and gitBranch to rollup build-metadata and banner

### DIFF
--- a/config/rollup.base.js
+++ b/config/rollup.base.js
@@ -5,6 +5,7 @@
  * Default rollup settings from @openshift/dynamic-plugin-sdk
  */
 
+import { execSync } from 'child_process';
 import analyzer from 'rollup-plugin-analyzer';
 import css from 'rollup-plugin-import-css';
 
@@ -48,6 +49,8 @@ export const getBuildMetadata = ({ name, version }) => {
     packageVersion: version,
     buildDate: now.toLocaleString('en-US', { dateStyle: 'long' }),
     buildTime: now.toLocaleString('en-US', { timeStyle: 'long' }),
+    gitCommit: execSync('git rev-parse HEAD').toString().trim(),
+    gitBranch: execSync('git rev-parse --abbrev-ref HEAD').toString().trim(),
   };
 };
 
@@ -62,7 +65,7 @@ export const getBanner = ({ repository }, buildMetadata) => {
   );
 
   const text = `
-  FPC (Forklift Plugin Components)
+  KFC (Kubernetes Forklift Components)
   ${repository.url.replace(/\.git$/, '')}
   ${Object.entries(buildMetadata)
     .map(([key, value]) => `${key.padEnd(padLength)} : ${value}`)


### PR DESCRIPTION
Issue:
currently our `banner` add to the top of compiled files, and `build-metadata.json` file are missing git commit hash.

Fix:
align our banner and build-metadata with `openshift/dynamic-plugin-sdk` example that include this fields.

Ref:
https://github.com/kubev2v/forklift-console-plugin/pull/450#discussion_r1189382202
