### PR TITLE
Update banner title

### DIFF
--- a/config/rollup.base.js
+++ b/config/rollup.base.js
@@ -46,7 +46,7 @@ export const getBanner = ({ repository }, buildMetadata) => {
   );
 
   const text = `
-  KFC (Kubernetes Forklift Components)
+  Forklift Console Plugin
   ${repository.url.replace(/\.git$/, '')}
   ${Object.entries(buildMetadata)
     .map(([key, value]) => `${key.padEnd(padLength)} : ${value}`)


### PR DESCRIPTION
Issue:
Concerns where made about the readability of our current title of our debugging banner comment that is added to compiled files, the comment may be visible to developers and QE teams when debugging compiled files. 

As suggested in https://github.com/kubev2v/forklift-console-plugin/pull/457#discussion_r1194141307 this PR will help with the title clarity and will better keep the projects context.

Comment before:
```js
/**
  KFC (Kubernetes Forklift Components)
  https://github.com/kubev2v/forklift-console-plugin
  packageName    : @kubev2v/types
  packageVersion : 0.0.1
  buildDate      : May 16, 2023
  buildTime      : 7:57:31 AM GMT+3
  gitCommit      : e68ee2f064397ee254da107bde1463d9e45d754e
  gitBranch      : main
 */
```

Comment after fix:
```js
/**
  Forklift Console Plugin
  https://github.com/kubev2v/forklift-console-plugin
  packageName    : @kubev2v/types
  packageVersion : 0.0.1
  buildDate      : May 16, 2023
  buildTime      : 7:52:57 AM GMT+3
  gitCommit      : e0df796b7d6e4293dedf0bd938fdfc7fde66d976
  gitBranch      : update-banner-title
 */
```

For reference, dynamic-plugin-sdk [1] uses this title for their comment banner:
```js
/**
  OpenShift Dynamic Plugin SDK
  https://github.c...
 */
```

Changes I made to the suggested title:
a. remove the `(package: @kubev2v/types)` because we have `packageName` field that holds this information
b. remove  `@kubev2v/forklift-console-plugin`  because it does not look like a title, and may missled users to think this package name is  `@kubev2v/forklift-console-plugin`  .

suggested banner from https://github.com/kubev2v/forklift-console-plugin/pull/457#discussion_r1194141307:
```js
/**
  @kubev2v/forklift-console-plugin (package: @kubev2v/types)
  https://github.com/kubev2v/forklift-console-plugin
  packageName    : @kubev2v/types
  packageVersion : 0.0.1
  buildDate      : May 16, 2023
  buildTime      : 7:52:57 AM GMT+3
  gitCommit      : e0df796b7d6e4293dedf0bd938fdfc7fde66d976
  gitBranch      : update-banner-title
 */
```

[1] https://github.com/openshift/dynamic-plugin-sdk/blob/main/packages/common/rollup/rollup-configs.js#L42