### PR TITLE
Fix UI refresh issues for providers secret data and for migration plan VMs list

### DIFF
--- a/packages/legacy/src/queries/plans.ts
+++ b/packages/legacy/src/queries/plans.ts
@@ -276,6 +276,8 @@ export const usePatchPlanMutation = (
         queryClient.invalidateQueries('plans');
         queryClient.invalidateQueries('hooks');
         queryClient.invalidateQueries('mappings');
+        queryClient.invalidateQueries('inventory-tree');
+        queryClient.invalidateQueries('vms');
         onSuccess && onSuccess();
       },
     }

--- a/packages/legacy/src/queries/providers.ts
+++ b/packages/legacy/src/queries/providers.ts
@@ -261,6 +261,7 @@ export const usePatchProviderMutation = (
       queryClient.invalidateQueries('cluster-providers');
       queryClient.invalidateQueries('inventory-providers');
       queryClient.invalidateQueries('secrets');
+      queryClient.invalidateQueries('secret');
       onSuccess && onSuccess();
     },
   });

--- a/packages/legacy/src/queries/tree.ts
+++ b/packages/legacy/src/queries/tree.ts
@@ -6,6 +6,7 @@ import { SourceInventoryProvider } from './types';
 import { IInventoryHostTree, InventoryTree, InventoryTreeType } from './types/tree.types';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { ProviderType } from '../common/constants';
+import { usePollingContext } from '../common/context';
 
 const sortTreeItemsByName = <T extends InventoryTree>(tree: T): T => ({
   ...tree,
@@ -115,8 +116,8 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
       queryFn: async () =>
         await consoleFetchJSON(getInventoryApiUrl(`${provider?.selfLink || ''}${apiSlug}`)),
       enabled: (isValidClusterTree || isValidVMTree) && !!provider,
-      keepPreviousData: true,
       cacheTime: 0,
+      refetchInterval: usePollingContext().refetchInterval,
       select: indexTreeCallback,
     },
     apiMockData as T,


### PR DESCRIPTION
Fixes: #369 

Fix two UI refresh issues that are a result of a wrong react query fetching/caching options.

1. For the providers secret data sync issue, apply the 'invalidateQueries' option for the 'secret' query.

2. For the migration plan VMs list sync issue, avoid the 'keepPreviousData' option and apply the 'invalidateQueries' option for the 'inventory-tree' query.

##### Fix result:
1. When editing an existing provider's secret data, the data is updated successfully and immediately in the UI, without the need to hard refresh.

3. When adding a new VM(s) to the source provider, while the migration plan UI wizard is already opened , the new VM is added successfully in the UI, without the need to re-open the migration plan wizard.

