### PR TITLE
Harmonize `package.json` basic field order and contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@monorepo/root",
-  "private": true,
   "version": "0.0.1",
-  "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
+  "description": "forklift-console-plugin monorepo root",
   "license": "Apache-2.0",
+  "private": true,
+  "repository": "https://github.com/kubev2v/forklift-console-plugin.git",
   "workspaces": [
     "packages/*"
   ],

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Legacy components and utilities for dynamic plugins",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/kubev2v/forklift-console-plugin.git",

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -1,9 +1,15 @@
 {
   "name": "@kubev2v/forklift-console-plugin",
   "version": "2.4.1",
-  "private": true,
-  "repository": "git@github.com:kubev2v/forklift-console-plugin.git",
+  "description": "UI for forklift as an openshift console dynamic plugin",
   "license": "Apache-2.0",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kubev2v/forklift-console-plugin.git",
+    "directory": "packages/forklift-console-plugin"
+  },
+
   "scripts": {
     "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Legacy components and utilities for dynamic plugins",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/kubev2v/forklift-console-plugin.git",

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@kubev2v/mocks",
   "version": "0.0.1",
-  "private": true,
+  "description": "forklift mock data and handlers used for testing",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
-    "url": "git@github.com:kubev2v/forklift-console-plugin.git",
+    "type": "git",
+    "url": "https://github.com/kubev2v/forklift-console-plugin.git",
     "directory": "packages/mocks"
   },
   "main": "./dist/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Typescript interfaces and types for forklift",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/kubev2v/forklift-console-plugin.git",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.1",
   "description": "Allow building openshift console dynamic plugins using the openshift dynamic plugin sdk.",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/kubev2v/forklift-console-plugin.git",
-    "directory": "packages/lib-webpack"
+    "directory": "packages/webpack"
   },
   "files": [
     "./dist/*"


### PR DESCRIPTION
  - Add `description` if missing
  - Mark all as private packages (they can be changed in future)
  - Harmonize and fixup the repository information
  - Basic field order set to: name, version, description, license, private, repository