### PR TITLE
Add data set name to mock data source descriptor

### DIFF
--- a/packages/forklift-console-plugin/src/mock-console-extension/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/mock-console-extension/dynamic-plugin.ts
@@ -1,4 +1,4 @@
-import { MSW_MOCK_SOURCES } from '@kubev2v/mocks';
+import { isDataSourceMock } from '@kubev2v/mocks';
 import { EncodedExtension } from '@openshift/dynamic-plugin-sdk';
 import { ContextProvider } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack/lib/schema/plugin-package';
@@ -20,7 +20,5 @@ const _extensions: EncodedExtension[] = [
 /**
  * The plugin will be configured only if the DATA_SOURCE is one of the MSW mock sources.
  */
-const isDataSourceMock = MSW_MOCK_SOURCES.includes(process.env.DATA_SOURCE);
-
-export const exposedModules = isDataSourceMock ? _exposedModules : {};
-export const extensions = isDataSourceMock ? _extensions : [];
+export const exposedModules = isDataSourceMock(process.env.DATA_SOURCE) ? _exposedModules : {};
+export const extensions = isDataSourceMock(process.env.DATA_SOURCE) ? _extensions : [];

--- a/packages/mocks/src/__tests__/isDataSourceMock.test.ts
+++ b/packages/mocks/src/__tests__/isDataSourceMock.test.ts
@@ -1,0 +1,19 @@
+import { isDataSourceMock, MSW_MOCK_SOURCES } from '../getMockData';
+
+describe('isDataSourceMock test', () => {
+  test.each(MSW_MOCK_SOURCES)('Mock data source %s', (mockSource) => {
+    expect(isDataSourceMock(mockSource)).toBeTruthy();
+  });
+
+  it('rejects legacy mock source', () => {
+    expect(isDataSourceMock('mock')).toBeFalsy();
+  });
+
+  it('rejects non-mock source', () => {
+    expect(isDataSourceMock('remote')).toBeFalsy();
+  });
+
+  it('detects mock source with data set', () => {
+    expect(isDataSourceMock('code:basic')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Mock data source can be now described by:
1. type i.e. DATA_SOURCE=har
2. type and data set name i.e. DATA_SOURCE=code:basic