### PR TITLE
Extend host secrets with data for verification

### DIFF
--- a/packages/legacy/src/queries/types/secrets.types.ts
+++ b/packages/legacy/src/queries/types/secrets.types.ts
@@ -13,6 +13,8 @@ export interface ISecret extends IMetaTypeMeta {
     token?: string;
     cacert?: string;
     insecureSkipVerify?: string;
+    provider?: string;
+    ip?: string;
   };
   metadata: IMetaObjectGenerateName | IMetaObjectMeta;
   type: string;


### PR DESCRIPTION
The flow of defining a migration network for an ESX host goes like this:
1. Creating a secret
2. Creating a host config
3. Setting the host config as the owner of the secret

In order to validate the secret at the first step, we need additional data, as the host config doesn't exist at this point, that is added in this patch:
1. The 'createdForResource' label points to id of the host in the inventory
2. Add provider type to the Data of the secret
3. Add the IP of the host to the Data of the secret