### PR TITLE
Set provider name instead of type

### DIFF
--- a/packages/legacy/src/queries/hosts.ts
+++ b/packages/legacy/src/queries/hosts.ts
@@ -89,7 +89,7 @@ const generateSecret = (
     data: {
       user: values.adminUsername && btoa(values.adminUsername),
       password: values.adminPassword && btoa(values.adminPassword),
-      provider: btoa('vsphere'),
+      provider: btoa(provider.name),
       ip: btoa(matchingNetworkAdapter?.ipAddress || ''),
     },
     kind: 'Secret',


### PR DESCRIPTION
Previously it worked since the vSphere provider was named 'vsphere' in my setup by in general we need to name of the provider on the secret for the provider's hosts.