### PR TITLE
Remove un used rollup node resolver

### DIFF
--- a/config/rollup.base.js
+++ b/config/rollup.base.js
@@ -10,7 +10,6 @@ import css from 'rollup-plugin-import-css';
 
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
-import nodeResolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
 import { createBannerComment, getBuildMetadata } from '../packages/build/src/metadata';
@@ -49,7 +48,6 @@ export const tsLibConfig = (pkg, inputFile, format = 'esm') => {
     },
     external: externalModules.map((m) => new RegExp(`^${m}(\\/.+)*$`)),
     plugins: [
-      nodeResolve(),
       commonjs(),
       json({
         compact: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@cspell/eslint-plugin": "^6.31.1",
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-json": "^6.0.0",
-        "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-typescript": "^11.0.0",
         "@rollup/pluginutils": "^5.0.2",
         "@testing-library/cypress": "^9.0.0",
@@ -2580,30 +2579,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "@types/resolve": "1.20.2",
-        "deepmerge": "^4.2.2",
-        "is-builtin-module": "^3.2.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/plugin-typescript": {
       "version": "11.0.0",
       "dev": true,
@@ -3208,11 +3183,6 @@
       "dependencies": {
         "@types/react": "^17"
       }
-    },
-    "node_modules/@types/resolve": {
-      "version": "1.20.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4948,17 +4918,6 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT"
-    },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/bytes": {
       "version": "3.0.0",
@@ -9662,20 +9621,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-builtin-module": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "builtin-modules": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "license": "MIT",
@@ -9884,11 +9829,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-negated-glob": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@cspell/eslint-plugin": "^6.31.1",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@rollup/pluginutils": "^5.0.2",
     "@testing-library/cypress": "^9.0.0",


### PR DESCRIPTION
Issue:
rollup node resolver is used to add npm dependencies to the package rollup is creating, in our setup we use webpack to create the final bundle, and all the npm dependencies are added at that point using webpacks node resolver.
 - We don't need to use rollup node resolver if we don't add new dependencies that are not covered by webpack
 - Node resolver increase the complle time and create a bigger package.

Fix:
remove rollup node resolver and relay on webpack to add the needed dependencies.