### PR TITLE
Add missing paths to tscofig of main app

### DIFF
--- a/packages/forklift-console-plugin/tsconfig.json
+++ b/packages/forklift-console-plugin/tsconfig.json
@@ -7,7 +7,9 @@
     "outDir": "./dist",
 
     "paths": {
-      "src/*": ["./src/*"]
+      "src/*": ["./src/*"],
+      "common/src/*": ["../common/src/*"],
+      "legacy/src/*": ["../legacy/src/*"]
     }
   },
 


### PR DESCRIPTION
When using type script project references, the main app need to know about the paths used by the referenced code.

Issue:
main application is referencing `common`  package use `paths` statement that affect the main app.

Fix:
add the missing paths to the main app tsconfig file