### PR TITLE
Use rollup for common package

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,30 +12,12 @@
   "files": [
     "./dist/*"
   ],
-  "exports": {
-    "./components/*": "./dist/components/*",
-    "./hooks/*": "./dist/hooks/*",
-    "./utils/*": "./dist/utils/*"
-  },
-  "typesVersions": {
-    "*": {
-      "components/*": [
-        "dist/components/*"
-      ],
-      "hooks/*": [
-        "dist/hooks/*"
-      ],
-      "utils/*": [
-        "dist/utils/*"
-      ]
-    }
-  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
     "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
-    "build": "npm run compile && npm run copy:css",
-    "compile": "tsc --build --verbose && tsc-alias -p tsconfig.json",
-    "copy:css": "copyfiles -u 1 ./src/**/*.css ./dist/",
+    "build": "rollup -c --bundleConfigAsCjs",
     "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "test": "TZ=UTC jest",

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -1,0 +1,5 @@
+import { tsLibConfig } from '../build/src/rollup.base';
+
+import pkg from './package.json';
+
+export default tsLibConfig(pkg, './src/index.ts');

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,0 +1,5 @@
+// @index(['./*', /__/g], f => `export * from '${f.path}';`)
+export * from './components';
+export * from './hooks';
+export * from './utils';
+// @endindex

--- a/packages/forklift-console-plugin/src/components/mappings/MappingPage.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/MappingPage.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import * as C from 'src/utils/constants';
 import { MAPPING_STATUS } from 'src/utils/enums';
 
-import { EnumToTuple } from '@kubev2v/common/components/FilterGroup';
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
-import { DefaultHeader, TableViewHeaderProps } from '@kubev2v/common/components/TableView';
-import { ResourceFieldFactory, ResourceFieldPartialFactory } from '@kubev2v/common/utils/types';
+import { EnumToTuple } from '@kubev2v/common';
+import { withQueryClient } from '@kubev2v/common';
+import { DefaultHeader, TableViewHeaderProps } from '@kubev2v/common';
+import { ResourceFieldFactory, ResourceFieldPartialFactory } from '@kubev2v/common';
 import { AddEditMappingModal } from '@kubev2v/legacy/Mappings/components/AddEditMappingModal';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 import { useModal } from '@openshift-console/dynamic-plugin-sdk';

--- a/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
@@ -3,8 +3,8 @@ import * as C from 'src/utils/constants';
 import { MAPPING_STATUS } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
-import { RowProps } from '@kubev2v/common/components/TableView';
+import { getResourceFieldValue } from '@kubev2v/common';
+import { RowProps } from '@kubev2v/common';
 import { MappingDetailView } from '@kubev2v/legacy/Mappings/components/MappingDetailView';
 import { Mapping, MappingType } from '@kubev2v/legacy/queries/types';
 import {

--- a/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'src/utils/i18n';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { ConfirmModal } from '@kubev2v/legacy/common/components/ConfirmModal';
 import { AddEditMappingModal } from '@kubev2v/legacy/Mappings/components/AddEditMappingModal';
 import { useDeleteMappingMutation } from '@kubev2v/legacy/queries';

--- a/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
+++ b/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'src/utils/i18n';
 
-import { ManageColumnsModal, ManageColumnsToolbarItem } from '@kubev2v/common/components/TableView';
-import { ResourceField } from '@kubev2v/common/utils/types';
+import { ManageColumnsModal, ManageColumnsToolbarItem } from '@kubev2v/common';
+import { ResourceField } from '@kubev2v/common';
 
 export interface ManageColumnsToolbarProps {
   /** Read only. State maintained by parent component. */

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -11,7 +11,7 @@ import {
   toFieldFilter,
   useUrlFilters,
   ValueMatcher,
-} from '@kubev2v/common/components/FilterGroup';
+} from '@kubev2v/common';
 import {
   DEFAULT_PER_PAGE,
   ErrorState,
@@ -21,15 +21,9 @@ import {
   useFields,
   usePagination,
   UserSettings,
-} from '@kubev2v/common/components/Page';
-import {
-  DefaultHeader,
-  RowProps,
-  TableView,
-  TableViewHeaderProps,
-  useSort,
-} from '@kubev2v/common/components/TableView';
-import { ResourceField } from '@kubev2v/common/utils/types';
+} from '@kubev2v/common';
+import { DefaultHeader, RowProps, TableView, TableViewHeaderProps, useSort } from '@kubev2v/common';
+import { ResourceField } from '@kubev2v/common';
 import {
   Level,
   LevelItem,

--- a/packages/forklift-console-plugin/src/components/page/__tests__/StandardPage.test.tsx
+++ b/packages/forklift-console-plugin/src/components/page/__tests__/StandardPage.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
-import { RowProps } from '@kubev2v/common/components/TableView';
-import { NAME, NAMESPACE } from '@kubev2v/common/utils/constants';
+import { RowProps } from '@kubev2v/common';
+import { NAME, NAMESPACE } from '@kubev2v/common';
 import { Td, Tr } from '@patternfly/react-table';
 import { cleanup, render } from '@testing-library/react';
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/EmptyStateNetworkMaps.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/EmptyStateNetworkMaps.tsx
@@ -6,7 +6,7 @@ import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { HELP_LINK_HREF } from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 
-import { ExternalLink } from '@kubev2v/common/components/ExternalLink';
+import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
 import { createK8sPath } from '@kubev2v/legacy/queries/helpers';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingRow.tsx
@@ -7,7 +7,7 @@ import MappingRow, {
 } from 'src/components/mappings/MappingRow';
 import * as C from 'src/utils/constants';
 
-import { RowProps } from '@kubev2v/common/components/TableView';
+import { RowProps } from '@kubev2v/common';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 import { Label } from '@patternfly/react-core';
 import { NetworkIcon } from '@patternfly/react-icons';

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
@@ -8,12 +8,12 @@ import * as C from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
-import { FreetextFilter } from '@kubev2v/common/components/Filter';
-import { ValueMatcher } from '@kubev2v/common/components/FilterGroup';
-import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
-import { loadUserSettings, UserSettings } from '@kubev2v/common/components/Page';
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
-import { ResourceFieldFactory } from '@kubev2v/common/utils/types';
+import { FreetextFilter } from '@kubev2v/common';
+import { ValueMatcher } from '@kubev2v/common';
+import { LoadingDots } from '@kubev2v/common';
+import { loadUserSettings, UserSettings } from '@kubev2v/common';
+import { withQueryClient } from '@kubev2v/common';
+import { ResourceFieldFactory } from '@kubev2v/common';
 import { AddEditMappingModal } from '@kubev2v/legacy/Mappings/components/AddEditMappingModal';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 import { useModal } from '@openshift-console/dynamic-plugin-sdk';

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsWrapper.tsx
@@ -1,4 +1,4 @@
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 
 import { NetworkMappingsPage } from './NetworkMappingsPage';
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/__tests__/MappingRow.test.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/__tests__/MappingRow.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { cleanup, render } from '@testing-library/react';
 
 import { FlatNetworkMapping } from '../dataForNetwork';

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/mappingActions.tsx
@@ -1,6 +1,6 @@
 import { useMappingActions } from 'src/components/mappings/mappingActions';
 
-import { withActionServiceContext } from '@kubev2v/common/components/ActionServiceDropdown';
+import { withActionServiceContext } from '@kubev2v/common';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 
 import { FlatNetworkMapping } from './dataForNetwork';

--- a/packages/forklift-console-plugin/src/modules/Plans/EmptyStatePlans.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/EmptyStatePlans.tsx
@@ -6,7 +6,7 @@ import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { HELP_LINK_HREF } from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 
-import { ExternalLink } from '@kubev2v/common/components/ExternalLink';
+import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
 import { CreatePlanButton } from '@kubev2v/legacy/Plans/components/CreatePlanButton';
 import { createK8sPath } from '@kubev2v/legacy/queries/helpers';

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -4,8 +4,8 @@ import * as C from 'src/utils/constants';
 import { PLAN_TYPE } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
-import { RowProps } from '@kubev2v/common/components/TableView';
+import { getResourceFieldValue } from '@kubev2v/common';
+import { RowProps } from '@kubev2v/common';
 import { StatusCondition } from '@kubev2v/legacy/common/components/StatusCondition';
 import { PATH_PREFIX } from '@kubev2v/legacy/common/constants';
 import {

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanWizardWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanWizardWrapper.tsx
@@ -1,4 +1,4 @@
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { PlanWizard } from '@kubev2v/legacy/Plans/components/Wizard/PlanWizard';
 
 const PlanWizardWrapper = withQueryClient(PlanWizard);

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -5,10 +5,10 @@ import { PLAN_STATUS_FILTER } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
-import { EnumToTuple } from '@kubev2v/common/components/FilterGroup';
-import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
-import { loadUserSettings, UserSettings } from '@kubev2v/common/components/Page';
-import { ResourceFieldFactory } from '@kubev2v/common/utils/types';
+import { EnumToTuple } from '@kubev2v/common';
+import { LoadingDots } from '@kubev2v/common';
+import { loadUserSettings, UserSettings } from '@kubev2v/common';
+import { ResourceFieldFactory } from '@kubev2v/common';
 import { MustGatherModal } from '@kubev2v/legacy/common/components/MustGatherModal';
 import { CreatePlanButton } from '@kubev2v/legacy/Plans/components/CreatePlanButton';
 

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import {
   MustGatherContextProvider,
   NotificationContextProvider,

--- a/packages/forklift-console-plugin/src/modules/Plans/VMMigrationDetailsWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/VMMigrationDetailsWrapper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import {
   MustGatherContextProvider,
   NotificationContextProvider,

--- a/packages/forklift-console-plugin/src/modules/Plans/__tests__/PlanRow.test.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/__tests__/PlanRow.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { IMustGatherContext, MustGatherContext } from '@kubev2v/legacy/common/context';
 import { cleanup, render } from '@testing-library/react';
 

--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -2,8 +2,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { useTranslation } from 'src/utils/i18n';
 
-import { withActionServiceContext } from '@kubev2v/common/components/ActionServiceDropdown';
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withActionServiceContext } from '@kubev2v/common';
+import { withQueryClient } from '@kubev2v/common';
 import { ConfirmModal } from '@kubev2v/legacy/common/components/ConfirmModal';
 import { PATH_PREFIX } from '@kubev2v/legacy/common/constants';
 import { MustGatherContext } from '@kubev2v/legacy/common/context';

--- a/packages/forklift-console-plugin/src/modules/Providers/AddProviderButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/AddProviderButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'src/utils/i18n';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { AddEditProviderModal } from '@kubev2v/legacy/Providers/components/AddEditProviderModal';
 import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Button } from '@patternfly/react-core';

--- a/packages/forklift-console-plugin/src/modules/Providers/HostsPageWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/HostsPageWrapper.tsx
@@ -1,4 +1,4 @@
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { HostsPage } from '@kubev2v/legacy/Providers/HostsPage';
 
 const HostsPageWrapper = withQueryClient(HostsPage);

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { TextWithIcon } from 'src/components/cells/TextWithIcon';
 import * as C from 'src/utils/constants';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
-import { RowProps } from '@kubev2v/common/components/TableView';
+import { getResourceFieldValue } from '@kubev2v/common';
+import { RowProps } from '@kubev2v/common';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { DatabaseIcon, NetworkIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/HostCell.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { TextWithIcon } from 'src/components/cells/TextWithIcon';
 import * as C from 'src/utils/constants';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
+import { getResourceFieldValue } from '@kubev2v/common';
 import { PATH_PREFIX } from '@kubev2v/legacy/common/constants';
 import { OutlinedHddIcon } from '@patternfly/react-icons';
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/StatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/StatusCell.tsx
@@ -3,7 +3,7 @@ import { StatusCell as Cell } from 'src/components/cells/StatusCell';
 import { PHASE } from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
+import { getResourceFieldValue } from '@kubev2v/common';
 
 import { phaseLabels, statusIcons } from './consts';
 import { CellProps } from './types';

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TextCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TextCell.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
+import { getResourceFieldValue } from '@kubev2v/common';
 import { Text } from '@patternfly/react-core';
 
 import { CellProps } from './types';

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TypeCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TypeCell.tsx
@@ -3,7 +3,7 @@ import * as C from 'src/utils/constants';
 import { PROVIDERS } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 
-import { getResourceFieldValue } from '@kubev2v/common/components/FilterGroup';
+import { getResourceFieldValue } from '@kubev2v/common';
 import { TARGET_PROVIDER_TYPES } from '@kubev2v/legacy/common/constants';
 import { Label } from '@patternfly/react-core';
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/types.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/types.ts
@@ -1,4 +1,4 @@
-import { ResourceField } from '@kubev2v/common/utils/types';
+import { ResourceField } from '@kubev2v/common';
 
 import { MergedProvider } from '../data';
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -5,10 +5,10 @@ import { PROVIDER_STATUS, PROVIDERS } from 'src/utils/enums';
 import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
-import { EnumToTuple } from '@kubev2v/common/components/FilterGroup';
-import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
-import { loadUserSettings, UserSettings } from '@kubev2v/common/components/Page';
-import { ResourceFieldFactory } from '@kubev2v/common/utils/types';
+import { EnumToTuple } from '@kubev2v/common';
+import { LoadingDots } from '@kubev2v/common';
+import { loadUserSettings, UserSettings } from '@kubev2v/common';
+import { ResourceFieldFactory } from '@kubev2v/common';
 import { ProviderType, SOURCE_PROVIDER_TYPES } from '@kubev2v/legacy/common/constants';
 
 import { AddProviderButton } from './AddProviderButton';

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersWrapper.tsx
@@ -1,4 +1,4 @@
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 
 import ProvidersPage from './ProvidersPage';
 

--- a/packages/forklift-console-plugin/src/modules/Providers/providerActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/providerActions.tsx
@@ -3,8 +3,8 @@ import { Trans } from 'react-i18next';
 import { DEFAULT_TRANSFER_NETWORK_ANNOTATION } from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 
-import { withActionServiceContext } from '@kubev2v/common/components/ActionServiceDropdown';
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withActionServiceContext } from '@kubev2v/common';
+import { withQueryClient } from '@kubev2v/common';
 import { ConfirmModal } from '@kubev2v/legacy/common/components/ConfirmModal';
 import { SelectOpenShiftNetworkModal } from '@kubev2v/legacy/common/components/SelectOpenShiftNetworkModal';
 import { ProviderType } from '@kubev2v/legacy/common/constants';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
@@ -7,7 +7,7 @@ import { AddMappingButton } from 'src/components/mappings/MappingPage';
 import { HELP_LINK_HREF } from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 
-import { ExternalLink } from '@kubev2v/common/components/ExternalLink';
+import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
 import { createK8sPath } from '@kubev2v/legacy/queries/helpers';
 import { MappingType } from '@kubev2v/legacy/queries/types';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingRow.tsx
@@ -7,7 +7,7 @@ import MappingRow, {
 } from 'src/components/mappings/MappingRow';
 import * as C from 'src/utils/constants';
 
-import { RowProps } from '@kubev2v/common/components/TableView';
+import { RowProps } from '@kubev2v/common';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 import { Label } from '@patternfly/react-core';
 import { StorageDomainIcon } from '@patternfly/react-icons';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
@@ -9,11 +9,11 @@ import * as C from 'src/utils/constants';
 import { useTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
-import { FreetextFilter } from '@kubev2v/common/components/Filter';
-import { ValueMatcher } from '@kubev2v/common/components/FilterGroup';
-import { LoadingDots } from '@kubev2v/common/components/LoadingDots';
-import { loadUserSettings } from '@kubev2v/common/components/Page';
-import { ResourceFieldFactory } from '@kubev2v/common/utils/types';
+import { FreetextFilter } from '@kubev2v/common';
+import { ValueMatcher } from '@kubev2v/common';
+import { LoadingDots } from '@kubev2v/common';
+import { loadUserSettings } from '@kubev2v/common';
+import { ResourceFieldFactory } from '@kubev2v/common';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 
 import { FlatStorageMapping, Storage, useFlatStorageMappings } from './dataForStorage';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsWrapper.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsWrapper.tsx
@@ -1,4 +1,4 @@
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 
 import StorageMappingsPage from './StorageMappingsPage';
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/__tests__/MappingRow.test.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/__tests__/MappingRow.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MemoryRouter } from 'react-router';
 
-import { withQueryClient } from '@kubev2v/common/components/QueryClientHoc';
+import { withQueryClient } from '@kubev2v/common';
 import { cleanup, render } from '@testing-library/react';
 
 import { FlatStorageMapping } from '../dataForStorage';

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/mappingActions.tsx
@@ -1,6 +1,6 @@
 import { useMappingActions } from 'src/components/mappings/mappingActions';
 
-import { withActionServiceContext } from '@kubev2v/common/components/ActionServiceDropdown';
+import { withActionServiceContext } from '@kubev2v/common';
 import { MappingType } from '@kubev2v/legacy/queries/types';
 
 import { FlatStorageMapping } from './dataForStorage';

--- a/packages/forklift-console-plugin/src/utils/enums.ts
+++ b/packages/forklift-console-plugin/src/utils/enums.ts
@@ -1,4 +1,4 @@
-import { K8sConditionStatus } from '@kubev2v/common/utils/types';
+import { K8sConditionStatus } from '@kubev2v/common';
 import { PlanState, ProviderType } from '@kubev2v/legacy/common/constants';
 import { PlanType } from '@kubev2v/legacy/queries/types';
 


### PR DESCRIPTION
## Finish the move to monorepo :tada: 

The move to monorepo improve build times, enforce logical separation between components, and organize the code.
Using TS project references allow coding in a referenced module using the same environment as the main bundle, e.g. code editors can find referenced code, webpack dev server can watch the modules for code chaves.

### Our monorepo packages:

**references** - webpack is watching the references, and will rebuild when the change.
**composite** - modules built as references for main bundle.

| name | packager | references |description |
|---|---|---|---|
| forklift-console-plugin | webpack | common, types, legacy| main console plugin modules |

| name | packager | composite |description |
|---|---|---|---|
| common | rollup | Yes | general purpose components, hooks, contexts and utility functions used by forklift |
| types | rollup | Yes |manual and automated type script types for forklift API |
| mocks | rollup | No |repository of mock data used for dev, demo and testing of forklift |
| legacy | - | Yes |general components, hooks, contexts and utility functions used by the legacy forklift ui |

| name | packager | description |
|---|---|---|
| webpack | rollup | webpack utilities |
| build | - | shared build scripts and config files |
| eslint-plugin | - | shared linting configurations |
