### PR TITLE
Generically config eslint to include all relevant file extensions

### DIFF
--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -12,7 +12,7 @@
   },
 
   "scripts": {
-    "lint": "eslint --ext .js,.cjs .",
-    "lint:fix": "eslint --ext .js,.cjs . --fix"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
   }
 }

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -73,6 +73,14 @@ const base = {
     'generated/',
     'node_modules/',
   ],
+
+  // this is a hack to make sure eslint will look at all of the file extensions we
+  // care about without having to put it on the command line
+  overrides: [
+    {
+      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs', '**/*.ts', '**/*.tsx'],
+    },
+  ],
 };
 
 const typescript = {


### PR DESCRIPTION
With multiple file extensions around the monorepo, it is easier to setup the eslint config plugin to force include all of the file extensions we care about.  This is done, in a very hacky way, using an `overrides` section to layer inclusions on top of the base directory. The `--ext` extension is no longer needed.

File extensions we care about linting:
  - .js
  - .jsx
  - .cjs
  - .mjs
  - .ts
  - .tsx

Follow up to #486 
Partial solution for #485