### PR TITLE
Enforce TLS on Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ With a user logged in to existing Kubernetes or Openshift environment with Forkl
 # Start a local Openshift console server on the background.
 # - The console will be available in http://localhost:9000
 # - The inventory URL can be set using an enviorment variable,
-#   ( default value for INVENTORY_SERVER_HOST is http://localhost:30088 )
+#   ( default value for INVENTORY_SERVER_HOST is https://localhost:30444 )
 #   for example:
 #     export INVENTORY_SERVER_HOST=https://virt-konveyor-forklift.apps.example.com
 # - To close the console server run:

--- a/ci/deploy-cert-manager.sh
+++ b/ci/deploy-cert-manager.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+script_dir=$(dirname "$0")
+
+K8S_TIMEOUT=${K8S_TIMEOUT:="360s"}
+
+echo ""
+echo "Installing Cert Manager"
+echo "======================="
+
+# Install cert-manager (we use basic functionality of cert-manager, we don't have to use its latest version)
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
+
+kubectl wait deployment -n cert-manager cert-manager-cainjector --for condition=Available=True --timeout=${K8S_TIMEOUT}
+kubectl wait deployment -n cert-manager cert-manager --for condition=Available=True --timeout=${K8S_TIMEOUT}
+kubectl wait deployment -n cert-manager cert-manager-webhook --for condition=Available=True --timeout=${K8S_TIMEOUT}

--- a/ci/deploy-cluster.sh
+++ b/ci/deploy-cluster.sh
@@ -48,8 +48,10 @@ nodes:
   extraPortMappings:
   - containerPort: 30080
     hostPort: 30080
-  - containerPort: 30088
-    hostPort: 30088
+  - containerPort: 30443
+    hostPort: 30443
+  - containerPort: 30444
+    hostPort: 30444
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]

--- a/ci/deploy-console.sh
+++ b/ci/deploy-console.sh
@@ -4,10 +4,12 @@ set -euo pipefail
 script_dir=$(dirname "$0")
 
 K8S_TIMEOUT=${K8S_TIMEOUT:="360s"}
-OKD_CONSOLE_YAML=${script_dir}/yaml/okd-console.yaml
+OKD_CONSOLE_YAML=${OKD_CONSOLE_YAML:="${script_dir}/yaml/okd-console-tls.yaml"}
 
 FORKLIFT_PLUGIN_UPSTREAM_IMG=quay.io/kubev2v/forklift-console-plugin:latest
 FORKLIFT_PLUGIN_IMAGE=${FORKLIFT_PLUGIN_IMAGE:="quay.io/kubev2v/forklift-console-plugin:latest"}
+
+#--------------------
 
 # Install OKD console
 # -------------------
@@ -22,7 +24,7 @@ kubectl apply -f ${script_dir}/yaml/crds/console
 kubectl apply -f ${script_dir}/yaml/crds/forklift
 
 echo ""
-echo "deploy OKD console (port: 30080)"
+echo "deploy OKD console"
 
 cat ${OKD_CONSOLE_YAML} | \
     sed "s/${FORKLIFT_PLUGIN_UPSTREAM_IMG//\//\\/}/${FORKLIFT_PLUGIN_IMAGE//\//\\/}/g" | \
@@ -32,7 +34,7 @@ echo ""
 echo "waiting for OKD console service..."
 echo "=================================="
 
-kubectl wait deployment -n okd-console console --for condition=Available=True --timeout=${K8S_TIMEOUT}
+kubectl wait deployment -n konveyor-forklift console --for condition=Available=True --timeout=${K8S_TIMEOUT}
 
 echo ""
 echo "waiting for forklift console plugin service..."

--- a/ci/deploy-forklift.sh
+++ b/ci/deploy-forklift.sh
@@ -62,14 +62,6 @@ EOF
 
 # --------------------
 
-echo ""
-echo "Installing VolumePopulator CRD"
-echo "=============================="
-
-kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/volume-data-source-validator/v1.0.1/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml
-
-# --------------------
-
 # Wait for forklift operator to start, and create a controller instance
 echo ""
 echo "Waiting for forklift-operator (may take a few minutes)"
@@ -103,4 +95,4 @@ EOF
 # Wait for forklift inventory service, then expose it on port 30088
 while ! kubectl get service -n ${FORKLIFT_NAMESPACE} forklift-inventory; do sleep 30; done
 kubectl patch service -n ${FORKLIFT_NAMESPACE} forklift-inventory --type='merge' \
-  -p '{"spec":{"type":"NodePort","ports":[{"name":"api-http","protocol":"TCP","targetPort":8080,"port":8080,"nodePort":30088}]}}'
+  -p '{"spec":{"type":"NodePort","ports":[{"name":"api-https","protocol":"TCP","targetPort":8443,"port":8443,"nodePort":30444}]}}'

--- a/ci/deploy-volume-populator.sh
+++ b/ci/deploy-volume-populator.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo ""
+echo "Installing VolumePopulator CRD"
+echo "=============================="
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/volume-data-source-validator/v1.0.1/client/config/crd/populator.storage.k8s.io_volumepopulators.yaml

--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -12,8 +12,8 @@ PLUGIN_URL=${PLUGIN_URL:-"http://localhost:9001"}
 CONTAINER_NETWORK_TYPE=${CONTAINER_NETWORK_TYPE:-"host"}
 CONSOLE_IMAGE=${CONSOLE_IMAGE:-"quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:-9000}
-INVENTORY_SERVER_HOST=${INVENTORY_SERVER_HOST:-"http://localhost:30088"}
-MUST_GATHER_API_SERVER_HOST=${MUST_GATHER_API_SERVER_HOST:-"http://localhost:30089"}
+INVENTORY_SERVER_HOST=${INVENTORY_SERVER_HOST:-"https://localhost:30444"}
+MUST_GATHER_API_SERVER_HOST=${MUST_GATHER_API_SERVER_HOST:-"https://localhost:30445"}
 
 if [[ ${CONSOLE_IMAGE} =~ ^localhost/ ]]; then
     PULL_POLICY="never"
@@ -26,8 +26,6 @@ if podman container exists ${CONSOLE_CONTAINER_NAME}; then
   echo "container named ${CONSOLE_CONTAINER_NAME} is running, exit."
   exit 1
 fi
-
-kubectl port-forward -n ${FORKLIFT_NAMESPACE} service/forklift-inventory 65300:8443 &
 
 # Base setup for the bridge
 if [[ $@ == *'--auth'* ]]; then

--- a/ci/stop-console.sh
+++ b/ci/stop-console.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 CONSOLE_CONTAINER_NAME=okd-console
 
-pkill kubectl
-
 # Test is console already running
 if podman container exists ${CONSOLE_CONTAINER_NAME}; then
   podman container stop ${CONSOLE_CONTAINER_NAME}

--- a/ci/yaml/okd-console-tls-cert.yaml
+++ b/ci/yaml/okd-console-tls-cert.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: console
+  namespace: konveyor-forklift
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: console-console-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: konveyor-forklift
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: console
+  namespace: konveyor-forklift
+  annotations:
+    kubernetes.io/service-account.name: console
+type: kubernetes.io/service-account-token
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: console-certificate
+  namespace: konveyor-forklift
+spec:
+  commonName: console-certificate
+  dnsNames:
+    - console.konveyor-forklift.svc
+    - console.konveyor-forklift.svc.cluster.local
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: forklift-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: console-serving-cert
+  

--- a/ci/yaml/okd-console-tls.yaml
+++ b/ci/yaml/okd-console-tls.yaml
@@ -29,25 +29,6 @@ spec:
           imagePullPolicy: Always
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: console
-  namespace: konveyor-forklift
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: console-console-admin
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: console
-    namespace: konveyor-forklift
----
-apiVersion: v1
 kind: Service
 metadata:
   name: forklift-console-plugin
@@ -81,10 +62,29 @@ spec:
         name: console
     spec:
       serviceAccountName: console
+      volumes:
+      - name: forklift-cert
+        secret:
+          secretName: forklift-cert
+      - name: console-serving-cert
+        secret:
+          secretName: console-serving-cert
       containers:
       - name: console
         image: quay.io/openshift/origin-console:latest
+        volumeMounts:
+        - name: console-serving-cert
+          mountPath: /var/run/secrets/forklift
+        - name: forklift-cert
+          mountPath: /etc/ssl/certs/forklift-ca.crt
+          subPath: ca.crt
         env:
+        - name: BRIDGE_LISTEN
+          value: "https://0.0.0.0:9000"
+        - name: BRIDGE_TLS_CERT_FILE
+          value: /var/run/secrets/forklift/tls.crt
+        - name: BRIDGE_TLS_KEY_FILE
+          value: /var/run/secrets/forklift/tls.key
         - name: BRIDGE_PLUGINS
           value: forklift-console-plugin=http://forklift-console-plugin.konveyor-forklift.svc.cluster.local:8080
         - name: BRIDGE_PLUGIN_PROXY
@@ -92,12 +92,12 @@ spec:
             {"services":[
               {
                   "consoleAPIPath":"/api/proxy/plugin/forklift-console-plugin/forklift-inventory/",
-                  "endpoint":"http://forklift-inventory.konveyor-forklift.svc.cluster.local:8080",
+                  "endpoint":"https://forklift-inventory.konveyor-forklift.svc.cluster.local:8443",
                   "authorize":true
               },
               {
                   "consoleAPIPath":"/api/proxy/plugin/forklift-console-plugin/must-gather-api/",
-                  "endpoint":"http://must-gather-api.konveyor-forklift.svc.cluster.local:8080",
+                  "endpoint":"https://must-gather-api.konveyor-forklift.svc.cluster.local:8443",
                   "authorize":true
               }]}
 ---
@@ -108,8 +108,8 @@ metadata:
   namespace: konveyor-forklift
 spec:
   ports:
-  - name: api-http
-    nodePort: 30080
+  - name: api-https
+    nodePort: 30443
     port: 9000
     protocol: TCP
     targetPort: 9000

--- a/docs/start-dev-server.md
+++ b/docs/start-dev-server.md
@@ -64,8 +64,8 @@ npm run cluster:delete
 | -------|--------------|
 | CONSOLE_IMAGE | The console image to run ( default `quay.io/openshift/origin-console:latest` )|
 | CONSOLE_PORT | Expose the console web application on port ( default `9000` )|
-| INVENTORY_SERVER_HOST | URL of Forklift inventory server ( default `http://localhost:8080` )|
-| MUST_GATHER_API_SERVER_HOST | URL of Forklift must gather server ( default `http://localhost:8090` )|
+| INVENTORY_SERVER_HOST | URL of Forklift inventory server ( default `https://localhost:30444` )|
+| MUST_GATHER_API_SERVER_HOST | URL of Forklift must gather server ( default `https://localhost:30445` )|
 | BRIDGE_K8S_AUTH_BEARER_TOKEN | Bearer token of user account ( on openshift token default to `$(oc whoami -t)` )|
 | BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT | Kubernetes API servere URL (default, guess useing kubeconfig file) |
 
@@ -85,8 +85,8 @@ In this scenario the inventory and must-gather URLs will be on the local machine
 
 ``` bash
 # When running locally the 
-export INVENTORY_SERVER_HOST=http://localhost:30088
-export MUST_GATHER_API_SERVER_HOST=http://localhost:< the port assigned for must gather role >
+export INVENTORY_SERVER_HOST=https://localhost:30444
+export MUST_GATHER_API_SERVER_HOST=https://localhost:< the port assigned for must gather role >
 ```
 
 ### Running forklift operator on CRC or Openshift
@@ -104,4 +104,4 @@ export INVENTORY_SERVER_HOST=https://<route found>
 
 ### KinD
 
-The development cluster using kind will expose the inventory server on port 30088 `http://loclhost:30088`.
+The development cluster using kind will expose the inventory server on port 30443 `https://loclhost:30443`.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cluster:delete": "bash ./ci/clean-cluster.sh",
     "e2e:cluster": "bash ./ci/deploy-cluster.sh",
     "e2e:build": "bash ./ci/build-and-push-images.sh",
-    "e2e:console": "bash ./ci/deploy-console.sh",
+    "e2e:console": "OKD_CONSOLE_YAML=./ci/yaml/okd-console.yaml bash ./ci/deploy-console.sh",
     "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:console"
   },
   "devDependencies": {


### PR DESCRIPTION
The Forklift operator is now enforcing TLS on K8s [1], this changes the inventory endpoint port from `8080` to `8443` and the shcema from `http` to `https`.

In [2] we started addressing the TLS use for out-of-cluster development, this PR address the in-cluster setup.

  - [x] Update docs to use the new schema and endpoints for the forklift services
  - [x] Update console deployment to use TLS and the new inventory endpoint
  - [x] Installed now required cert manager operator
  - [x] Create certification for the console TLS service
  - [x] Make the console and kubevirt optional ( opt out ) when creating a cluster 
  - [x] Expose inventory server on node port  30444, to replace the kubectl port forwarding
  - [x] Adjust cypress tests to use a non-tls console version that use mock data

Notes:
a. No change is needed for CRC and Openshift deployments that already enforce TLS
b. The ci console server is non-tls, it can not connect to a real inventory server (tls only), this is not an issue since the ci scripts will use mock data and will not connect to real inventory server.

[1] https://github.com/kubev2v/forklift/pull/383
[2] https://github.com/kubev2v/forklift-console-plugin/pull/492