### PR TITLE
Disable eslint any warning on legacy common types

### DIFF
--- a/packages/legacy/src/queries/types/common.types.ts
+++ b/packages/legacy/src/queries/types/common.types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: lib-ui candidate
 
 // TODO this is a confusing name


### PR DESCRIPTION
In https://github.com/kubev2v/forklift-console-plugin/pull/493 we finished the move to monorepo, legacy is one of the packages and we enforced eslint on it.

Issue:
the legacy package does not play nice with our linting rules, and require some tweaking.

Fix:
It's ok to use any in this instance, disabling eslint no-any rule for this file.