### PR TITLE
Move OKD_CONSOLE_YAML env var to github workflows

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -5,6 +5,7 @@ on:
 env:
   CONTAINER_CMD: docker
   FORKLIFT_PLUGIN_IMAGE: localhost:5001/forklift-console-plugin:latest
+  OKD_CONSOLE_YAML: ./ci/yaml/okd-console.yaml 
 
 jobs:
   tests:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cluster:delete": "bash ./ci/clean-cluster.sh",
     "e2e:cluster": "bash ./ci/deploy-cluster.sh",
     "e2e:build": "bash ./ci/build-and-push-images.sh",
-    "e2e:console": "OKD_CONSOLE_YAML=./ci/yaml/okd-console.yaml bash ./ci/deploy-console.sh",
+    "e2e:console": "bash ./ci/deploy-console.sh",
     "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:console"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue:
`OKD_CONSOLE_YAML` is set in `package.json` script, while it is used in the `on-pull-request.yaml` workflow to control the console creation in this action.

FIx:
move the env variable to the workflow action, and remove it from the more general purpose `package.json` file