### PR TITLE
link and page styling tweaks

### DIFF
--- a/packages/common/src/components/ExternalLink/ExternalLink.tsx
+++ b/packages/common/src/components/ExternalLink/ExternalLink.tsx
@@ -3,10 +3,16 @@ import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
-export const ExternalLink: React.FC<ExternalLinkProps> = ({ children, href, text, isInline }) => (
+export const ExternalLink: React.FC<ExternalLinkProps> = ({
+  children,
+  href,
+  text,
+  isInline,
+  hideIcon,
+}) => (
   <Button
     variant="link"
-    icon={<ExternalLinkAltIcon />}
+    icon={hideIcon ? undefined : <ExternalLinkAltIcon />}
     iconPosition="right"
     component="a"
     href={href}
@@ -22,4 +28,5 @@ type ExternalLinkProps = {
   text?: React.ReactNode;
   additionalClassName?: string;
   isInline?: boolean;
+  hideIcon?: boolean;
 };

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.style.css
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.style.css
@@ -1,0 +1,3 @@
+.forklift-page__main-title {
+  padding-bottom: 0;
+}

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -40,6 +40,8 @@ import { FilterIcon } from '@patternfly/react-icons';
 
 import { ManageColumnsToolbar } from './ManageColumnsToolbar';
 
+import './StandardPage.style.css';
+
 /**
  * Reduce two list of filters to one list.
  *
@@ -219,7 +221,7 @@ export function StandardPage<T>({
 
   return (
     <>
-      <PageSection variant="light">
+      <PageSection variant="light" className="forklift-page__main-title">
         <Level>
           <LevelItem>
             <Title headingLevel="h1">{title}</Title>

--- a/packages/forklift-console-plugin/src/components/page/__tests__/__snapshots__/StandardPage.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/components/page/__tests__/__snapshots__/StandardPage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`empty result set returned, no filters  1`] = `
 <DocumentFragment>
   <section
-    class="pf-c-page__main-section pf-m-light"
+    class="pf-c-page__main-section pf-m-light forklift-page__main-title"
   >
     <div
       class="pf-l-level"
@@ -241,7 +241,7 @@ exports[`empty result set returned, no filters  1`] = `
 exports[`single entry returned, both filters  1`] = `
 <DocumentFragment>
   <section
-    class="pf-c-page__main-section pf-m-light"
+    class="pf-c-page__main-section pf-m-light forklift-page__main-title"
   >
     <div
       class="pf-l-level"


### PR DESCRIPTION
Styling issues:
In list page title has a double padding between title and content - fixed by custom css.
Inline external link does not have an option for no icon - fixed by adding a `hideIcon` prop.
