### PR TITLE
Rename ProvidersInventory to ProvidersInventoryList

### DIFF
--- a/packages/mocks/src/definitions/basic/providers.mock.ts
+++ b/packages/mocks/src/definitions/basic/providers.mock.ts
@@ -5,7 +5,7 @@ import {
   OpenstackProvider,
   OVirtProvider,
   ProviderModelGroupVersionKind as gvk,
-  ProvidersInventory,
+  ProvidersInventoryList,
   V1beta1Provider,
   V1beta1ProviderStatus,
   VSphereProvider,
@@ -451,7 +451,7 @@ export const openshiftProviderHost: OpenshiftProvider = {
   },
 };
 
-export const MOCK_INVENTORY_PROVIDERS: ProvidersInventory = {
+export const MOCK_INVENTORY_PROVIDERS: ProvidersInventoryList = {
   vsphere: [vmwareProvider1, vmwareProvider2, vmwareProvider3],
   ovirt: [rhvProvider1, rhvProvider1i, rhvProvider2, rhvProvider3],
   openstack: [openstackProvider1, openstackProvider2],

--- a/packages/mocks/src/definitions/utils.ts
+++ b/packages/mocks/src/definitions/utils.ts
@@ -15,7 +15,7 @@ import {
   OVirtStorageDomain,
   OvirtTreeNode,
   OVirtVM,
-  ProvidersInventory,
+  ProvidersInventoryList,
   V1beta1Provider,
   VSphereDataStore,
   VSphereHost,
@@ -44,7 +44,7 @@ export const disks = ({
   ovirt,
   openstack,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   ovirt: { [uid: string]: OVirtDisk[] };
   openstack: OpenstackVolumeType[];
@@ -62,7 +62,7 @@ export const vms = ({
   vsphere,
   ovirt,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   vsphere: { [uid: string]: VSphereVM[] };
   ovirt: { [uid: string]: OVirtVM[] };
@@ -77,7 +77,7 @@ export const hosts = ({
   inventoryPath,
   vsphere,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   vsphere: { [uid: string]: VSphereHost[] };
 }) =>
@@ -91,7 +91,7 @@ export const namespaces = ({
   inventoryPath,
   openshift,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   openshift: { [uid: string]: OpenShiftNamespace[] };
 }) =>
@@ -107,7 +107,7 @@ export const networks = ({
   ovirt,
   openshift,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   vsphere: { [uid: string]: VSphereNetwork[] };
   ovirt: { [uid: string]: OVirtNetwork[] };
@@ -128,7 +128,7 @@ export const nicProfiles = ({
   inventoryPath,
   ovirt,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   ovirt: { [uid: string]: OVirtNicProfile[] };
 }) =>
@@ -145,7 +145,7 @@ export const storages = ({
   openstack,
   openshift,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   vsphere: { [uid: string]: VSphereDataStore[] };
   ovirt: { [uid: string]: OVirtStorageDomain[] };
@@ -177,7 +177,7 @@ export const trees = ({
   ovirt,
   openstack,
 }: {
-  providers: ProvidersInventory;
+  providers: ProvidersInventoryList;
   inventoryPath: string;
   vsphere: {
     hostTree: { [uid: string]: VSphereTreeNode };

--- a/packages/types/src/types/Modify.ts
+++ b/packages/types/src/types/Modify.ts
@@ -1,0 +1,1 @@
+export type Modify<T, R> = Omit<T, keyof R> & R;

--- a/packages/types/src/types/ProvidersInventoryList.ts
+++ b/packages/types/src/types/ProvidersInventoryList.ts
@@ -3,7 +3,7 @@ import { OpenshiftProvider, OpenstackProvider, OVirtProvider, VSphereProvider } 
 /**
  * Represents the inventory of providers, including their entities.
  */
-export interface ProvidersInventory {
+export interface ProvidersInventoryList {
   openshift?: OpenshiftProvider[] | null;
   openstack?: OpenstackProvider[] | null;
   ovirt?: OVirtProvider[] | null;

--- a/packages/types/src/types/index.ts
+++ b/packages/types/src/types/index.ts
@@ -1,11 +1,12 @@
 // @index('./*', f => `export * from '${f.path}';`)
 export * from './k8s';
+export * from './Modify';
 export * from './MustGatherResponse';
 export * from './provider';
 export * from './ProviderHost';
 export * from './ProviderInventory';
 export * from './ProviderSecret';
-export * from './ProvidersInventory';
+export * from './ProvidersInventoryList';
 export * from './ProviderVM';
 export * from './secret';
 // @endindex


### PR DESCRIPTION
Rename `ProvidersInventory` to `ProvidersInventoryList`

Issue:
the name `ProvidersInventory` that represent a struct holding a list of providers sound very similar to `ProviderInventory` that hold one provider.