### PR TITLE
Add sotry book action to main package.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ ci/yaml/openapi.yaml
 
 **/mockServiceWorker.js
 
+storybook-static
 .rollup.cache
 .vscode/

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "e2e:cluster": "bash ./ci/deploy-cluster.sh",
     "e2e:build": "bash ./ci/build-and-push-images.sh",
     "e2e:console": "bash ./ci/deploy-console.sh",
-    "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:console"
+    "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:console",
+    "storybook": "npm run storybook -w @kubev2v/common -- dev -p 6006",
+    "storybook:build": "npm run storybook -w @kubev2v/common -- build"
   },
   "devDependencies": {
     "@cspell/eslint-plugin": "^6.31.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf ./dist ./coverage tsconfig.tsbuildinfo",
-    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache",
+    "clean:all": "npm run clean -- ./node_modules ./.rollup.cache ./storybook-static",
     "build": "rollup -c --bundleConfigAsCjs",
     "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
@@ -24,7 +24,7 @@
     "test:coverage": "TZ=UTC jest --coverage",
     "test:updateSnapshot": "TZ=UTC jest --updateSnapshot",
     "storybook": "storybook dev  -p 6006",
-    "build-storybook": "storybook build"
+    "storybook:build": "storybook build"
   },
   "peerDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "0.0.18",


### PR DESCRIPTION
Add sotry book action to main package.json file

  - [x] add `storybook-static` to git ignore
  - [x] add `storybook-static` to `clean:all` script
  - [x] use `<action>:<sub action>`  naming convention for story book, `build-storybook` is now `storybook:build`
  - [x] add the storybook actions to the main `package.json` file so they can be called from the main project