### PR TITLE
Use useForkliftTranslation instead of useTranslation

### DIFF
--- a/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/MappingRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import * as C from 'src/utils/constants';
 import { MAPPING_STATUS } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { getResourceFieldValue } from '@kubev2v/common';
 import { RowProps } from '@kubev2v/common';
@@ -39,7 +39,7 @@ export const SourceCell = ({
   groups: unknown[];
   Icon: React.ComponentClass;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const isSingleGroup = groups.length === 1;
   return (
     <>
@@ -56,7 +56,7 @@ export type CellCreator<T extends CommonMapping> = Record<
 >;
 
 const NameCell: React.FC<CellProps<CommonMapping>> = ({ resourceData }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   return (
     <span className="forklift-table__flex-cell">
@@ -75,7 +75,7 @@ const NameCell: React.FC<CellProps<CommonMapping>> = ({ resourceData }) => {
 };
 
 const MappingStatusCell: React.FC<CellProps<CommonMapping>> = ({ resourceData }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   return (
     <StatusCell
@@ -113,7 +113,7 @@ function MappingRow<T extends CommonMapping>({
   mappingType: MappingType;
   mapping: Mapping;
 }) {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isRowExpanded, setIsRowExpanded] = useState(false);
   const toggleExpand = useCallback(
     () => setIsRowExpanded(!isRowExpanded),

--- a/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { withQueryClient } from '@kubev2v/common';
 import { ConfirmModal } from '@kubev2v/legacy/common/components/ConfirmModal';
@@ -17,7 +17,7 @@ export function useMappingActions<T extends CommonMapping>({
   resourceData: T;
   mappingType: MappingType;
 }) {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const launchModal = useModal();
 
   const actions = useMemo(
@@ -65,7 +65,7 @@ const EditMappingModal = ({
   mappingType: MappingType;
   namespace: string;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const title = mappingType === 'Network' ? t('Edit NetworkMap') : t('Edit StorageMap');
   return (
     <AddEditMappingModal
@@ -93,7 +93,7 @@ const DeleteMappingModal = ({
   namespace: string;
   name: string;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const deleteMappingMutation = useDeleteMappingMutation(mappingType, namespace, closeModal);
   const msg = {
     title: mappingType === 'Network' ? t('Delete NetworkMap?') : t('Delete StorageMap?'),

--- a/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
+++ b/packages/forklift-console-plugin/src/components/page/ManageColumnsToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ManageColumnsModal, ManageColumnsToolbarItem } from '@kubev2v/common';
 import { ResourceField } from '@kubev2v/common';
@@ -21,7 +21,7 @@ export const ManageColumnsToolbar = ({
   setColumns,
   defaultColumns,
 }: ManageColumnsToolbarProps) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
   return (
     <ManageColumnsToolbarItem

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useMemo } from 'react';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
   AttributeValueFilter,
@@ -181,7 +181,7 @@ export function StandardPage<T>({
   const {
     t,
     i18n: { resolvedLanguage },
-  } = useTranslation();
+  } = useForkliftTranslation();
   const [selectedFilters, setSelectedFilters] = useUrlFilters({
     fields: fieldsMetadata,
     filterPrefix,

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/EmptyStateNetworkMaps.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/EmptyStateNetworkMaps.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import ForkliftEmptyState from 'src/components/empty-states/ForkliftEmptyState';
 import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { HELP_LINK_HREF } from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
@@ -18,7 +18,7 @@ import { AddNetworkMappingButton } from './NetworkMappingsPage';
 const AutomationIcon = () => <img src={automationIcon} className="forklift-empty-state__icon" />;
 
 const EmptyStatePlans: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const hasSufficientProviders = useHasSufficientProviders(namespace);
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
@@ -5,7 +5,7 @@ import {
 } from 'src/components/mappings/MappingPage';
 import StandardPage from 'src/components/page/StandardPage';
 import * as C from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { FreetextFilter } from '@kubev2v/common';
@@ -45,7 +45,7 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const NetworkMappingsPage = ({ namespace }: ResourceConsolePageProps) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'NetworkMappings' }));
   const dataSource = useFlatNetworkMappings({
     namespace,
@@ -73,7 +73,7 @@ const Page = ({
   title: string;
   userSettings: UserSettings;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const [data, isLoadSuccess, isLoadError] = dataSource;
   const isLoading = !isLoadSuccess && !isLoadError;
@@ -108,7 +108,7 @@ const Page = ({
 const PageMemo = React.memo(Page);
 
 export const AddNetworkMappingButton: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const launchModal = useModal();
 
   return (
@@ -126,7 +126,7 @@ const AddMappingModal: React.FC<{
   currentNamespace: string;
   closeModal: () => void;
 }> = ({ closeModal, currentNamespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   return (
     <AddEditMappingModal
       onClose={closeModal}

--- a/packages/forklift-console-plugin/src/modules/Plans/EmptyStatePlans.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/EmptyStatePlans.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import ForkliftEmptyState from 'src/components/empty-states/ForkliftEmptyState';
 import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { HELP_LINK_HREF } from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
@@ -17,7 +17,7 @@ import { useHasSufficientProviders } from '../Providers/data';
 const AutomationIcon = () => <img src={automationIcon} className="forklift-empty-state__icon" />;
 
 const EmptyStatePlans: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const hasSufficientProviders = useHasSufficientProviders(namespace);
 

--- a/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlanRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import * as C from 'src/utils/constants';
 import { PLAN_TYPE } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { getResourceFieldValue } from '@kubev2v/common';
 import { RowProps } from '@kubev2v/common';
@@ -46,7 +46,7 @@ const TextCell = ({ value }: CellProps) => <>{value ?? ''}</>;
 const StatusCell = ({
   resourceData: { status, type, vmCount, vmDone, name, object, namespace },
 }: CellProps) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const isBeingStarted = status === 'Starting';
   const isWarmPlan = type === 'Warm';
   const { title, variant } = getMigStatusState(status, isWarmPlan);

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import * as C from 'src/utils/constants';
 import { PLAN_STATUS_FILTER } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { EnumToTuple } from '@kubev2v/common';
@@ -104,7 +104,7 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const PlansPage = ({ namespace }: ResourceConsolePageProps) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'Plans' }));
   const dataSource = useFlatPlans({
     namespace,
@@ -132,7 +132,7 @@ const Page = ({
   title: string;
   userSettings: UserSettings;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const [data, isLoadSuccess, isLoadError] = dataSource;
   const isLoading = !isLoadSuccess && !isLoadError;

--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { withActionServiceContext } from '@kubev2v/common';
 import { withQueryClient } from '@kubev2v/common';
@@ -65,7 +65,7 @@ export const useFlatPlanActions: ExtensionHook<
 > = ({ resourceData: plan }) => {
   const { migrationStarted, migrationCompleted, archived: isPlanArchived, name, namespace } = plan;
   const isPlanStarted = !!migrationStarted;
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const launchModal = useModal();
   const {
     withNs,
@@ -340,7 +340,7 @@ const DeleteModal = ({
   isPlanExecuting: boolean;
   isPlanStarted: boolean;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(true);
 
   const exit = useCallback(() => {
@@ -412,7 +412,7 @@ const RestartModal = ({ plan, closeModal }: { plan: FlatPlan; closeModal: () => 
 RestartModal.displayName = 'RestartModal';
 
 const DetailsModal = ({ plan, closeModal }: { plan: FlatPlan; closeModal: () => void }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(true);
 
   const exit = useCallback(() => {
@@ -440,7 +440,7 @@ const DetailsModal = ({ plan, closeModal }: { plan: FlatPlan; closeModal: () => 
 DetailsModal.displayName = 'DetailsModal';
 
 const ArchiveModal = ({ plan, closeModal }: { plan: FlatPlan; closeModal: () => void }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(true);
 
   const exit = useCallback(() => {

--- a/packages/forklift-console-plugin/src/modules/Providers/AddProviderButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/AddProviderButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { withQueryClient } from '@kubev2v/common';
 import { AddEditProviderModal } from '@kubev2v/legacy/Providers/components/AddEditProviderModal';
@@ -20,7 +20,7 @@ const AddProviderModal: React.FC<{
 };
 
 export const AddProviderButton: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const launchModal = useModal();
 
   return (

--- a/packages/forklift-console-plugin/src/modules/Providers/EmptyStateProviders.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/EmptyStateProviders.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 import ForkliftEmptyState from 'src/components/empty-states/ForkliftEmptyState';
 import digitalTransformationIcon from 'src/components/empty-states/images/digital-transformation.svg';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { Text, TextList, TextListItem } from '@patternfly/react-core';
 
@@ -13,7 +13,7 @@ const DigitalTransformationIcon = () => (
 );
 
 const EmptyStateProviders: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   return (
     <ForkliftEmptyState

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/ProviderLink.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/ProviderLink.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelGroupVersionKind } from '@kubev2v/types';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
@@ -10,7 +10,7 @@ import { isManaged } from '../data';
 import { CellProps } from './types';
 
 export const ProviderLink: React.FC<CellProps> = ({ resourceData }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const { name, namespace } = resourceData?.metadata || {};
   const managed = isManaged(resourceData);
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/StatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/StatusCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StatusCell as Cell } from 'src/components/cells/StatusCell';
 import { PHASE } from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { getResourceFieldValue } from '@kubev2v/common';
 
@@ -9,7 +9,7 @@ import { phaseLabels, statusIcons } from './consts';
 import { CellProps } from './types';
 
 export const StatusCell: React.FC<CellProps> = ({ resourceData, resourceFields }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const phase = getResourceFieldValue(resourceData, PHASE, resourceFields);
   const phaseLabel = phaseLabels[phase] ? t(phaseLabels[phase]) : t('Undefined');

--- a/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TypeCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProviderRow/TypeCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as C from 'src/utils/constants';
 import { PROVIDERS } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { getResourceFieldValue } from '@kubev2v/common';
 import { TARGET_PROVIDER_TYPES } from '@kubev2v/legacy/common/constants';
@@ -10,7 +10,7 @@ import { Label } from '@patternfly/react-core';
 import { CellProps } from './types';
 
 export const TypeCell: React.FC<CellProps> = ({ resourceData, resourceFields }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const type = getResourceFieldValue(resourceData, C.TYPE, resourceFields);
   const isTarget = TARGET_PROVIDER_TYPES.includes(type);
 

--- a/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/ProvidersPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import * as C from 'src/utils/constants';
 import { PROVIDER_STATUS, PROVIDERS } from 'src/utils/enums';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { EnumToTuple } from '@kubev2v/common';
@@ -131,7 +131,7 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 const ProvidersPage: React.FC<ResourceConsolePageProps> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'Providers' }));
   const dataSource = useProvidersWithInventory({
     namespace,
@@ -156,7 +156,7 @@ const Page: React.FC<{
   title: string;
   userSettings: UserSettings;
 }> = ({ dataSource, namespace, title, userSettings }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const [data, isLoadSuccess, isLoadError] = dataSource;
   const isLoading = !isLoadSuccess && !isLoadError;

--- a/packages/forklift-console-plugin/src/modules/Providers/providerActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/providerActions.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { DEFAULT_TRANSFER_NETWORK_ANNOTATION } from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { withActionServiceContext } from '@kubev2v/common';
 import { withQueryClient } from '@kubev2v/common';
@@ -21,7 +21,7 @@ import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { type MergedProvider, isManaged } from './data';
 
 export const useMergedProviderActions = ({ resourceData }: { resourceData: MergedProvider }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const launchModal = useModal();
   const plansQuery = usePlansQuery(resourceData.metadata.namespace);
   const managed = isManaged(resourceData);
@@ -95,7 +95,7 @@ const SelectNetworkForOpenshift = ({
   closeModal: () => void;
   resourceData: MergedProvider;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const migrationNetworkMutation = useOCPMigrationNetworkMutation(
     resourceData.metadata?.namespace,
     closeModal,
@@ -133,7 +133,7 @@ const DeleteModal = ({
   closeModal: () => void;
   resourceData: MergedProvider;
 }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(true);
 
   const toggleDeleteModal = useCallback(() => {

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/EmptyStateStorageMaps.tsx
@@ -5,7 +5,7 @@ import ForkliftEmptyState from 'src/components/empty-states/ForkliftEmptyState';
 import automationIcon from 'src/components/empty-states/images/automation.svg';
 import { AddMappingButton } from 'src/components/mappings/MappingPage';
 import { HELP_LINK_HREF } from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ExternalLink } from '@kubev2v/common';
 import { PROVIDERS_REFERENCE } from '@kubev2v/legacy/common/constants';
@@ -18,7 +18,7 @@ import { useHasSufficientProviders } from '../Providers/data';
 const AutomationIcon = () => <img src={automationIcon} className="forklift-empty-state__icon" />;
 
 const EmptyStatePlans: React.FC<{ namespace: string }> = ({ namespace }) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const hasSufficientProviders = useHasSufficientProviders(namespace);
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/StorageMappingsPage.tsx
@@ -6,7 +6,7 @@ import {
 } from 'src/components/mappings/MappingPage';
 import StandardPage, { StandardPageProps } from 'src/components/page/StandardPage';
 import * as C from 'src/utils/constants';
-import { useTranslation } from 'src/utils/i18n';
+import { useForkliftTranslation } from 'src/utils/i18n';
 import { ResourceConsolePageProps } from 'src/utils/types';
 
 import { FreetextFilter } from '@kubev2v/common';
@@ -42,7 +42,7 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const StorageMappingsPage = ({ namespace }: ResourceConsolePageProps) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'StorageMappings' }));
   const dataSource = useFlatStorageMappings({
     namespace,
@@ -65,7 +65,7 @@ const Page = ({
   title,
   userSettings,
 }: Partial<StandardPageProps<FlatStorageMapping>>) => {
-  const { t } = useTranslation();
+  const { t } = useForkliftTranslation();
 
   const [data, isLoadSuccess, isLoadError] = dataSource;
   const isLoading = !isLoadSuccess && !isLoadError;

--- a/packages/forklift-console-plugin/src/utils/i18n.ts
+++ b/packages/forklift-console-plugin/src/utils/i18n.ts
@@ -1,5 +1,5 @@
 import { useTranslation as useReactI18NextTranslation } from 'react-i18next';
 
-export function useTranslation() {
+export function useForkliftTranslation() {
   return useReactI18NextTranslation('plugin__forklift-console-plugin');
 }


### PR DESCRIPTION
Issue:
`useTranslation` is ambiguous, it can be from 'react-i18next' or the internal `useTranslation`  from our utils code.

FIx:
rename the internal method `useForkliftTranslation`