### PR TITLE
use namespace in details page breadcrumbs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
@@ -132,6 +132,7 @@ export const ProviderDetailsPage: React.FC<ProviderDetailsPageProps> = ({ name, 
       <PageHeadings
         model={ProviderModel}
         obj={data?.provider}
+        namespace={namespace}
         actions={<ProviderActionsDropdown data={data} fieldId={''} fields={[]} />}
       >
         {alerts && alerts.length > 0 && (

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -173,19 +173,14 @@ const ProvidersListPage: React.FC<{
   const providersListURL = getResourceUrl({
     reference: ProviderModelRef,
     namespace: namespace,
+    namespaced: namespace ? true : false,
   });
 
   const AddButton = (
     <Button
       data-testid="add-provider-button"
       variant="primary"
-      onClick={() =>
-        history.push(
-          namespace
-            ? `${providersListURL}/~new`
-            : `/k8s/cluster/forklift.konveyor.io~v1beta1~Provider/~new`,
-        )
-      }
+      onClick={() => history.push(`${providersListURL}/~new`)}
     >
       {t('Create Provider')}
     </Button>


### PR DESCRIPTION
use namespace in details page breadcrumbs

fixes: #529 