### PR TITLE
Don't restrict the length of a string with no spaces

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
@@ -82,6 +82,5 @@ export function validateK8sToken(token: string) {
 
 export function validateNoSpaces(value: string) {
   // any string without spaces
-  // max length 128 chars
-  return /^[^\s]{1,128}$/.test(value);
+  return /^[^\s]+$/.test(value);
 }


### PR DESCRIPTION
Issue:
tokens in Openstack can be more the 128 chars,

Fix:
don't test for length