### PR TITLE
[MTV-529] Add link to set default transfere network on openshift provider

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -252,6 +252,7 @@
   "Select provider type": "Select provider type",
   "Selected columns will be displayed in the table.": "Selected columns will be displayed in the table.",
   "Service account token": "Service account token",
+  "Set default transfer network": "Set default transfer network",
   "Settings": "Settings",
   "Show archived": "Show archived",
   "Show managed": "Show managed",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
@@ -5,3 +5,8 @@
 .forklift-page-section {
     border-top: 1px solid var(--pf-global--BorderColor--100);
 }
+
+.forklift-page-provider-networks-button {
+    padding-bottom: var(--pf-global--spacer--lg);
+}
+

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { useProviderInventory } from 'src/modules/Providers/hooks';
+import {
+  EditProviderDefaultTransferNetwork,
+  ModalHOC,
+  useModal,
+} from 'src/modules/Providers/modals';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { CnoConfig, OpenShiftNetworkAttachmentDefinition } from '@kubev2v/types';
-import { Label, PageSection, Title } from '@patternfly/react-core';
+import { Button, Label, PageSection, Title } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 interface ProviderNetworksProps extends RouteComponentProps {
@@ -16,8 +21,10 @@ interface ProviderNetworksProps extends RouteComponentProps {
   loadError?: unknown;
 }
 
-export const ProviderNetworks: React.FC<ProviderNetworksProps> = ({ obj }) => {
+const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
   const { t } = useForkliftTranslation();
+  const { showModal } = useModal();
+
   const { provider } = obj;
 
   const { inventory: networks } = useProviderInventory<OpenShiftNetworkAttachmentDefinition[]>({
@@ -49,8 +56,17 @@ export const ProviderNetworks: React.FC<ProviderNetworksProps> = ({ obj }) => {
         <Title headingLevel="h2" className="co-section-heading">
           {t('NetworkAttachmentDefinitions')}
         </Title>
-      </PageSection>
-      <PageSection>
+
+        <div className="forklift-page-provider-networks-button">
+          <Button
+            key="editTransferNetwork"
+            variant="secondary"
+            onClick={() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />)}
+          >
+            {t('Set default transfer network')}
+          </Button>
+        </div>
+
         <TableComposable aria-label="Expandable table" variant="compact">
           <Thead>
             <Tr>
@@ -92,3 +108,9 @@ export const ProviderNetworks: React.FC<ProviderNetworksProps> = ({ obj }) => {
     </div>
   );
 };
+
+export const ProviderNetworks: React.FC<ProviderNetworksProps> = (props) => (
+  <ModalHOC>
+    <ProviderNetworks_ {...props} />
+  </ModalHOC>
+);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/InventoryCellFactory.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/InventoryCellFactory.tsx
@@ -4,6 +4,7 @@ import { TableEmptyCell, TableIconCell } from 'src/modules/Providers/utils';
 import { getResourceFieldValue } from '@kubev2v/common';
 
 import { CellProps } from './CellProps';
+import { OpenshiftNetworkCell } from './OpenshiftNetworkCell';
 
 /**
  * Factory function for creating InventoryCell components.
@@ -19,11 +20,19 @@ export const InventoryCellFactory: CellFactory = ({ icon }) => {
   // eslint-disable-next-line react/display-name
   return ({ data, fieldId, fields }: CellProps) => {
     const { provider, inventory } = data;
+    const type = provider?.spec.type;
+
     const value = getResourceFieldValue({ ...provider, inventory }, fieldId, fields);
 
     if (value === undefined) {
       return <TableEmptyCell />;
     }
+
+    // Special cases
+    if (type === 'openshift' && fieldId === 'networkCount') {
+      return <OpenshiftNetworkCell data={data} fieldId={fieldId} fields={fields} />;
+    }
+
     return <TableIconCell icon={icon}>{value}</TableIconCell>;
   };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/OpenshiftNetworkCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/OpenshiftNetworkCell.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { getResourceUrl, TableEmptyCell, TableLabelCell } from 'src/modules/Providers/utils';
+
+import { getResourceFieldValue } from '@kubev2v/common';
+import { ProviderModelRef } from '@kubev2v/types';
+import { NetworkIcon } from '@patternfly/react-icons';
+
+import { CellProps } from './CellProps';
+
+export const OpenshiftNetworkCell: React.FC<CellProps> = ({ data, fieldId, fields }: CellProps) => {
+  const { provider, inventory } = data;
+  const value = getResourceFieldValue({ ...provider, inventory }, fieldId, fields);
+  const providerURL = getResourceUrl({
+    reference: ProviderModelRef,
+    name: provider?.metadata?.name,
+    namespace: provider?.metadata?.namespace,
+  });
+
+  if (value === undefined) {
+    return <TableEmptyCell />;
+  }
+
+  return (
+    <TableLabelCell>
+      <Link to={`${providerURL}/networks`}>
+        <NetworkIcon /> {value}
+      </Link>
+    </TableLabelCell>
+  );
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/index.ts
@@ -2,6 +2,7 @@
 export * from './CellProps';
 export * from './InventoryCellFactory';
 export * from './NamespaceCell';
+export * from './OpenshiftNetworkCell';
 export * from './ProviderLinkCell';
 export * from './StatusCell';
 export * from './TypeCell';


### PR DESCRIPTION
Issue:
Missing link from the providers list to set the default transfer network for openshift providers.

Fix:
Add a link to set the default transfer network.

Screenshot:
![default-network](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0fea7a43-ebc5-49c7-b689-9e240b521328)

Ref: https://issues.redhat.com/browse/MTV-529