### PR TITLE
Use labels instead of values in setting modal options dropdown

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditCleanupMaxAgeModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditCleanupMaxAgeModal.tsx
@@ -10,11 +10,11 @@ import SettingsSelectInput from './SettingsSelectInput';
 
 // Define the options
 const options = [
-  { key: -1, name: '-1', description: 'Never perform must gather cleanup' },
-  { key: 1, name: '1', description: 'Clean must gather API after 1 hour' },
-  { key: 12, name: '12', description: 'Clean must gather API after 12 hours' },
-  { key: 24, name: '24', description: 'Clean must gather API after 24 hours' },
-  { key: 72, name: '72', description: 'Clean must gather API after 72 hours' },
+  { key: -1, name: 'Disable', description: 'Never perform must gather cleanup' },
+  { key: 1, name: '1h', description: 'Clean must gather API after 1 hour' },
+  { key: 12, name: '12h', description: 'Clean must gather API after 12 hours' },
+  { key: 24, name: '24h', description: 'Clean must gather API after 24 hours' },
+  { key: 72, name: '72h', description: 'Clean must gather API after 72 hours' },
 ];
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditControllerCPULimitModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditControllerCPULimitModal.tsx
@@ -10,10 +10,10 @@ import SettingsSelectInput from './SettingsSelectInput';
 
 // Define the options
 const options = [
-  { key: 200, name: '200m', description: 'Low CPU limit' },
-  { key: 500, name: '500m', description: 'Moderate CPU limit' },
-  { key: 2000, name: '2000m', description: 'High CPU limit' },
-  { key: 8000, name: '8000m', description: 'Very high CPU limit' },
+  { key: '200m', name: '200m', description: 'Low CPU limit' },
+  { key: '500m', name: '500m', description: 'Moderate CPU limit' },
+  { key: '2000m', name: '2000m', description: 'High CPU limit' },
+  { key: '8000m', name: '8000m', description: 'Very high CPU limit' },
 ];
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditControllerMemoryLimitModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditControllerMemoryLimitModal.tsx
@@ -10,10 +10,10 @@ import SettingsSelectInput from './SettingsSelectInput';
 
 // Define the options
 const options = [
-  { key: 200, name: '200Mi', description: 'Low memory limit' },
-  { key: 800, name: '800Mi', description: 'Moderate memory limit' },
-  { key: 2000, name: '2000Mi', description: 'High memory limit' },
-  { key: 8000, name: '8000Mi', description: 'Very high memory limit' },
+  { key: '200Mi', name: '200Mi', description: 'Low memory limit' },
+  { key: '800Mi', name: '800Mi', description: 'Moderate memory limit' },
+  { key: '2000Mi', name: '2000Mi', description: 'High memory limit' },
+  { key: '8000Mi', name: '8000Mi', description: 'Very high memory limit' },
 ];
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditPreCopyIntervalModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditPreCopyIntervalModal.tsx
@@ -10,10 +10,10 @@ import SettingsSelectInput from './SettingsSelectInput';
 
 // Define the options
 const options = [
-  { key: 5, name: 5, description: 'Extra small precopy interval' },
-  { key: 30, name: 30, description: 'Small precopy interval' },
-  { key: 60, name: 60, description: 'Large precopy interval' },
-  { key: 120, name: 120, description: 'Extra large precopy interval' },
+  { key: 5, name: '5min', description: 'Extra small precopy interval' },
+  { key: 30, name: '30min', description: 'Small precopy interval' },
+  { key: 60, name: '60min', description: 'Large precopy interval' },
+  { key: 120, name: '120min', description: 'Extra large precopy interval' },
 ];
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditSnapshotPoolingIntervalModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditSnapshotPoolingIntervalModal.tsx
@@ -10,10 +10,10 @@ import SettingsSelectInput from './SettingsSelectInput';
 
 // Define the options
 const options = [
-  { key: 1, name: 1, description: 'Extra short snapshot polling interval' },
-  { key: 5, name: 5, description: 'Short snapshot polling interval' },
-  { key: 10, name: 10, description: 'Long snapshot polling interval' },
-  { key: 50, name: 60, description: 'Extra long snapshot polling interval' },
+  { key: 1, name: '1s', description: 'Extra short snapshot polling interval' },
+  { key: 5, name: '5s', description: 'Short snapshot polling interval' },
+  { key: 10, name: '10s', description: 'Long snapshot polling interval' },
+  { key: 50, name: '60s', description: 'Extra long snapshot polling interval' },
 ];
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
@@ -24,6 +24,11 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
+  const mustGatherAPICleanupMaxAge =
+    obj?.spec?.['must_gather_api_cleanup_max_age'] === -1
+      ? 'Disabled'
+      : obj?.spec?.['must_gather_api_cleanup_max_age'];
+
   return (
     <Card>
       <CardTitle>{t('Settings')}</CardTitle>
@@ -86,11 +91,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
 
           <DetailsItem
             title={'Must gather cleanup after (hours)'}
-            content={
-              obj?.spec?.['must_gather_api_cleanup_max_age'] || (
-                <span className="text-muted">{'Never'}</span>
-              )
-            }
+            content={mustGatherAPICleanupMaxAge || <span className="text-muted">{'Disabled'}</span>}
             moreInfoLink={
               'https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.4/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options'
             }


### PR DESCRIPTION
Fixes: #559 

In settings dialog, show labels (e.g. "Disabled") instead of value (e.g. "-1")

Screenshot:
Before:
![settings-modal-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/adf56ce8-b0c1-4cd2-bbe0-3159e44c39e0)

After:
![settings-modal-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3337f296-1160-43f0-b782-96ef20b50d6e)
