### PR TITLE
Use provider labels instead of raw value

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -221,7 +221,7 @@
   "Please enter the limit for memory usage by the controller in Mi, if empty default value will be used.": "Please enter the limit for memory usage by the controller in Mi, if empty default value will be used.",
   "Please enter the maximum age in hours for must gather cleanup, if empty default value will be used.": "Please enter the maximum age in hours for must gather cleanup, if empty default value will be used.",
   "Please enter the maximum number of concurrent VM migrations, if empty default value will be used.": "Please enter the maximum number of concurrent VM migrations, if empty default value will be used.",
-  "Please enter the URL for oVirt engine server.": "Please enter the URL for oVirt engine server.",
+  "Please enter the URL for RHV engine server.": "Please enter the URL for RHV engine server.",
   "Please enter URL for OpenStack services REST APIs.": "Please enter URL for OpenStack services REST APIs.",
   "Please enter URL for the kubernetes API server, if empty URL default to this cluster.": "Please enter URL for the kubernetes API server, if empty URL default to this cluster.",
   "Please enter URL for vSphere REST APIs server.": "Please enter URL for vSphere REST APIs server.",

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
+import { useToggle } from '../../hooks';
 import { getValueByJsonPath } from '../../utils';
 import { AlertMessageForModals, ItemIsOwnedAlert } from '../components';
 import { useModal } from '../ModalHOC';
@@ -21,7 +22,6 @@ import { defaultOnConfirm } from './utils/defaultOnConfirm';
 import { EditModalProps, ValidationResults } from './types';
 
 import './EditModal.style.css';
-import { useToggle } from '../../hooks';
 
 /**
  * `EditModal` is a React Functional Component that allows editing a Kubernetes resource property inside a modal.

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/OvirtEditURLModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/OvirtEditURLModal.tsx
@@ -40,7 +40,7 @@ export const OvirtEditURLModal: React.FC<EditProviderURLModalProps> = (props) =>
       body={t(
         'Specify the API end point URL, for example, https://<engine_host>/ovirt-engine/api/ for RHV.',
       )}
-      helperText={t('Please enter the URL for oVirt engine server.')}
+      helperText={t('Please enter the URL for RHV engine server.')}
       onConfirmHook={patchProviderURL}
       validationHook={urlValidationHook}
     />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OVADetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OVADetailsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { EditProviderURLModal, useModal } from 'src/modules/Providers/modals';
 import { HELP_LINK_HREF } from 'src/utils/constants';
+import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -15,6 +16,7 @@ export const OVADetailsSection: React.FC<DetailsSectionProps> = ({ data }) => {
   const { showModal } = useModal();
 
   const { provider } = data;
+  const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
     <DescriptionList
@@ -26,7 +28,7 @@ export const OVADetailsSection: React.FC<DetailsSectionProps> = ({ data }) => {
         title={t('Type')}
         content={
           <>
-            {provider?.spec?.type}{' '}
+            {type}{' '}
             {!provider?.spec?.url && (
               <Label isCompact color={'grey'} className="forklift-table__flex-cell-label">
                 {t('Host cluster')}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
@@ -5,6 +5,7 @@ import {
   useModal,
 } from 'src/modules/Providers/modals';
 import { HELP_LINK_HREF } from 'src/utils/constants';
+import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -19,6 +20,7 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
   const { showModal } = useModal();
 
   const { provider } = data;
+  const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
     <DescriptionList
@@ -30,7 +32,7 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
         title={t('Type')}
         content={
           <>
-            {provider?.spec?.type}{' '}
+            {type}{' '}
             {!provider?.spec?.url && (
               <Label isCompact color={'grey'} className="forklift-table__flex-cell-label">
                 {t('Host cluster')}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { EditProviderURLModal, useModal } from 'src/modules/Providers/modals';
 import { HELP_LINK_HREF } from 'src/utils/constants';
+import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -15,6 +16,7 @@ export const OpenstackDetailsSection: React.FC<DetailsSectionProps> = ({ data })
   const { showModal } = useModal();
 
   const { provider } = data;
+  const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
     <DescriptionList
@@ -24,7 +26,7 @@ export const OpenstackDetailsSection: React.FC<DetailsSectionProps> = ({ data })
     >
       <DetailsItem
         title={t('Type')}
-        content={provider?.spec?.type}
+        content={type}
         moreInfoLink={HELP_LINK_HREF}
         helpContent={
           <Text>{t(`Allowed values are openshift, ovirt, vsphere, and openstack.`)}</Text>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { EditProviderURLModal, useModal } from 'src/modules/Providers/modals';
 import { HELP_LINK_HREF } from 'src/utils/constants';
+import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -15,6 +16,7 @@ export const OvirtDetailsSection: React.FC<DetailsSectionProps> = ({ data }) => 
   const { showModal } = useModal();
 
   const { provider } = data;
+  const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
     <DescriptionList
@@ -24,7 +26,7 @@ export const OvirtDetailsSection: React.FC<DetailsSectionProps> = ({ data }) => 
     >
       <DetailsItem
         title={t('Type')}
-        content={provider?.spec?.type}
+        content={type}
         moreInfoLink={HELP_LINK_HREF}
         helpContent={
           <Text>{t(`Allowed values are openshift, ovirt, vsphere, and openstack.`)}</Text>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
@@ -5,6 +5,7 @@ import {
   useModal,
 } from 'src/modules/Providers/modals';
 import { HELP_LINK_HREF } from 'src/utils/constants';
+import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
@@ -19,6 +20,7 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
   const { showModal } = useModal();
 
   const { provider, inventory } = data;
+  const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
     <DescriptionList
@@ -28,7 +30,7 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
     >
       <DetailsItem
         title={t('Type')}
-        content={provider?.spec?.type}
+        content={type}
         moreInfoLink={HELP_LINK_HREF}
         helpContent={
           <Text>{t(`Allowed values are openshift, ovirt, vsphere, and openstack.`)}</Text>

--- a/packages/forklift-console-plugin/src/utils/enums.ts
+++ b/packages/forklift-console-plugin/src/utils/enums.ts
@@ -4,13 +4,22 @@ import { ProviderType } from '@kubev2v/types';
 
 import { MappingStatus, ProviderStatus } from './types';
 
-export const PROVIDERS: Record<ProviderType, string> = {
-  vsphere: 'VMware',
-  ovirt: 'oVirt',
-  openstack: 'OpenStack',
-  openshift: 'KubeVirt',
-  ova: 'OVA',
-};
+export const PROVIDERS: Record<ProviderType, string> =
+  process.env.BRAND_TYPE === 'RedHat'
+    ? {
+        vsphere: 'VMware',
+        ovirt: 'RHV',
+        openstack: 'OpenStack',
+        openshift: 'Openshift',
+        ova: 'OVA',
+      }
+    : {
+        vsphere: 'VMware',
+        ovirt: 'oVirt',
+        openstack: 'OpenStack',
+        openshift: 'KubeVirt',
+        ova: 'OVA',
+      };
 
 export const CONDITIONS: Record<K8sConditionStatus, string> = {
   True: 'True',


### PR DESCRIPTION
Issue:
users see the raw type value, which is always upstream, we want to show the type for downstream when users are downstream.

Fix:
when rendering the type name, show users a label instead of raw value.

Screeshot:
Before:
![type-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/414ee9ea-dae2-456f-b0ec-f4156e335ae8)


After:
![type-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/7c33c7ff-e436-45b8-bdf7-cf00da29bf53)
