### PR TITLE
Add spinner to create providers edit provider forms

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/DeleteModal/DeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/DeleteModal/DeleteModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
 
+import { useToggle } from '../../hooks';
 import { getResourceUrl } from '../../utils';
 import { AlertMessageForModals, ItemIsOwnedAlert } from '../components';
 import { useModal } from '../ModalHOC';
@@ -39,6 +40,7 @@ interface DeleteModalProps {
 export const DeleteModal: React.FC<DeleteModalProps> = ({ title, resource, model, redirectTo }) => {
   const { t } = useForkliftTranslation();
   const { toggleModal } = useModal();
+  const [isLoading, toggleIsLoading] = useToggle();
   const history = useHistory();
   const [alertMessage, setAlertMessage] = useState<ReactNode>(null);
 
@@ -57,6 +59,8 @@ export const DeleteModal: React.FC<DeleteModalProps> = ({ title, resource, model
       return re.test(window.location.pathname);
     };
 
+    toggleIsLoading();
+
     try {
       await k8sDelete({ model, resource });
       if (redirectTo) {
@@ -67,12 +71,14 @@ export const DeleteModal: React.FC<DeleteModalProps> = ({ title, resource, model
 
       toggleModal();
     } catch (err) {
+      toggleIsLoading();
+
       setAlertMessage(<AlertMessageForModals title={t('Error')} message={err.toString()} />);
     }
   }, [resource]);
 
   const actions = [
-    <Button key="confirm" variant="danger" onClick={onDelete}>
+    <Button key="confirm" variant="danger" onClick={onDelete} isLoading={isLoading}>
       {t('Delete')}
     </Button>,
     <Button key="cancel" variant="secondary" onClick={toggleModal}>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -16,7 +16,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-import { useK8sWatchProviderNames } from '../../hooks';
+import { useK8sWatchProviderNames, useToggle } from '../../hooks';
 import { getResourceUrl, Validation } from '../../utils';
 import { providerAndSecretValidator } from '../../utils/validators/providerAndSecretValidator';
 
@@ -41,6 +41,7 @@ export const ProvidersCreatePage: React.FC<{
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
   const history = useHistory();
+  const [isLoading, toggleIsLoading] = useToggle();
 
   const [providerNames] = useK8sWatchProviderNames({ namespace });
 
@@ -143,6 +144,8 @@ export const ProvidersCreatePage: React.FC<{
     let secret: V1Secret;
     let provider: V1beta1Provider;
 
+    toggleIsLoading();
+
     // try to generate a secret with data
     //
     // add generateName using provider name as prefix
@@ -156,6 +159,7 @@ export const ProvidersCreatePage: React.FC<{
         payload: err,
       });
 
+      toggleIsLoading();
       return;
     }
 
@@ -169,6 +173,7 @@ export const ProvidersCreatePage: React.FC<{
         payload: err,
       });
 
+      toggleIsLoading();
       return;
     }
 
@@ -181,6 +186,7 @@ export const ProvidersCreatePage: React.FC<{
         payload: err,
       });
 
+      toggleIsLoading();
       return;
     }
 
@@ -218,6 +224,7 @@ export const ProvidersCreatePage: React.FC<{
               variant="primary"
               onClick={onUpdate}
               isDisabled={state.validationError !== null}
+              isLoading={isLoading}
             >
               {t('Create provider')}
             </Button>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -102,7 +102,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
             <FormGroup
               label={t('Provider Resource Name')}
               isRequired
-              fieldId="name"
+              fieldId="k8sName"
               helperText={t('Unique Kubernetes resource name identifier')}
               validated={state.validation.name}
               helperTextInvalid={t(
@@ -112,8 +112,8 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
               <TextInput
                 isRequired
                 type="text"
-                id="url"
-                name="url"
+                id="k8sName"
+                name="name"
                 value={newProvider.metadata.name} // Use the appropriate prop value here
                 validated={state.validation.name}
                 onChange={(value) => handleNameChange(value)} // Call the custom handler method

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useReducer } from 'react';
+import React, { ReactNode, useReducer, useState } from 'react';
 import { AlertMessageForModals } from 'src/modules/Providers/modals';
 import { isSecretDataChanged, ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -67,6 +67,8 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
   EditComponent,
 }) => {
   const { t } = useForkliftTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+
   const initialState: BaseCredentialsSecretState = {
     reveal: false,
     edit: false,
@@ -134,11 +136,14 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
 
   // Handle user clicking "save"
   async function onUpdate() {
+    setIsLoading(true);
+
     try {
       // Patch provider secret, set clean to `true`
       // to remove old values from the secret
       await patchSecretData(state.newSecret, true);
 
+      setIsLoading(false);
       toggleEdit();
     } catch (err) {
       dispatch({
@@ -147,6 +152,8 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
           <AlertMessageForModals title={t('Error')} message={err.message || err.toString()} />
         ),
       });
+
+      setIsLoading(false);
     }
   }
 
@@ -158,6 +165,7 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
             variant="primary"
             onClick={onUpdate}
             isDisabled={!state.dataChanged || state.dataError !== null}
+            isLoading={isLoading}
           >
             {t('Update credentials')}
           </Button>

--- a/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
+++ b/packages/legacy/src/Providers/components/AddEditProviderModal/AddEditProviderModal.tsx
@@ -421,14 +421,14 @@ export const AddEditProviderModal: React.FunctionComponent<IAddEditProviderModal
                       <ValidatedTextInput
                         field={forms[providerType].fields.name}
                         isRequired
-                        fieldId="name"
+                        fieldId="provider-name"
                         formGroupProps={{
                           helperText: 'User specified name to display in the list of providers',
                         }}
                       />
                     ) : (
                       <FormGroup label="Provider name" fieldId="name">
-                        <div id="name" style={{ paddingLeft: 8, fontSize: 16 }}>
+                        <div id="provider-name" style={{ paddingLeft: 8, fontSize: 16 }}>
                           {forms[providerType].fields.name.value}
                         </div>
                       </FormGroup>


### PR DESCRIPTION
Isseu:
when user press a synchronous action, it can take some time before action is finished, we should indicate that the action is running.

Fix:
add a spinner running while waiting for the action to finish