### PR TITLE
Allow empty url and token on openshift

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/secret-fields/openshiftSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/secret-fields/openshiftSecretFieldValidator.ts
@@ -19,7 +19,7 @@ export const openshiftSecretFieldValidator = (id: string, value: string) => {
 
   switch (id) {
     case 'token':
-      validationState = validateK8sToken(trimmedValue) ? 'success' : 'error';
+      validationState = trimmedValue === '' || validateK8sToken(trimmedValue) ? 'success' : 'error';
       break;
     default:
       validationState = 'default';


### PR DESCRIPTION
Allow empty url and token on openshift

Issue:
currently validation does not allow null url + token

FIx:
  - add url to secret
  - test secret with the rule that empty token + url is ok 