### PR TITLE
Don't show no inventory error if provider is not ready

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
@@ -67,7 +67,12 @@ export const ProviderDetailsPage: React.FC<ProviderDetailsPageProps> = ({ name, 
   );
   const providerHasNetworks = ['openshift'].includes(type);
 
-  if (providerLoaded && !inventoryLoading && inventoryError) {
+  if (
+    providerLoaded &&
+    !inventoryLoading &&
+    inventoryError &&
+    provider?.status?.phase === 'Ready'
+  ) {
     alerts.push(<InventoryNotReachable key={'inventoryNotReachable'} />);
   }
 


### PR DESCRIPTION
Issue:
currently if no inventory is available the error "inventory server is not available is shown", even if the reason for no inventory is because the provider is not in Ready mode.

Fix:
check provider is in "Ready" phase before showing the error message