### PR TITLE
fix url typo

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/secret/openshiftSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/secret/openshiftSecretValidator.ts
@@ -5,7 +5,7 @@ import { V1Secret } from '@kubev2v/types';
 import { openshiftSecretFieldValidator } from '../secret-fields';
 
 export function openshiftSecretValidator(secret: V1Secret) {
-  const url = secret?.data?.URL || '';
+  const url = secret?.data?.url || '';
   const token = secret?.data?.token || '';
 
   // Empty URL + token is valid as host providers

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -109,7 +109,7 @@ export const ProvidersCreatePage: React.FC<{
         // Sync secret with new URL
         const updatedSecret = {
           ...state.newSecret,
-          data: { ...state.newSecret.data, URL: Base64.encode(value?.spec?.url || '') },
+          data: { ...state.newSecret.data, url: Base64.encode(value?.spec?.url || '') },
         };
 
         validationError = validationError || providerAndSecretValidator(value, updatedSecret);


### PR DESCRIPTION
Issue:
In the provider secret, there are two url fields, on is url, the other is URL, they have the same value.
Is the URL needed? if no, better to remove it.

Ref: #590