### PR TITLE
Don't fail on undefined vms

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
@@ -69,16 +69,20 @@ export const ProviderVirtualMachines: React.FC<ProviderVirtualMachinesProps> = (
     interval: customTimeoutAndInterval,
   };
 
-  const { inventory: vms, loading } =
-    useProviderInventory<ProviderVirtualMachine[]>(inventoryOptions);
+  const {
+    inventory: vms,
+    loading,
+    error,
+  } = useProviderInventory<ProviderVirtualMachine[]>(inventoryOptions);
 
-  const vmData: VmData[] = !loading
-    ? vms.map((vm) => ({
-        vm,
-        name: vm.name,
-        concerns: getHighestPriorityConcern(vm),
-      }))
-    : [];
+  const vmData: VmData[] =
+    !loading && !error && vms
+      ? vms.map((vm) => ({
+          vm,
+          name: vm.name,
+          concerns: getHighestPriorityConcern(vm),
+        }))
+      : [];
 
   return (
     <StandardPage<VmData>


### PR DESCRIPTION
Isseu:
the `useProviderInventory` hook may return undefined, we need to check for that condition before rendering the vm list

Fix:
add a check for error and vms not undefined.