### PR TITLE
Fix the fields shown in 'Credentials' tab in details page

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenstackCredentialsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenstackCredentialsList.tsx
@@ -180,17 +180,17 @@ export const OpenstackCredentialsList: React.FC<ListComponentProps> = ({ secret,
 
     case 'token':
       if (!secret?.data?.userID) {
-        openstackSecretFields = fields.tokenWithUserIDSecretFields;
-      } else if (!secret?.data?.username) {
         openstackSecretFields = fields.tokenWithUsernameSecretFields;
+      } else if (!secret?.data?.username) {
+        openstackSecretFields = fields.tokenWithUserIDSecretFields;
       }
       break;
 
     case 'applicationcredential':
       if (!secret?.data?.applicationCredentialID) {
-        openstackSecretFields = fields.applicationCredentialIdSecretFields;
-      } else if (!secret?.data?.applicationCredentialName) {
         openstackSecretFields = fields.applicationCredentialNameSecretFields;
+      } else if (!secret?.data?.applicationCredentialName) {
+        openstackSecretFields = fields.applicationCredentialIdSecretFields;
       }
       break;
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/588

Issue:
In Provider details page, in Credentials tab
when a user created a secret using token ID or application ID - then will see the Name version
when a user created a secret using token Name or application Name - then will see the ID version

Problem:
the check was for `!name` then show name, should be for `!name` show ID

Fix:
change the `if ... else` for showing the fields