### PR TITLE
Don't flicker on Invalid provider error

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.tsx
@@ -71,6 +71,7 @@ export const ProviderDetailsPage: React.FC<ProviderDetailsPageProps> = ({ name, 
     providerLoaded &&
     !inventoryLoading &&
     inventoryError &&
+    inventoryError.toString() !== 'Error: Invalid provider data' &&
     provider?.status?.phase === 'Ready'
   ) {
     alerts.push(<InventoryNotReachable key={'inventoryNotReachable'} />);


### PR DESCRIPTION
Issue:
an error "can't reach inventory server" is shown even if the error is about bad provider and not about no connection to inventory server

FIx:
add a special case to check for "invalid provider" before showing a "no connection" error