### PR TITLE
Make migration menu item inserted after virtualization menu item if exist

### DIFF
--- a/packages/forklift-console-plugin/plugin-extensions.ts
+++ b/packages/forklift-console-plugin/plugin-extensions.ts
@@ -16,7 +16,7 @@ const extensions: EncodedExtension[] = [
     properties: {
       id: 'migration',
       name: '%plugin__kubevirt-plugin~Migration%',
-      insertAfter: 'workloads',
+      insertAfter: ['virtualization', 'workloads'],
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-sec-migration',
         'data-testid': 'migration-nav-item',


### PR DESCRIPTION
Issue:
currently the "Migration" menu item is inserted after "Workloads" but "Virtualization" menu item is also marked to be inserted under "Workloads", in cases both extensions are  enabled this create a race.

Fix:
mark "Migration" as after "Virtualization" or "Workloads" 