### PR TITLE
Add a helper script to create a service account for developers

### DIFF
--- a/ci/create-forklift-user-account.sh
+++ b/ci/create-forklift-user-account.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# check if forklift-user account exist
+export SERVICE_ACCOUNT=forklift-user
+export NAMESPACE=default
+
+function setup_servie_account_token () {
+# Create forklift-user service account
+# ------------------------------------
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${SERVICE_ACCOUNT}
+  namespace: ${NAMESPACE}
+automountServiceAccountToken: true
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${SERVICE_ACCOUNT}
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/service-account.name: ${SERVICE_ACCOUNT}
+type: kubernetes.io/service-account-token
+EOF
+
+# Make forklift-user an admin
+# ---------------------------
+kubectl create clusterrolebinding ${SERVICE_ACCOUNT}-forklift-user \
+  --clusterrole=cluster-admin \
+  --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT}
+}
+
+if kubectl get serviceaccount ${SERVICE_ACCOUNT} -n ${NAMESPACE} >/dev/null 2>&1 ; then
+    echo "Service account ${SERVICE_ACCOUNT} already exist"
+else
+    echo "Creating service account ${SERVICE_ACCOUNT}"
+
+    setup_servie_account_token
+fi
+
+# Print out token
+export TOKEN=$(kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o=jsonpath={.data.token} | base64 -d)
+
+echo "Token:"
+echo "------"
+echo ${TOKEN}
+echo


### PR DESCRIPTION
Issue:
when working on QE environments a user will need a service account and a token

Fix:
add a script that create a service account and token 