### PR TITLE
Allow to create plan with ova and openshift as source

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/data.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/data.ts
@@ -143,7 +143,7 @@ export const useHasSourceAndTargetProviders = (
     namespace,
   });
 
-  const hasSourceProviders = providers.some((p) => p?.spec?.type !== 'openshift');
+  const hasSourceProviders = providers.length > 0;
   const hasTargetProviders = providers.some((p) => p?.spec?.type === 'openshift');
 
   return [hasSourceProviders, hasTargetProviders, providersLoaded, providersError];

--- a/packages/legacy/src/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
+++ b/packages/legacy/src/Providers/components/ProvidersTable/Source/SourceProvidersTable.tsx
@@ -19,6 +19,7 @@ import {
   IVMwareProvider,
   IOpenStackProvider,
   SourceInventoryProvider,
+  IOpenShiftProvider,
 } from 'legacy/src/queries/types';
 import { ProviderActionsDropdown } from '../ProviderActionsDropdown';
 import { StatusCondition } from 'legacy/src/common/components/StatusCondition';
@@ -55,6 +56,12 @@ export const SourceProvidersTable: React.FunctionComponent<ISourceProvidersTable
     }
     if (providerType === 'openstack') {
       return (provider.inventory as IOpenStackProvider).volumeTypeCount;
+    }
+    if (providerType === 'openshift') {
+      return (provider.inventory as IOpenShiftProvider).storageClassCount;
+    }
+    if (providerType === 'ova') {
+      return 1;
     }
     return 0;
   };

--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -38,9 +38,15 @@ export const PRODUCT_DOCO_LINK = {
   label: 'product documentation',
 };
 
-export const PROVIDER_TYPES = ['vsphere', 'ovirt', 'openstack', 'openshift'] as const;
+export const PROVIDER_TYPES = ['vsphere', 'ovirt', 'openstack', 'openshift', 'ova'] as const;
 export type ProviderType = (typeof PROVIDER_TYPES)[number];
-export const SOURCE_PROVIDER_TYPES: ProviderType[] = ['vsphere', 'ovirt', 'openstack'];
+export const SOURCE_PROVIDER_TYPES: ProviderType[] = [
+  'vsphere',
+  'ovirt',
+  'openstack',
+  'openshift',
+  'ova',
+];
 export const TARGET_PROVIDER_TYPES: ProviderType[] = ['openshift'];
 
 export const PROVIDER_TYPE_NAMES: Record<ProviderType, string> = {
@@ -48,6 +54,7 @@ export const PROVIDER_TYPE_NAMES: Record<ProviderType, string> = {
   ovirt: ENV.BRAND_TYPE === 'RedHat' ? 'Red Hat Virtualization' : 'oVirt',
   openstack: ENV.BRAND_TYPE === 'RedHat' ? 'Red Hat OpenStack Platform' : 'OpenStack',
   openshift: ENV.BRAND_TYPE === 'RedHat' ? 'OpenShift Virtualization' : 'KubeVirt',
+  ova: 'OVA',
 };
 
 export enum StatusCategoryType {

--- a/packages/legacy/src/queries/mocks/providers.mock.ts
+++ b/packages/legacy/src/queries/mocks/providers.mock.ts
@@ -12,6 +12,7 @@ export let MOCK_INVENTORY_PROVIDERS: IProvidersByType = {
   ovirt: [],
   openstack: [],
   openshift: [],
+  ova: [],
 };
 
 export let MOCK_CLUSTER_PROVIDERS: IProviderObject[];
@@ -215,6 +216,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     vmCount: 36,
     networkCount: 15,
     storageDomainCount: 9,
+    datastoreCount: 0,
   };
 
   const rhvProvider1i: IRHVProvider = {
@@ -299,8 +301,8 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
         ...providerStatusReadyFields.status,
       },
     },
-    clusterCount: 0, // TODO need to remove when refactoring since there is no such counter for openStack, i.e. This field won't return from a real server
-    hostCount: 0, // TODO need to remove when refactoring since there is no such counter for openStack, i.e. This field won't return from a real server
+    clusterCount: 0,
+    hostCount: 0,
     regionCount: 1,
     projectCount: 1,
     vmCount: 3,
@@ -308,6 +310,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     volumeCount: 5,
     volumeTypeCount: 2,
     networkCount: 3,
+    datastoreCount: 0,
   };
 
   const openstackProvider2: IOpenStackProvider = {
@@ -363,6 +366,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     vmCount: 26,
     networkCount: 8,
+    clusterCount: 0,
+    hostCount: 0,
+    storageClassCount: 0,
+    datastoreCount: 0,
   };
 
   const openshiftProvider2: IOpenShiftProvider = {
@@ -445,6 +452,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     ovirt: [rhvProvider1, rhvProvider1i, rhvProvider2, rhvProvider3],
     openstack: [openstackProvider1, openstackProvider2],
     openshift: [openshiftProvider1, openshiftProvider2, openshiftProvider3, openshiftProvider4],
+    ova: [],
   };
 
   MOCK_CLUSTER_PROVIDERS = [

--- a/packages/legacy/src/queries/tree.ts
+++ b/packages/legacy/src/queries/tree.ts
@@ -98,13 +98,15 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
     vsphere: '/tree/host',
     ovirt: '/tree/cluster',
     openstack: '/tree/project',
-    openshift: '',
+    openshift: '/tree/namespace',
+    ova: '/tree/vms',
   };
   const mockTreeData: Record<ProviderType, IInventoryHostTree> = {
     vsphere: MOCK_VMWARE_HOST_TREE,
     ovirt: MOCK_RHV_HOST_TREE,
     openstack: MOCK_OPENSTACK_HOST_TREE,
     openshift: undefined,
+    ova: undefined,
   };
 
   const apiSlug =

--- a/packages/legacy/src/queries/types/providers.types.ts
+++ b/packages/legacy/src/queries/types/providers.types.ts
@@ -54,11 +54,21 @@ export interface IRHVProvider extends ICommonProvider {
   vmCount: number;
   networkCount: number;
   storageDomainCount: number;
+
+  datastoreCount: number;
+}
+
+export interface IOvaProvider extends ICommonProvider {
+  vmCount: number;
+  networkCount: number;
+  DiskCount: number;
+
+  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  datastoreCount: number;
 }
 
 export interface IOpenStackProvider extends ICommonProvider {
-  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
-  hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
   regionCount: number;
   projectCount: number;
   vmCount: number;
@@ -66,25 +76,42 @@ export interface IOpenStackProvider extends ICommonProvider {
   volumeCount: number;
   volumeTypeCount: number;
   networkCount: number;
+
+  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  datastoreCount: number;
 }
 
 export interface IOpenShiftProvider extends ICommonProvider {
   vmCount: number;
   networkCount: number;
+  storageClassCount: number;
+
+  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  datastoreCount: number;
 }
 
 export type InventoryProvider =
   | IVMwareProvider
   | IRHVProvider
   | IOpenStackProvider
-  | IOpenShiftProvider;
-export type SourceInventoryProvider = IVMwareProvider | IRHVProvider | IOpenStackProvider;
+  | IOpenShiftProvider
+  | IOvaProvider;
+
+export type SourceInventoryProvider =
+  | IVMwareProvider
+  | IRHVProvider
+  | IOpenStackProvider
+  | IOpenShiftProvider
+  | IOvaProvider;
 
 export interface IProvidersByType {
   vsphere: IVMwareProvider[];
   ovirt: IRHVProvider[];
   openstack: IOpenStackProvider[];
   openshift: IOpenShiftProvider[];
+  ova: IOvaProvider[];
 }
 
 export interface ICorrelatedProvider<T extends InventoryProvider> extends IProviderObject {


### PR DESCRIPTION
Allow to create plan with ova and Openshift as source

Issue:
currently OVA and Openshit are not selectable as source providers

FIx:
add them as sources

Screenshot:
[Screencast from 2023-07-24 15-23-18.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f72ba57f-df6c-4324-88c5-386028c6a472)

