### PR TITLE
Support OCP as source provider for Mappings and for Plans providers//mapping steps

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/dataForNetwork.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/dataForNetwork.ts
@@ -11,7 +11,7 @@ import { groupVersionKindForObj, resolveProviderRef } from 'src/utils/resources'
 import { NetworkMapResource, ProviderRef } from 'src/utils/types';
 
 import {
-  IdOrNameRef,
+  IdNameNamespaceTypeRef,
   INameNamespaceRef,
   INetworkMapping,
   INetworkMappingItem,
@@ -20,24 +20,24 @@ import { V1beta1NetworkMapStatusConditions, V1beta1Provider } from '@kubev2v/typ
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 export interface FlatNetworkMapping extends CommonMapping {
-  [C.FROM]: [Network, IdOrNameRef[]][];
+  [C.FROM]: [Network, IdNameNamespaceTypeRef[]][];
   [C.TO]: Network[];
   [C.OBJECT]: INetworkMapping;
 }
 
 const groupMultusNetworks = (
-  tuples: [INameNamespaceRef, IdOrNameRef][],
-): [RemoteNetworkResource, IdOrNameRef[]][] => {
+  tuples: [INameNamespaceRef, IdNameNamespaceTypeRef][],
+): [RemoteNetworkResource, IdNameNamespaceTypeRef[]][] => {
   const namespaceNameTree = tuples.reduce(
     (acc, [{ name, namespace }, source]) => ({
       ...acc,
       [namespace]: { ...acc[namespace], [name]: [...(acc[namespace]?.[name] ?? []), source] },
     }),
-    {} as { [k: string]: { [l: string]: IdOrNameRef[] } },
+    {} as { [k: string]: { [l: string]: IdNameNamespaceTypeRef[] } },
   );
   return Object.entries(namespaceNameTree).flatMap(([namespace, nameToSrc]) =>
     Object.entries(nameToSrc).map(
-      ([name, sourceNetworks]): [RemoteNetworkResource, IdOrNameRef[]] => [
+      ([name, sourceNetworks]): [RemoteNetworkResource, IdNameNamespaceTypeRef[]] => [
         {
           name,
           namespace,
@@ -51,7 +51,7 @@ const groupMultusNetworks = (
 
 export const groupByTarget = (
   networkItems: INetworkMappingItem[] = [],
-): [Network, IdOrNameRef[]][] => {
+): [Network, IdNameNamespaceTypeRef[]][] => {
   const types = networkItems.reduce(
     (acc, it) => ({
       pod: [...acc.pod, ...(it.destination.type === 'pod' ? [it] : [])],
@@ -66,14 +66,14 @@ export const groupByTarget = (
     },
   );
 
-  const podNet: [Network, IdOrNameRef[]][] = types.pod.length
+  const podNet: [Network, IdNameNamespaceTypeRef[]][] = types.pod.length
     ? [[{ name: '', type: 'pod' }, types.pod.map((it) => it.source)]]
     : [];
 
   return [
     ...podNet,
     ...groupMultusNetworks(
-      types.multus.map(({ source, destination }): [INameNamespaceRef, IdOrNameRef] => [
+      types.multus.map(({ source, destination }): [INameNamespaceRef, IdNameNamespaceTypeRef] => [
         destination as INameNamespaceRef,
         source,
       ]),
@@ -95,7 +95,7 @@ export const mergeData = (
         K8sGroupVersionKind,
         ProviderRef,
         ProviderRef,
-        [Network, IdOrNameRef[]][],
+        [Network, IdNameNamespaceTypeRef[]][],
         OwnerRef,
       ] => [
         mapping, // to extract props

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/dataForStorage.ts
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/dataForStorage.ts
@@ -10,7 +10,7 @@ import { useStorageMappings } from 'src/utils/fetch';
 import { groupVersionKindForObj, resolveProviderRef } from 'src/utils/resources';
 import { ProviderRef, StorageMapResource } from 'src/utils/types';
 
-import { IdOrNameRef, IStorageMapping } from '@kubev2v/legacy/queries/types';
+import { IdNameNamespaceTypeRef, IStorageMapping } from '@kubev2v/legacy/queries/types';
 import { V1beta1Provider, V1beta1StorageMapStatusConditions } from '@kubev2v/types';
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -19,7 +19,7 @@ export interface Storage {
 }
 
 export interface FlatStorageMapping extends CommonMapping {
-  [C.FROM]: [Storage, IdOrNameRef[]][];
+  [C.FROM]: [Storage, IdNameNamespaceTypeRef[]][];
   [C.TO]: Storage[];
   [C.OBJECT]: IStorageMapping;
 }
@@ -40,14 +40,16 @@ export interface FlatStorageMapping extends CommonMapping {
  *  ]
  * ]
  */
-export const groupByTarget = (tuples: [string, IdOrNameRef][]): [Storage, IdOrNameRef[]][] =>
+export const groupByTarget = (
+  tuples: [string, IdNameNamespaceTypeRef][],
+): [Storage, IdNameNamespaceTypeRef[]][] =>
   Object.entries(
     tuples.reduce(
       (acc, [targetStorageName, sourceStorage]) => ({
         ...acc,
         [targetStorageName]: [...(acc[targetStorageName] ?? []), sourceStorage],
       }),
-      {} as { [k: string]: IdOrNameRef[] },
+      {} as { [k: string]: IdNameNamespaceTypeRef[] },
     ),
   ).map(([targetStorageName, sources]) => [{ name: targetStorageName }, sources]);
 
@@ -66,7 +68,7 @@ export const mergeData = (
         ProviderRef,
         ProviderRef,
         OwnerRef,
-        [Storage, IdOrNameRef[]][],
+        [Storage, IdNameNamespaceTypeRef[]][],
       ] => [
         mapping, // to extract props
         mapping, // to pass as object blob

--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -10,6 +10,8 @@ import {
   MappingTarget,
   POD_NETWORK,
   IAnnotatedStorageClass,
+  ISourceNetwork,
+  ISourceStorage,
 } from 'legacy/src/queries/types';
 import { LineArrow } from 'legacy/src/common/components/LineArrow';
 import { MappingSourceSelect } from './MappingSourceSelect';
@@ -88,7 +90,9 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
         <Text component="p">{instructionText}</Text>
       </TextContent>
       {builderItems.map((item, itemIndex) => {
-        const key = item.source ? item.source.path : 'empty';
+        const key = item.source
+          ? (item.source as ISourceNetwork).path || (item.source as ISourceStorage).path || ''
+          : 'empty';
         return (
           <Grid key={key}>
             {itemIndex === 0 ? (
@@ -116,13 +120,16 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                 <Bullseye style={{ justifyContent: 'left' }} className={spacing.plSm}>
                   <TextContent>
                     <TruncatedText>{item.source.name}</TruncatedText>
-                    {item.source.path ? (
+                    {(item.source as ISourceNetwork).path ||
+                    (item.source as ISourceStorage).path ? (
                       <TruncatedText>
                         <Text
                           component="small"
                           style={{ fontSize: 'var(--pf-global--FontSize--xs)' }}
                         >
-                          {item.source.path}
+                          {(item.source as ISourceNetwork).path ||
+                            (item.source as ISourceStorage).path ||
+                            ''}
                         </Text>
                       </TruncatedText>
                     ) : null}
@@ -135,6 +142,7 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
                   itemIndex={itemIndex}
                   setBuilderItems={setBuilderItems}
                   availableSources={availableSources}
+                  mappingType={mappingType}
                   // Maybe use these instead of extraSelectMargin if we can get it to be dynamic to always fit the screen
                   //menuAppendTo="parent"
                   //maxHeight="200px"

--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingSourceSelect.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingSourceSelect.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { MappingSource } from 'legacy/src/queries/types';
+import { ISourceNetwork, MappingSource, MappingType } from 'legacy/src/queries/types';
 import {
   SimpleSelect,
   ISimpleSelectProps,
@@ -7,6 +7,7 @@ import {
 } from 'legacy/src/common/components/SimpleSelect';
 import { IMappingBuilderItem } from './MappingBuilder';
 import { TruncatedText } from 'legacy/src/common/components/TruncatedText';
+import { getMappingName } from '../MappingDetailView/helpers';
 
 interface IMappingSourceSelectProps extends Partial<ISimpleSelectProps> {
   id: string;
@@ -14,6 +15,7 @@ interface IMappingSourceSelectProps extends Partial<ISimpleSelectProps> {
   itemIndex: number;
   setBuilderItems: (items: IMappingBuilderItem[]) => void;
   availableSources: MappingSource[];
+  mappingType: MappingType;
 }
 
 export const MappingSourceSelect: React.FunctionComponent<IMappingSourceSelectProps> = ({
@@ -22,6 +24,7 @@ export const MappingSourceSelect: React.FunctionComponent<IMappingSourceSelectPr
   itemIndex,
   setBuilderItems,
   availableSources,
+  mappingType,
   ...props
 }: IMappingSourceSelectProps) => {
   const setSource = (source: MappingSource) => {
@@ -38,14 +41,18 @@ export const MappingSourceSelect: React.FunctionComponent<IMappingSourceSelectPr
       )
   );
 
-  const options: OptionWithValue<MappingSource>[] = filteredSources.map((source) => ({
-    value: source,
-    toString: () => source.name,
-    props: {
-      children: <TruncatedText>{source.name}</TruncatedText>,
-      description: <TruncatedText>{source.path}</TruncatedText>,
-    },
-  }));
+  const options: OptionWithValue<MappingSource>[] = filteredSources.map((source) => {
+    const sourceName = getMappingName(source, mappingType);
+
+    return {
+      value: source,
+      toString: () => sourceName,
+      props: {
+        children: <TruncatedText>{sourceName}</TruncatedText>,
+        description: <TruncatedText>{(source as ISourceNetwork).path || ''}</TruncatedText>,
+      },
+    };
+  });
   const selectedOption = options.filter(
     (option) => option.value.selfLink === builderItems[itemIndex].source?.selfLink
   );

--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingTargetSelect.tsx
@@ -11,7 +11,7 @@ import {
   MappingType,
 } from 'legacy/src/queries/types';
 import { IMappingBuilderItem } from './MappingBuilder';
-import { getMappingTargetName } from '../MappingDetailView/helpers';
+import { getMappingName } from '../MappingDetailView/helpers';
 import { TruncatedText } from 'legacy/src/common/components/TruncatedText';
 
 interface IMappingTargetSelectProps extends Partial<ISimpleSelectProps> {
@@ -42,7 +42,7 @@ export const MappingTargetSelect: React.FunctionComponent<IMappingTargetSelectPr
   );
 
   const targetOptions: OptionWithValue<MappingTarget>[] = availableTargets.map((target) => {
-    let name = getMappingTargetName(target, mappingType);
+    let name = getMappingName(target, mappingType);
     let isDefault = false;
     if (mappingType === MappingType.Storage) {
       const targetStorage = target as IAnnotatedStorageClass;

--- a/packages/legacy/src/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/packages/legacy/src/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -3,7 +3,7 @@ import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import text from '@patternfly/react-styles/css/utilities/Text/text';
 
-import { Mapping, MappingType } from 'legacy/src/queries/types';
+import { ISourceNetwork, ISourceStorage, Mapping, MappingType } from 'legacy/src/queries/types';
 import { LineArrow } from 'legacy/src/common/components/LineArrow';
 import { useResourceQueriesForMapping } from 'legacy/src/queries';
 import { TruncatedText } from 'legacy/src/common/components/TruncatedText';
@@ -73,22 +73,25 @@ export const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps>
                       item.source
                     );
                     const sourceName = source ? source.name : '';
+                    const path = source
+                      ? (source as ISourceNetwork).path || (source as ISourceStorage).path || ''
+                      : null;
                     return (
                       <li
-                        key={`${sourceName}-${source?.path || ''}`}
+                        key={`${sourceName}-${path || ''}`}
                         className={itemIndex !== items.length - 1 ? spacing.mbSm : ''}
                       >
                         <TextContent>
                           <TruncatedText>
                             {sourceName || <span className="missing-item">Not available</span>}
                           </TruncatedText>
-                          {source?.path ? (
+                          {path ? (
                             <TruncatedText>
                               <Text
                                 component="small"
                                 style={{ fontSize: 'var(--pf-global--FontSize--xs)' }}
                               >
-                                {source.path}
+                                {path}
                               </Text>
                             </TruncatedText>
                           ) : null}

--- a/packages/legacy/src/Mappings/components/MappingDetailView/helpers.ts
+++ b/packages/legacy/src/Mappings/components/MappingDetailView/helpers.ts
@@ -2,8 +2,10 @@ import {
   IAnnotatedStorageClass,
   INetworkMappingItem,
   IOpenShiftNetwork,
+  ISourceNetwork,
   IStorageMappingItem,
   MappingItem,
+  MappingSource,
   MappingTarget,
   MappingType,
   POD_NETWORK,
@@ -41,11 +43,18 @@ export const groupMappingItemsByTarget = (
   );
 };
 
-export const getMappingTargetName = (target: MappingTarget, mappingType: MappingType): string => {
+export const getMappingName = (
+  SourceOrTarget: MappingTarget | MappingSource,
+  mappingType: MappingType
+): string => {
   if (mappingType === MappingType.Network) {
-    const network = target as IOpenShiftNetwork | typeof POD_NETWORK;
+    if ((SourceOrTarget as ISourceNetwork).path) {
+      return (SourceOrTarget as ISourceNetwork).name;
+    }
+
+    const network = SourceOrTarget as IOpenShiftNetwork | typeof POD_NETWORK;
     if ((network as typeof POD_NETWORK).type === 'pod') return POD_NETWORK.name;
     return `${network.namespace} / ${network.name}`;
   }
-  return (target as IAnnotatedStorageClass).name;
+  return (SourceOrTarget as IAnnotatedStorageClass).name;
 };

--- a/packages/legacy/src/Mappings/components/helpers.ts
+++ b/packages/legacy/src/Mappings/components/helpers.ts
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { isSameResource } from 'legacy/src/queries/helpers';
 import {
-  IdOrNameRef,
+  IdNameNamespaceTypeRef,
   IMetaObjectMeta,
   INetworkMappingItem,
+  IOpenShiftNetwork,
   IOpenShiftProvider,
   IProvidersByType,
+  ISourceNetwork,
+  ISourceStorage,
   IStorageMappingItem,
   Mapping,
   MappingItem,
@@ -23,9 +26,27 @@ import { getStorageTitle } from 'legacy/src/common/helpers';
 
 export const getMappingSourceByRef = (
   sources: MappingSource[],
-  ref: IdOrNameRef
+  ref: IdNameNamespaceTypeRef
 ): MappingSource | null =>
-  sources.find((source) => (ref.id ? source.id === ref.id : source.name === ref.name)) || null;
+  sources.find((source) => {
+    if (ref.type && ref.type == 'pod') {
+      return (source as IOpenShiftNetwork).selfLink === 'pod';
+    } else if (ref.id) {
+      return (
+        ((source as IOpenShiftNetwork).uid ||
+          (source as ISourceNetwork).id ||
+          (source as ISourceStorage).id) === ref.id
+      );
+    } else if (ref.namespace) {
+      return (source as IOpenShiftNetwork).namespace === ref.namespace;
+    } else if (ref.name) {
+      return (
+        ((source as IOpenShiftNetwork).name ||
+          (source as ISourceNetwork).name ||
+          (source as ISourceStorage).name) === ref.name
+      );
+    }
+  }) || null;
 
 export const getMappingTargetByRef = (
   targets: MappingTarget[],

--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -18,6 +18,9 @@ import {
   IVMwareVM,
   IRHVVM,
   IOpenStackVM,
+  IOpenShiftNetwork,
+  ISourceNetwork,
+  ISourceStorage,
 } from 'legacy/src/queries/types';
 import EnterpriseIcon from '@patternfly/react-icons/dist/esm/icons/enterprise-icon';
 import ClusterIcon from '@patternfly/react-icons/dist/esm/icons/cluster-icon';
@@ -427,7 +430,12 @@ export const filterSourcesBySelectedVMs = (
   );
 
   const filteredSources = availableSources.filter(
-    (source) => sourceIds.includes(source.id) || sourceIds.includes(source.name)
+    (source) =>
+      sourceIds.includes(
+        (source as IOpenShiftNetwork).uid ||
+          (source as ISourceNetwork).id ||
+          (source as ISourceStorage).id
+      ) || sourceIds.includes(source.name)
   );
   return filteredSources;
 };

--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -40,6 +40,7 @@ export const PRODUCT_DOCO_LINK = {
 
 export const PROVIDER_TYPES = ['vsphere', 'ovirt', 'openstack', 'openshift', 'ova'] as const;
 export type ProviderType = (typeof PROVIDER_TYPES)[number];
+
 export const SOURCE_PROVIDER_TYPES: ProviderType[] = [
   'vsphere',
   'ovirt',

--- a/packages/legacy/src/queries/mappings.ts
+++ b/packages/legacy/src/queries/mappings.ts
@@ -197,7 +197,13 @@ export const useMappingResourceQueries = (
   let availableSources: MappingSource[] = [];
   let availableTargets: MappingTarget[] = [];
   if (mappingType === MappingType.Network) {
-    availableSources = (sourceProvider && sourceNetworksQuery.data) || [];
+    availableSources =
+      sourceProvider?.type === 'openshift'
+        ? sourceProvider && sourceNetworksQuery.data
+          ? [POD_NETWORK, ...(sourceNetworksQuery.data || [])]
+          : []
+        : (sourceProvider && sourceNetworksQuery.data) || [];
+
     availableTargets =
       targetProvider && openshiftNetworksQuery.data
         ? [POD_NETWORK, ...(openshiftNetworksQuery.data || [])]

--- a/packages/legacy/src/queries/mocks/providers.mock.ts
+++ b/packages/legacy/src/queries/mocks/providers.mock.ts
@@ -104,6 +104,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     vmCount: 41,
     networkCount: 8,
     datastoreCount: 3,
+    storageClassCount: 0, // TODO need to remove when refactoring
   };
 
   const vmwareProvider2: IVMwareProvider = {
@@ -217,6 +218,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     networkCount: 15,
     storageDomainCount: 9,
     datastoreCount: 0,
+    storageClassCount: 0, // TODO need to remove when refactoring
   };
 
   const rhvProvider1i: IRHVProvider = {
@@ -311,6 +313,7 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     volumeTypeCount: 2,
     networkCount: 3,
     datastoreCount: 0,
+    storageClassCount: 0, // TODO need to remove when refactoring
   };
 
   const openstackProvider2: IOpenStackProvider = {
@@ -366,10 +369,10 @@ if (process.env.NODE_ENV === 'test' || process.env.DATA_SOURCE === 'mock') {
     },
     vmCount: 26,
     networkCount: 8,
-    clusterCount: 0,
-    hostCount: 0,
-    storageClassCount: 0,
-    datastoreCount: 0,
+    clusterCount: 0, // TODO need to remove when refactoring since there is no such counter for OpenShift
+    hostCount: 0, // TODO need to remove when refactoring since there is no such counter for OpenShift
+    storageClassCount: 0, // TODO need to remove when refactoring since there is no such counter for OpenShift
+    datastoreCount: 0, // TODO need to remove when refactoring since there is no such counter for OpenShift
   };
 
   const openshiftProvider2: IOpenShiftProvider = {

--- a/packages/legacy/src/queries/networks.ts
+++ b/packages/legacy/src/queries/networks.ts
@@ -22,7 +22,10 @@ export const useNetworksQuery = <T extends ISourceNetwork | IOpenShiftNetwork>(
   mappingType: MappingType | null,
   mockNetworks: T[]
 ) => {
-  const apiSlug = providerRole === 'source' ? '/networks' : '/networkattachmentdefinitions';
+  const apiSlug =
+    providerRole === 'source' && provider?.type !== 'openshift'
+      ? '/networks'
+      : '/networkattachmentdefinitions';
   const sortByNameCallback = React.useCallback((data): T[] => sortByName(data), []);
   const result = useMockableQuery<T[]>(
     {
@@ -42,11 +45,16 @@ export const useSourceNetworksQuery = (
   provider: SourceInventoryProvider | null,
   mappingType?: MappingType
 ) =>
-  useNetworksQuery(
+  useNetworksQuery<ISourceNetwork | IOpenShiftNetwork>(
     provider,
     'source',
     mappingType || null,
-    provider?.type === 'vsphere' ? MOCK_VMWARE_NETWORKS : MOCK_RHV_NETWORKS
+
+    provider?.type === 'openshift'
+      ? MOCK_OPENSHIFT_NETWORKS
+      : provider?.type === 'vsphere'
+      ? MOCK_VMWARE_NETWORKS
+      : MOCK_RHV_NETWORKS
   );
 
 export const useOpenShiftNetworksQuery = (

--- a/packages/legacy/src/queries/storages.ts
+++ b/packages/legacy/src/queries/storages.ts
@@ -29,6 +29,9 @@ export const useSourceStoragesQuery = (
     if (provider?.type === 'openstack') {
       return '/volumetypes';
     }
+    if (provider?.type === 'openshift') {
+      return '/storageclasses?detail=1';
+    }
     return '/storagedomains';
   };
   const mockStorage = (provider: SourceInventoryProvider) => {

--- a/packages/legacy/src/queries/types/common.types.ts
+++ b/packages/legacy/src/queries/types/common.types.ts
@@ -60,7 +60,9 @@ export interface INameNamespaceRef {
   namespace: string;
 }
 
-export interface IdOrNameRef {
+export interface IdNameNamespaceTypeRef {
   id?: string;
   name?: string;
+  namespace?: string;
+  type?: string;
 }

--- a/packages/legacy/src/queries/types/mappings.types.ts
+++ b/packages/legacy/src/queries/types/mappings.types.ts
@@ -2,7 +2,7 @@ import { ISourceNetwork, IOpenShiftNetwork } from './networks.types';
 import { ISourceStorage } from './storages.types';
 import { IAnnotatedStorageClass } from './storages.types';
 import {
-  IdOrNameRef,
+  IdNameNamespaceTypeRef,
   IMetaObjectGenerateName,
   IMetaObjectMeta,
   IMetaTypeMeta,
@@ -16,7 +16,7 @@ export enum MappingType {
 }
 
 export interface INetworkMappingItem {
-  source: IdOrNameRef;
+  source: IdNameNamespaceTypeRef;
   destination:
     | {
         name: string;
@@ -27,7 +27,7 @@ export interface INetworkMappingItem {
 }
 
 export interface IStorageMappingItem {
-  source: IdOrNameRef;
+  source: IdNameNamespaceTypeRef;
   destination: {
     storageClass: string;
   };
@@ -110,5 +110,5 @@ export const POD_NETWORK: IOpenShiftNetwork = {
   selfLink: 'pod',
   uid: 'pod',
 };
-export type MappingSource = ISourceStorage | ISourceNetwork;
+export type MappingSource = ISourceStorage | ISourceNetwork | IOpenShiftNetwork;
 export type MappingTarget = IOpenShiftNetwork | IAnnotatedStorageClass;

--- a/packages/legacy/src/queries/types/plans.types.ts
+++ b/packages/legacy/src/queries/types/plans.types.ts
@@ -1,6 +1,6 @@
 import {
   ICR,
-  IdOrNameRef,
+  IdNameNamespaceTypeRef,
   IMetaObjectMeta,
   INameNamespaceRef,
   IStatusCondition,
@@ -61,7 +61,7 @@ export interface IPlanVMHook {
   step: HookStep;
 }
 
-export interface IPlanVM extends IdOrNameRef {
+export interface IPlanVM extends IdNameNamespaceTypeRef {
   hooks?: IPlanVMHook[];
 }
 

--- a/packages/legacy/src/queries/types/providers.types.ts
+++ b/packages/legacy/src/queries/types/providers.types.ts
@@ -45,6 +45,7 @@ export interface IVMwareProvider extends ICommonProvider {
   vmCount: number;
   networkCount: number;
   datastoreCount: number;
+  storageClassCount: number; // TODO need to remove when refactoring since there is no such counter for VMware
 }
 
 export interface IRHVProvider extends ICommonProvider {
@@ -56,6 +57,7 @@ export interface IRHVProvider extends ICommonProvider {
   storageDomainCount: number;
 
   datastoreCount: number;
+  storageClassCount: number; // TODO need to remove when refactoring since there is no such counter for RHV
 }
 
 export interface IOvaProvider extends ICommonProvider {
@@ -66,6 +68,7 @@ export interface IOvaProvider extends ICommonProvider {
   clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
   hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
   datastoreCount: number;
+  storageClassCount: number; //// TODO need to remove when refactoring since there is no such counter for OVA
 }
 
 export interface IOpenStackProvider extends ICommonProvider {
@@ -80,6 +83,7 @@ export interface IOpenStackProvider extends ICommonProvider {
   clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
   hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
   datastoreCount: number;
+  storageClassCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
 }
 
 export interface IOpenShiftProvider extends ICommonProvider {
@@ -87,8 +91,8 @@ export interface IOpenShiftProvider extends ICommonProvider {
   networkCount: number;
   storageClassCount: number;
 
-  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
-  hostCount: number; // TODO need to remove when refactoring since there is no such counter for openStack
+  clusterCount: number; // TODO need to remove when refactoring since there is no such counter for OpenShift
+  hostCount: number; // TODO need to remove when refactoring since there is no such counter for OpenShift
   datastoreCount: number;
 }
 

--- a/packages/legacy/src/queries/vms.ts
+++ b/packages/legacy/src/queries/vms.ts
@@ -3,7 +3,7 @@ import { usePollingContext } from 'legacy/src/common/context';
 import { UseQueryResult } from 'react-query';
 import { useMockableQuery, sortByName, getInventoryApiUrl } from './helpers';
 import { MOCK_RHV_VMS, MOCK_VMWARE_VMS } from './mocks/vms.mock';
-import { IdOrNameRef, SourceInventoryProvider } from './types';
+import { IdNameNamespaceTypeRef, SourceInventoryProvider } from './types';
 import { SourceVM, IVMwareVM } from './types/vms.types';
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -12,8 +12,8 @@ type SourceVMsRecord = Record<string, SourceVM | undefined>;
 export interface IndexedSourceVMs {
   vms: SourceVM[];
   vmsBySelfLink: SourceVMsRecord;
-  findVMByRef: (ref: IdOrNameRef) => SourceVM | undefined;
-  findVMsByRefs: (refs: IdOrNameRef[]) => SourceVM[];
+  findVMByRef: (ref: IdNameNamespaceTypeRef) => SourceVM | undefined;
+  findVMsByRefs: (refs: IdNameNamespaceTypeRef[]) => SourceVM[];
   findVMsBySelfLinks: (selfLinks: string[]) => SourceVM[];
 }
 
@@ -32,7 +32,7 @@ export const indexVMs = (vms: SourceVM[]): IndexedSourceVMs => {
     vmsByName[vm.name] = vm;
     vmsBySelfLink[vm.selfLink] = vm;
   });
-  const findVMByRef = (ref: IdOrNameRef): SourceVM | undefined => {
+  const findVMByRef = (ref: IdNameNamespaceTypeRef): SourceVM | undefined => {
     const record = ref.id ? vmsById : vmsByName;
     return record[ref.id ? ref.id : ref.name || ''];
   };


### PR DESCRIPTION
As part of the feature for supporting OCP as a source provider:

- Support managing OCP as source provider for mappings: both Network mapping and Storage mapping.
- Enable creating a plan with OCP as a source provider on first wizard step (this is combined with #605) and enable adding mappings to the plan wizard.