### PR TITLE
Add openshift and ova tree fetch

### DIFF
--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -304,8 +304,25 @@ export const getAvailableVMs = (
       .flatMap(({ object }) => (object ? [object.selfLink] : []))
       .filter((selfLink) => !includeExtraVMs.some((extraVM) => selfLink === extraVM.selfLink)),
   ];
-  const matchingVMs = indexedVMs?.findVMsBySelfLinks(vmSelfLinks) || [];
-  return matchingVMs;
+
+  // Check if `indexedVMs` is defined, and if so, use its `findVMsBySelfLinks` method
+  let matchingVMs = [];
+  if (indexedVMs) {
+    matchingVMs = indexedVMs.findVMsBySelfLinks(vmSelfLinks);
+  }
+
+  // If no matching VMs were found, use an empty array
+  matchingVMs = matchingVMs || [];
+
+  // Create a new array from `matchingVMs` by mapping over it
+  // Each element of the new array is an object with an `id` property and all the properties of the original VM
+  return matchingVMs.map((vm) => {
+    // If the VM is not defined, its id would be `undefined`, and the spread operator will have no effect
+    const id = vm?.uid;
+    const vmProperties = vm || {};
+
+    return { id, ...vmProperties };
+  });
 };
 
 export interface IVMTreePathInfo {


### PR DESCRIPTION
Issue:
  - The OCP tree API is missing vm `id`
  - the OVA VM is missing vm `id`
  - the OVA tree API is missing

Fixes:
  - use OCP `uid` and copy it into the `id` field
  - use OVA `name` field and copy it int the id`` field
  - use OVA vm endpoint as the tree endpoint
  