### PR TITLE
Move the default authtype for openstack credentials first in options

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -155,10 +155,17 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
       >
         <Radio
           name="authType"
-          label="Password"
-          id="passwordSecretFields"
-          isChecked={state.authenticationType === 'passwordSecretFields'}
-          onChange={() => handleAuthTypeChange('passwordSecretFields')}
+          label="Application Credential ID"
+          id="applicationCredentialIdSecretFields"
+          isChecked={state.authenticationType === 'applicationCredentialIdSecretFields'}
+          onChange={() => handleAuthTypeChange('applicationCredentialIdSecretFields')}
+        />
+        <Radio
+          name="authType"
+          label="Application Credential Name"
+          id="applicationCredentialNameSecretFields"
+          isChecked={state.authenticationType === 'applicationCredentialNameSecretFields'}
+          onChange={() => handleAuthTypeChange('applicationCredentialNameSecretFields')}
         />
         <Radio
           name="authType"
@@ -176,17 +183,10 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         />
         <Radio
           name="authType"
-          label="Application Credential ID"
-          id="applicationCredentialIdSecretFields"
-          isChecked={state.authenticationType === 'applicationCredentialIdSecretFields'}
-          onChange={() => handleAuthTypeChange('applicationCredentialIdSecretFields')}
-        />
-        <Radio
-          name="authType"
-          label="Application Credential Name"
-          id="applicationCredentialNameSecretFields"
-          isChecked={state.authenticationType === 'applicationCredentialNameSecretFields'}
-          onChange={() => handleAuthTypeChange('applicationCredentialNameSecretFields')}
+          label="Password"
+          id="passwordSecretFields"
+          isChecked={state.authenticationType === 'passwordSecretFields'}
+          onChange={() => handleAuthTypeChange('passwordSecretFields')}
         />
       </FormGroup>
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/609

Issue:
the default authtype option is not the first option

Fix:
move default option to be the first

Screeshot:
Before:
![screenshot-localhost_9000-2023 07 25-18_17_49](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/32998502-b8b6-43c5-a0c3-14e1ff605e97)

After:
![screenshot-localhost_9000-2023 07 25-18_14_22](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/87ddc588-12f8-4c4b-8726-349f0e45a3d4)


