### PR TITLE
OCP has ID no need to manually add it

### DIFF
--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -312,17 +312,7 @@ export const getAvailableVMs = (
   }
 
   // If no matching VMs were found, use an empty array
-  matchingVMs = matchingVMs || [];
-
-  // Create a new array from `matchingVMs` by mapping over it
-  // Each element of the new array is an object with an `id` property and all the properties of the original VM
-  return matchingVMs.map((vm) => {
-    // If the VM is not defined, its id would be `undefined`, and the spread operator will have no effect
-    const id = vm?.uid;
-    const vmProperties = vm || {};
-
-    return { id, ...vmProperties };
-  });
+  return matchingVMs || [];
 };
 
 export interface IVMTreePathInfo {
@@ -492,7 +482,7 @@ export const getVMConcernStatusLabel = (concern: ISourceVMConcern | null): strin
     : concern?.category || 'Ok';
 
 export const someVMHasConcern = (vms: SourceVM[], concernLabel: string): boolean =>
-  vms.some((vm) => vm.concerns.some((concern) => concern.label === concernLabel));
+  vms?.some((vm) => vm.concerns?.some((concern) => concern.label === concernLabel));
 
 export interface IGenerateMappingsArgs {
   forms: PlanWizardFormState;

--- a/packages/legacy/src/queries/tree.ts
+++ b/packages/legacy/src/queries/tree.ts
@@ -104,7 +104,7 @@ export const useInventoryTreeQuery = <T extends InventoryTree>(
     ovirt: '/tree/cluster',
     openstack: '/tree/project',
     openshift: '/tree/namespace',
-    ova: '/vms',
+    ova: '/vms?detail=4',
   };
   const mockTreeData: Record<ProviderType, IInventoryHostTree> = {
     vsphere: MOCK_VMWARE_HOST_TREE,


### PR DESCRIPTION
Issue:
before https://github.com/kubev2v/forklift/pull/460 we needed to manually add id to ocp objects, it's redundant now.

Fix:
remove the manually added id