### PR TITLE
Use namespace/name notation for OCP  mapping source

### DIFF
--- a/packages/legacy/src/Mappings/components/MappingBuilder/helpers.ts
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/helpers.ts
@@ -67,6 +67,9 @@ interface IGetMappingParams {
   builderItems: IMappingBuilderItem[];
 }
 
+const buildItemToOCPNetworkName = (source: IOpenShiftNetwork) =>
+  `${source.namespace}/${source.name}`;
+
 export const getMappingFromBuilderItems = ({
   mappingType,
   mappingName,
@@ -89,8 +92,7 @@ export const getMappingFromBuilderItems = ({
               : isSourceMapNetworkTypeOCP
               ? {
                   // a non default OpenShift's network is mapped
-                  name: (builderItem.source as IOpenShiftNetwork).name,
-                  namespace: (builderItem.source as IOpenShiftNetwork).namespace,
+                  name: buildItemToOCPNetworkName(builderItem.source as IOpenShiftNetwork),
                   type: 'multus',
                 }
               : { id: (builderItem.source as ISourceNetwork).id || null }, // a non OpenShift provider


### PR DESCRIPTION
Issue:
when creating network mapping for ocp we need to use `namespace/name` notation, currently we only return the name.

Fix:
add the namespace to the name

before:
``` yaml
spec:
  map:
    - destination:
        type: pod
      source:
        name: example
        type: multus
  provider:
    destination:
      name: host
      namespace: konveyor-forklift
    source:
      name: host
      namespace: konveyor-forklift
```
after:
``` yaml
spec:
  map:
    - destination:
        type: pod
      source:
        name: cluster-network-addons/example
        type: multus
  provider:
    destination:
      name: host
      namespace: konveyor-forklift
    source:
      name: host
      namespace: konveyor-forklift
```