### PR TITLE
Be less restrictive when validating CA public certs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
@@ -30,8 +30,8 @@ const NFS_REGEX = new RegExp(`^((${IPV4})|(${HOSTNAME})):(${NFS_PATH})$`);
 // validate CA certification.
 const CERTIFICATE_HEADER = '-----BEGIN CERTIFICATE-----';
 const CERTIFICATE_FOOTER = '-----END CERTIFICATE-----';
-const BASE64_LINE = '([A-Za-z0-9+\\/]{64}\\r?\\n)';
-const LAST_BASE64_LINE = '([A-Za-z0-9+\\/=]{1,64}\\r?\\n)?';
+const BASE64_LINE = '([A-Za-z0-9+\\/=]{1,1256}\\r?\\n)';
+const LAST_BASE64_LINE = '([A-Za-z0-9+\\/=]{1,1256}\\r?\\n)?';
 const BASE64_CONTENT = `(${BASE64_LINE}*${LAST_BASE64_LINE})`;
 
 const EMPTY_LINES = '((\\#[^\\r\\n]*)?\\s*\\r?\\n)*';


### PR DESCRIPTION
Issue:
It is common to use 64 chars lines when formatting a public cert .pem file, but it's not a strict rule.
We currently enforce the 64 chars limit

Fix:
be less restrictive, and allow more line length

FIxes: 
https://github.com/kubev2v/forklift-console-plugin/issues/615