### PR TITLE
Fix 'not available' label for source mappings and disabled mappings issues

### DIFF
--- a/packages/legacy/src/Mappings/components/MappingBuilder/helpers.ts
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/helpers.ts
@@ -67,7 +67,7 @@ interface IGetMappingParams {
   builderItems: IMappingBuilderItem[];
 }
 
-const buildItemToOCPNetworkName = (source: IOpenShiftNetwork) =>
+const buildItemToOCPSourceNetworkName = (source: IOpenShiftNetwork) =>
   `${source.namespace}/${source.name}`;
 
 export const getMappingFromBuilderItems = ({
@@ -92,7 +92,7 @@ export const getMappingFromBuilderItems = ({
               : isSourceMapNetworkTypeOCP
               ? {
                   // a non default OpenShift's network is mapped
-                  name: buildItemToOCPNetworkName(builderItem.source as IOpenShiftNetwork),
+                  name: buildItemToOCPSourceNetworkName(builderItem.source as IOpenShiftNetwork),
                   type: 'multus',
                 }
               : { id: (builderItem.source as ISourceNetwork).id || null }, // a non OpenShift provider

--- a/packages/legacy/src/Mappings/components/helpers.ts
+++ b/packages/legacy/src/Mappings/components/helpers.ts
@@ -24,12 +24,17 @@ import { getBuilderItemsFromMapping } from './MappingBuilder/helpers';
 import { ProviderType } from 'legacy/src/common/constants';
 import { getStorageTitle } from 'legacy/src/common/helpers';
 
+const domainAndNameToName = (domainnAndName: string): string => {
+  const name = domainnAndName.split('/', 2);
+  return name[1] ? name[1] : domainnAndName;
+};
+
 export const getMappingSourceByRef = (
   sources: MappingSource[],
   ref: IdNameNamespaceTypeRef
 ): MappingSource | null =>
   sources.find((source) => {
-    if (ref.type && ref.type == 'pod') {
+    if (ref.type && ref.type === 'pod') {
       return (source as IOpenShiftNetwork).selfLink === 'pod';
     } else if (ref.id) {
       return (
@@ -39,12 +44,10 @@ export const getMappingSourceByRef = (
       );
     } else if (ref.namespace) {
       return (source as IOpenShiftNetwork).namespace === ref.namespace;
+    } else if (ref.name && (source as IOpenShiftNetwork).name) {
+      return (source as IOpenShiftNetwork).name === domainAndNameToName(ref.name);
     } else if (ref.name) {
-      return (
-        ((source as IOpenShiftNetwork).name ||
-          (source as ISourceNetwork).name ||
-          (source as ISourceStorage).name) === ref.name
-      );
+      return ((source as ISourceNetwork).name || (source as ISourceStorage).name) === ref.name;
     }
   }) || null;
 


### PR DESCRIPTION
Fix two regression issues generated by a previous patch fix

#### Issue 1:

**Before**: all source mapping labels were displayed as 'Not available'. 

**After the fix**: source storage and network mappings names should be displayed for all provider types.

#### Issues 2:
**Before**: when trying to choose an exisiting mapping via the plan wizard, all mapping options were disabled and therefore can't be chosen even if fits.

**After the fix**: suitable mapping options shoule be enabled for selection via the plan wizard.