### PR TITLE
Don't flicker overview page

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
@@ -5,8 +5,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import { HorizontalNav, K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection } from '@patternfly/react-core';
 
-import { useProvidersInventoryIsLive } from '../../hooks';
-import { useK8sWatchForkliftController } from '../../hooks/useK8sWatchProviderNames';
+import { useK8sWatchForkliftController, useProvidersInventoryIsLive } from '../../hooks';
 import { getOperatorPhase } from '../../utils/helpers/getOperatorPhase';
 
 import OperatorStatus from './components/OperatorStatus';
@@ -18,51 +17,22 @@ import './OverviewPage.style.css';
 export const OverviewPage: React.FC<OverviewPageProps> = () => {
   const { t } = useForkliftTranslation();
 
-  const [forkliftController, loaded, loadError] = useK8sWatchForkliftController();
-  const { loadError: inventoryLivelinessError } = useProvidersInventoryIsLive({});
-
-  const phaseObj = getOperatorPhase(forkliftController);
-
   const pages = [
     {
       href: '',
       name: t('Overview'),
-      component: () => {
-        return (
-          <ForkliftControllerDetailsTab
-            obj={forkliftController}
-            loaded={loaded}
-            loadError={loadError}
-          />
-        );
-      },
+      component: ForkliftControllerDetailsTabWrapper,
     },
     {
       href: 'yaml',
       name: t('YAML'),
-      component: () => {
-        return (
-          <ForkliftControllerYAMLTab
-            obj={forkliftController}
-            loaded={loaded}
-            loadError={loadError}
-          />
-        );
-      },
+      component: ForkliftControllerYAMLTabWrapper,
     },
   ];
 
   return (
     <>
-      <HeaderTitle
-        title={t('Migration Toolkit for Virtualization')}
-        status={<OperatorStatus status={phaseObj.phase} />}
-      />
-
-      {inventoryLivelinessError && (
-        <PageSection>{[<InventoryNotReachable key={'inventoryNotReachable'} />]}</PageSection>
-      )}
-
+      <HeaderTitleWrapper />
       <HorizontalNav pages={pages.filter((p) => p)} />
     </>
   );
@@ -75,6 +45,43 @@ type OverviewPageProps = {
   match: { path: string; url: string; isExact: boolean; params: unknown };
   name: string;
   namespace?: string;
+};
+
+const HeaderTitleWrapper: React.FC = () => {
+  const [forkliftController] = useK8sWatchForkliftController();
+  const { loadError: inventoryLivelinessError } = useProvidersInventoryIsLive({});
+
+  const { t } = useForkliftTranslation();
+
+  const phaseObj = getOperatorPhase(forkliftController);
+
+  return (
+    <>
+      <HeaderTitle
+        title={t('Migration Toolkit for Virtualization')}
+        status={<OperatorStatus status={phaseObj.phase} />}
+      />
+      {inventoryLivelinessError && (
+        <PageSection>{[<InventoryNotReachable key={'inventoryNotReachable'} />]}</PageSection>
+      )}
+    </>
+  );
+};
+
+const ForkliftControllerDetailsTabWrapper: React.FC = () => {
+  const [forkliftController, loaded, loadError] = useK8sWatchForkliftController();
+
+  return (
+    <ForkliftControllerDetailsTab obj={forkliftController} loaded={loaded} loadError={loadError} />
+  );
+};
+
+const ForkliftControllerYAMLTabWrapper: React.FC = () => {
+  const [forkliftController, loaded, loadError] = useK8sWatchForkliftController();
+
+  return (
+    <ForkliftControllerYAMLTab obj={forkliftController} loaded={loaded} loadError={loadError} />
+  );
 };
 
 export default OverviewPage;

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/index.ts
@@ -1,4 +1,5 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './components';
 export * from './OverviewPage';
 export * from './tabs';
 // @endindex


### PR DESCRIPTION
Issue:
in the overview page tabs get re rendered on each props change

Fix:
use components instead of methods to render the tabs
