### PR TITLE
FIx typeo namepace to namespace

### DIFF
--- a/packages/legacy/src/Plans/components/Wizard/helpers.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/helpers.tsx
@@ -555,9 +555,9 @@ function genrateNodesByVmID(data, kind) {
 }
 
 function getNameNamespaceByID(id, nodes) {
-  const { name, namepace } = nodes[id];
+  const { name, namespace } = nodes[id];
 
-  return { name, namepace };
+  return { name, namespace };
 }
 
 function getVmsListForPlan(hooksRef: IHookRef[], forms) {


### PR DESCRIPTION
FIx typeo namepace to namespace

Screeshot:
[Screencast from 2023-07-27 16-36-16.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/2038cffe-4a87-4c15-a5b0-2b2a29ccddf8)
