### PR TITLE
Enhance mapping's source field usage by displaying OCP namepsace and allow re-select

### DIFF
--- a/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
+++ b/packages/legacy/src/Mappings/components/MappingBuilder/MappingBuilder.tsx
@@ -22,7 +22,6 @@ import { ConditionalTooltip } from 'legacy/src/common/components/ConditionalTool
 import './MappingBuilder.css';
 import { ProviderType } from 'legacy/src/common/constants';
 import { getStorageTitle } from 'legacy/src/common/helpers';
-import { TruncatedText } from 'legacy/src/common/components/TruncatedText';
 
 export interface IMappingBuilderItem {
   source: MappingSource | null;
@@ -116,38 +115,17 @@ export const MappingBuilder: React.FunctionComponent<IMappingBuilderProps> = ({
               </>
             ) : null}
             <GridItem span={5} className={`mapping-builder-box ${spacing.pSm}`}>
-              {item.source ? (
-                <Bullseye style={{ justifyContent: 'left' }} className={spacing.plSm}>
-                  <TextContent>
-                    <TruncatedText>{item.source.name}</TruncatedText>
-                    {(item.source as ISourceNetwork).path ||
-                    (item.source as ISourceStorage).path ? (
-                      <TruncatedText>
-                        <Text
-                          component="small"
-                          style={{ fontSize: 'var(--pf-global--FontSize--xs)' }}
-                        >
-                          {(item.source as ISourceNetwork).path ||
-                            (item.source as ISourceStorage).path ||
-                            ''}
-                        </Text>
-                      </TruncatedText>
-                    ) : null}
-                  </TextContent>
-                </Bullseye>
-              ) : (
-                <MappingSourceSelect
-                  id={`mapping-source-for-${key}`}
-                  builderItems={builderItems}
-                  itemIndex={itemIndex}
-                  setBuilderItems={setBuilderItems}
-                  availableSources={availableSources}
-                  mappingType={mappingType}
-                  // Maybe use these instead of extraSelectMargin if we can get it to be dynamic to always fit the screen
-                  //menuAppendTo="parent"
-                  //maxHeight="200px"
-                />
-              )}
+              <MappingSourceSelect
+                id={`mapping-source-for-${key}`}
+                builderItems={builderItems}
+                itemIndex={itemIndex}
+                setBuilderItems={setBuilderItems}
+                availableSources={availableSources}
+                mappingType={mappingType}
+                // Maybe use these instead of extraSelectMargin if we can get it to be dynamic to always fit the screen
+                //menuAppendTo="parent"
+                //maxHeight="200px"
+              />
             </GridItem>
             <GridItem span={1}>
               <Bullseye>

--- a/packages/legacy/src/Mappings/components/MappingDetailView/MappingDetailView.tsx
+++ b/packages/legacy/src/Mappings/components/MappingDetailView/MappingDetailView.tsx
@@ -9,7 +9,7 @@ import { useResourceQueriesForMapping } from 'legacy/src/queries';
 import { TruncatedText } from 'legacy/src/common/components/TruncatedText';
 import { ResolvedQueries } from 'legacy/src/common/components/ResolvedQuery';
 import { getMappingSourceByRef, getMappingSourceTitle, getMappingTargetTitle } from '../helpers';
-import { getMappingItemTargetName, groupMappingItemsByTarget } from './helpers';
+import { getMappingItemTargetName, getMappingName, groupMappingItemsByTarget } from './helpers';
 
 import './MappingDetailView.css';
 import { ProviderType } from 'legacy/src/common/constants';
@@ -72,7 +72,7 @@ export const MappingDetailView: React.FunctionComponent<IMappingDetailViewProps>
                       mappingResourceQueries.availableSources,
                       item.source
                     );
-                    const sourceName = source ? source.name : '';
+                    const sourceName = source ? getMappingName(source, mappingType) : '';
                     const path = source
                       ? (source as ISourceNetwork).path || (source as ISourceStorage).path || ''
                       : null;


### PR DESCRIPTION
Enhance the mapping's source field usage by:

1. Displaying '`namespace / name`' instead of just '`name`' for OCP source network mapping fields (the same as for OCP target  network mapping fields).

     Example after fix::

    ![image](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/54f34bd8-2552-4dd5-98df-832d7985f6a7)



2. Allow re-selecting of values from the source mappping list instead of deleting and adding.

Screencast - before the fix:


https://github.com/kubev2v/forklift-console-plugin/assets/18169498/ed5645e8-9d8e-4743-9e53-6389147a6bfc



Screencast - after fix for network mapping:

https://github.com/kubev2v/forklift-console-plugin/assets/18169498/b103a08f-a5e4-4949-8822-51f04f71b3e5



Screencast - after fix for storage mapping:

https://github.com/kubev2v/forklift-console-plugin/assets/18169498/1001890d-dcfc-4b2e-8838-e49b700e0a71



