### PR TITLE
Add CI service account for admin user and reader roles

### DIFF
--- a/ci/configure/openshift.sh
+++ b/ci/configure/openshift.sh
@@ -29,15 +29,22 @@ function setup_bridge_for_bearer_token () {
     BRIDGE_USER_AUTH="disabled"
 
     if [[ -n "${BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT-}" && -n "${BRIDGE_K8S_AUTH_BEARER_TOKEN-}" ]]; then
-        # Setup with fixed cluster endpoint
-        return
+        echo  "Setup with fixed cluster endpoint and token"
+    elif [[ -n "${BRIDGE_K8S_AUTH_BEARER_TOKEN-}" ]]; then
+        echo "Setup with fixed cluster token"
+
+        BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$(kubectl config current-context)\")].cluster.server}")
     elif oc_available_loggedin; then
+        echo "Setup for Openshift enviorment"
+
         # If we have oc tool and an Openshift token, assume we are connected to openshift
         BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
         BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
         BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=${BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT:=$(oc whoami --show-server)}
         BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
     else
+        echo "Setup for K8s enviorment"
+
         BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$(kubectl config current-context)\")].cluster.server}")
         BRIDGE_K8S_AUTH_BEARER_TOKEN="abcdef.0123456789abcdef"
     fi

--- a/ci/create-forklift-user-account.sh
+++ b/ci/create-forklift-user-account.sh
@@ -1,53 +1,131 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # check if forklift-user account exist
-export SERVICE_ACCOUNT=forklift-user
+export SERVICE_ACCOUNT=forklift
 export NAMESPACE=default
 
-function setup_servie_account_token () {
-# Create forklift-user service account
+# Function for creating forklift roles
 # ------------------------------------
-cat <<EOF | kubectl apply -f -
+function setup_k8s_roles () {
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forklift-reader
+rules:
+- apiGroups: ["forklift.konveyor.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["console.openshift.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+EOF
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: forklift-user
+rules:
+- apiGroups: ["forklift.konveyor.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["console.openshift.io"]
+  resources: ["*"]
+  verbs: ["get", "watch", "list"]
+EOF
+}
+
+# Function for creating a forklift-user service account
+# $1 is the service account name
+# ------------------------------------
+function setup_servie_account () {
+  service_account=$1
+
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${SERVICE_ACCOUNT}
+  name: ${service_account}
   namespace: ${NAMESPACE}
 automountServiceAccountToken: true
 EOF
 
-cat <<EOF | kubectl apply -f -
+  cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ${SERVICE_ACCOUNT}
+  name: ${service_account}
   namespace: ${NAMESPACE}
   annotations:
-    kubernetes.io/service-account.name: ${SERVICE_ACCOUNT}
+    kubernetes.io/service-account.name: ${service_account}
 type: kubernetes.io/service-account-token
 EOF
-
-# Make forklift-user an admin
-# ---------------------------
-kubectl create clusterrolebinding ${SERVICE_ACCOUNT}-forklift-user \
-  --clusterrole=cluster-admin \
-  --serviceaccount=${NAMESPACE}:${SERVICE_ACCOUNT}
 }
 
-if kubectl get serviceaccount ${SERVICE_ACCOUNT} -n ${NAMESPACE} >/dev/null 2>&1 ; then
-    echo "Service account ${SERVICE_ACCOUNT} already exist"
-else
-    echo "Creating service account ${SERVICE_ACCOUNT}"
+# Function for binding roles to service account
+# $1 is the service account name
+# $2 is the role
+# ---------------------------------------------
+function bind_service_accont_to_role () {
+  service_account=$1
+  role=$2
 
-    setup_servie_account_token
-fi
+  cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  ${service_account}
+  namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${role} 
+subjects:
+- kind: ServiceAccount
+  name:  ${service_account}
+  namespace: ${NAMESPACE}
+EOF
+}
 
-# Print out token
-export TOKEN=$(kubectl get secret ${SERVICE_ACCOUNT} -n ${NAMESPACE} -o=jsonpath={.data.token} | base64 -d)
 
-echo "Token:"
-echo "------"
-echo ${TOKEN}
+# Creare forklift user and reader roles
+# -------------------------------------
+setup_k8s_roles
+
+echo "Creating/Updating service accounts ${SERVICE_ACCOUNT}, ${SERVICE_ACCOUNT}-user, ${SERVICE_ACCOUNT}-reader"
+
+setup_servie_account ${SERVICE_ACCOUNT}-admin
+bind_service_accont_to_role ${SERVICE_ACCOUNT}-admin cluster-admin
+
+setup_servie_account ${SERVICE_ACCOUNT}-user
+bind_service_accont_to_role ${SERVICE_ACCOUNT}-user forklift-user
+
+setup_servie_account ${SERVICE_ACCOUNT}-reader
+bind_service_accont_to_role ${SERVICE_ACCOUNT}-reader forklift-reader
+
+# Print out tokens
+export TOKEN_ADMIN=$(kubectl get secret ${SERVICE_ACCOUNT}-admin -n ${NAMESPACE} -o=jsonpath={.data.token} | base64 -d)
+export TOKEN_USER=$(kubectl get secret ${SERVICE_ACCOUNT}-user -n ${NAMESPACE} -o=jsonpath={.data.token} | base64 -d)
+export TOKEN_READER=$(kubectl get secret ${SERVICE_ACCOUNT}-reader -n ${NAMESPACE} -o=jsonpath={.data.token} | base64 -d)
+
 echo
+echo Tokens:
+echo "-------"
+echo forklift-admin:
+echo export TOKEN_ADMIN=${TOKEN_ADMIN}
+echo
+echo forklift-user:
+echo export TOKEN_USER=${TOKEN_USER}
+echo
+echo forklift-reader:
+echo export TOKEN_READER=${TOKEN_READER}
+echo
+echo Note:
+echo to use he tokens set BRIDGE_K8S_AUTH_BEARER_TOKEN
+echo   export TOKEN_ADMIN=...
+echo   export BRIDGE_K8S_AUTH_BEARER_TOKEN=$\{TOKEN_ADMIN \| TOKEN_USER \| TOKEN_READER\}
+echo
+echo before starting the bridge
+echo   npm run console

--- a/ci/deploy-all.sh
+++ b/ci/deploy-all.sh
@@ -91,6 +91,14 @@ if [[ $@ == *'--with-openstack-provider'* ]]; then
   (cd ${script_dir}/forkliftci && bash ${script_dir}/deploy-openstack-provider.sh)
 fi
 
+# Create some service accounts
+# ----------------------------
+
+echo ""
+echo "==========================================="
+
+bash ${script_dir}/create-forklift-user-account.sh
+
 # Print some help
 # ---------------
 


### PR DESCRIPTION
Add CI service account for admin user and reader roles

add more roles to the script `ci/create-forklift-user-account.sh`
``` bash
# running the script for creating the new service accounts:
source ci/create-forklift-user-account.sh

# will export TOKEN_ADMIN, TOKEN_USER and TOKEN_READER environment variables 
```

running a local console:
```
# running a local console with forklift user credentials:
export BRIDGE_K8S_AUTH_BEARER_TOKEN=${TOKEN_USER}; npm run console
```