### PR TITLE
[MTV-431] Hide overview for users that can't list namespaces

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/Overview/dynamic-plugin.ts
@@ -16,6 +16,9 @@ export const extensions: EncodedExtension[] = [
       path: ['/mtv/settings/ns/:ns', '/mtv/settings/all-namespaces'],
       exact: false,
     },
+    flags: {
+      required: ['CAN_LIST_NS'],
+    },
   } as EncodedExtension<RoutePage>,
 
   {
@@ -29,6 +32,9 @@ export const extensions: EncodedExtension[] = [
       namespaced: true,
       // t('plugin__forklift-console-plugin~Overview')
       name: '%plugin__forklift-console-plugin~Overview%',
+    },
+    flags: {
+      required: ['CAN_LIST_NS'],
     },
   } as EncodedExtension<HrefNavItem>,
 ];


### PR DESCRIPTION
Ref:
Jira: https://issues.redhat.com/browse/MTV-431
GH: https://github.com/kubev2v/forklift-console-plugin/issues/630

Issue:
Overview page should be hidden for none admins

Hide overview for users that can't list namespaces

Screenshot:
Before:
![overview-not-hidden-for-non-admin](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/a43cf094-e9d0-4b3c-8c59-46e5c3499123)


After:
![overview-hidden-for-non-admin](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/a5c85c81-1831-4d4d-ad24-ee8d6858c5b1)
