### PR TITLE
[MTV-431] Disable delete for reader users

### DIFF
--- a/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
@@ -6,7 +6,8 @@ import { ConfirmModal } from '@kubev2v/legacy/common/components/ConfirmModal';
 import { AddEditMappingModal } from '@kubev2v/legacy/Mappings/components/AddEditMappingModal';
 import { useDeleteMappingMutation } from '@kubev2v/legacy/queries';
 import { Mapping, MappingType } from '@kubev2v/legacy/queries/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { NetworkMapModel } from '@kubev2v/types';
+import { useAccessReview, useModal } from '@openshift-console/dynamic-plugin-sdk';
 
 import { CommonMapping } from './data';
 
@@ -20,6 +21,22 @@ export function useMappingActions<T extends CommonMapping>({
   const { t } = useForkliftTranslation();
   const launchModal = useModal();
 
+  const [canDelete] = useAccessReview({
+    group: NetworkMapModel.apiVersion,
+    resource: NetworkMapModel.plural,
+    verb: 'delete',
+    name: resourceData.name,
+    namespace: resourceData.namespace,
+  });
+
+  const [canPatch] = useAccessReview({
+    group: NetworkMapModel.apiVersion,
+    resource: NetworkMapModel.plural,
+    verb: 'patch',
+    name: resourceData.name,
+    namespace: resourceData.namespace,
+  });
+
   const actions = useMemo(
     () => [
       {
@@ -31,7 +48,7 @@ export function useMappingActions<T extends CommonMapping>({
             namespace: resourceData.namespace,
           }),
         label: t('Edit Mapping'),
-        disabled: resourceData.managed,
+        disabled: !canPatch || resourceData.managed,
         disabledTooltip: t('Manged mappings can not be edited'),
       },
       {
@@ -44,7 +61,7 @@ export function useMappingActions<T extends CommonMapping>({
             name: resourceData.name,
           }),
         label: t('Delete Mapping'),
-        disabled: resourceData.managed,
+        disabled: !canDelete || resourceData.managed,
         disabledTooltip: t('Manged mappings can not be deleted'),
       },
     ],


### PR DESCRIPTION
Ref:
Jira: https://issues.redhat.com/browse/MTV-431
GH: #631

Issue:
We currently allow users without permissions to try and edit or delete Plans and Mappings from the list view

Fix:
Check for permissions and disable actions that requires patch or delete permissions when users are not allowed to do this actions

Screenshots:
Before:
![no-RBAC-plans](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/774e6a6e-be6c-4bdc-bf08-ebe3b739701d)

![no-RBAC-mappings](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0fbdfd27-e7fe-423b-a001-09ec281c2146)


After:
![RBAC-providers](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/260de90a-5705-4c0e-85bb-74df9e163a9b)

![RBAC-mappings](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/18a589fd-cc70-46f6-834d-5f4344e43c0c)

![RBAC-plans](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/07d3f38c-0d14-4b6f-9093-b7dcf0f47da0)