### PR TITLE
Move create buttons to bottom

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -228,36 +228,6 @@ export const ProvidersCreatePage: React.FC<{
           </HelperTextItem>
         </HelperText>
 
-        <Flex>
-          <FlexItem>
-            <Button
-              variant="primary"
-              onClick={onUpdate}
-              isDisabled={state.validationError !== null}
-              isLoading={isLoading}
-            >
-              {t('Create provider')}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <Button onClick={() => history.push(providersListURL)} variant="secondary">
-              {t('Cancel')}
-            </Button>
-          </FlexItem>
-        </Flex>
-
-        <HelperText className="forklift-create-subtitle-errors">
-          {state.validationError ? (
-            <HelperTextItem variant="indeterminate">
-              {state.validationError.toString()}
-            </HelperTextItem>
-          ) : (
-            <HelperTextItem variant="indeterminate">{t('Create new provider')}</HelperTextItem>
-          )}
-        </HelperText>
-
-        <Divider className="forklift-section-secret-edit" />
-
         {state.apiError && (
           <Alert
             className="co-alert co-alert--margin-top"
@@ -291,6 +261,36 @@ export const ProvidersCreatePage: React.FC<{
           onNewSecretChange={onNewSecretChange}
           providerNames={providerNames}
         />
+
+        <Divider className="forklift-section-create-deviser" />
+
+        <Flex>
+          <FlexItem>
+            <Button
+              variant="primary"
+              onClick={onUpdate}
+              isDisabled={state.validationError !== null}
+              isLoading={isLoading}
+            >
+              {t('Create provider')}
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Button onClick={() => history.push(providersListURL)} variant="secondary">
+              {t('Cancel')}
+            </Button>
+          </FlexItem>
+        </Flex>
+
+        <HelperText className="forklift-create-subtitle-errors">
+          {state.validationError && state?.newProvider?.spec?.type ? (
+            <HelperTextItem variant="indeterminate">
+              {state.validationError.toString()}
+            </HelperTextItem>
+          ) : (
+            <HelperTextItem variant="indeterminate">{t('Create new provider')}</HelperTextItem>
+          )}
+        </HelperText>
       </PageSection>
     </div>
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.style.css
@@ -43,3 +43,7 @@
   padding-top: var(--pf-global--spacer--xs);
   padding-bottom: var(--pf-global--spacer--sm);
 }
+
+.forklift-section-create-deviser {
+  padding-bottom: var(--pf-global--spacer--md);
+}


### PR DESCRIPTION
Fixes: #637 

Screeshots:
before:
![create-button-top](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/1464b03e-9a86-4988-bf2d-e425656d1d1a)

after:
![create-button-bottom](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0ade421a-b928-41af-bc72-a755f9232e73)
