### PR TITLE
[MTV-431] Disable create for reader only users

### DIFF
--- a/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
+++ b/packages/forklift-console-plugin/src/components/mappings/mappingActions.tsx
@@ -22,7 +22,7 @@ export function useMappingActions<T extends CommonMapping>({
   const launchModal = useModal();
 
   const [canDelete] = useAccessReview({
-    group: NetworkMapModel.apiVersion,
+    group: NetworkMapModel.apiGroup,
     resource: NetworkMapModel.plural,
     verb: 'delete',
     name: resourceData.name,
@@ -30,7 +30,7 @@ export function useMappingActions<T extends CommonMapping>({
   });
 
   const [canPatch] = useAccessReview({
-    group: NetworkMapModel.apiVersion,
+    group: NetworkMapModel.apiGroup,
     resource: NetworkMapModel.plural,
     verb: 'patch',
     name: resourceData.name,

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/NetworkMappingsPage.tsx
@@ -15,7 +15,8 @@ import { withQueryClient } from '@kubev2v/common';
 import { ResourceFieldFactory } from '@kubev2v/common';
 import { AddEditMappingModal } from '@kubev2v/legacy/Mappings/components/AddEditMappingModal';
 import { MappingType } from '@kubev2v/legacy/queries/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { NetworkMapModel } from '@kubev2v/types';
+import { useAccessReview, useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Button } from '@patternfly/react-core';
 
 import { FlatNetworkMapping, Network, useFlatNetworkMappings } from './dataForNetwork';
@@ -50,12 +51,20 @@ export const NetworkMappingsPage = ({ namespace }: ResourceConsolePageProps) => 
     namespace,
   });
 
+  const [canCreate] = useAccessReview({
+    group: NetworkMapModel.apiGroup,
+    resource: NetworkMapModel.plural,
+    verb: 'create',
+    namespace,
+  });
+
   return (
     <PageMemo
       dataSource={dataSource}
       namespace={namespace}
       title={t('NetworkMaps')}
       userSettings={userSettings}
+      canCreate={canCreate}
     />
   );
 };
@@ -66,17 +75,19 @@ const Page = ({
   namespace,
   title,
   userSettings,
+  canCreate,
 }: {
   dataSource: [FlatNetworkMapping[], boolean, boolean];
   namespace: string;
   title: string;
   userSettings: UserSettings;
+  canCreate: boolean;
 }) => {
   const { t } = useForkliftTranslation();
 
   return (
     <StandardPage<FlatNetworkMapping>
-      addButton={<AddNetworkMappingButton namespace={namespace} />}
+      addButton={canCreate && <AddNetworkMappingButton namespace={namespace} />}
       dataSource={dataSource}
       RowMapper={NetworkMappingRow}
       HeaderMapper={StartWithEmptyColumnMapper}

--- a/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/PlansPage.tsx
@@ -10,6 +10,8 @@ import { loadUserSettings, UserSettings } from '@kubev2v/common';
 import { ResourceFieldFactory } from '@kubev2v/common';
 import { MustGatherModal } from '@kubev2v/legacy/common/components/MustGatherModal';
 import { CreatePlanButton } from '@kubev2v/legacy/Plans/components/CreatePlanButton';
+import { PlanModel } from '@kubev2v/types';
+import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 
 import { FlatPlan, useFlatPlans } from './data';
 import EmptyStatePlans from './EmptyStatePlans';
@@ -109,12 +111,20 @@ export const PlansPage = ({ namespace }: ResourceConsolePageProps) => {
     namespace,
   });
 
+  const [canCreate] = useAccessReview({
+    group: PlanModel.apiGroup,
+    resource: PlanModel.plural,
+    verb: 'create',
+    namespace,
+  });
+
   return (
     <PageMemo
       dataSource={dataSource}
       namespace={namespace}
       title={t('Plans')}
       userSettings={userSettings}
+      canCreate={canCreate}
     />
   );
 };
@@ -125,18 +135,20 @@ const Page = ({
   namespace,
   title,
   userSettings,
+  canCreate,
 }: {
   dataSource: [FlatPlan[], boolean, boolean];
   namespace: string;
   title: string;
   userSettings: UserSettings;
+  canCreate: boolean;
 }) => {
   const { t } = useForkliftTranslation();
 
   return (
     <>
       <StandardPage<FlatPlan>
-        addButton={<CreatePlanButton namespace={namespace} />}
+        addButton={canCreate && <CreatePlanButton namespace={namespace} />}
         dataSource={dataSource}
         RowMapper={PlanRow}
         fieldsMetadata={fieldsMetadataFactory(t)}

--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -90,7 +90,7 @@ export const useFlatPlanActions: ExtensionHook<
   const cutoverMutation = useSetCutoverMutation(plan.namespace);
 
   const [canDelete] = useAccessReview({
-    group: PlanModel.apiVersion,
+    group: PlanModel.apiGroup,
     resource: PlanModel.plural,
     verb: 'delete',
     name,
@@ -98,7 +98,7 @@ export const useFlatPlanActions: ExtensionHook<
   });
 
   const [canPatch] = useAccessReview({
-    group: PlanModel.apiVersion,
+    group: PlanModel.apiGroup,
     resource: PlanModel.plural,
     verb: 'patch',
     name,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -193,7 +193,7 @@ const ProvidersListPage: React.FC<{
   return (
     <StandardPage<ProviderData>
       data-testid="providers-list"
-      addButton={AddButton}
+      addButton={permissions.canCreate && AddButton}
       dataSource={[data || [], providersLoaded, providersLoadError]}
       RowMapper={ProviderRow}
       fieldsMetadata={fieldsMetadataFactory(t)}


### PR DESCRIPTION
Ref:
Jira: https://issues.redhat.com/browse/MTV-431
GH: https://github.com/kubev2v/forklift-console-plugin/issues/631

[ Note: this PR fix a type in the edit permissions too, `group: apiGroup` instead of `group apiVersion` ]

Issue:
We currently allow users without permissions to try and create Providers Plans and Mappings from the list view

Fix:
Check for permissions and disable actions that requires patch or delete permissions when users are not allowed to do this actions

Screenshots:
Before:
![RBAC-plans](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/67de81ef-8144-4c7f-9e93-49a28b1e1c75)

![RBAC-providers](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f91e877d-fcc4-4cf4-b447-e494053cb874)

![RBAC-mappings](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/315d651e-fef4-4ac6-b7ab-9139d1c0ff21)


After:
![RBAC-mappings](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/e7aa45bc-f23c-476c-84f1-73359c06768d)

![RBAC-plans](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/912a2192-dbfa-4b3b-bdf6-8a79323e2dd3)

![RBAC-providers](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/1384fc16-1b25-4b5a-a577-f93bb1e74cfd)

