### PR TITLE
[MTV-431] Disable editing in providers details views

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
@@ -4,6 +4,7 @@ import { isSecretDataChanged } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { V1Secret } from '@kubev2v/types';
+import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   Divider,
@@ -65,6 +66,14 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
   const [isLoading, setIsLoading] = useState(false);
+
+  const [canPatch] = useAccessReview({
+    group: '',
+    resource: 'secrets',
+    verb: 'patch',
+    namespace: secret.metadata.namespace,
+    name: secret.metadata.name,
+  });
 
   const initialState: BaseCredentialsSecretState = {
     reveal: false,
@@ -167,6 +176,7 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
             {t('Update credentials')}
           </Button>
         </FlexItem>
+
         <FlexItem>
           <Button variant="secondary" onClick={onCancel}>
             {t('Cancel')}
@@ -194,11 +204,13 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
   ) : (
     <>
       <Flex>
-        <FlexItem>
-          <Button variant="secondary" icon={<Pencil />} onClick={toggleEdit}>
-            {t('Edit credentials')}
-          </Button>
-        </FlexItem>
+        {canPatch && (
+          <FlexItem>
+            <Button variant="secondary" icon={<Pencil />} onClick={toggleEdit}>
+              {t('Edit credentials')}
+            </Button>
+          </FlexItem>
+        )}
         <FlexItem align={{ default: 'alignRight' }}>
           <Button
             variant="link"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OVADetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OVADetailsSection.tsx
@@ -15,7 +15,8 @@ export const OVADetailsSection: React.FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider } = data;
+  const { provider, permissions } = data;
+  const canEdit = permissions.canPatch;
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
@@ -88,7 +89,9 @@ export const OVADetailsSection: React.FC<DetailsSectionProps> = ({ data }) => {
         helpContent={<Text>{t(`The provider URL. Empty may be used for the host provider.`)}</Text>}
         crumbs={['Provider', 'spec', 'url']}
         onEdit={
-          provider?.spec?.url && (() => showModal(<EditProviderURLModal resource={provider} />))
+          canEdit &&
+          provider?.spec?.url &&
+          (() => showModal(<EditProviderURLModal resource={provider} />))
         }
       />
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
@@ -19,7 +19,8 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider } = data;
+  const { provider, permissions } = data;
+  const canEdit = permissions.canPatch;
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
@@ -92,7 +93,9 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
         helpContent={<Text>{t(`The provider URL. Empty may be used for the host provider.`)}</Text>}
         crumbs={['Provider', 'spec', 'url']}
         onEdit={
-          provider?.spec?.url && (() => showModal(<EditProviderURLModal resource={provider} />))
+          canEdit &&
+          provider?.spec?.url &&
+          (() => showModal(<EditProviderURLModal resource={provider} />))
         }
       />
 
@@ -151,7 +154,9 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
           'annotations',
           'forklift.konveyor.io/defaultTransferNetwork',
         ]}
-        onEdit={() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />)}
+        onEdit={
+          canEdit && (() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />))
+        }
       />
 
       <DetailsItem

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
@@ -15,7 +15,8 @@ export const OpenstackDetailsSection: React.FC<DetailsSectionProps> = ({ data })
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider } = data;
+  const { provider, permissions } = data;
+  const canEdit = permissions.canPatch;
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
@@ -78,7 +79,7 @@ export const OpenstackDetailsSection: React.FC<DetailsSectionProps> = ({ data })
         }
         helpContent={<Text>{t(`The provider URL. Empty may be used for the host provider.`)}</Text>}
         crumbs={['Provider', 'spec', 'url']}
-        onEdit={() => showModal(<EditProviderURLModal resource={provider} />)}
+        onEdit={canEdit && (() => showModal(<EditProviderURLModal resource={provider} />))}
       />
 
       <DetailsItem

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
@@ -15,7 +15,8 @@ export const OvirtDetailsSection: React.FC<DetailsSectionProps> = ({ data }) => 
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider } = data;
+  const { provider, permissions } = data;
+  const canEdit = permissions.canPatch;
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
@@ -78,7 +79,7 @@ export const OvirtDetailsSection: React.FC<DetailsSectionProps> = ({ data }) => 
         }
         helpContent={<Text>{t(`The provider URL. Empty may be used for the host provider.`)}</Text>}
         crumbs={['Provider', 'spec', 'url']}
-        onEdit={() => showModal(<EditProviderURLModal resource={provider} />)}
+        onEdit={canEdit && (() => showModal(<EditProviderURLModal resource={provider} />))}
       />
 
       <DetailsItem

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
@@ -19,7 +19,8 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider, inventory } = data;
+  const { provider, inventory, permissions } = data;
+  const canEdit = permissions.canPatch;
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   return (
@@ -87,7 +88,7 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
         }
         helpContent={<Text>{t(`The provider URL. Empty may be used for the host provider.`)}</Text>}
         crumbs={['Provider', 'spec', 'url']}
-        onEdit={() => showModal(<EditProviderURLModal resource={provider} />)}
+        onEdit={canEdit && (() => showModal(<EditProviderURLModal resource={provider} />))}
       />
 
       <DetailsItem
@@ -133,7 +134,7 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
         }
         helpContent={<Text>{t(`VMware only: Specify the VDDK image that you created.`)}</Text>}
         crumbs={['Provider', 'spec', 'settings', 'vddkInitImage']}
-        onEdit={() => showModal(<EditProviderVDDKImage resource={provider} />)}
+        onEdit={canEdit && (() => showModal(<EditProviderVDDKImage resource={provider} />))}
       />
 
       <DetailsItem

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
@@ -68,7 +68,7 @@ export const VSphereHostsList: React.FC<ProviderHostsProps> = ({ obj }) => {
   const [userSettings] = useState(() => loadUserSettings({ pageId: 'ProviderHosts' }));
   const [selected, setSelected]: [string[], (selected: string[]) => void] = useState([]);
 
-  const { provider } = obj;
+  const { provider, permissions } = obj;
   const { namespace } = provider?.metadata || {};
 
   const {
@@ -154,7 +154,7 @@ export const VSphereHostsList: React.FC<ProviderHostsProps> = ({ obj }) => {
   return (
     <StandardPage<InventoryHostPair>
       data-testid="hosts-list"
-      addButton={<AddButton />}
+      addButton={permissions.canPatch && <AddButton />}
       dataSource={[hostsData || [], !loading, error]}
       RowMapper={RowMapper}
       HeaderMapper={HeaderMapper}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -25,7 +25,7 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const { provider } = obj;
+  const { provider, permissions } = obj;
 
   const { inventory: networks } = useProviderInventory<OpenShiftNetworkAttachmentDefinition[]>({
     provider,
@@ -49,15 +49,17 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
           {t('NetworkAttachmentDefinitions')}
         </Title>
 
-        <div className="forklift-page-provider-networks-button">
-          <Button
-            key="editTransferNetwork"
-            variant="secondary"
-            onClick={() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />)}
-          >
-            {t('Set default transfer network')}
-          </Button>
-        </div>
+        {permissions.canPatch && (
+          <div className="forklift-page-provider-networks-button">
+            <Button
+              key="editTransferNetwork"
+              variant="secondary"
+              onClick={() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />)}
+            >
+              {t('Set default transfer network')}
+            </Button>
+          </div>
+        )}
 
         <TableComposable aria-label="Expandable table" variant="compact">
           <Thead>


### PR DESCRIPTION
Ref:
Jira: https://issues.redhat.com/browse/MTV-431
GH: https://github.com/kubev2v/forklift-console-plugin/issues/631

Issue:
We currently allow users without permissions to try and edit Providers from the dtails view

Fix:
Check for permissions and disable actions that requires patch permissions when users are not allowed to do this actions

Screenshots:
Before:
![RBAC-secret](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/230e3722-34de-47ca-ac1b-e61ff1137ac1)

![RBAC-hosts](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/26975252-3242-40c4-9b36-92fb309729d8)

![RBAC-networks](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c96d7517-cf90-429a-858d-d9a73cd41e65)

![RBAC-url](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/afe886da-09fc-47cb-9aec-8a617446c81e)

After:
![RBAC-url](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/55ff45ec-952b-4e99-b679-e331ef01e313)

![RBAC-secret](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/217be7de-a48d-4f9b-9295-40c4bb6569c8)

![RBAC-networks](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d1b6bff8-9d94-429e-a92e-d50644f3dd3c)

![RBAC-hosts](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5d1afcc4-f8d7-4dc4-a3d4-f47027324a53)
