### PR TITLE
Remove unneeded create forklift CRDs lint from CI script

### DIFF
--- a/ci/deploy-console.sh
+++ b/ci/deploy-console.sh
@@ -19,7 +19,6 @@ echo ""
 echo "deploy console CRDs"
 
 kubectl apply -f ${script_dir}/yaml/crds/console
-kubectl apply -f ${script_dir}/yaml/crds/forklift
 
 echo ""
 echo "deploy OKD console"

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_hosts.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_hosts.yaml
@@ -53,6 +53,9 @@ spec:
               name:
                 description: 'An object Name. vsphere: A qualified name.'
                 type: string
+              namespace:
+                description: The VM Namespace Only relevant for an openshift source.
+                type: string
               provider:
                 description: Provider
                 properties:

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_migrations.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_migrations.yaml
@@ -61,6 +61,10 @@ spec:
                     name:
                       description: 'An object Name. vsphere: A qualified name.'
                       type: string
+                    namespace:
+                      description: The VM Namespace Only relevant for an openshift
+                        source.
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -284,6 +288,10 @@ spec:
                       type: string
                     name:
                       description: 'An object Name. vsphere: A qualified name.'
+                      type: string
+                    namespace:
+                      description: The VM Namespace Only relevant for an openshift
+                        source.
                       type: string
                     phase:
                       description: Phase

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_networkmaps.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_networkmaps.yaml
@@ -74,6 +74,10 @@ spec:
                         name:
                           description: 'An object Name. vsphere: A qualified name.'
                           type: string
+                        namespace:
+                          description: The VM Namespace Only relevant for an openshift
+                            source.
+                          type: string
                         type:
                           description: Type used to qualify the name.
                           type: string
@@ -223,6 +227,10 @@ spec:
                       type: string
                     name:
                       description: 'An object Name. vsphere: A qualified name.'
+                      type: string
+                    namespace:
+                      description: The VM Namespace Only relevant for an openshift
+                        source.
                       type: string
                     type:
                       description: Type used to qualify the name.

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_openstackvolumepopulators.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_openstackvolumepopulators.yaml
@@ -5,17 +5,17 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: ovirtvolumepopulators.forklift.konveyor.io
+  name: openstackvolumepopulators.forklift.konveyor.io
 spec:
   group: forklift.konveyor.io
   names:
-    kind: OvirtVolumePopulator
-    listKind: OvirtVolumePopulatorList
-    plural: ovirtvolumepopulators
+    kind: OpenstackVolumePopulator
+    listKind: OpenstackVolumePopulatorList
+    plural: openstackvolumepopulators
     shortNames:
-    - ovvp
-    - ovvps
-    singular: ovirtvolumepopulator
+    - osvp
+    - osvps
+    singular: openstackvolumepopulator
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -36,11 +36,11 @@ spec:
             type: object
           spec:
             properties:
-              diskId:
+              identityUrl:
                 type: string
-              engineSecretName:
+              imageId:
                 type: string
-              engineUrl:
+              secretName:
                 type: string
               transferNetwork:
                 description: The network attachment definition that should be used
@@ -81,13 +81,13 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
             required:
-            - diskId
-            - engineSecretName
-            - engineUrl
+            - identityUrl
+            - imageId
+            - secretName
             type: object
           status:
             properties:
-              progress:
+              transferred:
                 type: string
             type: object
         required:

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_plans.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_plans.yaml
@@ -323,6 +323,10 @@ spec:
                     name:
                       description: 'An object Name. vsphere: A qualified name.'
                       type: string
+                    namespace:
+                      description: The VM Namespace Only relevant for an openshift
+                        source.
+                      type: string
                     type:
                       description: Type used to qualify the name.
                       type: string
@@ -720,6 +724,10 @@ spec:
                           type: string
                         name:
                           description: 'An object Name. vsphere: A qualified name.'
+                          type: string
+                        namespace:
+                          description: The VM Namespace Only relevant for an openshift
+                            source.
                           type: string
                         phase:
                           description: Phase

--- a/ci/yaml/crds/forklift/forklift.konveyor.io_storagemaps.yaml
+++ b/ci/yaml/crds/forklift/forklift.konveyor.io_storagemaps.yaml
@@ -78,6 +78,10 @@ spec:
                         name:
                           description: 'An object Name. vsphere: A qualified name.'
                           type: string
+                        namespace:
+                          description: The VM Namespace Only relevant for an openshift
+                            source.
+                          type: string
                         type:
                           description: Type used to qualify the name.
                           type: string
@@ -227,6 +231,10 @@ spec:
                       type: string
                     name:
                       description: 'An object Name. vsphere: A qualified name.'
+                      type: string
+                    namespace:
+                      description: The VM Namespace Only relevant for an openshift
+                        source.
                       type: string
                     type:
                       description: Type used to qualify the name.

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "cluster:delete": "bash ./ci/clean-cluster.sh",
     "e2e:cluster": "bash ./ci/deploy-cluster.sh",
     "e2e:build": "bash ./ci/build-and-push-images.sh",
+    "e2e:deployCrds": "kubectl apply -f ./ci/yaml/crds/forklift",
     "e2e:console": "bash ./ci/deploy-console.sh",
-    "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:console",
+    "e2e:pre-test": "npm run e2e:cluster && npm run e2e:build && npm run e2e:deployCrds && npm run e2e:console",
     "storybook": "npm run storybook -w @kubev2v/common -- dev -p 6006",
     "storybook:build": "npm run storybook -w @kubev2v/common -- build"
   },


### PR DESCRIPTION
Remove unneeded create forklift CRDs lint from CI script

Issue:
when creating a dev environment we deploy forklift CRDs twice, once using CI yaml CRDs, and once using forklift operator, we should only use forklift operator

Fix:
remove the CI line deploying CRDs from yaml