### PR TITLE
Skip create empty secrets

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createProvider.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createProvider.ts
@@ -21,13 +21,25 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
  *  .catch(err => console.error(err));
  */
 export async function createProvider(provider: V1beta1Provider, secret: V1Secret) {
-  const newProvider: V1beta1Provider = {
-    ...provider,
-    spec: {
-      ...provider?.spec,
-      secret: { name: secret?.metadata?.name, namespace: secret?.metadata?.namespace },
-    },
-  };
+  // Sanity check, don't try to create empty provider
+  if (!provider) {
+    return;
+  }
+
+  let newProvider: V1beta1Provider;
+
+  // Skip referencing to empty secret or a secret with no url
+  if (!secret || provider?.spec?.url) {
+    newProvider = {
+      ...provider,
+      spec: {
+        ...provider?.spec,
+        secret: { name: secret?.metadata?.name, namespace: secret?.metadata?.namespace },
+      },
+    };
+  } else {
+    newProvider = provider;
+  }
 
   const obj = await k8sCreate({
     model: ProviderModel,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createSecret.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createSecret.ts
@@ -24,6 +24,12 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
  */
 export async function createSecret(provider: V1beta1Provider, secret: V1Secret) {
   const url = provider?.spec?.url;
+
+  // Sanity check, don't try to create empty secret, or a secret without url
+  if (!secret || !url) {
+    return;
+  }
+
   const encodedURL = url ? Base64.encode(url) : undefined;
   const generateName = `${provider.metadata.name}-`;
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/patchSecretOwner.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/patchSecretOwner.ts
@@ -20,6 +20,11 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
  *  .catch(err => console.error(err));
  */
 export async function patchSecretOwner(provider: V1beta1Provider, secret: V1Secret) {
+  // Sanity check, don't try to patch empty secret
+  if (!secret) {
+    return;
+  }
+
   const op = secret?.metadata?.ownerReferences ? 'replace' : 'add';
 
   await k8sPatch({


### PR DESCRIPTION
Fixes: #643

When url is empty we still try to create a secret, this secret is empty and forklift verification will reject it.