### PR TITLE
Re-enable mock console extension

### DIFF
--- a/packages/forklift-console-plugin/src/__mock-console-extension/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/__mock-console-extension/dynamic-plugin.ts
@@ -4,7 +4,7 @@ import { ContextProvider } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack/lib/schema/plugin-package';
 
 const _exposedModules: ConsolePluginMetadata['exposedModules'] = {
-  MockPlugin: './mock-console-extension',
+  MockPlugin: './__mock-console-extension',
 };
 
 const _extensions: EncodedExtension[] = [

--- a/packages/mocks/src/definitions/basic/hosts.mock.ts
+++ b/packages/mocks/src/definitions/basic/hosts.mock.ts
@@ -14,7 +14,7 @@ import {
 export const HOST_01_ID = 'host-44';
 const host1: VSphereHost = {
   id: HOST_01_ID,
-  name: 'esx12.v2v.bos.redhat.com',
+  name: 'esx12.v2v.example.com',
   selfLink: `providers/vsphere/${VMWARE_01_UID}/hosts/${HOST_01_ID}`,
   managementServerIp: '10.19.2.10',
   parent: {
@@ -71,7 +71,7 @@ export const HOST_02_ID = 'host-29';
 const host2: VSphereHost = {
   ...host1,
   id: HOST_02_ID,
-  name: 'esx13.v2v.bos.redhat.com',
+  name: 'esx13.v2v.example.com',
   selfLink: `providers/vsphere/${VMWARE_01_UID}/hosts/${HOST_02_ID}`,
 };
 

--- a/packages/mocks/src/definitions/basic/paths.ts
+++ b/packages/mocks/src/definitions/basic/paths.ts
@@ -127,15 +127,19 @@ const paths = [
       vmTree: MOCK_VMWARE_VM_TREE,
     },
   }),
-  ...Object.entries(k8s).flatMap(([kind, data]) =>
-    toPath({
+  ...Object.entries(k8s).flatMap(([kind, data]) => [
+    ...toPath({
       resources: data,
       name: kind,
       namespaces: NAMESPACES,
       allNamespacesPath: ALL_NAMESPACES_PATH,
       namespacePath: NAMESPACE_PATH,
     }),
-  ),
+    ...data.map((it) => [
+      `${NAMESPACE_PATH}${it.metadata.namespace}/${kind}/${it.metadata.name}`,
+      it,
+    ]),
+  ]),
 ];
 
 export default Object.fromEntries(paths);


### PR DESCRIPTION
1. fix extension path
2. configure paths for fetching single k8s resources (by name)
3. use *.example.com as example URL