### PR TITLE
Refactor the hooks used on the details page tabs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import {
-  ProviderInventory,
-  ProviderModel,
-  ProviderModelGroupVersionKind,
-  V1beta1Provider,
-} from '@kubev2v/types';
+import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection, Title } from '@patternfly/react-core';
 
@@ -53,10 +47,7 @@ export const ProviderCredentialsWrapper: React.FC<{ name: string; namespace: str
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
-  const permissions = useGetDeleteAndEditAccessReview({ model: ProviderModel, namespace });
-
-  const data = { provider, inventory, permissions };
+  const data = { provider };
 
   return <ProviderCredentials obj={data} loaded={providerLoaded} loadError={providerLoadError} />;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/ProviderHosts.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/ProviderHosts.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
+import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { ModalHOC } from 'src/modules/Providers/modals';
 import { ProviderData } from 'src/modules/Providers/utils';
 
-import {
-  ProviderInventory,
-  ProviderModel,
-  ProviderModelGroupVersionKind,
-  V1beta1Provider,
-} from '@kubev2v/types';
+import { ProviderModel, ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { VSphereHostsList } from './VSphereHostsList';
@@ -50,10 +45,9 @@ export const ProviderHostsWrapper: React.FC<{ name: string; namespace: string }>
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
   const permissions = useGetDeleteAndEditAccessReview({ model: ProviderModel, namespace });
 
-  const data = { provider, inventory, permissions };
+  const data = { provider, permissions };
 
   return <ProviderHosts obj={data} loaded={providerLoaded} loadError={providerLoadError} />;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -12,7 +12,6 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import {
   CnoConfig,
   OpenShiftNetworkAttachmentDefinition,
-  ProviderInventory,
   ProviderModel,
   ProviderModelGroupVersionKind,
   V1beta1Provider,
@@ -128,10 +127,9 @@ export const ProviderNetworksWrapper: React.FC<{ name: string; namespace: string
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
   const permissions = useGetDeleteAndEditAccessReview({ model: ProviderModel, namespace });
 
-  const data = { provider, inventory, permissions };
+  const data = { provider, permissions };
 
   return <ProviderNetworks obj={data} loaded={providerLoaded} loadError={providerLoadError} />;
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
@@ -1,18 +1,13 @@
 import React, { useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import StandardPage from 'src/components/page/StandardPage';
-import {
-  useGetDeleteAndEditAccessReview,
-  useProviderInventory,
-  UseProviderInventoryParams,
-} from 'src/modules/Providers/hooks';
+import { useProviderInventory, UseProviderInventoryParams } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { EnumToTuple, loadUserSettings, ResourceFieldFactory } from '@kubev2v/common';
 import {
   ProviderInventory,
-  ProviderModel,
   ProviderModelGroupVersionKind,
   ProviderVirtualMachine,
   V1beta1Provider,
@@ -120,9 +115,8 @@ export const ProviderVirtualMachinesWrapper: React.FC<{ name: string; namespace:
   });
 
   const { inventory } = useProviderInventory<ProviderInventory>({ provider });
-  const permissions = useGetDeleteAndEditAccessReview({ model: ProviderModel, namespace });
 
-  const data = { provider, inventory, permissions };
+  const data = { provider, inventory };
 
   return (
     <ProviderVirtualMachines obj={data} loaded={providerLoaded} loadError={providerLoadError} />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/YAML/ProviderYAML.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/YAML/ProviderYAML.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import {
-  ProviderInventory,
-  ProviderModel,
-  ProviderModelGroupVersionKind,
-  V1beta1Provider,
-} from '@kubev2v/types';
+import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { ResourceYAMLEditor, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye } from '@patternfly/react-core';
 
@@ -59,10 +53,7 @@ export const ProviderYAMLPageWrapper: React.FC<{ name: string; namespace: string
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
-  const permissions = useGetDeleteAndEditAccessReview({ model: ProviderModel, namespace });
-
-  const data = { provider, inventory, permissions };
+  const data = { provider };
 
   return <ProviderYAMLPage obj={data} loaded={providerLoaded} loadError={providerLoadError} />;
 };


### PR DESCRIPTION
Issue:
each tab in the inventory page requires different data, but we currently fetch all data for each of them

FIx:
fetch only required data 