### PR TITLE
Change the storage mapping for OVA

### DIFF
--- a/packages/legacy/src/queries/storages.ts
+++ b/packages/legacy/src/queries/storages.ts
@@ -33,7 +33,7 @@ export const useSourceStoragesQuery = (
       return '/storageclasses?detail=1';
     }
     if (provider?.type === 'ova') {
-      return '/disks?detail=1';
+      return '/storages?detail=1';
     }
     return '/storagedomains';
   };


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift/pull/492

Issue:
Currently in OVA provider as source we need to map each source disk to a target storage class

FIx:
Map a group of OVA disks as a storage type on a targed storage class

Requiers:
https://github.com/kubev2v/forklift/pull/492