### PR TITLE
Remove unneeded dot after link

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
@@ -80,7 +80,6 @@ export const DescriptionTitleWithHelp: React.FC<{
               <ExternalLink href={moreInfoLink} isInline hideIcon>
                 <Truncate content={moreInfoLink} />
               </ExternalLink>
-              .
             </FlexItem>
           )}
 


### PR DESCRIPTION
Issue:
In the edit modal we have an un needed dot after the link.

Screenshot:
Before
![dot-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/88ca661a-829f-4ebe-b310-ce1fb8aef848)

After:
![dot-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3a7e70e9-f5d0-4279-a00a-4edf21e9bff6)
