### PR TITLE
Put vsphere product name above numeric values

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/InventorySection/VSphereInventorySection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/InventorySection/VSphereInventorySection.tsx
@@ -20,6 +20,7 @@ export const VSphereInventorySection: React.FC<InventoryProps> = ({ data }) => {
       title: t('Product'),
       helpContent: t('vSphere product name'),
     },
+    empty: {},
     vmCount: {
       title: t('Virtual machines'),
       helpContent: t('Number of virtual machines in cluster'),
@@ -52,7 +53,10 @@ export const VSphereInventorySection: React.FC<InventoryProps> = ({ data }) => {
     const item = inventoryItems?.[key];
 
     if (item) {
-      const value = inventory[key] || '-';
+      const isEmpty = key === 'empty';
+      const inventoryValue = inventory[key] || '-';
+      const value = isEmpty ? '' : inventoryValue;
+
       items.push(
         <DetailsItem
           title={item.title}


### PR DESCRIPTION
Issue:
vsphere product name is not part of the numeric inventory values list

Fix:
put it in a different line to highlight it's a little different from the other items in the inventory section

Screenshots:
Before:
![screenshot-localhost_9000-2023 08 06-16_07_38](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0ad633e0-c749-4d47-8422-4975e437df5e)

After:
![screenshot-localhost_9000-2023 08 06-16_06_52](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/a39b31fa-60c5-42f4-b45d-c9e44a70c352)
