### PR TITLE
Add permissions to the depenedencie of vmware host list

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
@@ -106,7 +106,7 @@ export const VSphereHostsList: React.FC<ProviderHostsProps> = ({ obj }) => {
         />
       );
     },
-    [selected], // dependency array
+    [selected, permissions],
   );
 
   const HeaderMapper = React.useCallback(
@@ -139,7 +139,7 @@ export const VSphereHostsList: React.FC<ProviderHostsProps> = ({ obj }) => {
         </>
       );
     },
-    [selected],
+    [selected, permissions],
   );
 
   const AddButton = useCallback(


### PR DESCRIPTION
Issue:
we now support different view of hosts list depending on user permissions,

Fix:
add permissions to the view dependencies

Screenshot:
Before:
![screenshot-localhost_9000-2023 08 06-16_24_14](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/862ebfe4-8f4d-4047-8d99-f4c26a0b55fa)

After:
![screenshot-localhost_9000-2023 08 06-16_25_34](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/4d196d19-a143-44c6-acef-ecabf55512a3)
