### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/build/Containerfile
+++ b/build/Containerfile
@@ -7,7 +7,7 @@ FROM registry.access.redhat.com/ubi9/nodejs-16 AS build
 #      -t quay.io/kubev2v/forklift-console-plugin \
 #      -f ./build/Containerfile \
 #      --build-arg VERSION=1.2.3 .
-ARG VERSION=2.4.1
+ARG VERSION=2.5.0
 ENV VERSION=${VERSION}
 
 # Copy app source

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubev2v/forklift-console-plugin",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "UI for forklift as an openshift console dynamic plugin",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
Bump version to 2.5.0 :tada: 

Issue:
upstream main is now 2.5.z stream, need to bump version to 2.5.0 on upstream.

- package.json - plugin version
- Containerfile - default upstream image version ( downstream version controlled by CI automation )