### PR TITLE
Wrap label within TableLinkCell to a new line if needed

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableCell.tsx
@@ -10,7 +10,7 @@ import './TableCells.style.css';
  * @param {TableCellProps} props - The props for the component.
  * @returns {ReactElement} The rendered TableCell component.
  */
-export const TableCell: React.FC<TableCellProps> = ({ children }) => {
+export const TableCell: React.FC<TableCellProps> = ({ children, isWrap = false }) => {
   const arrayChildren = Children.toArray(children);
 
   return (
@@ -18,7 +18,7 @@ export const TableCell: React.FC<TableCellProps> = ({ children }) => {
       <Flex
         spaceItems={{ default: 'spaceItemsXs' }}
         display={{ default: 'inlineFlex' }}
-        flexWrap={{ default: 'nowrap' }}
+        flexWrap={!isWrap ? { default: 'nowrap' } : {}}
       >
         {Children.map(arrayChildren, (child) => (
           <FlexItem>{child}</FlexItem>
@@ -30,4 +30,5 @@ export const TableCell: React.FC<TableCellProps> = ({ children }) => {
 
 export interface TableCellProps {
   children?: ReactNode;
+  isWrap?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLabelCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLabelCell.tsx
@@ -12,12 +12,13 @@ import { TableCell, TableCellProps } from './TableCell';
  */
 export const TableLabelCell: React.FC<TableLabelCellProps> = ({
   children,
+  isWrap = false,
   hasLabel = false,
   label,
   labelColor = 'grey',
 }) => {
   return (
-    <TableCell>
+    <TableCell isWrap={isWrap}>
       {children}
       {hasLabel && (
         <Label isCompact color={labelColor} className="forklift-table__flex-cell-label">
@@ -32,4 +33,5 @@ export interface TableLabelCellProps extends TableCellProps {
   hasLabel?: boolean;
   label?: ReactNode;
   labelColor?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey';
+  isWrap?: boolean;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
@@ -19,7 +19,7 @@ export const TableLinkCell: React.FC<TableLinkCellProps> = ({
   labelColor = 'grey',
 }) => {
   return (
-    <TableLabelCell hasLabel={hasLabel} label={label} labelColor={labelColor}>
+    <TableLabelCell hasLabel={hasLabel} label={label} labelColor={labelColor} isWrap={true}>
       <ResourceLink groupVersionKind={groupVersionKind} name={name} namespace={namespace} />
     </TableLabelCell>
   );


### PR DESCRIPTION
This fix is mainly relevant for the alignment of the `host` provider and the  `Host cluster` label

####  before the fix:
https://github.com/kubev2v/forklift-console-plugin/assets/18169498/31b095f9-8a47-49f5-910c-a1cfa744fb0d

####  after the fix:

https://github.com/kubev2v/forklift-console-plugin/assets/18169498/951fdea8-ef5a-4fc3-b427-944c1c6807df

