### PR TITLE
Add canPatch to plan duplicat action dependencies

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/planActions.tsx
@@ -245,7 +245,7 @@ export const useFlatPlanActions: ExtensionHook<
           )
         : '',
     }),
-    [t, areProvidersReady, name, namespace],
+    [t, canPatch, areProvidersReady, name, namespace],
   );
 
   const archiveAction = useMemo(


### PR DESCRIPTION
Ref: #676

Issue:
the plan duplicate action is always disabled because `canPatch` is never updated

Fix:
add `canPatch` to the action dependencies

Screenshot:
Before:
![plan-duplicate-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5fd44554-54f2-40b7-96b5-9d6a482b089a)

After:
![plan-duplicate-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/8f8a8901-4382-46d8-a029-f5fce8916926)

