### PR TITLE
Each provider has differetn storage count, use specific storage count

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -202,6 +202,7 @@
   "Number of regions in OpenStack cluster": "Number of regions in OpenStack cluster",
   "Number of storage classes in provider cluster": "Number of storage classes in provider cluster",
   "Number of storage domains in provider": "Number of storage domains in provider",
+  "Number of storage types found in OVA server": "Number of storage types found in OVA server",
   "Number of storage types in cluster": "Number of storage types in cluster",
   "Number of storage volumes in cluster": "Number of storage volumes in cluster",
   "Number of virtual machines in cluster": "Number of virtual machines in cluster",

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/getValueByJsonPath.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/getValueByJsonPath.ts
@@ -1,17 +1,23 @@
 /**
- * Retrieves the deep value of an object given a JSON path.
+ * Retrieves the deep value of an object given a JSON path or a function.
  *
  * @param obj - The object to retrieve the value from.
- * @param path - The JSON path (dot notation) to the property.
- * @returns The value at the given path, or undefined if the path doesn't exist.
+ * @param pathOrFunction - The JSON path (dot notation) to the property, or a function that returns the desired value.
+ * @returns The value at the given path, or the result of the function, or undefined if the path doesn't exist or the function returns undefined.
  */
-export function getValueByJsonPath<T>(obj: T, path: string | string[]): unknown {
-  let pathParts = [];
+export function getValueByJsonPath<T>(
+  obj: T,
+  pathOrFunction: string | string[] | ((obj: T) => unknown),
+): unknown {
+  if (typeof pathOrFunction === 'function') {
+    return pathOrFunction(obj);
+  }
 
-  if (typeof path === 'string') {
-    pathParts = path.split('.');
+  let pathParts = [];
+  if (typeof pathOrFunction === 'string') {
+    pathParts = pathOrFunction.split('.');
   } else {
-    pathParts = path;
+    pathParts = pathOrFunction;
   }
 
   return pathParts.reduce((o, key) => o?.[key], obj);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/InventorySection/OVAInventorySection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/InventorySection/OVAInventorySection.tsx
@@ -20,6 +20,10 @@ export const OVAInventorySection: React.FC<InventoryProps> = ({ data }) => {
       title: t('Virtual machines'),
       helpContent: t('Number of virtual machines in OVA files'),
     },
+    storageCount: {
+      title: t('Storage'),
+      helpContent: t('Number of storage types found in OVA server'),
+    },
   };
 
   const items = [];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -13,11 +13,16 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { EnumToTuple, loadUserSettings, ResourceFieldFactory } from '@kubev2v/common';
 import {
+  OpenshiftProvider,
+  OpenstackProvider,
+  OvaProvider,
+  OVirtProvider,
   ProviderModel,
   ProviderModelGroupVersionKind,
   ProviderModelRef,
   ProviderType,
   V1beta1Provider,
+  VSphereProvider,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -130,7 +135,30 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
   },
   {
     resourceFieldId: 'storageCount',
-    jsonPath: '$.inventory.storageCount',
+    jsonPath: (obj: ProviderData) => {
+      let storageCount: number;
+      const { inventory } = obj;
+
+      switch (inventory?.type) {
+        case 'ova':
+          storageCount = (inventory as OvaProvider).storageCount;
+          break;
+        case 'openshift':
+          storageCount = (inventory as OpenshiftProvider).storageClassCount;
+          break;
+        case 'vsphere':
+          storageCount = (inventory as VSphereProvider).datastoreCount;
+          break;
+        case 'openstack':
+          storageCount = (inventory as OpenstackProvider).volumeTypeCount;
+          break;
+        case 'ovirt':
+          storageCount = (inventory as OVirtProvider).storageDomainCount;
+          break;
+      }
+
+      return storageCount;
+    },
     label: t('Storage'),
     isVisible: false,
     sortable: true,

--- a/packages/types/src/types/provider/ova/Provider.ts
+++ b/packages/types/src/types/provider/ova/Provider.ts
@@ -17,4 +17,6 @@ export interface OvaProvider extends OpenshiftResource {
   networkCount: number;
   // DatastoreCount  int64        `json:"datastoreCount"`
   DiskCount: number;
+  // StorageCount  int64        `json:"storageCount"`
+  storageCount: number;
 }


### PR DESCRIPTION
Issue:
Each provider has different way to count storage types. we currently use `storageCount` for all.

Fix:
We should use the specific count according to the provider type.

Screenhost:
Before:
![screenshot-localhost_9000-2023 08 10-06_52_37](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/16f27b08-5db1-45d0-a93d-a3b2a5f0dbca)


After:
![screenshot-localhost_9000-2023 08 10-06_50_38](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/8a2714ad-c411-4012-ad27-e984f7a149e9)
