### PR TITLE
Maintain unique data-testid for Create Provider button

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -213,6 +213,7 @@ const ProvidersListPage: React.FC<{
     <ProvidersAddButton
       onClick={() => history.push(`${providersListURL}/~new`)}
       buttonText={t('Create Provider')}
+      dataTestId="add-provider-button"
     />
   );
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersAddButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersAddButton.tsx
@@ -5,11 +5,16 @@ import { Button } from '@patternfly/react-core';
 interface AProvidersAddButtonProps {
   onClick: () => void;
   buttonText: string;
+  dataTestId?: string;
 }
 
-export const ProvidersAddButton: React.FC<AProvidersAddButtonProps> = ({ onClick, buttonText }) => {
+export const ProvidersAddButton: React.FC<AProvidersAddButtonProps> = ({
+  onClick,
+  buttonText,
+  dataTestId,
+}) => {
   return (
-    <Button data-testid="add-provider-button" variant="primary" onClick={onClick}>
+    <Button data-testid={dataTestId} variant="primary" onClick={onClick}>
       {buttonText}
     </Button>
   );


### PR DESCRIPTION
Cypress tests may fail if 2 buttons are found on the screen with the same data-testid. Currently this happens if empty state is displayed.