### PR TITLE
Set OpenShift vm power status in plans wizard

### DIFF
--- a/packages/legacy/src/common/components/VMNameWithPowerState.tsx
+++ b/packages/legacy/src/common/components/VMNameWithPowerState.tsx
@@ -11,6 +11,7 @@ import {
   SourceVM,
   IVMStatus,
   IOpenStackVM,
+  IOpenShiftVM,
 } from 'legacy/src/queries/types';
 import { ProviderType } from 'legacy/src/common/constants';
 
@@ -43,6 +44,15 @@ export const getVMPowerState = (
         powerStatus = 'on';
       }
       if (status === 'SHUTOFF') {
+        powerStatus = 'off';
+      }
+      break;
+    }
+    case 'openshift': {
+      const status = (vm as IOpenShiftVM)?.object?.status?.printableStatus;
+      if (status === 'Running') {
+        powerStatus = 'on';
+      } else {
         powerStatus = 'off';
       }
       break;

--- a/packages/legacy/src/queries/types/vms.types.ts
+++ b/packages/legacy/src/queries/types/vms.types.ts
@@ -49,6 +49,14 @@ export interface IOpenStackVM extends IBaseSourceVM {
   status?: 'ACTIVE' | 'SHUTOFF' | 'PAUSED' | 'SHELVED_OFFLOADED' | 'SUSPENDED';
 }
 
+export interface IOpenShiftVM extends IBaseSourceVM {
+  object?: {
+    status?: {
+      printableStatus?: string;
+    };
+  };
+}
+
 export interface IOpenStackNIC {
   'OS-EXT-IPS-MAC:mac_addr'?: string;
   'OS-EXT-IPS:type'?: string;


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/682

Issue:
The source VM’s power state is ‘Unknown power state’ on the ‘Select VMs’ page for OCP source

Screenshot:
Before:
![screenshot-localhost_9000-2023 08 10-23_23_15](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/aa766301-a501-4cfe-8c2f-4337564345ce)


After:
![screenshot-localhost_9000-2023 08 10-23_26_41](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5d0b1524-3a36-4ebd-a431-d00a24d235c3)

