### PR TITLE
Add createdForResourceType labels to secrets created for hosts and pr…

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createSecret.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createSecret.ts
@@ -41,7 +41,7 @@ export async function createSecret(provider: V1beta1Provider, secret: V1Secret) 
       labels: {
         ...secret?.metadata?.labels,
         createdForProviderType: provider?.spec?.type,
-        createdForResourceType: 'provider',
+        createdForResourceType: 'providers',
       },
     },
     data: { ...secret?.data, url: encodedURL },

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
@@ -127,6 +127,9 @@ async function processHostPair(
       metadata: {
         generateName: `${provider.metadata.name}-${inventory.id}-`,
         namespace: provider.metadata.namespace,
+        labels: {
+          createdForResourceType: 'hosts',
+        },
         ownerReferences: [
           {
             apiVersion: 'forklift.konveyor.io/v1beta1',


### PR DESCRIPTION
Add createdForResourceType labels to secrets created for hosts and providers

Issue:
webhooks for secrets are not running, because the labels is not set correctly:
- providers secret: for the createdForResourceType it should be providers but set as provider.
- hosts secrets: missing  createdForResourceType label.