### PR TITLE
Enable auto select for OCP source network mapping within a plan

### DIFF
--- a/packages/legacy/src/queries/types/vms.types.ts
+++ b/packages/legacy/src/queries/types/vms.types.ts
@@ -54,6 +54,13 @@ export interface IOpenShiftVM extends IBaseSourceVM {
     status?: {
       printableStatus?: string;
     };
+    spec?: {
+      template?: {
+        spec: {
+          networks?: IOpenShiftNIC[];
+        };
+      };
+    };
   };
 }
 
@@ -66,6 +73,13 @@ export interface IOpenStackNIC {
 
 export interface IOpenStackDiskAttachment {
   ID?: string;
+}
+
+export interface IOpenShiftNIC {
+  pod?: NonNullable<unknown>;
+  multus?: {
+    networkName: string;
+  };
 }
 
 export type SourceVM = IVMwareVM | IRHVVM | IOpenStackVM;


### PR DESCRIPTION
Fixes the network mapping for: #672 

When creating/editing a plan with OCP as a source provider, enable auto selection of the source network mappings for the selected plan's VMs.

It also notifies in case there are non mapped unnecessary source networks mapping when editing a plan.