### PR TITLE
Set the storage mapping source title for OpenShift

### DIFF
--- a/cypress/e2e/tests/Providers/CreateProvider.cy.ts
+++ b/cypress/e2e/tests/Providers/CreateProvider.cy.ts
@@ -9,7 +9,7 @@ describe('Providers list view', () => {
   });
 
   it('has a add-provider button', () => {
-    // find and click the create provider button
-    cy.findByTestId('add-provider-button').should('exist').click();
+    // find and click the create provider button (the 1st one since there are two occurrences)
+    cy.findAllByTestId('add-provider-button').should('exist').click();
   });
 });

--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -143,7 +143,7 @@
   "Managed resource": "Managed resource",
   "Manged mappings can not be deleted": "Manged mappings can not be deleted",
   "Manged mappings can not be edited": "Manged mappings can not be edited",
-  "Map source datastores or storage domains or volume types and networks to target storage classes and networks.": "Map source datastores or storage domains or volume types and networks to target storage classes and networks.",
+  "Map source datastores, storage domains, volume types, storage classes and networks to their respective target storage classes and networks.": "Map source datastores, storage domains, volume types, storage classes and networks to their respective target storage classes and networks.",
   "Mapping graph": "Mapping graph",
   "Maximum concurrent VM migrations": "Maximum concurrent VM migrations",
   "Maximum number of concurrent VM migrations. Default value is 20.": "Maximum number of concurrent VM migrations. Default value is 20.",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersEmptyState.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersEmptyState.tsx
@@ -59,7 +59,7 @@ export const ProvidersEmptyState: React.FC<ProvidersEmptyStateProps> = ({
                   </TextListItem>
                   <TextListItem>
                     {t(
-                      'Map source datastores or storage domains or volume types and networks to target storage classes and networks.',
+                      'Map source datastores, storage domains, volume types, storage classes and networks to their respective target storage classes and networks.',
                     )}
                   </TextListItem>
                   <TextListItem>

--- a/packages/legacy/src/Mappings/Mappings.tsx
+++ b/packages/legacy/src/Mappings/Mappings.tsx
@@ -50,7 +50,7 @@ export const Mappings: React.FunctionComponent<IMappingsProps> = ({
           <EmptyStateBody>
             {mappingType === MappingType.Network
               ? 'Map source provider networks to target provider networks.'
-              : 'Map source provider datastores or storage domains or volume types to target provider storage classes.'}
+              : 'Map datastores, storage domains, volume types or storage classes from the source provider to storage classes of the target provider.'}
           </EmptyStateBody>
           <CreateMappingButton onClick={toggleModalAndResetEdit} />
         </EmptyState>

--- a/packages/legacy/src/common/helpers.ts
+++ b/packages/legacy/src/common/helpers.ts
@@ -212,6 +212,7 @@ export const getStorageTitle = (sourceProviderType: ProviderType, cap = false): 
   if (sourceProviderType === 'vsphere') return `${cap ? 'D' : 'd'}atastores`;
   if (sourceProviderType === 'ovirt') return `${cap ? 'S' : 's'}torage domains`;
   if (sourceProviderType === 'openstack') return `${cap ? 'V' : 'v'}olume types`;
+  if (sourceProviderType === 'openshift') return `${cap ? 'S' : 's'}torage classes`;
   return '';
 };
 


### PR DESCRIPTION
Set the storage mapping source title, in case the source provider type is OpenShift, to 'Source storage classes'.

In addition, add 'storage classes' mapping for legacy empty state messages, for keeping code persistency.