### PR TITLE
Service Account Token to Service Account Bearer Token

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -278,7 +278,7 @@
   "Select migration network": "Select migration network",
   "Select provider type": "Select provider type",
   "Selected columns will be displayed in the table.": "Selected columns will be displayed in the table.",
-  "Service account token": "Service account token",
+  "Service account bearer token": "Service account bearer token",
   "Set default transfer network": "Set default transfer network",
   "Sets the maximum number of VMs that can be migrated simultaneously. The default value is 20 virtual machines.": "Sets the maximum number of VMs that can be migrated simultaneously. The default value is 20 virtual machines.",
   "Sets the memory limits allocated to the controller container. The default value is 800Mi.": "Sets the memory limits allocated to the controller container. The default value is 800Mi.",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -68,7 +68,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroup
-        label={t('Service account token')}
+        label={t('Service account bearer token')}
         isRequired
         fieldId="token"
         helperText={t(

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenshiftCredentialsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenshiftCredentialsList.tsx
@@ -14,7 +14,7 @@ export const OpenshiftCredentialsList: React.FC<ListComponentProps> = ({ secret,
 
   const fields = {
     token: {
-      label: t('Service account token'),
+      label: t('Service account bearer token'),
       description: t(
         'User or service account bearer token for service accounts or user authentication.',
       ),


### PR DESCRIPTION
Ref:
https://github.com/kubev2v/forklift-console-plugin/issues/695

Issue:
"Service account token" should be "Service account bearer token"

Screeshot:
Before:
![screenshot-localhost_9000-2023 08 17-16_54_49](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/e60ba354-f785-4d1f-9f4e-394aa88dc611)

After:
![screenshot-localhost_9000-2023 08 17-16_58_15(1)](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f161cc1c-cd12-4cef-918b-eb270e5bcc32)
