### PR TITLE
use findByTestId and not findAllByTestId

### DIFF
--- a/cypress/e2e/tests/Providers/CreateProvider.cy.ts
+++ b/cypress/e2e/tests/Providers/CreateProvider.cy.ts
@@ -10,6 +10,6 @@ describe('Providers list view', () => {
 
   it('has a add-provider button', () => {
     // find and click the create provider button (the 1st one since there are two occurrences)
-    cy.findAllByTestId('add-provider-button').should('exist').click();
+    cy.findByTestId('add-provider-button').should('exist').click();
   });
 });


### PR DESCRIPTION
use findByTestId and not findAllByTestId

I must have re-intruducced the mulitple id issue somewere ¯\_(ツ)_/¯

this removed the not nice `findAllByTestId` and put things in there right place again.