### PR TITLE
After create redirect to providers namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -203,7 +203,7 @@ export const ProvidersCreatePage: React.FC<{
     // go to providers derails page
     const providerURL = getResourceUrl({
       reference: ProviderModelRef,
-      namespace: namespace,
+      namespace: provider.metadata.namespace,
       name: provider.metadata.name,
     });
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/703

Issue:
After creating a provider, we redirect to the provider page, assuming the namespace provided for the creating form is the same one the provider will be created in. but when in "all-namespaces" this does not happen

Fix:
use the new providers namespace instead of the namespace provided for the form.