### PR TITLE
Local OCP target can have null or undefined URL, not just empty string

### DIFF
--- a/packages/legacy/src/common/helpers.ts
+++ b/packages/legacy/src/common/helpers.ts
@@ -206,7 +206,7 @@ export function checkIfOvirtInsecureProvider(
  * Can this provider be considered a local target provider?
  */
 export const isProviderLocalTarget = (provider: IProviderObject): boolean =>
-  provider.spec.type === 'openshift' && provider.spec.url === '';
+  provider?.spec?.type === 'openshift' && (!provider?.spec?.url || provider?.spec?.url === '');
 
 export const getStorageTitle = (sourceProviderType: ProviderType, cap = false): string => {
   if (sourceProviderType === 'vsphere') return `${cap ? 'D' : 'd'}atastores`;


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/709

Issue:
Local OCP target can have null or undefined URL, not just empty string

A local OCP provider can be defined with URL as '', but it can also be defined with no URL, than the URL is `undefined`

Fix:
test for `!value` that will work for both empty string and other null values

Screenshots:
Before:
[Screencast from 2023-08-30 17-20-26.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/db8dd5ad-0b09-4fcb-913a-3647dc30362e)

After:

[Screencast from 2023-08-30 17-36-20.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/61f2424c-252b-4088-bc99-57ad54884852)
