### PR TITLE
Update error text for insecure ovirt and remote target

### DIFF
--- a/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
@@ -189,7 +189,7 @@ export const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
         <ProviderSelect
           providerRole="target"
           providerAllowRemote={!isLocalTargetRequired}
-          providerAllowRemoteTooltip="This is a remote target provider.  The source provider is insecure and this target provider must be a cluster local target."
+          providerAllowRemoteTooltip="This is a remote target provider. When the source RHV provider uses insecure connection, the target provider must be local OCP provider."
           // TODO: If the source is ovirt+insecure AND the target is remote, invalidate the field, put it in an error state
           field={form.fields.targetProvider}
           onProviderSelect={(inventoryProvider) => {


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/709

Update error text when user try to create a plan with insecure oVirt and remote OCP

Fix:
was:
This is a remote target provider.  The source provider is insecure and this target provider must be a cluster local target.

after:
This is a remote target provider. When the source RHV provider uses insecure connection, the target provider must be local OCP provider.

Screenhot:
Before:
[Screencast from 2023-08-30 19-26-19.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/2d5a8877-f119-4ed6-9ce7-9f59fc822f51)

After:
[Screencast from 2023-08-30 19-32-15.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/966a975c-fc78-416f-b12e-7fd001132945)


