### PR TITLE
Update provider name field's validation rules to align with k8s rules

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/__tests__/common.test.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/__tests__/common.test.ts
@@ -126,13 +126,19 @@ BAYTAkFVMRMwEQYDVQQIDApTb21lLVN 0YXRlMSEwHwYDVQQKDBhJ=
   describe('validateK8sName', () => {
     it('validates correct k8s names', () => {
       expect(validateK8sName('k8s-name')).toBe(true);
+      expect(validateK8sName('k8s.name')).toBe(true);
       expect(validateK8sName('k8sname')).toBe(true);
       expect(validateK8sName('k8')).toBe(true);
+      expect(validateK8sName('1a-k8')).toBe(true);
     });
 
     it('invalidates k8s names with invalid characters', () => {
       expect(validateK8sName('k8s_name')).toBe(false);
-      expect(validateK8sName('k8s.name')).toBe(false);
+      expect(validateK8sName('k8s%name')).toBe(false);
+      expect(validateK8sName('k8sname.')).toBe(false);
+      expect(validateK8sName('.k8sname')).toBe(false);
+      expect(validateK8sName('k8..sname')).toBe(false);
+      expect(validateK8sName('k8.-sname')).toBe(false);
     });
 
     it('invalidates k8s names that are too long', () => {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
@@ -43,8 +43,13 @@ const CERTIFICATE_REGEX = new RegExp(
 // validate CA certification fingerprint.
 const FINGERPRINT_REGEX = /^([a-fA-F0-9]{2}:){19}[a-fA-F0-9]{2}$/;
 
-// validate sub domain names, used in K8s
-const DNS_SUBDOMAINS_NAME_REGEXP = /^[a-z][a-z0-9-]{0,251}[a-z0-9]$/;
+/**
+ * Validate sub domain names, used in K8s.
+ * This is based on k8s doc: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+ * @see  https://github.com/kubernetes/apimachinery/blob/0d057e543013c79e20abb000df19bc16d286b777/pkg/util/validation/validation.go#L205
+ */
+const DNS_SUBDOMAINS_NAME_REGEXP =
+  /^(?=.{1,253}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 // validate bearer tokens, used in K8s
 const JWT_TOKEN_REGEX = /^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-+/=]*)/gm;


### PR DESCRIPTION
Fixes: #712 

The current UI validation rules for the `Provider resource name` field are not aligned with Kubernetes DNS Subdomain Name standards: 

(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)

- The '.' character should be allowed
- Allow starting with an alphanumeric character.

This patch fixes the validation rules for this field.