### PR TITLE
Name validation should use k8s name rules

### DIFF
--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -107,9 +107,9 @@ export enum StepType {
 export const dnsLabelNameSchema = yup
   .string()
   .max(63)
-  .matches(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/, {
+  .matches(/^(?=.{1,253}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/, {
     message: ({ label }) =>
-      `${label} can only contain lowercase alphanumeric characters and dashes (-), and must start and end with an alphanumeric character`,
+      `${label} can only contain lowercase alphanumeric characters, dashes and dots, and must start and end with an alphanumeric character, see k8s documentation for more details.`,
     excludeEmptyString: true,
   });
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/714

Issue:
The UI validation rules for the Plan/NetworkMap/StorageMap names are not allow '.', it's not aligned with Kubernetes standards.

Fix:
Align with k8s standrd.

Screenshot:
Before:
![name-validation-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/b59b06dd-5689-4b01-b8e0-3f7ff8e1ff13)

After:
![name-validation-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f35db157-a460-4464-88fd-cae276d2b913)

Updated error message:
![name-validation-new-error](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/4a13aced-2bc3-4fd1-b582-255092bb0eba)
