### PR TITLE
Update validation text msg for the provider name field

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -97,7 +97,7 @@
   "Error: CA Certificate must be valid.": "Error: CA Certificate must be valid.",
   "Error: Fingerprint is required and must be valid.": "Error: Fingerprint is required and must be valid.",
   "Error: Insecure Skip Verify must be a boolean value.": "Error: Insecure Skip Verify must be a boolean value.",
-  "Error: Name is required and must be a unique and valid Kubernetes name.": "Error: Name is required and must be a unique and valid Kubernetes name.",
+  "Error: Name is required and must be a unique within a namespace and valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).": "Error: Name is required and must be a unique within a namespace and valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).",
   "Error: NFS mount end point should be in the form NFS_SERVER:EXPORTED_DIRECTORY, for example: 10.10.0.10:/ova.": "Error: NFS mount end point should be in the form NFS_SERVER:EXPORTED_DIRECTORY, for example: 10.10.0.10:/ova.",
   "Error: Password is required and must be valid.": "Error: Password is required and must be valid.",
   "Error: This field must be a boolean.": "Error: This field must be a boolean.",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -106,7 +106,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
               helperText={t('Unique Kubernetes resource name identifier')}
               validated={state.validation.name}
               helperTextInvalid={t(
-                'Error: Name is required and must be a unique and valid Kubernetes name.',
+                "Error: Name is required and must be a unique within a namespace and valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).",
               )}
             >
               <TextInput


### PR DESCRIPTION
A followup fix for:  https://github.com/kubev2v/forklift-console-plugin/issues/646
References: https://github.com/kubev2v/forklift-console-plugin/pull/713

Update the validation error message for the '`Provider resource name`' field to align with k8s rules.
This is following the [field validation fix](https://github.com/kubev2v/forklift-console-plugin/pull/713).