### PR TITLE
Update validation text msg for legacy name fields

### DIFF
--- a/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
+++ b/packages/legacy/src/Mappings/components/AddEditMappingModal.tsx
@@ -64,7 +64,7 @@ const useMappingFormState = (
   useFormState({
     name: useFormField(
       '',
-      getMappingNameSchema(mappingsQuery, mappingBeingEdited).label('Name').required()
+      getMappingNameSchema(mappingsQuery, mappingBeingEdited).label('Mapping Name').required()
     ),
     sourceProvider: useFormField<SourceInventoryProvider | null>(
       null,

--- a/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
@@ -67,7 +67,7 @@ export type PlanWizardMode = 'create' | 'edit' | 'duplicate';
 
 const useMappingFormState = (mappingsQuery: UseQueryResult<IKubeList<Mapping>>) => {
   const isSaveNewMapping = useFormField(false, yup.boolean().required());
-  const newMappingNameSchema = getMappingNameSchema(mappingsQuery, null).label('Name');
+  const newMappingNameSchema = getMappingNameSchema(mappingsQuery, null).label('Mapping Name');
   const isCreateMappingSelected = useFormField(false, yup.boolean().required());
   const selectedExistingMapping = useFormField<Mapping | null>(null, yup.mixed<Mapping | null>());
   const isPrefilled = useFormField(false, yup.boolean());

--- a/packages/legacy/src/common/constants.ts
+++ b/packages/legacy/src/common/constants.ts
@@ -106,10 +106,10 @@ export enum StepType {
 
 export const dnsLabelNameSchema = yup
   .string()
-  .max(63)
-  .matches(/^(?=.{1,253}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/, {
+  .max(253)
+  .matches(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/, {
     message: ({ label }) =>
-      `${label} can only contain lowercase alphanumeric characters, dashes and dots, and must start and end with an alphanumeric character, see k8s documentation for more details.`,
+      `${label} must be a valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).`,
     excludeEmptyString: true,
   });
 


### PR DESCRIPTION
A followup fix for: https://github.com/kubev2v/forklift-console-plugin/issues/646
References: https://github.com/kubev2v/forklift-console-plugin/pull/715

Update the validation error message for the '`mapping name`', '`plan name`' and '`namespace name`' fields (legacy code), to be aligned with k8s rules. 
This is a follow up for https://github.com/kubev2v/forklift-console-plugin/pull/715.