### PR TITLE
Handle incorrect inventory data in case of connectivity error between k8s and the provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -60,7 +60,7 @@ export const ProviderVirtualMachinesList: React.FC<ProviderVirtualMachinesListPr
   } = useProviderInventory<ProviderVirtualMachine[]>(inventoryOptions);
 
   const vmData: VmData[] =
-    !loading && !error && vms
+    !loading && !error && Array.isArray(vms)
       ? vms.map((vm) => ({
           vm,
           name: vm.name,


### PR DESCRIPTION
Steps to reproduce:
1. disrupt network connectivity between Forklift inventory and the provider i.e. by disabling VPN
2. enter provider details -> Virtual Machines
3. expected result: empty table. actual result: loading spinner followed by Console error page (below)
![Screenshot from 2023-09-08 16-00-25](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/6957db33-0c09-4ab1-9ea0-023059fce817)

Fixed by adding ` isArray()` check for received inventory data

@yaacov  please take a look if this needs to be backported - the code was moved as-it-is from previous location.