### PR TITLE
Hide chart for 251

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/ForkliftControllerDetailsTab.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/ForkliftControllerDetailsTab.tsx
@@ -7,6 +7,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import { ChartsCard } from './cards/ChartsCard';
 import { ConditionsCard, MigrationsCard, OperatorCard, OverviewCard, SettingsCard } from './cards';
 
+/**
+ * Due to QE capacity we will hide the chart in 2.5.1
+ */
+const HIDE_FOR_2_5_1 = true;
+
 interface ForkliftControllerDetailsTabProps extends RouteComponentProps {
   obj: V1beta1ForkliftController;
   ns?: string;
@@ -44,9 +49,11 @@ export const ForkliftControllerDetailsTab: React.FC<ForkliftControllerDetailsTab
             <SettingsCard obj={obj} />
           </FlexItem>
 
-          <FlexItem>
-            <ChartsCard obj={obj} />
-          </FlexItem>
+          {!HIDE_FOR_2_5_1 && (
+            <FlexItem>
+              <ChartsCard obj={obj} />
+            </FlexItem>
+          )}
         </Flex>
       </Flex>
     </div>


### PR DESCRIPTION
Issue:
In 2.5.1 we will not be able to run QE tests on the overview chart

This PR hide it for the 2.5.1 release, this flag will be removed in next release

Screenshot:
![hide-chart-for-251](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d785b7eb-ea61-4094-aa51-2b6b2bfa283f)
