### PR TITLE
Unhide the overview chart

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/ForkliftControllerDetailsTab.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/ForkliftControllerDetailsTab.tsx
@@ -7,11 +7,6 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import { ChartsCard } from './cards/ChartsCard';
 import { ConditionsCard, MigrationsCard, OperatorCard, OverviewCard, SettingsCard } from './cards';
 
-/**
- * Due to QE capacity we will hide the chart in 2.5.1
- */
-const HIDE_FOR_2_5_1 = true;
-
 interface ForkliftControllerDetailsTabProps extends RouteComponentProps {
   obj: V1beta1ForkliftController;
   ns?: string;
@@ -49,11 +44,9 @@ export const ForkliftControllerDetailsTab: React.FC<ForkliftControllerDetailsTab
             <SettingsCard obj={obj} />
           </FlexItem>
 
-          {!HIDE_FOR_2_5_1 && (
-            <FlexItem>
-              <ChartsCard obj={obj} />
-            </FlexItem>
-          )}
+          <FlexItem>
+            <ChartsCard obj={obj} />
+          </FlexItem>
         </Flex>
       </Flex>
     </div>


### PR DESCRIPTION
In https://github.com/kubev2v/forklift-console-plugin/pull/731 we hide the chart for v2.5.1, this PR un hide it.

Screenshot:
![unhidechart](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0bafd471-c4e6-44ef-9464-84d967328138)
