### PR TITLE
Add region and project fields to the OpenStack Credentials view page

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenstackCredentialsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenstackCredentialsList.tsx
@@ -64,6 +64,10 @@ export const OpenstackCredentialsList: React.FC<ListComponentProps> = ({ secret,
         label: t('Project ID'),
         description: t('OpenStack project ID for token credentials.'),
       },
+      regionName: {
+        label: t('Region'),
+        description: t('OpenStack region.'),
+      },
       insecureSkipVerify: {
         label: t('Skip certificate validation'),
         description: t("If true, the provider's REST API TLS certificate won't be validated."),
@@ -88,6 +92,10 @@ export const OpenstackCredentialsList: React.FC<ListComponentProps> = ({ secret,
       username: {
         label: t('Username'),
         description: t('OpenStack REST API user name.'),
+      },
+      regionName: {
+        label: t('Region'),
+        description: t('OpenStack region.'),
       },
       projectName: {
         label: t('Project'),
@@ -122,6 +130,14 @@ export const OpenstackCredentialsList: React.FC<ListComponentProps> = ({ secret,
         label: t('Application credential secret'),
         description: t('OpenStack REST API application credential secret.'),
       },
+      regionName: {
+        label: t('Region'),
+        description: t('OpenStack region.'),
+      },
+      projectName: {
+        label: t('Project'),
+        description: t('OpenStack project.'),
+      },
       insecureSkipVerify: {
         label: t('Skip certificate validation'),
         description: t("If true, the provider's REST API TLS certificate won't be validated."),
@@ -150,6 +166,14 @@ export const OpenstackCredentialsList: React.FC<ListComponentProps> = ({ secret,
       username: {
         label: t('Username'),
         description: t('OpenStack REST API user name.'),
+      },
+      regionName: {
+        label: t('Region'),
+        description: t('OpenStack region.'),
+      },
+      projectName: {
+        label: t('Project'),
+        description: t('OpenStack project.'),
       },
       domainName: {
         label: t('Domain'),


### PR DESCRIPTION
Reference:  https://issues.redhat.com/browse/MTV-709

As a followup to https://github.com/kubev2v/forklift-console-plugin/pull/730, need to add the Region and Project fields to the OpenStack `Credentials view` mode dialog as well (in addition to `Create Provider` and `edit Credentials` dialogs that were handled in #730).

Screenshot before the fix:
![image](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/8af9d14d-b156-4ea2-a124-31777223a70b)

Screenshot after the fix:
![image](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/388b9b5d-6551-4fab-8d4d-8db92048790c)
