### PR TITLE
Remove concerns prop from OpenshiftVM

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
@@ -22,19 +22,6 @@ const openShiftVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
     sortable: true,
   },
   {
-    resourceFieldId: 'concerns',
-    jsonPath: '$.concerns',
-    label: t('Concerns'),
-    isVisible: true,
-    sortable: true,
-    filter: {
-      type: 'enum',
-      primary: true,
-      placeholderLabel: t('Concerns'),
-      values: EnumToTuple({ Critical: 'Critical', Warning: 'Warning', Information: 'Information' }),
-    },
-  },
-  {
     resourceFieldId: 'status',
     jsonPath: (data: VmData) => getVmPowerState(data?.vm),
     label: t('Status'),

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -4,11 +4,10 @@ import { ResourceField, RowProps } from '@kubev2v/common';
 import { Td, Tr } from '@patternfly/react-table';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
-import { VMCellProps, VMConcernsCellRenderer, VmData, VMNameCellRenderer } from './components';
+import { VMCellProps, VmData, VMNameCellRenderer } from './components';
 
 const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   name: VMNameCellRenderer,
-  concerns: VMConcernsCellRenderer,
   status: PowerStateCellRenderer,
 };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMConcernsCellRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMConcernsCellRenderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TFunction } from 'react-i18next';
-import { TableCell } from 'src/modules/Providers/utils';
+import { TableCell, TableEmptyCell } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { Concern } from '@kubev2v/types';
@@ -20,6 +20,10 @@ import { VMCellProps } from './VMCellProps';
  * @returns {ReactElement} The rendered table cell.
  */
 export const VMConcernsCellRenderer: React.FC<VMCellProps> = ({ data }) => {
+  if (data?.vm?.providerType === 'openshift') {
+    return <TableEmptyCell />;
+  }
+
   const groupedConcerns = groupConcernsByCategory(data?.vm?.concerns);
 
   return (

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/helpers/getHighestPriorityConcern.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/helpers/getHighestPriorityConcern.ts
@@ -3,7 +3,7 @@ import { ProviderVirtualMachine } from '@kubev2v/types';
 type ConcernCategory = 'Critical' | 'Warning' | 'Information';
 
 export const getHighestPriorityConcern = (vm: ProviderVirtualMachine): ConcernCategory => {
-  if (!vm?.concerns) {
+  if (vm?.providerType === 'openshift' || !vm?.concerns) {
     return undefined;
   }
 

--- a/packages/types/src/types/provider/openshift/VM.ts
+++ b/packages/types/src/types/provider/openshift/VM.ts
@@ -1,10 +1,8 @@
 import { V1VirtualMachine } from '../../k8s/V1VirtualMachine';
-import { Concern } from '../base';
 
 import { TypedOpenshiftResource } from './TypedResource';
 
 // https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/web/ocp/vm.go
 export interface OpenshiftVM extends TypedOpenshiftResource {
-  concerns: Concern[];
   object: V1VirtualMachine;
 }


### PR DESCRIPTION
There is no validation for the OpenShift providers. The assumption is that migrations are done between clusters that have the same version of OpenShift and KubeVirt.

Reference-Url: https://github.com/kubev2v/forklift/blob/ea39abb9a03e788fd63af010e8d48944d38a1fbf/pkg/controller/provider/web/ocp/vm.go#L131