### PR TITLE
[MTV-712] bump msw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4430,15 +4430,15 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.9",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
-      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
       "dependencies": {
         "@open-draft/until": "^1.0.3",
         "@types/debug": "^4.1.7",
         "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
+        "headers-polyfill": "3.2.5",
         "outvariant": "^1.2.1",
         "strict-event-emitter": "^0.2.4",
         "web-encoding": "^1.1.5"
@@ -8036,9 +8036,9 @@
       "peer": true
     },
     "node_modules/@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -8332,9 +8332,9 @@
       "dev": true
     },
     "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.32.tgz",
+      "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "node_modules/@types/netmask": {
       "version": "1.0.30",
@@ -8951,9 +8951,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.9.tgz",
-      "integrity": "sha512-4VSbbcMoxc4KLjb1gs96SRmi7w4h1SF+fCoiK0XaQX62buCc1G5d0DC5bJ9xJBNPDSVCmIrcl8BiYxzjrqaaJA==",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -15747,9 +15747,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz",
-      "integrity": "sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -16005,9 +16005,9 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.1.2.tgz",
-      "integrity": "sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA=="
     },
     "node_modules/heimdalljs": {
       "version": "0.2.6",
@@ -20907,21 +20907,21 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.3.tgz",
-      "integrity": "sha512-Fqy/TaLKR32x4IkMwudJHJysBzVM/v/lSoMPS9f3QaHLOmb3xHN9YurSUnRt+2eEvNXLjVPij1wMBQtLmTbKsg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
+      "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
       "hasInstallScript": true,
       "dependencies": {
         "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
+        "@mswjs/interceptors": "^0.17.10",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "chalk": "^4.1.1",
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "3.2.5",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -20943,27 +20943,12 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.1.x"
+        "typescript": ">= 4.4.x <= 5.2.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/msw/node_modules/cliui": {
@@ -31500,7 +31485,7 @@
       "dependencies": {
         "harproxyserver": "^0.0.19",
         "luxon": "^3.3.0",
-        "msw": "^1.2.1"
+        "msw": "^1.3.2"
       },
       "devDependencies": {
         "@types/har-format": "^1.2.10"

--- a/packages/mocks/package.json
+++ b/packages/mocks/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "harproxyserver": "^0.0.19",
     "luxon": "^3.3.0",
-    "msw": "^1.2.1"
+    "msw": "^1.3.2"
   },
   "devDependencies": {
     "@types/har-format": "^1.2.10"


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/MTV-712

Issue:
msw uses old version of graphql

FIx:
update "msw": "^1.3.2"
forcing:
"graphql": "^16.8.1"

Fix in:
https://github.com/kubev2v/forklift-console-plugin/pull/758/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R20923