### PR TITLE
Render VM name as resource link for local cluster 

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -5,11 +5,12 @@ import { ResourceField, RowProps } from '@kubev2v/common';
 import { Td, Tr } from '@patternfly/react-table';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
-import { VMCellProps, VmData, VMNameCellRenderer } from './components';
+import { VmResourceLinkRenderer } from './components/VmResourceLinkRenderer';
+import { VMCellProps, VmData } from './components';
 import { getVmTemplate } from './utils';
 
 const cellRenderers: Record<string, React.FC<VMCellProps>> = {
-  name: VMNameCellRenderer,
+  name: VmResourceLinkRenderer,
   status: PowerStateCellRenderer,
   template: ({ data }) => <TableCell>{getVmTemplate(data?.vm)}</TableCell>,
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMCellProps.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMCellProps.ts
@@ -4,6 +4,7 @@ import { ProviderVirtualMachine } from '@kubev2v/types';
 export interface VmData {
   vm: ProviderVirtualMachine;
   name: string;
+  isProviderLocalTarget?: boolean;
 }
 
 export interface VMCellProps {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TableCell } from 'src/modules/Providers/utils';
+import { groupVersionKindForObj } from 'src/utils/resources';
+
+import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+
+import { VMCellProps } from './VMCellProps';
+import { VMNameCellRenderer } from './VMNameCellRenderer';
+
+export const VmResourceLinkRenderer: React.FC<VMCellProps> = (props) => {
+  const { name, isProviderLocalTarget, vm } = props.data;
+  if (vm.providerType === 'openshift' && isProviderLocalTarget) {
+    return (
+      <TableCell>
+        <ResourceLink
+          name={name}
+          groupVersionKind={groupVersionKindForObj(vm.object)}
+          namespace={vm.namespace}
+        />
+      </TableCell>
+    );
+  }
+
+  return <VMNameCellRenderer {...props} />;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
@@ -1,5 +1,6 @@
 import { useProviderInventory, UseProviderInventoryParams } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
+import { isProviderLocalTarget } from 'src/utils/resources';
 
 import { ProviderVirtualMachine } from '@kubev2v/types';
 
@@ -44,6 +45,7 @@ export const useInventoryVms = (
             providerType: provider?.spec?.type,
           } as ProviderVirtualMachine,
           name: vm.name,
+          isProviderLocalTarget: isProviderLocalTarget(validProvider),
         }))
       : [];
 

--- a/packages/forklift-console-plugin/src/utils/resources.ts
+++ b/packages/forklift-console-plugin/src/utils/resources.ts
@@ -69,3 +69,9 @@ export enum ResourceKind {
   Host = 'Host',
   Hook = 'Hook',
 }
+
+/**
+ * Can this provider be considered a local target provider?
+ */
+export const isProviderLocalTarget = (provider: V1beta1Provider): boolean =>
+  provider?.spec?.type === 'openshift' && (!provider?.spec?.url || provider?.spec?.url === '');

--- a/packages/mocks/src/definitions/basic/vms.mock.ts
+++ b/packages/mocks/src/definitions/basic/vms.mock.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @cspell/spellchecker */
 import { OpenshiftVM, OVirtVM, VSphereVM } from '@kubev2v/types';
 
+import { NAMESPACE_FORKLIFT } from '../utils';
+
 import { MOCK_DISK_ATTACHMENTS } from './disks.mock';
 import { MOCK_NICS } from './nicProfiles.mock';
 import {
@@ -376,7 +378,7 @@ export const MOCK_OPENSHIFT_VMS: { [uid in OpenshiftProviderIDs]: OpenshiftVM[] 
     // source: https://kubevirt.io/user-guide/virtual_machines/templates/
     {
       name: 'rheltinyvm',
-      namespace: '',
+      namespace: NAMESPACE_FORKLIFT,
       selfLink: `providers/openshift/${OPENSHIFT_HOST_UID}/vms/3dcaf3ec-6b51-4ca0-8345-6d61841731d7`,
       uid: '',
       version: '',
@@ -404,6 +406,7 @@ export const MOCK_OPENSHIFT_VMS: { [uid in OpenshiftProviderIDs]: OpenshiftVM[] 
             ['vm.kubevirt.io/template.version']: '0.11.3',
           },
           name: 'rheltinyvm',
+          namespace: NAMESPACE_FORKLIFT,
         },
         spec: {
           dataVolumeTemplates: [


### PR DESCRIPTION
VMs on local cluster:
![Screenshot from 2023-10-30 21-31-16](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/d75e6c68-0907-49eb-b62e-e7d4e96815b5)

Other VMs:
![Screenshot from 2023-10-30 21-14-44](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/f813d6a3-51fe-432d-a741-90e35b134883)
