### PR TITLE
Enhance EditModal to refresh the helperText field value based on validationHook result

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -178,7 +178,7 @@ export const EditModal: React.FC<EditModalProps> = ({
           label={label}
           labelIcon={LabelIcon}
           fieldId="modal-with-form-form-field"
-          helperText={helperText}
+          helperText={validation.helperText ? validation.helperText : helperText}
           helperTextInvalid={validation.helperText}
           validated={validation.validated}
         >


### PR DESCRIPTION
For Enable refreshing the displayed value of the `helperText` field of the `EditModal` component, based on the `ValidationResults` (e.g., success, warning), need to set it to the `validation.helperText` value instead of the constant `helperText` prop value.

If `validation.helperText` is set to an empty string `''` (in case of an initial state or for backward compatible use), then use the initial `helperText` prop as was done before this fix.