### PR TITLE
Add type-ahead search to GroupedEnumFilter

### DIFF
--- a/packages/common/src/components/Filter/SearchableGroupedEnumFilter.tsx
+++ b/packages/common/src/components/Filter/SearchableGroupedEnumFilter.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { GroupedEnumFilter } from './GroupedEnumFilter';
+import { FilterTypeProps } from './types';
+
+/**
+ * GroupedEnumFilter with inline search enabled.
+ */
+export const SearchableGroupedEnumFilter = (props: FilterTypeProps) => (
+  <GroupedEnumFilter {...props} hasInlineFilter={true} />
+);

--- a/packages/common/src/components/Filter/index.ts
+++ b/packages/common/src/components/Filter/index.ts
@@ -4,6 +4,7 @@ export * from './DateRangeFilter';
 export * from './EnumFilter';
 export * from './FreetextFilter';
 export * from './GroupedEnumFilter';
+export * from './SearchableGroupedEnumFilter';
 export * from './SwitchFilter';
 export * from './types';
 // @endindex

--- a/packages/common/src/components/Filter/types.ts
+++ b/packages/common/src/components/Filter/types.ts
@@ -44,3 +44,7 @@ export interface FilterTypeProps {
   /** Text that explains how to use the filter. */
   helperText?: string | React.ReactNode;
 }
+
+export interface InlineFilter {
+  hasInlineFilter?: boolean;
+}

--- a/packages/common/src/components/FilterGroup/matchers.ts
+++ b/packages/common/src/components/FilterGroup/matchers.ts
@@ -7,6 +7,7 @@ import {
   EnumFilter,
   FreetextFilter,
   GroupedEnumFilter,
+  SearchableGroupedEnumFilter,
   SwitchFilter,
 } from '../Filter';
 
@@ -103,6 +104,11 @@ const groupedEnumMatcher = {
   matchValue: enumMatcher.matchValue,
 };
 
+const searchableGroupedEnumMatcher = {
+  filterType: 'searchableGroupedEnum',
+  matchValue: enumMatcher.matchValue,
+};
+
 const dateMatcher = {
   filterType: 'date',
   matchValue: (value: string) => (filter: string) => areSameDayInUTCZero(value, filter),
@@ -122,6 +128,7 @@ export const defaultValueMatchers: ValueMatcher[] = [
   freetextMatcher,
   enumMatcher,
   groupedEnumMatcher,
+  searchableGroupedEnumMatcher,
   sliderMatcher,
   dateMatcher,
   dateRangeMatcher,
@@ -134,6 +141,7 @@ export const defaultSupportedFilters: Record<string, FilterRenderer> = {
   freetext: FreetextFilter,
   groupedEnum: GroupedEnumFilter,
   slider: SwitchFilter,
+  searchableGroupedEnum: SearchableGroupedEnumFilter,
 };
 
 /**


### PR DESCRIPTION
Depends on #777 

Reference-Url: http://v4-archive.patternfly.org/v4/demos/filters/design-guidelines/#type-ahead
Reference-Url: http://v4-archive.patternfly.org/v4/components/select/#grouped-checkbox-input-with-filtering

Example usage:
![Screenshot from 2023-11-10 15-48-36](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/97bf16bd-d42e-4f73-9a9e-7c545dfb4730)
