### PR TITLE
Set user-auth to disabled, default in newer images is now openshift

### DIFF
--- a/ci/yaml/okd-console-tls.yaml
+++ b/ci/yaml/okd-console-tls.yaml
@@ -79,6 +79,8 @@ spec:
           mountPath: /etc/ssl/certs/forklift-ca.crt
           subPath: ca.crt
         env:
+        - name: BRIDGE_USER_AUTH
+          value: disabled
         - name: BRIDGE_LISTEN
           value: "https://0.0.0.0:9000"
         - name: BRIDGE_TLS_CERT_FILE

--- a/ci/yaml/okd-console.yaml
+++ b/ci/yaml/okd-console.yaml
@@ -85,6 +85,8 @@ spec:
       - name: console
         image: quay.io/openshift/origin-console:latest
         env:
+        - name: BRIDGE_USER_AUTH
+          value: disabled
         - name: BRIDGE_PLUGINS
           value: forklift-console-plugin=http://forklift-console-plugin.konveyor-forklift.svc.cluster.local:8080
         - name: BRIDGE_PLUGIN_PROXY


### PR DESCRIPTION
Issue:
the user-auth command line argument has default value of "openshift" in some quay.io/openshift/origin-console images.

Fix:
instead of assuming default value is "disabled" set the user-auth manually to "disabled"