### PR TITLE
Make RowMapper optional for StandardPage

### DIFF
--- a/packages/common/src/components/TableView/DefaultHeader.tsx
+++ b/packages/common/src/components/TableView/DefaultHeader.tsx
@@ -11,11 +11,11 @@ import { TableViewHeaderProps } from './types';
  * [<img src="static/media/src/components-stories/assets/github-logo.svg"><i class="fi fi-brands-github"></i>
  * <font color="green">View component source on GitHub</font>](https://github.com/kubev2v/forklift-console-plugin/blob/main/packages/common/src/components/TableView/DefaultHeader.tsx)
  */
-export const DefaultHeader = ({
+export function DefaultHeader<T>({
   visibleColumns,
   setActiveSort,
   activeSort,
-}: TableViewHeaderProps<unknown>) => {
+}: TableViewHeaderProps<T>) {
   return (
     <>
       {visibleColumns.map(({ resourceFieldId, label, sortable }, columnIndex) => (
@@ -36,4 +36,4 @@ export const DefaultHeader = ({
       ))}
     </>
   );
-};
+}

--- a/packages/common/src/components/TableView/DefaultRow.tsx
+++ b/packages/common/src/components/TableView/DefaultRow.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Td, Tr } from '@patternfly/react-table';
+
+import { getResourceFieldValue } from '../FilterGroup';
+
+import { RowProps } from './types';
+
+/**
+ * Renders the value for each field as string.
+ */
+export function DefaultRow<T>({ resourceFields, resourceData }: RowProps<T>) {
+  return (
+    <Tr>
+      {resourceFields?.map(({ resourceFieldId, label }) => (
+        <Td key={resourceFieldId} dataLabel={label}>
+          {String(getResourceFieldValue(resourceData, resourceFieldId, resourceFields) ?? '')}
+        </Td>
+      ))}
+    </Tr>
+  );
+}

--- a/packages/common/src/components/TableView/index.ts
+++ b/packages/common/src/components/TableView/index.ts
@@ -1,5 +1,6 @@
 // @index(['./*', /__/g], f => `export * from '${f.path}';`)
 export * from './DefaultHeader';
+export * from './DefaultRow';
 export * from './ManageColumnsModal';
 export * from './ManageColumnsToolbarItem';
 export * from './sort';

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo } from 'react';
+import React, { FC, ReactNode, useMemo } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
@@ -25,6 +25,7 @@ import {
 } from '@kubev2v/common';
 import { DefaultHeader, RowProps, TableView, TableViewHeaderProps, useSort } from '@kubev2v/common';
 import { ResourceField } from '@kubev2v/common';
+import { DefaultRow } from '@kubev2v/common';
 import {
   Level,
   LevelItem,
@@ -92,15 +93,16 @@ export interface StandardPageProps<T> {
    */
   namespace: string;
   /**
-   * Maps resourceData of type T to a table row.
+   * (optional) Maps resourceData of type T to a table row.
+   * Defaults to rendering values as strings.
    */
-  RowMapper: React.FunctionComponent<RowProps<T>>;
+  RowMapper?: FC<RowProps<T>>;
 
   /**
    * (optional) Maps field list to table header.
    * Defaults to all visible fields.
    */
-  HeaderMapper?: (props: TableViewHeaderProps<T>) => JSX.Element;
+  HeaderMapper?: FC<TableViewHeaderProps<T>>;
 
   /**
    * Filter types that will be used.
@@ -154,7 +156,7 @@ export interface StandardPageProps<T> {
   /**
    * Toolbar items with global actions.
    */
-  GlobalActionToolbarItems?: ((props: GlobalActionToolbarProps<T>) => JSX.Element)[];
+  GlobalActionToolbarItems?: FC<GlobalActionToolbarProps<T>>[];
 }
 
 /**
@@ -163,7 +165,7 @@ export interface StandardPageProps<T> {
 export function StandardPage<T>({
   namespace,
   dataSource: [flatData, loaded, error],
-  RowMapper,
+  RowMapper = DefaultRow<T>,
   title,
   addButton,
   fieldsMetadata,
@@ -174,7 +176,7 @@ export function StandardPage<T>({
   userSettings,
   filterPrefix = '',
   extraSupportedMatchers,
-  HeaderMapper = DefaultHeader,
+  HeaderMapper = DefaultHeader<T>,
   GlobalActionToolbarItems = [],
   alerts,
 }: StandardPageProps<T>) {


### PR DESCRIPTION
Fallback to default row mapper that renders all values as string.

Motivation:
1.  for simple pages custom mapper is an overhead
2. simplifies debugging row mapper related issues
3. prepares ground for adding cell-level mappers (follow-up PRs)

### Provider list with custom mapper
![Screenshot from 2023-12-07 15-55-43](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/6110146e-2f15-46b7-ac50-6bc13f40810d)


### Provider list with default row mapper
![Screenshot from 2023-12-07 15-56-12](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/e6a54bc7-f060-4e91-a239-255c9850cadc)
