### PR TITLE
Add CellMapper to StandardPage

### DIFF
--- a/packages/common/src/components/TableView/index.ts
+++ b/packages/common/src/components/TableView/index.ts
@@ -6,4 +6,5 @@ export * from './ManageColumnsToolbarItem';
 export * from './sort';
 export * from './TableView';
 export * from './types';
+export * from './withTr';
 // @endindex

--- a/packages/common/src/components/TableView/withTr.tsx
+++ b/packages/common/src/components/TableView/withTr.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Tr } from '@patternfly/react-table';
+
+import { RowProps } from './types';
+
+export function withTr<T>(Component: React.FC<RowProps<T>>) {
+  const Enhanced = (props: RowProps<T>) => (
+    <Tr>
+      <Component {...props} />
+    </Tr>
+  );
+  Enhanced.displayName = `${Component.displayName || 'Component'}WithTr`;
+  return Enhanced;
+}

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -4,28 +4,31 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import {
   AttributeValueFilter,
   createMetaMatcher,
+  DEFAULT_PER_PAGE,
+  DefaultHeader,
+  DefaultRow,
   defaultSupportedFilters,
   defaultValueMatchers,
+  ErrorState,
   FilterGroup,
   FilterRenderer,
   GlobalActionToolbarProps,
-  toFieldFilter,
-  useUrlFilters,
-  ValueMatcher,
-} from '@kubev2v/common';
-import {
-  DEFAULT_PER_PAGE,
-  ErrorState,
   Loading,
   NoResultsFound,
   NoResultsMatchFilter,
+  ResourceField,
+  RowProps,
+  TableView,
+  TableViewHeaderProps,
+  toFieldFilter,
   useFields,
   usePagination,
   UserSettings,
+  useSort,
+  useUrlFilters,
+  ValueMatcher,
+  withTr,
 } from '@kubev2v/common';
-import { DefaultHeader, RowProps, TableView, TableViewHeaderProps, useSort } from '@kubev2v/common';
-import { ResourceField } from '@kubev2v/common';
-import { DefaultRow } from '@kubev2v/common';
 import {
   Level,
   LevelItem,
@@ -99,6 +102,12 @@ export interface StandardPageProps<T> {
   RowMapper?: FC<RowProps<T>>;
 
   /**
+   * (optional) Maps entity to a list of cells (without wrapping them in <Tr>).
+   * If present, it is used instead of RowMapper.
+   */
+  CellMapper?: FC<RowProps<T>>;
+
+  /**
    * (optional) Maps field list to table header.
    * Defaults to all visible fields.
    */
@@ -166,6 +175,7 @@ export function StandardPage<T>({
   namespace,
   dataSource: [flatData, loaded, error],
   RowMapper = DefaultRow<T>,
+  CellMapper,
   title,
   addButton,
   fieldsMetadata,
@@ -298,7 +308,7 @@ export function StandardPage<T>({
           entities={showPagination ? pageData : filteredData}
           visibleColumns={fields.filter(({ isVisible, isHidden }) => isVisible && !isHidden)}
           aria-label={title}
-          Row={RowMapper}
+          Row={CellMapper ? withTr(CellMapper) : RowMapper}
           Header={HeaderMapper}
           activeSort={activeSort}
           setActiveSort={setActiveSort}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import { NameCellRenderer } from './components/NameCellRenderer';
 import { InventoryHostPair } from './utils/helpers';
@@ -12,31 +12,16 @@ import {
   NetworkCellRenderer,
 } from './components';
 
-export const VSphereHostsRow: React.FC<RowProps<InventoryHostPair>> = ({
+export const VSphereHostsCells: React.FC<RowProps<InventoryHostPair>> = ({
   resourceFields,
   resourceData,
-  isSelected,
-  toggleSelect,
-  resourceIndex: rowIndex,
 }) => {
   return (
-    <Tr>
-      {!!toggleSelect && (
-        <Td
-          select={{
-            rowIndex,
-            onSelect: toggleSelect,
-            isSelected,
-            disable:
-              resourceData?.inventory?.networkAdapters === undefined ||
-              resourceData?.inventory?.networkAdapters?.length === 0,
-          }}
-        />
-      )}
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
@@ -4,7 +4,7 @@ import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 
 import { concernFilter } from './utils/concernFilter';
 import { ProviderVirtualMachinesList, VmData } from './components';
-import { OVirtVirtualMachinesRow } from './OVirtVirtualMachinesRow';
+import { OVirtVirtualMachinesCells } from './OVirtVirtualMachinesRow';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 import { getVmPowerState } from './utils';
 
@@ -97,7 +97,7 @@ export const OVirtVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = 
     obj={obj}
     loaded={loaded}
     loadError={loadError}
-    rowMapper={OVirtVirtualMachinesRow}
+    cellMapper={OVirtVirtualMachinesCells}
     fieldsMetadataFactory={oVirtVmFieldsMetadataFactory}
     pageId="OVirtVirtualMachinesList"
   />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesRow.tsx
@@ -3,7 +3,7 @@ import { TableCell } from 'src/modules/Providers/utils';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { OVirtVM } from '@kubev2v/types';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
 import { VMCellProps, VMConcernsCellRenderer, VMNameCellRenderer } from './components';
@@ -41,15 +41,15 @@ const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   description: ({ data }) => <TableCell>{(data?.vm as OVirtVM)?.description}</TableCell>,
 };
 
-export const OVirtVirtualMachinesRow: React.FC<RowProps<VmData>> = ({
+export const OVirtVirtualMachinesCells: React.FC<RowProps<VmData>> = ({
   resourceFields,
   resourceData,
 }) => {
   return (
-    <Tr>
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
@@ -4,7 +4,7 @@ import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 
 import { toVmFeatureEnum } from './utils/helpers/toVmFeatureEnum';
 import { ProviderVirtualMachinesList, VmData } from './components';
-import { OpenShiftVirtualMachinesRow } from './OpenShiftVirtualMachinesRow';
+import { OpenShiftVirtualMachinesCells } from './OpenShiftVirtualMachinesRow';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 import { getOpenShiftFeatureMap, getVmPowerState } from './utils';
 
@@ -70,7 +70,7 @@ export const OpenShiftVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
     obj={obj}
     loaded={loaded}
     loadError={loadError}
-    rowMapper={OpenShiftVirtualMachinesRow}
+    cellMapper={OpenShiftVirtualMachinesCells}
     fieldsMetadataFactory={openShiftVmFieldsMetadataFactory}
     pageId="OpenShiftVirtualMachinesList"
   />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TableCell } from 'src/modules/Providers/utils';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
 import { VmResourceLinkRenderer } from './components/VmResourceLinkRenderer';
@@ -33,15 +33,15 @@ interface RenderTdProps {
   resourceFields: ResourceField[];
 }
 
-export const OpenShiftVirtualMachinesRow: React.FC<RowProps<VmData>> = ({
+export const OpenShiftVirtualMachinesCells: React.FC<RowProps<VmData>> = ({
   resourceFields,
   resourceData,
 }) => {
   return (
-    <Tr>
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
@@ -5,7 +5,7 @@ import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 import { concernFilter } from './utils/concernFilter';
 import { getVmPowerState } from './utils/helpers/getVmPowerState';
 import { ProviderVirtualMachinesList, VmData } from './components';
-import { OpenStackVirtualMachinesRow } from './OpenStackVirtualMachinesRow';
+import { OpenStackVirtualMachinesCells } from './OpenStackVirtualMachinesRow';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 
 export const openStackVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
@@ -113,7 +113,7 @@ export const OpenStackVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
     obj={obj}
     loaded={loaded}
     loadError={loadError}
-    rowMapper={OpenStackVirtualMachinesRow}
+    cellMapper={OpenStackVirtualMachinesCells}
     fieldsMetadataFactory={openStackVmFieldsMetadataFactory}
     pageId="OpenStackVirtualMachinesList"
   />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesRow.tsx
@@ -3,7 +3,7 @@ import { TableCell } from 'src/modules/Providers/utils';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { OpenstackVM } from '@kubev2v/types';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import { VMCellProps, VMConcernsCellRenderer, VmData, VMNameCellRenderer } from './components';
 
@@ -35,15 +35,15 @@ const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   flavorID: ({ data }) => <TableCell>{(data?.vm as OpenstackVM)?.flavorID}</TableCell>,
 };
 
-export const OpenStackVirtualMachinesRow: React.FC<RowProps<VmData>> = ({
+export const OpenStackVirtualMachinesCells: React.FC<RowProps<VmData>> = ({
   resourceFields,
   resourceData,
 }) => {
   return (
-    <Tr>
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
@@ -4,7 +4,7 @@ import { ResourceFieldFactory } from '@kubev2v/common';
 
 import { concernFilter } from './utils/concernFilter';
 import { ProviderVirtualMachinesList } from './components';
-import { OvaVirtualMachinesRow } from './OvaVirtualMachinesRow';
+import { OvaVirtualMachinesCells } from './OvaVirtualMachinesRow';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 
 export const ovaVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
@@ -51,7 +51,7 @@ export const OvaVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
     obj={obj}
     loaded={loaded}
     loadError={loadError}
-    rowMapper={OvaVirtualMachinesRow}
+    cellMapper={OvaVirtualMachinesCells}
     fieldsMetadataFactory={ovaVmFieldsMetadataFactory}
     pageId="OvaVirtualMachinesList"
   />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
@@ -3,7 +3,7 @@ import { TableCell } from 'src/modules/Providers/utils';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { OvaVM } from '@kubev2v/types';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import { VMCellProps, VMConcernsCellRenderer, VMNameCellRenderer } from './components';
 
@@ -35,15 +35,15 @@ const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   ovaPath: ({ data }) => <TableCell>{(data?.vm as OvaVM)?.OvaPath}</TableCell>,
 };
 
-export const OvaVirtualMachinesRow: React.FC<RowProps<VmData>> = ({
+export const OvaVirtualMachinesCells: React.FC<RowProps<VmData>> = ({
   resourceFields,
   resourceData,
 }) => {
   return (
-    <Tr>
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -6,7 +6,7 @@ import { concernFilter } from './utils/concernFilter';
 import { ProviderVirtualMachinesList, VmData } from './components';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 import { getVmPowerState } from './utils';
-import { VSphereVirtualMachinesRow } from './VSphereVirtualMachinesRow';
+import { VSphereVirtualMachinesCells } from './VSphereVirtualMachinesRow';
 
 export const vSphereVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
   {
@@ -85,7 +85,7 @@ export const VSphereVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> 
     obj={obj}
     loaded={loaded}
     loadError={loadError}
-    rowMapper={VSphereVirtualMachinesRow}
+    cellMapper={VSphereVirtualMachinesCells}
     fieldsMetadataFactory={vSphereVmFieldsMetadataFactory}
     pageId="VSphereVirtualMachinesList"
   />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesRow.tsx
@@ -3,7 +3,7 @@ import { TableCell } from 'src/modules/Providers/utils';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { VSphereVM } from '@kubev2v/types';
-import { Td, Tr } from '@patternfly/react-table';
+import { Td } from '@patternfly/react-table';
 
 import {
   PowerStateCellRenderer,
@@ -46,15 +46,15 @@ const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   powerState: PowerStateCellRenderer,
 };
 
-export const VSphereVirtualMachinesRow: React.FC<RowProps<VmData>> = ({
+export const VSphereVirtualMachinesCells: React.FC<RowProps<VmData>> = ({
   resourceFields,
   resourceData,
 }) => {
   return (
-    <Tr>
+    <>
       {resourceFields?.map(({ resourceFieldId }) =>
         renderTd({ resourceData, resourceFieldId, resourceFields }),
       )}
-    </Tr>
+    </>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { FC, useState } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import StandardPage from 'src/components/page/StandardPage';
 import { ProviderData } from 'src/modules/Providers/utils';
@@ -24,16 +24,16 @@ export interface ProviderVirtualMachinesListProps extends RouteComponentProps {
   name?: string;
   loaded?: boolean;
   loadError?: unknown;
-  rowMapper: React.FunctionComponent<RowProps<VmData>>;
+  cellMapper: FC<RowProps<VmData>>;
   fieldsMetadataFactory: ResourceFieldFactory;
   pageId: string;
 }
 
-export const ProviderVirtualMachinesList: React.FC<ProviderVirtualMachinesListProps> = ({
+export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> = ({
   obj,
   loaded,
   loadError,
-  rowMapper,
+  cellMapper,
   fieldsMetadataFactory,
   pageId,
 }) => {
@@ -47,7 +47,7 @@ export const ProviderVirtualMachinesList: React.FC<ProviderVirtualMachinesListPr
     <StandardPage<VmData>
       data-testid="vm-list"
       dataSource={[vmData || [], !loading, null]}
-      RowMapper={rowMapper}
+      CellMapper={cellMapper}
       fieldsMetadata={fieldsMetadataFactory(t)}
       namespace={obj?.provider?.metadata?.namespace}
       title={t('Virtual Machines')}


### PR DESCRIPTION
Depends on #794 

Switch to CellMapper in VM List pages and VSPhere Hosts List.

Cell mapper allows enhancing the row by adding cells before or after the
main content. Main use case is adding technical columns i.e. for
selection or with actions.
