### PR TITLE
Add 'createdForResource' label back to host secrets (backport)

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
@@ -129,7 +129,7 @@ async function processHostPair(
         namespace: provider.metadata.namespace,
         labels: {
           createdForResourceType: 'hosts',
-          createdForResource: createdHost.metadata.uid,
+          createdForResource: inventory.id,
         },
         ownerReferences: [
           {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
@@ -129,6 +129,7 @@ async function processHostPair(
         namespace: provider.metadata.namespace,
         labels: {
           createdForResourceType: 'hosts',
+          createdForResource: createdHost.metadata.uid,
         },
         ownerReferences: [
           {


### PR DESCRIPTION
Without this label, the validation webhook rejects the creation of Host objects, making it impossible to set the network of ESXi hosts to use for the migration.

This is a regression, see:
https://github.com/kubev2v/forklift-console-plugin/pull/466