### PR TITLE
Thanos and alert servers are now optional

### DIFF
--- a/ci/configure/openshift.sh
+++ b/ci/configure/openshift.sh
@@ -38,8 +38,6 @@ function setup_bridge_for_bearer_token () {
         echo "Setup for Openshift enviorment"
 
         # If we have oc tool and an Openshift token, assume we are connected to openshift
-        BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
-        BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
         BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=${BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT:=$(oc whoami --show-server)}
         BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
     else
@@ -63,8 +61,6 @@ function setup_bridge_for_openshift_oauth () {
         BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-dev"
         setup_oauth_client "$(pwd)/tmp"
 
-        BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}')
-        BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}')
         BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=${BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT:=$(oc whoami --show-server)}
     else
         echo "Please login to a cluster with 'oc' first"


### PR DESCRIPTION
Issue:
When starting a development server we assume OCP installs THANOS and ALERTMANAGER

This servers are no longer (OCP 4.14 and above) installed by default.

Fix:
Don't look for this services, our plugin do not use them.