### PR TITLE
Don't cache dev webserver, a workaround bridge bug

### DIFF
--- a/packages/forklift-console-plugin/webpack.config.ts
+++ b/packages/forklift-console-plugin/webpack.config.ts
@@ -158,6 +158,7 @@ const config: WebpackConfiguration & {
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
       'Access-Control-Allow-Headers': 'X-Requested-With, Content-Type, Authorization',
       'Service-Worker-Allowed': '/', // needed to support MockServiceWorker
+      'Cache-Control': 'no-store', // Jan-4-2024, workaround for a caching bug in bridge
     },
     devMiddleware: {
       writeToDisk: true,


### PR DESCRIPTION
Don't cache dev webserver, a workaround bridge bug

Issue:
Current images of bridge have a caching bug, no fix yet, this workaround is the recomended one in https://github.com/openshift/console-plugin-template until the bug is fixed.

Note:
**Can be safely remove after bridge is fixed**

Ref:
https://github.com/openshift/console-plugin-template/pull/56