### PR TITLE
Display resource icons for remote VMs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -7,28 +7,28 @@ import { Td } from '@patternfly/react-table';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
 import { withResourceLink } from './components/VmResourceLinkRenderer';
-import { VMCellProps, VmData, VmFeaturesCell, VMNameCellRenderer } from './components';
+import { VMCellProps, VmData, VmFeaturesCell } from './components';
 import { getVmTemplate } from './utils';
+
+const toNamespace = ({ data }: VMCellProps) =>
+  (data.vm.providerType === 'openshift' && data.vm.object?.metadata?.namespace) || '';
+
+const toGVK = ({ data }) =>
+  (data.vm.providerType === 'openshift' && groupVersionKindForObj(data.vm.object)) || {
+    version: '',
+    kind: '',
+  };
 
 const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   name: withResourceLink({
     toName: ({ data }) => data.name,
-    toGVK: ({ data }) =>
-      (data.vm.providerType === 'openshift' && groupVersionKindForObj(data.vm.object)) || {
-        version: '',
-        kind: '',
-      },
-    Component: VMNameCellRenderer,
+    toNamespace,
+    toGVK,
   }),
   possibly_remote_namespace: withResourceLink({
-    toName: ({ data }) =>
-      (data.vm.providerType === 'openshift' && data.vm.object?.metadata?.namespace) || '',
+    toName: toNamespace,
     toGVK: () => ({ kind: 'Namespace', version: 'v1', group: 'core' }),
-    Component: ({ data }: VMCellProps) => (
-      <TableCell>
-        {(data.vm.providerType === 'openshift' && data.vm.object?.metadata?.namespace) || ''}
-      </TableCell>
-    ),
+    toNamespace: () => '',
   }),
   status: PowerStateCellRenderer,
   template: ({ data }) => <TableCell>{getVmTemplate(data?.vm)}</TableCell>,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
@@ -7,29 +7,27 @@ import { VMCellProps } from './VMCellProps';
 
 export const withResourceLink = ({
   toName,
+  toNamespace,
   toGVK,
-  Component,
 }: {
   toName: (props: VMCellProps) => string;
+  toNamespace: (props: VMCellProps) => string;
   toGVK: (props: VMCellProps) => K8sGroupVersionKind;
-  Component: FC<VMCellProps>;
 }) => {
   const Enhanced: FC<VMCellProps> = (props: VMCellProps) => {
     const { isProviderLocalTarget, vm } = props.data;
-    if (vm.providerType === 'openshift' && isProviderLocalTarget) {
-      return (
-        <TableCell>
-          <ResourceLink
-            name={toName(props)}
-            groupVersionKind={toGVK(props)}
-            namespace={vm.namespace}
-          />
-        </TableCell>
-      );
-    }
-
-    return <Component {...props} />;
+    const isLocal = vm.providerType === 'openshift' && !isProviderLocalTarget;
+    return (
+      <TableCell>
+        <ResourceLink
+          name={toName(props)}
+          groupVersionKind={toGVK(props)}
+          namespace={toNamespace(props)}
+          linkTo={isLocal}
+        />
+      </TableCell>
+    );
   };
-  Enhanced.displayName = `${Component?.displayName ?? 'Component'}WithResourceLink`;
+  Enhanced.displayName = `CellWithResourceLink`;
   return Enhanced;
 };


### PR DESCRIPTION
### Before 
Name and namespace are plain text.

![Screenshot from 2024-01-04 11-02-16](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/ee444305-6e5d-4afb-8573-799375239395)

### After
The name and namespace look are not links but look similar to local VMs.

![Screenshot from 2024-01-05 16-38-25](https://github.com/kubev2v/forklift-console-plugin/assets/64194103/1485ad1b-405a-4f94-b39b-a430f2cf60a7)
