### PR TITLE
Fix errors showing vm list

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { TableCell } from 'src/modules/Providers/utils';
-import { groupVersionKindForObj } from 'src/utils/resources';
 
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { Td } from '@patternfly/react-table';
@@ -13,21 +12,15 @@ import { getVmTemplate } from './utils';
 const toNamespace = ({ data }: VMCellProps) =>
   (data.vm.providerType === 'openshift' && data.vm.object?.metadata?.namespace) || '';
 
-const toGVK = ({ data }) =>
-  (data.vm.providerType === 'openshift' && groupVersionKindForObj(data.vm.object)) || {
-    version: '',
-    kind: '',
-  };
-
 const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   name: withResourceLink({
     toName: ({ data }) => data.name,
     toNamespace,
-    toGVK,
+    toGVK: () => ({ kind: 'VirtualMachine', version: 'v1', group: 'kubevirt.io' }),
   }),
   possibly_remote_namespace: withResourceLink({
     toName: toNamespace,
-    toGVK: () => ({ kind: 'Namespace', version: 'v1', group: 'core' }),
+    toGVK: () => ({ kind: 'Namespace', version: 'v1', group: '' }),
     toNamespace: () => '',
   }),
   status: PowerStateCellRenderer,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMCellProps.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMCellProps.ts
@@ -4,7 +4,7 @@ import { ProviderVirtualMachine } from '@kubev2v/types';
 export interface VmData {
   vm: ProviderVirtualMachine;
   name: string;
-  isProviderLocalTarget?: boolean;
+  isProviderLocalOpenshift?: boolean;
 }
 
 export interface VMCellProps {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
@@ -15,15 +15,14 @@ export const withResourceLink = ({
   toGVK: (props: VMCellProps) => K8sGroupVersionKind;
 }) => {
   const Enhanced: FC<VMCellProps> = (props: VMCellProps) => {
-    const { isProviderLocalTarget, vm } = props.data;
-    const isLocal = vm.providerType === 'openshift' && !isProviderLocalTarget;
+    const { isProviderLocalOpenshift } = props.data;
     return (
       <TableCell>
         <ResourceLink
           name={toName(props)}
           groupVersionKind={toGVK(props)}
           namespace={toNamespace(props)}
-          linkTo={isLocal}
+          linkTo={isProviderLocalOpenshift}
         />
       </TableCell>
     );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
@@ -1,6 +1,6 @@
 import { useProviderInventory, UseProviderInventoryParams } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
-import { isProviderLocalTarget } from 'src/utils/resources';
+import { isProviderLocalOpenshift } from 'src/utils/resources';
 
 import { ProviderVirtualMachine } from '@kubev2v/types';
 
@@ -45,7 +45,7 @@ export const useInventoryVms = (
             providerType: provider?.spec?.type,
           } as ProviderVirtualMachine,
           name: vm.name,
-          isProviderLocalTarget: isProviderLocalTarget(validProvider),
+          isProviderLocalOpenshift: isProviderLocalOpenshift(validProvider),
         }))
       : [];
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer.ts
@@ -1,5 +1,5 @@
 import { Draft } from 'immer';
-import { isProviderLocalTarget } from 'src/utils/resources';
+import { isProviderLocalOpenshift } from 'src/utils/resources';
 import { v4 as randomId } from 'uuid';
 
 import { V1beta1Plan, V1beta1Provider } from '@kubev2v/types';
@@ -88,7 +88,7 @@ const actions: {
     ) {
       // set the default provider if none is set
       // reset the provider if provider was removed
-      const firstHostProvider = availableProviders.find((p) => isProviderLocalTarget(p));
+      const firstHostProvider = availableProviders.find((p) => isProviderLocalOpenshift(p));
       draft.newPlan.spec.provider.destination =
         firstHostProvider && getObjectRef(firstHostProvider);
       draft.newPlan.spec.targetNamespace = undefined;

--- a/packages/forklift-console-plugin/src/utils/resources.ts
+++ b/packages/forklift-console-plugin/src/utils/resources.ts
@@ -19,6 +19,10 @@ export const referenceFor = (group: string, version: string, kind: string) =>
  * @param  {K8sResourceCommon} obj
  */
 export const groupVersionKindForObj = (obj: K8sResourceCommon) => {
+  if (!obj?.apiVersion) {
+    return null;
+  }
+
   const [group, version] = obj.apiVersion.split('/');
   return { group, version, kind: obj.kind };
 };
@@ -73,5 +77,5 @@ export enum ResourceKind {
 /**
  * Can this provider be considered a local target provider?
  */
-export const isProviderLocalTarget = (provider: V1beta1Provider): boolean =>
+export const isProviderLocalOpenshift = (provider: V1beta1Provider): boolean =>
   provider?.spec?.type === 'openshift' && (!provider?.spec?.url || provider?.spec?.url === '');

--- a/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/GeneralForm.tsx
@@ -31,7 +31,7 @@ import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 import { usePausedPollingEffect } from 'legacy/src/common/context';
 import { isSameResource } from 'legacy/src/queries/helpers';
 import { PROVIDER_TYPE_NAMES } from 'legacy/src/common/constants';
-import { isProviderLocalTarget, checkIfOvirtInsecureProvider } from 'legacy/src/common/helpers';
+import { isProviderLocalOpenshift, checkIfOvirtInsecureProvider } from 'legacy/src/common/helpers';
 
 interface IGeneralFormProps {
   form: PlanWizardFormState['general'];
@@ -177,7 +177,7 @@ export const GeneralForm: React.FunctionComponent<IGeneralFormProps> = ({
               !isLocalTargetRequired &&
               nextLocalTargetRequired &&
               form.fields.targetProvider.value &&
-              !isProviderLocalTarget(form.fields.targetProvider.value.object)
+              !isProviderLocalOpenshift(form.fields.targetProvider.value.object)
             ) {
               form.fields.targetProvider.clear();
             }

--- a/packages/legacy/src/common/components/ProviderSelect.tsx
+++ b/packages/legacy/src/common/components/ProviderSelect.tsx
@@ -18,7 +18,7 @@ import {
   SelectProps,
 } from '@patternfly/react-core';
 import { ProviderType, PROVIDER_TYPE_NAMES } from '../constants';
-import { getAvailableProviderTypes, hasCondition, isProviderLocalTarget } from '../helpers';
+import { getAvailableProviderTypes, hasCondition, isProviderLocalOpenshift } from '../helpers';
 import { ConditionalTooltip } from './ConditionalTooltip';
 import { QuerySpinnerMode, ResolvedQueries } from './ResolvedQuery';
 
@@ -102,7 +102,8 @@ export const ProviderSelect: React.FunctionComponent<ProviderSelectProps> = ({
     const clusterProvider = option.value;
     const inventoryProvider = getMatchingInventoryProvider(clusterProvider);
 
-    const isProviderRemote = providerRole === 'target' && !isProviderLocalTarget(clusterProvider);
+    const isProviderRemote =
+      providerRole === 'target' && !isProviderLocalOpenshift(clusterProvider);
     const isReady =
       !!inventoryProvider && hasCondition(clusterProvider.status?.conditions || [], 'Ready');
 

--- a/packages/legacy/src/common/helpers.ts
+++ b/packages/legacy/src/common/helpers.ts
@@ -205,7 +205,7 @@ export function checkIfOvirtInsecureProvider(
 /**
  * Can this provider be considered a local target provider?
  */
-export const isProviderLocalTarget = (provider: IProviderObject): boolean =>
+export const isProviderLocalOpenshift = (provider: IProviderObject): boolean =>
   provider?.spec?.type === 'openshift' && (!provider?.spec?.url || provider?.spec?.url === '');
 
 export const getStorageTitle = (sourceProviderType: ProviderType, cap = false): string => {


### PR DESCRIPTION
Fix problems when showing vm list in providers details list:

a. vms `GVK` is always the same, no need to call a method
b. namespace group is ''
c. `isProviderLocalTarget` is testing specific for ''openshift, rename `isProviderLocalOpenshift` to be more concise 
d. `isLocal` is true if `isProviderLocalOpenshift`, not if `!isProviderLocalOpenshift`
e. `groupVersionKindForObj` is assuming `obj?.apiVersion` exist, add a sanity check

This improvements will help the stability of the vm list

Screenshots:
Before with full data:
![local-host-with-no-links](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/361488ea-f574-4f71-9b4a-b46ecf39b123)

Before with partial data:
![vms-list-error](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/18dea077-b53e-4dac-ac03-86e13a0d1396)


After:
![local-host-with-links](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/89f9ec6f-71ab-4286-85c7-14892cd7da00)
