### PR TITLE
:lady_beetle: Add margin under section headers

### DIFF
--- a/packages/forklift-console-plugin/src/components/headers/SectionHeading.tsx
+++ b/packages/forklift-console-plugin/src/components/headers/SectionHeading.tsx
@@ -1,0 +1,29 @@
+import React, { FC, ReactNode } from 'react';
+
+export interface SectionHeadingProps {
+  text: ReactNode;
+  className?: string;
+  id?: string;
+  'data-testid'?: string;
+}
+
+/**
+ * SectionHeading Component
+ *
+ * @param {SectionHeadingProps} props - Props for the component.
+ * @returns {ReactNode} - The rendered h2 element.
+ */
+export const SectionHeading: FC<SectionHeadingProps> = ({
+  children,
+  text,
+  className,
+  id,
+  'data-testid': dataTestid,
+}) => (
+  <h2 className={`co-section-heading ${className || ''}`} data-testid={dataTestid} id={id}>
+    <span>{text}</span>
+    {children}
+  </h2>
+);
+
+export default SectionHeading;

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -2,6 +2,7 @@ import React, { useReducer } from 'react';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { Base64 } from 'js-base64';
+import SectionHeading from 'src/components/headers/SectionHeading';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelRef, V1beta1Provider, V1Secret } from '@kubev2v/types';
@@ -14,7 +15,6 @@ import {
   HelperText,
   HelperTextItem,
   PageSection,
-  Title,
 } from '@patternfly/react-core';
 
 import { useK8sWatchProviderNames, useToggle } from '../../hooks';
@@ -218,7 +218,7 @@ export const ProvidersCreatePage: React.FC<{
   return (
     <div>
       <PageSection>
-        <Title headingLevel="h2">{t('Create Provider')}</Title>
+        <SectionHeading text={t('Create Provider')} />
 
         <HelperText className="forklift-create-subtitle">
           <HelperTextItem variant="default">

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import SectionHeading from 'src/components/headers/SectionHeading';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { PageSection, Title } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core';
 
 import { CredentialsSection } from '../../components';
 
@@ -27,9 +28,7 @@ export const ProviderCredentials: React.FC<ProviderCredentialsProps> = ({
   return (
     <div>
       <PageSection>
-        <Title headingLevel="h2" className="co-section-heading">
-          {t('Credentials')}
-        </Title>
+        <SectionHeading text={t('Credentials')} />
         <CredentialsSection data={obj} loaded={loaded} loadError={loadError} />
       </PageSection>
     </div>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { SectionHeading } from 'src/components/headers/SectionHeading';
 import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -11,7 +12,7 @@ import {
   V1beta1Provider,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { PageSection, Title } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core';
 
 import { ConditionsSection, DetailsSection, InventorySection } from '../../components';
 
@@ -34,23 +35,17 @@ export const ProviderDetails: React.FC<ProviderDetailsProps> = ({ obj, loaded, l
   return (
     <div>
       <PageSection>
-        <Title headingLevel="h2" className="co-section-heading">
-          {t('Provider details')}
-        </Title>
+        <SectionHeading text={t('Provider details')} />
         <DetailsSection data={obj} />
       </PageSection>
 
       <PageSection className="forklift-page-section">
-        <Title headingLevel="h2" className="co-section-heading">
-          {t('Provider inventory')}
-        </Title>
+        <SectionHeading text={t('Provider inventory')} />
         <InventorySection data={obj} />
       </PageSection>
 
       <PageSection className="forklift-page-section">
-        <Title headingLevel="h2" className="co-section-heading">
-          {t('Conditions')}
-        </Title>
+        <SectionHeading text={t('Conditions')} />
         <ConditionsSection conditions={provider?.status?.conditions} />
       </PageSection>
     </div>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import SectionHeading from 'src/components/headers/SectionHeading';
 import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
 import {
   EditProviderDefaultTransferNetwork,
@@ -17,7 +18,7 @@ import {
   V1beta1Provider,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Label, PageSection, Title } from '@patternfly/react-core';
+import { Button, Label, PageSection } from '@patternfly/react-core';
 import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 interface ProviderNetworksProps extends RouteComponentProps {
@@ -52,9 +53,7 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
   return (
     <div>
       <PageSection>
-        <Title headingLevel="h2" className="co-section-heading">
-          {t('NetworkAttachmentDefinitions')}
-        </Title>
+        <SectionHeading text={t('NetworkAttachmentDefinitions')} />
 
         {permissions.canPatch && (
           <div className="forklift-page-provider-networks-button">

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/ProvidersCreateVmMigrationPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/ProvidersCreateVmMigrationPage.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useEffect } from 'react';
 import { useHistory } from 'react-router';
+import SectionHeading from 'src/components/headers/SectionHeading';
 import { useForkliftTranslation } from 'src/utils/i18n';
 import { useImmerReducer } from 'use-immer';
 
 import { ProviderModelGroupVersionKind, ProviderModelRef, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Flex, FlexItem, PageSection, Title } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, PageSection } from '@patternfly/react-core';
 
 import { useToggle } from '../../hooks';
 import { getResourceUrl } from '../../utils';
@@ -63,7 +64,7 @@ const ProvidersCreateVmMigrationPage: FC<{
 
   return (
     <PageSection>
-      <Title headingLevel="h2">{t('Create Plan')}</Title>
+      <SectionHeading text={t('Create Plan')} />
 
       <PlansCreateForm state={state} dispatch={dispatch} />
 


### PR DESCRIPTION
Issue:
in console 4.15 we changed some css classes, one of them is the margin below a section header

Fix:
Add the missing margin by using `h2` instead of `Title`, wrap the `h2` in custom component to hide the not nice use of `h2`

Screenshots
Before:
![no-margin](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5e538c0b-0b8a-4ef1-884d-93d4409e43de)

After:
![with-margin](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/8b6beb52-6816-4f9e-a5f9-20cdc2f6ea5b)


