### PR TITLE
:lady_beetle: Set page section variant light

### DIFF
--- a/packages/common/src/components-stories/TableView/TableView.stories.tsx
+++ b/packages/common/src/components-stories/TableView/TableView.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof TableView> = {
             </LevelItem>
           </Level>
         </PageSection>
-        <PageSection>
+        <PageSection variant="light">
           <Story />
         </PageSection>
       </>

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -243,8 +243,8 @@ export function StandardPage<T>({
           {addButton && <LevelItem>{addButton}</LevelItem>}
         </Level>
       </PageSection>
-      {alerts && <PageSection>{alerts}</PageSection>}
-      <PageSection>
+      {alerts && <PageSection variant="light">{alerts}</PageSection>}
+      <PageSection variant="light">
         <Toolbar clearAllFilters={clearAllFilters} clearFiltersButtonText={t('Clear all filters')}>
           <ToolbarContent>
             <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">

--- a/packages/forklift-console-plugin/src/components/page/__tests__/__snapshots__/StandardPage.test.tsx.snap
+++ b/packages/forklift-console-plugin/src/components/page/__tests__/__snapshots__/StandardPage.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`empty result set returned, no filters  1`] = `
     </div>
   </section>
   <section
-    class="pf-c-page__main-section"
+    class="pf-c-page__main-section pf-m-light"
   >
     <div
       class="pf-c-toolbar"
@@ -259,7 +259,7 @@ exports[`single entry returned, both filters  1`] = `
     </div>
   </section>
   <section
-    class="pf-c-page__main-section"
+    class="pf-c-page__main-section pf-m-light"
   >
     <div
       class="pf-c-toolbar"

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
@@ -62,7 +62,9 @@ const HeaderTitleWrapper: React.FC = () => {
         status={<OperatorStatus status={phaseObj.phase} />}
       />
       {inventoryLivelinessError && (
-        <PageSection>{[<InventoryNotReachable key={'inventoryNotReachable'} />]}</PageSection>
+        <PageSection variant="light">
+          {[<InventoryNotReachable key={'inventoryNotReachable'} />]}
+        </PageSection>
       )}
     </>
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -217,7 +217,7 @@ export const ProvidersCreatePage: React.FC<{
 
   return (
     <div>
-      <PageSection>
+      <PageSection variant="light">
         <SectionHeading text={t('Create Provider')} />
 
         <HelperText className="forklift-create-subtitle">

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/ProviderPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/ProviderPageHeadings.tsx
@@ -73,7 +73,9 @@ export const ProviderPageHeadings: React.FC<{ name: string; namespace: string }>
         actions={<ProviderActionsDropdown data={data} fieldId={''} fields={[]} />}
       >
         {alerts && alerts.length > 0 && (
-          <PageSection className="forklift-page-headings-alerts">{alerts}</PageSection>
+          <PageSection variant="light" className="forklift-page-headings-alerts">
+            {alerts}
+          </PageSection>
         )}
       </PageHeadings>
     </>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Credentials/ProviderCredentials.tsx
@@ -27,7 +27,7 @@ export const ProviderCredentials: React.FC<ProviderCredentialsProps> = ({
 
   return (
     <div>
-      <PageSection>
+      <PageSection variant="light">
         <SectionHeading text={t('Credentials')} />
         <CredentialsSection data={obj} loaded={loaded} loadError={loadError} />
       </PageSection>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
@@ -34,17 +34,17 @@ export const ProviderDetails: React.FC<ProviderDetailsProps> = ({ obj, loaded, l
 
   return (
     <div>
-      <PageSection>
+      <PageSection variant="light">
         <SectionHeading text={t('Provider details')} />
         <DetailsSection data={obj} />
       </PageSection>
 
-      <PageSection className="forklift-page-section">
+      <PageSection variant="light" className="forklift-page-section">
         <SectionHeading text={t('Provider inventory')} />
         <InventorySection data={obj} />
       </PageSection>
 
-      <PageSection className="forklift-page-section">
+      <PageSection variant="light" className="forklift-page-section">
         <SectionHeading text={t('Conditions')} />
         <ConditionsSection conditions={provider?.status?.conditions} />
       </PageSection>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -52,7 +52,7 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
 
   return (
     <div>
-      <PageSection>
+      <PageSection variant="light">
         <SectionHeading text={t('NetworkAttachmentDefinitions')} />
 
         {permissions.canPatch && (

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/ProvidersCreateVmMigrationPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/ProvidersCreateVmMigrationPage.tsx
@@ -63,7 +63,7 @@ const ProvidersCreateVmMigrationPage: FC<{
   }
 
   return (
-    <PageSection>
+    <PageSection variant="light">
       <SectionHeading text={t('Create Plan')} />
 
       <PlansCreateForm state={state} dispatch={dispatch} />

--- a/packages/legacy/src/Mappings/MappingsPage.tsx
+++ b/packages/legacy/src/Mappings/MappingsPage.tsx
@@ -58,7 +58,7 @@ const MappingsPage: React.FunctionComponent = () => {
         </Tabs>
       </PageSection>
 
-      <PageSection>
+      <PageSection variant="light">
         <Mappings
           mappingType={MappingType[activeMapType]}
           key={activeMapType.toLowerCase()}

--- a/packages/legacy/src/Plans/PlansPage.tsx
+++ b/packages/legacy/src/Plans/PlansPage.tsx
@@ -37,7 +37,7 @@ export const PlansPage: React.FunctionComponent = () => {
       <PageSection variant="light">
         <Title headingLevel="h1">Migration plans</Title>
       </PageSection>
-      <PageSection>
+      <PageSection variant="light">
         <ResolvedQueries
           results={[
             sufficientProvidersQuery.result,

--- a/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
+++ b/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
@@ -368,7 +368,7 @@ export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps
         </Breadcrumb>
         <Title headingLevel="h1">Migration details by VM</Title>
       </PageSection>
-      <PageSection>
+      <PageSection variant="light">
         <ResolvedQueries
           results={[plansQuery, providersQuery, vmsQuery]}
           errorTitles={['Cannot load plan details', 'Cannot load providers', 'Cannot load VMs']}

--- a/packages/legacy/src/Providers/HostsPage.tsx
+++ b/packages/legacy/src/Providers/HostsPage.tsx
@@ -65,7 +65,7 @@ export const HostsPage: React.FunctionComponent<RouteComponentProps<IHostsMatchP
           </LevelItem>
         </Level>
       </PageSection>
-      <PageSection>
+      <PageSection variant="light">
         <ResolvedQueries
           results={[hostsQuery, providersQuery]}
           errorTitles={['Cannot load hosts', 'Cannot load providers']}

--- a/packages/legacy/src/Providers/ProvidersPage.tsx
+++ b/packages/legacy/src/Providers/ProvidersPage.tsx
@@ -138,7 +138,7 @@ export const ProvidersPage: React.FunctionComponent = () => {
           </Tabs>
         )}
       </PageSection>
-      <PageSection>
+      <PageSection variant="light">
         <ResolvedQueries results={allQueries} errorTitles={allErrorTitles} errorsInline={false}>
           {!clusterProvidersQuery.data ||
           !inventoryProvidersQuery.data ||


### PR DESCRIPTION
Issue:
in console 4.15 changed some css classes, one of them is setting default background to gray

Fix:
Set background implicitly to "light"

Screenshots:
Before:
![screenshot-localhost_9000-2024 01 17-21_33_07](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/15f3d146-556f-43e0-97cc-af902267a74b)

After:
![screenshot-localhost_9000-2024 01 17-21_28_35](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5ddc392f-cebc-4f0b-b4f5-f7d823e2b70c)

