### PR TITLE
Replace the data-test attribute to data-testid with a unique value

### DIFF
--- a/packages/common/src/components/LoadingDots/LoadingDots.tsx
+++ b/packages/common/src/components/LoadingDots/LoadingDots.tsx
@@ -34,7 +34,10 @@ export const LoadingDots = ({ delayInMs = 500 }: LoadingDotsProps) => {
 
   return (
     <div className="cos-status-box cos-status-box--loading loading-box loading-box__loading">
-      <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
+      <div
+        className="co-m-loader co-an-fade-in-out"
+        data-testid="loading-indicator-loading-dots-comp"
+      >
         <div className="co-m-loader-dot__one" />
         <div className="co-m-loader-dot__two" />
         <div className="co-m-loader-dot__three" />

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/YAML/ForkliftControllerYAMLTab.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/YAML/ForkliftControllerYAMLTab.tsx
@@ -36,7 +36,10 @@ export const ForkliftControllerYAMLTab: React.FC<ForkliftControllerYAMLTabProps>
 };
 
 const Loading: React.FC = () => (
-  <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
+  <div
+    className="co-m-loader co-an-fade-in-out"
+    data-testid="loading-indicator-forklift-controller-yaml"
+  >
     <div className="co-m-loader-dot__one" />
     <div className="co-m-loader-dot__two" />
     <div className="co-m-loader-dot__three" />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/NetworkCellRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/NetworkCellRenderer.tsx
@@ -48,7 +48,7 @@ export const NetworkCellRenderer: React.FC<HostCellProps> = (props) => {
         }
         bodyContent={<div>{hostStatus.message}</div>}
       >
-        <Button variant="link" isInline data-test="popover-status-button">
+        <Button variant="link" isInline data-testid="popover-status-button-host-network">
           {cellContent}
         </Button>
       </Popover>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/YAML/ProviderYAML.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/YAML/ProviderYAML.tsx
@@ -35,7 +35,7 @@ export const ProviderYAMLPage: React.FC<ProviderYAMLPageProps> = ({ obj, loaded,
 };
 
 const Loading: React.FC = () => (
-  <div className="co-m-loader co-an-fade-in-out" data-test="loading-indicator">
+  <div className="co-m-loader co-an-fade-in-out" data-testid="loading-indicator-provider-yaml">
     <div className="co-m-loader-dot__one" />
     <div className="co-m-loader-dot__two" />
     <div className="co-m-loader-dot__three" />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/StatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/StatusCell.tsx
@@ -84,7 +84,7 @@ export const ErrorStatusCell: React.FC<CellProps & { t: TFunction }> = ({ t, dat
       bodyContent={bodyContent && <Linkify>{bodyContent}</Linkify>}
       footerContent={footerContent}
     >
-      <Button variant="link" isInline data-test="popover-status-button">
+      <Button variant="link" isInline data-testid="popover-status-button-providers-list">
         <TableIconCell icon={statusIcons[phase]}>{phaseLabel}</TableIconCell>
       </Button>
     </Popover>


### PR DESCRIPTION
Reference: #837 

Replace the `data-test` attribute name for few components with the more recommended `data-testid` name and also replace the replaced attribute's values with a unique value.

This is required for identifying components well, as needed for automatic testing purposes.