### PR TITLE
:feet: Display the "x" icon in the Overview ShowWelcomeCardButton button

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/ShowWelcomeCardButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/ShowWelcomeCardButton.tsx
@@ -19,6 +19,10 @@ export const ShowWelcomeCardButton: React.FC = () => {
       onClick={() => {
         setData({ hideWelcomeCardByContext: false });
       }}
+      onClose={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
       style={{ cursor: 'pointer' }}
       data-testid="show-welcome-card"
     >


### PR DESCRIPTION
Reference: #800 

To be consistent with the appearance on the console `Home->Overview page`, display the "x" (close) icon in the `ShowWelcomeCardButton` button label. The `ShowWelcomeCardButton` button label appears in the Overview page when the Welcome card is hidden

Note: in comparing to the console `Home->Overview` page, the "x" action is disabled, so the button won't be closed/vanised as a result of clicking it.

### Screenshot
![Screenshot from 2024-01-23 18-38-48](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/d358e483-9ae3-470c-bfd8-7112b8369ab7)
