### PR TITLE
:lady_beetle:  Remove out of line help icon

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -318,7 +318,6 @@
   "Provider YAML": "Provider YAML",
   "Providers": "Providers",
   "Providers for virtualization": "Providers for virtualization",
-  "Read this introduction to help you get started with the Migration Toolkit for Virtualization (MTV).<br> <br>Note: This welcome card can be hidden at any time.": "Read this introduction to help you get started with the Migration Toolkit for Virtualization (MTV).<br> <br>Note: This welcome card can be hidden at any time.",
   "Ready": "Ready",
   "Reason": "Reason",
   "Region": "Region",

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/WelcomeCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/WelcomeCard.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 import { Trans } from 'react-i18next';
 import automationIcon from 'src/modules/Overview/images/automation.svg';
-import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { V1beta1ForkliftController } from '@kubev2v/types';
@@ -77,20 +76,6 @@ export const OverviewCard: FC<OverviewCardProps> = ({ onHide }) => {
           <SplitItem>
             <div className="forklift-welcome-header">
               <Text component={TextVariants.h3}>{t('Welcome')}&nbsp;&nbsp;</Text>
-              <DetailsItem
-                title={t('')}
-                helpContent={
-                  <Text>
-                    <Trans t={t} ns="plugin__forklift-console-plugin">
-                      {
-                        'Read this introduction to help you get started with the Migration Toolkit for Virtualization (MTV).<br> <br>Note: This welcome card can be hidden at any time.'
-                      }
-                    </Trans>
-                  </Text>
-                }
-                showHelpIconNextToTitle={true}
-                content={''}
-              />
             </div>
             <Text className="forklift-welcome-text">
               <Trans t={t} ns="plugin__forklift-console-plugin">


### PR DESCRIPTION
Issue:
The help icon for the welcome card is too high

Fix:
Remove the icon

Screenshot:
Before:
![icon-too-high](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/ece70be3-b645-4699-9e29-ad538a81cc70)


After:
![no-icon-too-high](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d4bcb402-b2c7-48a7-94e9-9a89e5176493)
