### PR TITLE
:soap: Refactor create actions list in overview card

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/WelcomeCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/WelcomeCard.tsx
@@ -48,12 +48,10 @@ const hideFromViewDropdownOption = (onHide: () => void, t) => {
 
 export const OverviewCard: FC<OverviewCardProps> = ({ onHide }) => {
   const { t } = useForkliftTranslation();
-  const actionDropdownItem: any[] = [];
-
   const [menuIsOpen, setMenuIsOpen] = React.useState(false);
-  const onToggle = () => setMenuIsOpen((open) => !open);
 
-  actionDropdownItem.push(hideFromViewDropdownOption(onHide, t));
+  const actionDropdownItems = [hideFromViewDropdownOption(onHide, t)];
+  const onToggle = () => setMenuIsOpen((open) => !open);
 
   return (
     <Card>
@@ -68,8 +66,8 @@ export const OverviewCard: FC<OverviewCardProps> = ({ onHide }) => {
                 isOpen={menuIsOpen}
                 isPlain
                 toggle={<KebabToggle onToggle={onToggle} data-testid="actions" />}
-                position="left"
-                dropdownItems={actionDropdownItem}
+                position="right"
+                dropdownItems={actionDropdownItems}
               />
             </CardActions>
             <CardTitle>{t('Welcome')}</CardTitle>


### PR DESCRIPTION
Some code styling cleanups:
  - [x] `actionDropdownItem` is created in one place, instead of define first and then push one new item
  - [x] don't use `any`
  - [x] rename actions list to plural
  - [x] align open menu to the right to open inside the card  