### PR TITLE
:lady_beetle: Add space between help text to input field when using Obj for TextInput.helperText

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.style.css
@@ -6,13 +6,16 @@
 .forklift-edit-modal-field-error-validation {
   color: var(--pf-c-form__helper-text--m-error--Color);
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
 
 .forklift-edit-modal-field-success-validation {
   color: var(--pf-c-form__helper-text--m-success--Color);
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
 
 .forklift-edit-modal-field-default-validation {
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
@@ -16,27 +16,27 @@ export const OpenshiftEditURLModal: React.FC<EditProviderURLModalProps> = (props
 
   const helperTextMsgs = {
     error: (
-      <span className="forklift-edit-modal-field-error-validation">
+      <div className="forklift-edit-modal-field-error-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           Error: The format of the provided URL is invalid. Ensure the URL includes a scheme, a
           domain name, and, optionally, a port. For example: {'<strong>'}
           https://api.&#8249;your-openshift-domain&#8250;:6443{'</strong>'}.
         </Trans>
-      </span>
+      </div>
     ),
     success: (
-      <span className="forklift-edit-modal-field-success-validation">
+      <div className="forklift-edit-modal-field-success-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           {'URL of the Openshift Virtualization API endpoint.'}
         </Trans>
-      </span>
+      </div>
     ),
     default: (
-      <span className="forklift-edit-modal-field-default-validation">
+      <div className="forklift-edit-modal-field-default-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           {'URL of the Openshift Virtualization API endpoint.'}
         </Trans>
-      </span>
+      </div>
     ),
   };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
@@ -17,13 +17,16 @@
 .forklift--create-provider-field-error-validation {
   color: var(--pf-c-form__helper-text--m-error--Color);
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
 
 .forklift--create-provider-field-success-validation {
   color: var(--pf-c-form__helper-text--m-success--Color);
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
 
 .forklift--create-provider-field-default-validation {
   font-size: small;
+  padding-top: var(--pf-c-form__helper-text--MarginTop);
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
@@ -21,31 +21,31 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
 
   const helperTextMsgs = {
     error: (
-      <span className="forklift--create-provider-field-error-validation">
+      <div className="forklift--create-provider-field-error-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           Error: The format of the provided URL is invalid. Ensure the URL is in the following
           format: {'<strong>'}ip_or_hostname_of_nfs_server:/nfs_path{'</strong>'}. For example:{' '}
           {'<strong>'}10.10.0.10:/ova{'</strong>'} .
         </Trans>
-      </span>
+      </div>
     ),
     success: (
-      <span className="forklift--create-provider-field-success-validation">
+      <div className="forklift--create-provider-field-success-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           URL of the NFS file share that serves the OVA. Ensure the URL is in the following format:{' '}
           {'<strong>'}ip_or_hostname_of_nfs_server:/nfs_path{'</strong>'}. For example: {'<strong>'}
           10.10.0.10:/ova{'</strong>'} .
         </Trans>
-      </span>
+      </div>
     ),
     default: (
-      <span className="forklift--create-provider-field-default-validation">
+      <div className="forklift--create-provider-field-default-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           URL of the NFS file share that serves the OVA. Ensure the URL is in the following format:{' '}
           {'<strong>'}ip_or_hostname_of_nfs_server:/nfs_path{'</strong>'}. For example: {'<strong>'}
           10.10.0.10:/ova{'</strong>'} .
         </Trans>
-      </span>
+      </div>
     ),
   };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -21,31 +21,31 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
 
   const helperTextMsgs = {
     error: (
-      <span className="forklift--create-provider-field-error-validation">
+      <div className="forklift--create-provider-field-error-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           Error: The format of the provided URL is invalid. Ensure the URL includes a scheme, a
           domain name, and, optionally, a port. For example: {'<strong>'}
           https://api.&#8249;your-openshift-domain&#8250;:6443{'</strong>'}.
         </Trans>
-      </span>
+      </div>
     ),
     success: (
-      <span className="forklift--create-provider-field-success-validation">
+      <div className="forklift--create-provider-field-success-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           {
             'URL of the Openshift Virtualization API endpoint. If both <strong>URL</strong> and <strong>Service account bearer token</strong> are left blank, the local OpenShift cluster is used.'
           }
         </Trans>
-      </span>
+      </div>
     ),
     default: (
-      <span className="forklift--create-provider-field-default-validation">
+      <div className="forklift--create-provider-field-default-validation">
         <Trans t={t} ns="plugin__forklift-console-plugin">
           {
             'URL of the Openshift Virtualization API endpoint. If both <strong>URL</strong> and <strong>Service account bearer token</strong> are left blank, the local OpenShift cluster is used.'
           }
         </Trans>
-      </span>
+      </div>
     ),
   };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
@@ -17,13 +17,16 @@
 .forklift-page-provider-field-error-validation {
     color: var(--pf-c-form__helper-text--m-error--Color);
     font-size: small;
+    padding-top: var(--pf-c-form__helper-text--MarginTop);
   }
 
   .forklift-page-provider-field-success-validation {
     color: var(--pf-c-form__helper-text--m-success--Color);
     font-size: small;
+    padding-top: var(--pf-c-form__helper-text--MarginTop);
   }
 
   .forklift-page-provider-field-default-validation {
     font-size: small;
+    padding-top: var(--pf-c-form__helper-text--MarginTop);
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenshiftCredentialsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/list/OpenshiftCredentialsList.tsx
@@ -17,13 +17,13 @@ export const OpenshiftCredentialsList: React.FC<ListComponentProps> = ({ secret,
     token: {
       label: t('Service account bearer token'),
       description: (
-        <span className="forklift-page-provider-field-default-validation">
+        <div className="forklift-page-provider-field-default-validation">
           <Trans t={t} ns="plugin__forklift-console-plugin">
             {
               'A service account token with cluster admin privileges, required for authenticating the connection to the API server.'
             }
           </Trans>
-        </span>
+        </div>
       ),
     },
   };


### PR DESCRIPTION
Reference: #646 

When using a React Obj for the TextInput.helperText instead of a String, the padding between the input field to the helper text field was removed.
Fix that by replacing the React Obj from Span to Div and by updating the CSS file.

### Few example screenshots
#### Before
![Screenshot from 2024-01-28 19-38-11](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/b6d534cd-c596-475b-a232-4ee16f2a44ee)

![Screenshot from 2024-01-28 19-37-51](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/1f7b3ca3-780f-4493-b82b-943182fda4ac)

#### After
![Screenshot from 2024-01-28 19-45-29](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/42f9c35b-b824-45f1-9016-2e40e9423bd6)
![Screenshot from 2024-01-28 19-45-04](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/21ba49e6-7afe-49d6-8247-1c9e60d5d1a0)

