### PR TITLE
:soap:  Move secret to a section

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -346,6 +346,7 @@
   "Secret": "Secret",
   "Secret failed to load, check if the secret exist.": "Secret failed to load, check if the secret exist.",
   "Secret is loading, please wait.": "Secret is loading, please wait.",
+  "Secrets": "Secrets",
   "Select migration network": "Select migration network",
   "Select provider type": "Select provider type",
   "Selected columns will be displayed in the table.": "Selected columns will be displayed in the table.",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenshiftDetailsSection.tsx
@@ -11,7 +11,6 @@ import {
   NameDetailsItem,
   NamespaceDetailsItem,
   OwnerDetailsItem,
-  SecretDetailsItem,
   TransferNetworkDetailsItem,
   TypeDetailsItem,
   URLDetailsItem,
@@ -49,15 +48,9 @@ export const OpenshiftDetailsSection: React.FC<DetailsSectionProps> = ({ data })
 
       <CreatedAtDetailsItem resource={provider} />
 
-      <SecretDetailsItem
-        resource={provider}
-        helpContent={`A Secret containing credentials and other confidential information.
-          Empty may be used for the host provider.`}
-      />
+      <TransferNetworkDetailsItem resource={provider} canPatch={permissions.canPatch} />
 
       <OwnerDetailsItem resource={provider} />
-
-      <TransferNetworkDetailsItem resource={provider} canPatch={permissions.canPatch} />
     </DescriptionList>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OpenstackDetailsSection.tsx
@@ -11,7 +11,6 @@ import {
   NameDetailsItem,
   NamespaceDetailsItem,
   OwnerDetailsItem,
-  SecretDetailsItem,
   TypeDetailsItem,
   URLDetailsItem,
 } from './components';
@@ -48,7 +47,7 @@ export const OpenstackDetailsSection: React.FC<DetailsSectionProps> = ({ data })
 
       <CreatedAtDetailsItem resource={provider} />
 
-      <SecretDetailsItem resource={provider} />
+      <DetailsItem title={''} content={''} />
 
       <OwnerDetailsItem resource={provider} />
     </DescriptionList>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/OvirtDetailsSection.tsx
@@ -11,7 +11,6 @@ import {
   NameDetailsItem,
   NamespaceDetailsItem,
   OwnerDetailsItem,
-  SecretDetailsItem,
   TypeDetailsItem,
   URLDetailsItem,
 } from './components';
@@ -48,7 +47,7 @@ export const OvirtDetailsSection: React.FC<DetailsSectionProps> = ({ data }) => 
 
       <CreatedAtDetailsItem resource={provider} />
 
-      <SecretDetailsItem resource={provider} />
+      <DetailsItem title={''} content={''} />
 
       <OwnerDetailsItem resource={provider} />
     </DescriptionList>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/VSphereDetailsSection.tsx
@@ -12,7 +12,6 @@ import {
   NameDetailsItem,
   NamespaceDetailsItem,
   OwnerDetailsItem,
-  SecretDetailsItem,
   TypeDetailsItem,
   URLDetailsItem,
   VDDKDetailsItem,
@@ -63,11 +62,9 @@ export const VSphereDetailsSection: React.FC<DetailsSectionProps> = ({ data }) =
 
       <CreatedAtDetailsItem resource={provider} />
 
-      <SecretDetailsItem resource={provider} />
+      <VDDKDetailsItem resource={provider} canPatch={permissions.canPatch} />
 
       <OwnerDetailsItem resource={provider} />
-
-      <VDDKDetailsItem resource={provider} canPatch={permissions.canPatch} />
     </DescriptionList>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/index.ts
@@ -5,7 +5,6 @@ export * from './NameDetailsItem';
 export * from './NamespaceDetailsItem';
 export * from './OwnerDetailsItem';
 export * from './ProviderDetailsItem';
-export * from './SecretDetailsItem';
 export * from './TransferNetworkDetailsItem';
 export * from './TypeDetailsItem';
 export * from './URLDetailsItem';

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/SecretsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/SecretsSection.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ProviderData } from 'src/modules/Providers/utils';
+
+import { DescriptionList } from '@patternfly/react-core';
+
+import { SecretDetailsItem } from './components';
+
+export const SecretsSection: React.FC<SecretsSectionProps> = (props) => {
+  const { provider } = props.data;
+
+  return (
+    <DescriptionList
+      isHorizontal
+      columnModifier={{
+        default: '2Col',
+      }}
+    >
+      <SecretDetailsItem resource={provider} />
+    </DescriptionList>
+  );
+};
+
+export type SecretsSectionProps = {
+  data: ProviderData;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/SecretDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/SecretDetailsItem.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
+import { V1beta1Provider } from '@kubev2v/types';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
 import { DetailsItem } from '../../../../../utils';
 
-import { ProviderDetailsItemProps } from './ProviderDetailsItem';
+export interface SecretDetailsItemProps {
+  resource: V1beta1Provider;
+  moreInfoLink?: string;
+  helpContent?: ReactNode;
+}
 
-export const SecretDetailsItem: React.FC<ProviderDetailsItemProps> = ({
+export const SecretDetailsItem: React.FC<SecretDetailsItemProps> = ({
   resource: provider,
   moreInfoLink,
   helpContent,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/components/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './SecretDetailsItem';
+// @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/SecretsSection/index.ts
@@ -1,0 +1,4 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './components';
+export * from './SecretsSection';
+// @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/index.ts
@@ -4,4 +4,5 @@ export * from './CredentialsSection';
 export * from './DetailsSection';
 export * from './InventorySection';
 export * from './ProviderPageHeadings';
+export * from './SecretsSection';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
@@ -14,7 +14,12 @@ import {
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection } from '@patternfly/react-core';
 
-import { ConditionsSection, DetailsSection, InventorySection } from '../../components';
+import {
+  ConditionsSection,
+  DetailsSection,
+  InventorySection,
+  SecretsSection,
+} from '../../components';
 
 interface ProviderDetailsProps extends RouteComponentProps {
   obj: ProviderData;
@@ -37,6 +42,11 @@ export const ProviderDetails: React.FC<ProviderDetailsProps> = ({ obj, loaded, l
       <PageSection variant="light">
         <SectionHeading text={t('Provider details')} />
         <DetailsSection data={obj} />
+      </PageSection>
+
+      <PageSection variant="light" className="forklift-page-section">
+        <SectionHeading text={t('Secrets')} />
+        <SecretsSection data={obj} />
       </PageSection>
 
       <PageSection variant="light" className="forklift-page-section">


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/835

In the details page, move the secrets details item to a secrets section, instead of the details section

Screenshots:
Before
![secret-before](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/7ad6b6a1-a114-4509-8f4c-bb14419bfb03)

After
![secret-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/240e6022-d64e-4cdb-9bc5-d93e6b4d7e26)
