### PR TITLE
:feet: Add sections to the provider create form

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
@@ -2,6 +2,11 @@
   padding-top: var(--pf-global--spacer--md);
 }
 
+.forklift-create-provider-edit-section-header {
+  padding-top: var(--pf-global--spacer--lg);
+  margin-bottom: 0;
+}
+
 .forklift--create-provider-edit-card-selected {
   min-width: 25%;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
   OpenshiftCredentialsEdit,
@@ -7,6 +8,7 @@ import {
   VSphereCredentialsEdit,
 } from '../../details';
 
+import { EditProviderSectionHeading } from './EditProviderSectionHeading';
 import { OpenshiftProviderFormCreate } from './OpenshiftProviderCreateForm';
 import { OpenstackProviderCreateForm } from './OpenstackProviderCreateForm';
 import { OVAProviderCreateForm } from './OVAProviderCreateForm';
@@ -20,11 +22,15 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
   onNewProviderChange,
   onNewSecretChange,
 }) => {
+  const { t } = useForkliftTranslation();
+
   switch (newProvider?.spec?.type) {
     case 'openstack':
       return (
         <>
           <OpenstackProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+
+          <EditProviderSectionHeading text={t('Provider credentials')} />
           <OpenstackCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
         </>
       );
@@ -32,6 +38,8 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
       return (
         <>
           <OpenshiftProviderFormCreate provider={newProvider} onChange={onNewProviderChange} />
+
+          <EditProviderSectionHeading text={t('Provider credentials')} />
           <OpenshiftCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
         </>
       );
@@ -39,6 +47,8 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
       return (
         <>
           <OvirtProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+
+          <EditProviderSectionHeading text={t('Provider credentials')} />
           <OvirtCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
         </>
       );
@@ -46,6 +56,8 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
       return (
         <>
           <VSphereProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+
+          <EditProviderSectionHeading text={t('Provider credentials')} />
           <VSphereCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
         </>
       );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProviderSectionHeading.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProviderSectionHeading.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SectionHeading from 'src/components/headers/SectionHeading';
+
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+
+/**
+ * `EditProviderSectionHeading` is a functional component that renders a section heading with a divider above it.
+ *
+ * @param {Object} props - The properties passed to the component.
+ * @param {string} props.text - The text to display as the section heading.
+ * @param {string} props.helpText - The text to display as the section description help text.
+ *
+ * @returns {React.ReactElement} The rendered JSX element.
+ */
+export const EditProviderSectionHeading: React.FC<EditProviderSectionHeadingProps> = ({
+  text,
+  helpText,
+}) => (
+  <>
+    <SectionHeading text={text} className="forklift-create-provider-edit-section-header" />
+
+    {helpText && (
+      <HelperText className="forklift-create-subtitle">
+        <HelperTextItem variant="default">{helpText}</HelperTextItem>
+      </HelperText>
+    )}
+  </>
+);
+
+export type EditProviderSectionHeadingProps = {
+  text: string;
+  helpText?: string;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -10,6 +10,7 @@ import { Flex, FlexItem, Form, FormGroup, TextInput } from '@patternfly/react-co
 
 import { EditProvider } from './EditProvider';
 import { providerCardItems } from './providerCardItems';
+import { EditProviderSectionHeading } from './EditProviderSectionHeading';
 export interface ProvidersCreateFormProps {
   newProvider: V1beta1Provider;
   newSecret: V1Secret;
@@ -73,6 +74,8 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
   return (
     <>
       <div className="forklift-create-provider-edit-section">
+        <EditProviderSectionHeading text={t('Provider details')} />
+
         <Form isWidthLimited className="forklift-section-secret-edit">
           <FormGroup label={t('Select provider type')} isRequired fieldId="type">
             {newProvider?.spec?.type ? (


### PR DESCRIPTION
When creating a new provider, make it clear that some information is provider details, while other is provider credentials

Screenshot:
Before:
![provider-create-no-sections](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f0126ab3-0832-426f-8b0e-4bea336755e3)

After:
![provider-create-sections](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/9196dc27-d3e4-4220-a319-1c08b09a1274)
