### PR TITLE
:soap: Use regular route instead of new route for the fast create form

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/dynamic-plugin.ts
@@ -1,9 +1,4 @@
-import {
-  PlanModel,
-  PlanModelGroupVersionKind,
-  ProviderModel,
-  ProviderModelGroupVersionKind,
-} from '@kubev2v/types';
+import { ProviderModel, ProviderModelGroupVersionKind } from '@kubev2v/types';
 import { EncodedExtension } from '@openshift/dynamic-plugin-sdk';
 import {
   ContextProvider,
@@ -12,6 +7,7 @@ import {
   ResourceDetailsPage,
   ResourceListPage,
   ResourceNSNavItem,
+  RoutePage,
 } from '@openshift-console/dynamic-plugin-sdk';
 import type { ConsolePluginMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack/lib/schema/plugin-package';
 
@@ -24,6 +20,9 @@ export const exposedModules: ConsolePluginMetadata['exposedModules'] = {
   ProvidersCreateVmMigrationPage:
     './modules/Providers/views/migrate/ProvidersCreateVmMigrationPage',
 };
+
+const plansListURL = '/k8s/ns/:ns/forklift.konveyor.io~v1beta1~Plan';
+const plansListURLAllNamespaces = '/k8s/all-namespaces/forklift.konveyor.io~v1beta1~Plan';
 
 export const extensions: EncodedExtension[] = [
   {
@@ -90,14 +89,15 @@ export const extensions: EncodedExtension[] = [
       },
     },
   } as EncodedExtension<ContextProvider>,
+
   {
-    type: 'console.resource/create',
+    type: 'console.page/route',
     properties: {
       component: {
         $codeRef: 'ProvidersCreateVmMigrationPage',
       },
-      model: PlanModelGroupVersionKind,
-      ...PlanModel,
+      path: [`${plansListURL}/fast-create`, `${plansListURLAllNamespaces}/fast-create`],
+      exact: false,
     },
-  } as EncodedExtension<CreateResource>,
+  } as EncodedExtension<RoutePage>,
 ];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
@@ -28,7 +28,7 @@ export const MigrationAction: FC<{
         variant="secondary"
         onClick={() => {
           setData({ selectedVms, provider });
-          history.push(`${planListURL}/~new`);
+          history.push(`${planListURL}/fast-create`);
         }}
         isDisabled={!selectedVms?.length}
       >


### PR DESCRIPTION
Issue:
The fast create form is not a "Create" from because it requires the source provider and vms.

Fix:
Change the route to reflect that the fast create is a regular form and not a "Create" page 