### PR TITLE
Add a fast Create Plan page - step 4

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/MappingList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/MappingList.tsx
@@ -35,7 +35,7 @@ interface MappingListProps {
   availableDestinations: string[];
   replaceMapping: (val: { current: Mapping; next: Mapping }) => void;
   deleteMapping: (mapping: Mapping) => void;
-  addMapping: (mapping: Mapping) => void;
+  addMapping: () => void;
   usedSourcesLabel: string;
   generalSourcesLabel: string;
   noSourcesLabel: string;
@@ -80,13 +80,7 @@ export const MappingList: FC<MappingListProps> = ({
         ))}
       </DataList>
       <Button
-        onClick={() =>
-          addMapping({
-            source: usedSources?.[0]?.label ?? generalSources?.[0]?.label,
-            // assume that the default exists and is first in the list
-            destination: availableDestinations?.[0],
-          })
-        }
+        onClick={addMapping}
         type="button"
         variant="link"
         isDisabled={allMapped || isDisabled}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/PlansCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/PlansCreateForm.tsx
@@ -34,6 +34,8 @@ import { DetailsItem, getIsTarget } from '../../utils';
 import { concernsMatcher, featuresMatcher, VmData } from '../details';
 
 import {
+  addNetworkMapping,
+  deleteNetworkMapping,
   PageAction,
   replaceNetworkMapping,
   replaceStorageMapping,
@@ -249,17 +251,17 @@ export const PlansCreateForm = ({
                     namespace={netMap.metadata?.namespace}
                     name={netMap.metadata?.name}
                     className="forklift-page-resource-link-in-description-item"
-                    linkTo={flow.netMapCreated}
+                    linkTo={false}
                   />
                 </span>
               </DescriptionListTerm>
               <DescriptionListDescription className="forklift-page-mapping-list">
                 <MappingList
-                  addMapping={(newMapping) => dispatch(replaceNetworkMapping({ next: newMapping }))}
+                  addMapping={() => dispatch(addNetworkMapping())}
                   replaceMapping={({ current, next }) =>
                     dispatch(replaceNetworkMapping({ current, next }))
                   }
-                  deleteMapping={(current) => dispatch(replaceNetworkMapping({ current }))}
+                  deleteMapping={(current) => dispatch(deleteNetworkMapping({ ...current }))}
                   availableDestinations={targetNetworks}
                   sources={sourceNetworks}
                   mappings={networkMappings}
@@ -279,17 +281,17 @@ export const PlansCreateForm = ({
                     namespace={storageMap.metadata?.namespace}
                     name={storageMap.metadata?.name}
                     className="forklift-page-resource-link-in-description-item"
-                    linkTo={flow.storageMapCreated}
+                    linkTo={false}
                   />
                 </span>
               </DescriptionListTerm>
               <DescriptionListDescription className="forklift-page-mapping-list">
                 <MappingList
-                  addMapping={(newMapping) => dispatch(replaceStorageMapping({ next: newMapping }))}
+                  addMapping={() => dispatch(addNetworkMapping())}
                   replaceMapping={({ current, next }) =>
                     dispatch(replaceStorageMapping({ current, next }))
                   }
-                  deleteMapping={(current) => dispatch(replaceStorageMapping({ current }))}
+                  deleteMapping={() => undefined}
                   availableDestinations={targetStorages}
                   sources={[]}
                   mappings={storageMappings}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/actions.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/actions.ts
@@ -24,12 +24,14 @@ export const SET_EXISTING_PLANS = 'SET_EXISTING_PLANS';
 export const SET_AVAILABLE_TARGET_NAMESPACES = 'SET_AVAILABLE_TARGET_NAMESPACES';
 export const REPLACE_NETWORK_MAPPING = 'REPLACE_NETWORK_MAPPING';
 export const REPLACE_STORAGE_MAPPING = 'REPLACE_STORAGE_MAPPING';
+export const ADD_NETWORK_MAPPING = 'ADD_NETWORK_MAPPING';
+export const DELETE_NETWORK_MAPPING = 'DELETE_NETWORK_MAPPING';
 export const SET_AVAILABLE_TARGET_NETWORKS = 'SET_AVAILABLE_TARGET_NETWORKS';
 export const SET_AVAILABLE_SOURCE_NETWORKS = 'SET_AVAILABLE_SOURCE_NETWORKS';
 export const SET_NICK_PROFILES = 'SET_NICK_PROFILES';
 export const SET_EXISTING_NET_MAPS = 'SET_EXISTING_NET_MAPS';
 export const START_CREATE = 'START_CREATE';
-export const SET_NET_MAP = 'SET_NET_MAP';
+export const SET_ERROR = 'SET_ERROR';
 
 export type CreateVmMigration =
   | typeof SET_NAME
@@ -40,13 +42,15 @@ export type CreateVmMigration =
   | typeof SET_EXISTING_PLANS
   | typeof SET_AVAILABLE_TARGET_NAMESPACES
   | typeof REPLACE_NETWORK_MAPPING
+  | typeof ADD_NETWORK_MAPPING
+  | typeof DELETE_NETWORK_MAPPING
   | typeof REPLACE_STORAGE_MAPPING
   | typeof SET_AVAILABLE_TARGET_NETWORKS
   | typeof SET_AVAILABLE_SOURCE_NETWORKS
   | typeof SET_NICK_PROFILES
   | typeof SET_EXISTING_NET_MAPS
   | typeof START_CREATE
-  | typeof SET_NET_MAP;
+  | typeof SET_ERROR;
 
 export interface PageAction<S, T> {
   type: S;
@@ -113,14 +117,13 @@ export interface PlanNickProfiles {
   error?: Error;
 }
 
-export interface PlanCrateNetMap {
-  netMap?: V1beta1NetworkMap;
-  error?: Error;
+export interface PlanError {
+  error: Error;
 }
 
 export interface PlanMapping {
-  current?: Mapping;
-  next?: Mapping;
+  current: Mapping;
+  next: Mapping;
 }
 
 // action creators
@@ -209,12 +212,25 @@ export const replaceStorageMapping = ({
   payload: { current, next },
 });
 
+export const addNetworkMapping = (): PageAction<CreateVmMigration, unknown> => ({
+  type: 'ADD_NETWORK_MAPPING',
+  payload: {},
+});
+
 export const replaceNetworkMapping = ({
   current,
   next,
 }: PlanMapping): PageAction<CreateVmMigration, PlanMapping> => ({
   type: 'REPLACE_NETWORK_MAPPING',
   payload: { current, next },
+});
+
+export const deleteNetworkMapping = ({
+  source,
+  destination,
+}: Mapping): PageAction<CreateVmMigration, Mapping> => ({
+  type: 'DELETE_NETWORK_MAPPING',
+  payload: { source, destination },
 });
 
 export const setAvailableTargetNetworks = (
@@ -249,10 +265,7 @@ export const startCreate = (): PageAction<CreateVmMigration, unknown> => ({
   payload: {},
 });
 
-export const setNetMap = ({
-  netMap,
-  error,
-}: PlanCrateNetMap): PageAction<CreateVmMigration, PlanCrateNetMap> => ({
-  type: 'SET_NET_MAP',
-  payload: { netMap, error },
+export const setError = (error: Error): PageAction<CreateVmMigration, PlanError> => ({
+  type: 'SET_ERROR',
+  payload: { error },
 });

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
@@ -1,0 +1,134 @@
+import { Dispatch, useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { useImmerReducer } from 'use-immer';
+
+import {
+  NetworkMapModelGroupVersionKind,
+  PlanModelGroupVersionKind,
+  ProviderModelGroupVersionKind,
+  ProviderModelRef,
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1Provider,
+} from '@kubev2v/types';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { useNamespaces } from '../../hooks/useNamespaces';
+import { useOpenShiftNetworks, useSourceNetworks } from '../../hooks/useNetworks';
+import { useNicProfiles } from '../../hooks/useNicProfiles';
+import { getResourceUrl } from '../../utils';
+
+import {
+  CreateVmMigration,
+  PageAction,
+  setAvailableProviders,
+  setAvailableSourceNetworks,
+  setAvailableTargetNamespaces,
+  setAvailableTargetNetworks,
+  setExistingNetMaps,
+  setExistingPlans,
+  setNicProfiles,
+} from './actions';
+import { useCreateVmMigrationData } from './ProvidersCreateVmMigrationContext';
+import { CreateVmMigrationPageState, reducer } from './reducer';
+import { createInitialState } from './stateHelpers';
+
+export const useFetchEffects = (): [
+  CreateVmMigrationPageState,
+  Dispatch<PageAction<CreateVmMigration, unknown>>,
+  boolean,
+] => {
+  const history = useHistory();
+
+  const { data: { selectedVms = [], provider: sourceProvider = undefined } = {} } =
+    useCreateVmMigrationData();
+  // error state - the page was entered directly without choosing the VMs
+  const emptyContext = !selectedVms?.length || !sourceProvider;
+  const namespace = sourceProvider?.metadata?.namespace ?? '';
+  // error recovery - redirect to provider list
+  useEffect(() => {
+    if (emptyContext) {
+      history.push(
+        getResourceUrl({
+          reference: ProviderModelRef,
+          namespace: namespace,
+        }),
+      );
+    }
+  }, [emptyContext]);
+
+  const [state, dispatch] = useImmerReducer(
+    reducer,
+    { namespace, sourceProvider, selectedVms },
+    createInitialState,
+  );
+  const {
+    workArea: { targetProvider },
+  } = state;
+
+  const [providers, providersLoaded, providerError] = useK8sWatchResource<V1beta1Provider[]>({
+    groupVersionKind: ProviderModelGroupVersionKind,
+    namespaced: true,
+    isList: true,
+    namespace,
+  });
+  useEffect(
+    () => dispatch(setAvailableProviders(providers, providersLoaded, providerError)),
+    [providers],
+  );
+
+  const [plans, plansLoaded, plansError] = useK8sWatchResource<V1beta1Plan[]>({
+    groupVersionKind: PlanModelGroupVersionKind,
+    namespaced: true,
+    isList: true,
+    namespace,
+  });
+  useEffect(
+    () => dispatch(setExistingPlans(plans, plansLoaded, plansError)),
+    [plans, plansLoaded, plansError],
+  );
+
+  const [netMaps, netMapsLoaded, netMapsError] = useK8sWatchResource<V1beta1NetworkMap[]>({
+    groupVersionKind: NetworkMapModelGroupVersionKind,
+    namespaced: true,
+    isList: true,
+    namespace,
+  });
+  useEffect(
+    () => dispatch(setExistingNetMaps(netMaps, netMapsLoaded, netMapsError)),
+    [netMaps, netMapsLoaded, netMapsError],
+  );
+
+  const [namespaces, nsLoading, nsError] = useNamespaces(targetProvider);
+  useEffect(
+    () => dispatch(setAvailableTargetNamespaces(namespaces, nsLoading, nsError)),
+    [namespaces, nsLoading, nsError],
+  );
+
+  const [targetNetworks, targetNetworksLoading, targetNetworksError] =
+    useOpenShiftNetworks(targetProvider);
+  useEffect(
+    () =>
+      dispatch(
+        setAvailableTargetNetworks(targetNetworks, targetNetworksLoading, targetNetworksError),
+      ),
+    [targetNetworks, targetNetworksLoading, targetNetworksError],
+  );
+
+  const [sourceNetworks, sourceNetworksLoading, sourceNetworksError] =
+    useSourceNetworks(sourceProvider);
+  useEffect(
+    () =>
+      dispatch(
+        setAvailableSourceNetworks(sourceNetworks, sourceNetworksLoading, sourceNetworksError),
+      ),
+    [sourceNetworks, sourceNetworksLoading, sourceNetworksError],
+  );
+
+  const [nicProfiles, nicProfilesLoading, nicProfilesError] = useNicProfiles(sourceProvider);
+  useEffect(
+    () => dispatch(setNicProfiles(nicProfiles, nicProfilesLoading, nicProfilesError)),
+    [nicProfiles, nicProfilesLoading, nicProfilesError],
+  );
+  return [state, dispatch, emptyContext];
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import { useHistory } from 'react-router';
+import { produce } from 'immer';
+
+import {
+  NetworkMapModel,
+  PlanModel,
+  PlanModelRef,
+  StorageMapModel,
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1StorageMap,
+} from '@kubev2v/types';
+import { k8sCreate, K8sModel, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getResourceUrl } from '../../utils';
+
+import { setError } from './actions';
+import { CreateVmMigrationPageState } from './reducer';
+import { getObjectRef } from './stateHelpers';
+
+const createStorage = (storageMap: V1beta1StorageMap) =>
+  k8sCreate({
+    model: StorageMapModel,
+    data: storageMap,
+  });
+
+const createNetwork = (netMap: V1beta1NetworkMap) =>
+  k8sCreate({
+    model: NetworkMapModel,
+    data: netMap,
+  });
+
+const createPlan = async (
+  plan: V1beta1Plan,
+  netMap: V1beta1NetworkMap,
+  storageMap: V1beta1StorageMap,
+) => {
+  const createdPlan = await k8sCreate({
+    model: PlanModel,
+    data: plan,
+  });
+  const ownerReferences = [getObjectRef(createdPlan)];
+  return [ownerReferences, netMap, storageMap];
+};
+
+const addOwnerRef = async (model: K8sModel, resource, ownerReferences) => {
+  return await k8sPatch({
+    model,
+    resource,
+    data: [
+      {
+        op: 'add',
+        path: '/metadata/ownerReferences',
+        value: ownerReferences,
+      },
+    ],
+  });
+};
+
+export const useSaveEffect = (state: CreateVmMigrationPageState, dispatch) => {
+  const history = useHistory();
+  const mounted = useRef(true);
+  useEffect(
+    () => () => {
+      mounted.current = false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const {
+      flow,
+      underConstruction: { plan, netMap, storageMap },
+    } = state;
+    if (!flow.editingDone || !mounted.current) {
+      return;
+    }
+
+    Promise.all([createStorage(storageMap), createNetwork(netMap)])
+      .then(([storageMap, netMap]) =>
+        createPlan(
+          produce(plan, (draft) => {
+            draft.spec.map.network = getObjectRef(netMap);
+            draft.spec.map.storage = getObjectRef(storageMap);
+          }),
+          netMap,
+          storageMap,
+        ),
+      )
+      .then(([ownerReferences, netMap, storageMap]) =>
+        Promise.all([
+          addOwnerRef(StorageMapModel, storageMap, ownerReferences),
+          addOwnerRef(NetworkMapModel, netMap, ownerReferences),
+        ]),
+      )
+      .then(
+        () =>
+          mounted.current &&
+          history.push(
+            getResourceUrl({
+              reference: PlanModelRef,
+              namespace: plan.metadata.namespace,
+              name: plan.metadata.name,
+            }),
+          ),
+      )
+      .catch((error) => mounted.current && dispatch(setError(error)));
+  }, [state.flow.editingDone, state.underConstruction.storageMap]);
+};


### PR DESCRIPTION
Implements #801 

Changes:
1. create plan flow implemented via promise chain (storage mapping is still empty)
2. move fetch/save effects to hooks
3. add loading indicator based on editDone/apiError flags
4. implement actions for adding/removing/replacing network mappings
5. use namespace from the source provider - follow-up after switching to RoutePage extension
