### PR TITLE
:lady_beetle:  VM list how to create info should be blue

### DIFF
--- a/packages/eslint-plugin/cspell.wordlist.txt
+++ b/packages/eslint-plugin/cspell.wordlist.txt
@@ -69,3 +69,10 @@ typeahead
 immer
 networkattachmentdefinitions
 nicprofiles
+bootable
+consistencygroup
+multiattach
+volumetypes
+storageclasses
+storageclass
+storagedomains

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/OVirtProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/OVirtProviderDetailsPage.tsx
@@ -7,7 +7,7 @@ import { ProviderPageHeadings } from './components';
 import {
   ProviderCredentialsWrapper,
   ProviderDetailsWrapper,
-  ProviderVirtualMachinesWrapper,
+  ProviderVirtualMachines,
   ProviderYAMLPageWrapper,
 } from './tabs';
 
@@ -37,7 +37,7 @@ export const OVirtProviderDetailsPage: React.FC<{ name: string; namespace: strin
     {
       href: 'vms',
       name: t('Virtual Machines'),
-      component: () => <ProviderVirtualMachinesWrapper name={name} namespace={namespace} />,
+      component: () => <ProviderVirtualMachines name={name} namespace={namespace} />,
     },
   ];
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/OpenStackProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/OpenStackProviderDetailsPage.tsx
@@ -7,7 +7,7 @@ import { ProviderPageHeadings } from './components';
 import {
   ProviderCredentialsWrapper,
   ProviderDetailsWrapper,
-  ProviderVirtualMachinesWrapper,
+  ProviderVirtualMachines,
   ProviderYAMLPageWrapper,
 } from './tabs';
 
@@ -37,7 +37,7 @@ export const OpenStackProviderDetailsPage: React.FC<{ name: string; namespace: s
     {
       href: 'vms',
       name: t('Virtual Machines'),
-      component: () => <ProviderVirtualMachinesWrapper name={name} namespace={namespace} />,
+      component: () => <ProviderVirtualMachines name={name} namespace={namespace} />,
     },
   ];
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/OpenshiftProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/OpenshiftProviderDetailsPage.tsx
@@ -8,7 +8,7 @@ import {
   ProviderCredentialsWrapper,
   ProviderDetailsWrapper,
   ProviderNetworksWrapper,
-  ProviderVirtualMachinesWrapper,
+  ProviderVirtualMachines,
   ProviderYAMLPageWrapper,
 } from './tabs';
 
@@ -38,7 +38,7 @@ export const OpenshiftProviderDetailsPage: React.FC<{ name: string; namespace: s
     {
       href: 'vms',
       name: t('Virtual Machines'),
-      component: () => <ProviderVirtualMachinesWrapper name={name} namespace={namespace} />,
+      component: () => <ProviderVirtualMachines name={name} namespace={namespace} />,
     },
     {
       href: 'networks',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/OvaProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/OvaProviderDetailsPage.tsx
@@ -4,11 +4,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
 
 import { ProviderPageHeadings } from './components';
-import {
-  ProviderDetailsWrapper,
-  ProviderVirtualMachinesWrapper,
-  ProviderYAMLPageWrapper,
-} from './tabs';
+import { ProviderDetailsWrapper, ProviderVirtualMachines, ProviderYAMLPageWrapper } from './tabs';
 
 // OvaProviderDetailsPage
 export const OvaProviderDetailsPage: React.FC<{ name: string; namespace: string }> = ({
@@ -31,7 +27,7 @@ export const OvaProviderDetailsPage: React.FC<{ name: string; namespace: string 
     {
       href: 'vms',
       name: t('Virtual Machines'),
-      component: () => <ProviderVirtualMachinesWrapper name={name} namespace={namespace} />,
+      component: () => <ProviderVirtualMachines name={name} namespace={namespace} />,
     },
   ];
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/VSphereProviderDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/VSphereProviderDetailsPage.tsx
@@ -8,7 +8,7 @@ import {
   ProviderCredentialsWrapper,
   ProviderDetailsWrapper,
   ProviderHostsWrapper,
-  ProviderVirtualMachinesWrapper,
+  ProviderVirtualMachines,
   ProviderYAMLPageWrapper,
 } from './tabs';
 
@@ -38,7 +38,7 @@ export const VSphereProviderDetailsPage: React.FC<{ name: string; namespace: str
     {
       href: 'vms',
       name: t('Virtual Machines'),
-      component: () => <ProviderVirtualMachinesWrapper name={name} namespace={namespace} />,
+      component: () => <ProviderVirtualMachines name={name} namespace={namespace} />,
     },
     {
       href: 'hosts',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
@@ -50,11 +50,7 @@ export const ProviderDetails: React.FC<ProviderDetailsProps> = ({ obj, loaded, l
   return (
     <div>
       <PageSection variant="light" className="forklift-page-section--info">
-        <Alert
-          customIcon={<BellIcon />}
-          variant="warning"
-          title={t('How to create a migration plan')}
-        >
+        <Alert customIcon={<BellIcon />} variant="info" title={t('How to create a migration plan')}>
           <Trans t={t} ns="plugin__forklift-console-plugin">
             To migrate virtual machines from <strong>{provider.metadata.name}</strong> provider,
             select the virtual machines to migrate from the list of available virtual machines

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
@@ -89,11 +89,13 @@ export const oVirtVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const OVirtVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
+  title,
   obj,
   loaded,
   loadError,
 }) => (
   <ProviderVirtualMachinesList
+    title={title}
     obj={obj}
     loaded={loaded}
     loadError={loadError}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
@@ -74,11 +74,13 @@ export const openShiftVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const OpenShiftVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
+  title,
   obj,
   loaded,
   loadError,
 }) => (
   <ProviderVirtualMachinesList
+    title={title}
     obj={obj}
     loaded={loaded}
     loadError={loadError}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
@@ -105,11 +105,13 @@ export const openStackVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const OpenStackVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
+  title,
   obj,
   loaded,
   loadError,
 }) => (
   <ProviderVirtualMachinesList
+    title={title}
     obj={obj}
     loaded={loaded}
     loadError={loadError}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
@@ -43,11 +43,13 @@ export const ovaVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const OvaVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
+  title,
   obj,
   loaded,
   loadError,
 }) => (
   <ProviderVirtualMachinesList
+    title={title}
     obj={obj}
     loaded={loaded}
     loadError={loadError}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -77,11 +77,13 @@ export const vSphereVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
 ];
 
 export const VSphereVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
+  title,
   obj,
   loaded,
   loadError,
 }) => (
   <ProviderVirtualMachinesList
+    title={title}
     obj={obj}
     loaded={loaded}
     loadError={loadError}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -1,5 +1,4 @@
 import React, { FC, useState } from 'react';
-import { Trans } from 'react-i18next';
 import { RouteComponentProps } from 'react-router-dom';
 import { GlobalActionWithSelection, withIdBasedSelection } from 'src/components/page/withSelection';
 import { ProviderData } from 'src/modules/Providers/utils';
@@ -14,8 +13,6 @@ import {
   ValueMatcher,
 } from '@kubev2v/common';
 import { Concern } from '@kubev2v/types';
-import { Alert, PageSection } from '@patternfly/react-core';
-import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 
 import { useInventoryVms } from '../utils/useInventoryVms';
 
@@ -23,9 +20,9 @@ import { MigrationAction } from './MigrationAction';
 import { VmData } from './VMCellProps';
 
 export interface ProviderVirtualMachinesListProps extends RouteComponentProps {
+  title?: string;
   obj: ProviderData;
   ns?: string;
-  name?: string;
   loaded?: boolean;
   loadError?: unknown;
   cellMapper: FC<RowProps<VmData>>;
@@ -41,6 +38,7 @@ const PageWithSelection = withIdBasedSelection<VmData>({
 });
 
 export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> = ({
+  title,
   obj,
   loaded,
   loadError,
@@ -65,37 +63,21 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   ];
 
   return (
-    <>
-      <PageSection variant="light" className="forklift-page-section--info">
-        <Alert
-          customIcon={<BellIcon />}
-          variant="warning"
-          title={t('How to create a migration plan')}
-        >
-          <Trans t={t} ns="plugin__forklift-console-plugin">
-            To migrate virtual machines from <strong>{obj?.provider.metadata.name}</strong>{' '}
-            provider, select the virtual machines to migrate from the list of available virtual
-            machines and click the <strong>Migrate</strong> button.
-          </Trans>
-        </Alert>
-      </PageSection>
-
-      <PageWithSelection
-        data-testid="vm-list"
-        dataSource={[vmData || [], !loading, null]}
-        CellMapper={cellMapper}
-        fieldsMetadata={fieldsMetadataFactory(t)}
-        namespace={obj?.provider?.metadata?.namespace}
-        title={t('Virtual Machines')}
-        userSettings={userSettings}
-        extraSupportedFilters={{
-          concerns: SearchableGroupedEnumFilter,
-          features: EnumFilter,
-        }}
-        extraSupportedMatchers={[concernsMatcher, featuresMatcher]}
-        GlobalActionToolbarItems={actions}
-      />
-    </>
+    <PageWithSelection
+      data-testid="vm-list"
+      dataSource={[vmData || [], !loading, null]}
+      CellMapper={cellMapper}
+      fieldsMetadata={fieldsMetadataFactory(t)}
+      namespace={obj?.provider?.metadata?.namespace}
+      title={title ?? t('Virtual Machines')}
+      userSettings={userSettings}
+      extraSupportedFilters={{
+        concerns: SearchableGroupedEnumFilter,
+        features: EnumFilter,
+      }}
+      extraSupportedMatchers={[concernsMatcher, featuresMatcher]}
+      GlobalActionToolbarItems={actions}
+    />
   );
 };
 


### PR DESCRIPTION
Issue:
The note about how to do migrations is an info (blue) and not warning (yellow)

Ref: https://github.com/kubev2v/forklift-console-plugin/issues/880

Fix:
make it blue

Screenshot:
Before:
![yellow](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/38f8f811-e678-41f5-940c-5652587b3f57)

After:
![blue](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/74a7ea89-2c82-4c02-afbf-89da17d8c2b2)
