### PR TITLE
:soap:  ocp resources use ids

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -30,8 +30,8 @@ export interface ProviderVirtualMachinesListProps extends RouteComponentProps {
   pageId: string;
 }
 
-export const toId = (item: VmData) =>
-  item.vm.providerType === 'openshift' ? item.vm.uid : item.vm.id;
+export const toId = (item: VmData) => item.vm.id;
+
 const PageWithSelection = withIdBasedSelection<VmData>({
   toId,
   canSelect: (item: VmData) => !!item,

--- a/packages/types/src/types/provider/openshift/Resource.ts
+++ b/packages/types/src/types/provider/openshift/Resource.ts
@@ -15,4 +15,6 @@ export interface OpenshiftResource {
   // self link.
   // SelfLink string `json:"selfLink"`
   selfLink: string;
+  // forklift ID
+  id: string;
 }


### PR DESCRIPTION
OCP resources include id field

FIx: add it to the types

Ref: https://github.com/kubev2v/forklift/blob/main/pkg/controller/provider/web/ocp/resource.go#L22C2-L23C33