### PR TITLE
Create a new Metrics tab - part 2

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.style.css
@@ -50,6 +50,6 @@
 }
 
 .forklift-status-migration-chart {
-  height: 60%;
-  width: 60%;
+  height: 90%;
+  width: 90%;
 }

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/ChartsCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/ChartsCard.tsx
@@ -154,19 +154,19 @@ export const ChartsCard: React.FC<MigrationsCardProps> = () => {
               { name: t('Succeeded'), symbol: { fill: chart_color_green_400.var } },
               { name: t('Failed'), symbol: { fill: chart_color_red_100.var } },
             ]}
-            legendPosition="bottom-left"
+            legendPosition="bottom"
             height={400}
-            width={450}
+            width={900}
             padding={{
               bottom: 75,
-              left: isDaysViewSelected ? 100 : 110,
+              left: 100,
               right: 100,
               top: 50,
             }}
           >
             <ChartAxis />
             <ChartAxis dependentAxis showGrid />
-            <ChartGroup offset={11} horizontal>
+            <ChartGroup offset={11} horizontal={false}>
               <ChartBar
                 data={migrationsDataPoints.total.map(({ dateLabel, value }) => ({
                   x: dateLabel,


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/799

Rotate the migration chart so that the time is set to x axis (horizontal) instead of previous y axis.

Note: the migration table card should still be redesign as part of the follow up tasks.

#### Screenshots

#### Before:
![Screenshot from 2024-02-06 20-03-09](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/4008d7a3-24f1-4165-82a0-daf6f471d393)
![Screenshot from 2024-02-06 20-03-40](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/5c499c3d-b435-4b9d-be8c-d1332c212081)


### After:
![Screenshot from 2024-02-06 20-05-19](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/15dd18a0-eebf-4195-ab1a-311ac40d0fca)


![Screenshot from 2024-02-06 20-05-00](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/8eb28556-261a-40c2-acd3-a4e68960efef)
