### PR TITLE
:soap: Rename the migrate button create migration plan

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -65,6 +65,7 @@
   "Create a migration plan and select VMs from the source provider for migration.": "Create a migration plan and select VMs from the source provider for migration.",
   "Create and edit": "Create and edit",
   "Create and start": "Create and start",
+  "Create migration plan": "Create migration plan",
   "Create NetworkMap": "Create NetworkMap",
   "Create new provider": "Create new provider",
   "Create plan": "Create plan",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
@@ -12,7 +12,8 @@ import { VmData } from './VMCellProps';
 export const MigrationAction: FC<{
   selectedVms: VmData[];
   provider: V1beta1Provider;
-}> = ({ selectedVms, provider }) => {
+  className?: string;
+}> = ({ selectedVms, provider, className }) => {
   const { t } = useForkliftTranslation();
   const history = useHistory();
   const namespace = provider?.metadata?.namespace;
@@ -23,16 +24,16 @@ export const MigrationAction: FC<{
   });
   const { setData } = useCreateVmMigrationData();
   return (
-    <ToolbarItem>
+    <ToolbarItem className={className}>
       <Button
-        variant="secondary"
+        variant="primary"
         onClick={() => {
           setData({ selectedVms, provider });
           history.push(`${planListURL}/fast-create`);
         }}
         isDisabled={!selectedVms?.length}
       >
-        {t('Migrate')}
+        {t('Create migration plan')}
       </Button>
     </ToolbarItem>
   );


### PR DESCRIPTION
Issue:
We will remove the "create and migrate" action from the create plan flow, users will only be able to create a plan, and not start a migration.

Fix:
Call the action "Create migration plan" instead of "migrate" to inform users we only create a plan, and not start a migration.

Screenshot:
Before:
![screenshot-localhost_9000-2024 02 06-23_35_27](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/50542b1e-c961-437b-bcff-bcf6699936c7)

After:
![screenshot-localhost_9000-2024 02 06-23_34_02](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/71105ff5-437e-4727-a168-d3dc2bbd683f)

