### PR TITLE
:feet: Update provider types

### DIFF
--- a/packages/eslint-plugin/cspell.wordlist.txt
+++ b/packages/eslint-plugin/cspell.wordlist.txt
@@ -76,3 +76,4 @@ volumetypes
 storageclasses
 storageclass
 storagedomains
+esxi

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphereProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphereProviderValidator.ts
@@ -6,6 +6,7 @@ export function vsphereProviderValidator(provider: V1beta1Provider) {
   const name = provider?.metadata?.name;
   const url = provider?.spec?.url || '';
   const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'] || '';
+  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
 
   if (!validateK8sName(name)) {
     return new Error('invalided kubernetes resource name');
@@ -17,6 +18,10 @@ export function vsphereProviderValidator(provider: V1beta1Provider) {
 
   if (vddkInitImage !== '' && !validateContainerImage(vddkInitImage)) {
     return new Error('invalided VDDK init image');
+  }
+
+  if (sdkEndpoint !== '' && !['vcenter', 'esxi'].includes(sdkEndpoint)) {
+    return new Error('invalided sdkEndpoint, can be vcenter or esxi');
   }
 
   return null;

--- a/packages/types/src/models/V1beta1PlanSpec.ts
+++ b/packages/types/src/models/V1beta1PlanSpec.ts
@@ -45,6 +45,14 @@ export interface V1beta1PlanSpec {
    * @required {false}
    */
   provider?: V1beta1PlanSpecProvider;
+
+  /** preserveClusterCpuModel
+   * Allow the perseverance of the cluster CPU model from oVirt provider.
+   *
+   * @required {false}
+   */
+  preserveClusterCpuModel?: boolean;
+
   /** targetNamespace
    * Target namespace.
    *

--- a/packages/types/src/types/secret/OVirtProviderSecret.ts
+++ b/packages/types/src/types/secret/OVirtProviderSecret.ts
@@ -34,11 +34,7 @@ export interface OVirtProviderSecret {
   /**
    * OVirt server cacerts, can be a linked list of multiple certifications.
    *
-   * NOTE: ATM cacert is not optional because
-   *       insecureSkipVerify is not implemented in our ovirt image-io client
-   *
    * Provider type: OVirt
-   * Conditions: Required if insecureSkipVerify is false
    * Validation Regexp:
    *    ssl public key: .*
    *

--- a/packages/types/src/types/secret/OpenShiftProviderSecret.ts
+++ b/packages/types/src/types/secret/OpenShiftProviderSecret.ts
@@ -20,4 +20,27 @@ export interface OpenShiftProviderSecret {
    * @memberof ProviderSecret
    */
   token: string;
+
+  /**
+   * OpenShift server cacerts, can be a linked list of multiple certifications.
+   *
+   * Provider type: OpenShift
+   * Validation Regexp:
+   *    ssl public key: .*
+   *
+   * @type {string}
+   * @memberof ProviderSecret
+   */
+  cacert?: string;
+
+  /**
+   * Indicate that the client can ignore certificate verification.
+   *
+   * Provider type: OpenShift
+   * Conditions: Optional
+   *
+   * @type {boolean}
+   * @memberof ProviderSecret
+   */
+  insecureSkipVerify?: boolean;
 }

--- a/packages/types/src/types/secret/OpenstackProviderSecret.ts
+++ b/packages/types/src/types/secret/OpenstackProviderSecret.ts
@@ -82,7 +82,6 @@ export interface OpenstackProviderSecret {
    * openstack server cacerts, can be a linked list of multiple certifications.
    *
    * Provider type: openstack
-   * Conditions: Required if insecureSkipVerify is false
    * Validation Regexp:
    *    ssl public key: .*
    *

--- a/packages/types/src/types/secret/VSphereProviderSecret.ts
+++ b/packages/types/src/types/secret/VSphereProviderSecret.ts
@@ -34,13 +34,25 @@ export interface VSphereProviderSecret {
   /**
    * Indicate that the client can ignore certificate verification.
    *
-   * Provider type: OVirt
+   * Provider type: VSphere
    * Conditions: Optional
    *
    * @type {boolean}
    * @memberof ProviderSecret
    */
   insecureSkipVerify?: boolean;
+
+  /**
+   * VSphere server cacerts, can be a linked list of multiple certifications.
+   *
+   * Provider type: VSphere
+   * Validation Regexp:
+   *    ssl public key: .*
+   *
+   * @type {string}
+   * @memberof ProviderSecret
+   */
+  cacert?: string;
 
   /**
    * VSphere server thumbprint


### PR DESCRIPTION
Update provider types

  - [x] Add `sdkEndpoint` to vsphere settings validation https://github.com/kubev2v/forklift-console-plugin/issues/765
  - [x] Add `preserveClusterCpuModel` to Plan spec https://github.com/kubev2v/forklift-console-plugin/issues/803
  - [x] Add  cacert and insecureSkipVerify to OCP provider https://github.com/kubev2v/forklift-console-plugin/issues/882
  - [x] Add cacert to vsphere provider  https://github.com/kubev2v/forklift-console-plugin/issues/827