### PR TITLE
:lady_beetle: Use validationState instead of validationMsg

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -49,11 +49,11 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
       if (id !== 'url') return;
 
       const trimmedUrl: string = value.toString().trim();
-      const validationMsg = validateOpenshiftURL(trimmedUrl);
+      const validationState = validateOpenshiftURL(trimmedUrl);
 
       dispatch({
         type: 'SET_FIELD_VALIDATED',
-        payload: { field: 'url', validationMsg },
+        payload: { field: 'url', validationState },
       });
 
       onChange({ ...provider, spec: { ...provider.spec, url: trimmedUrl } });


### PR DESCRIPTION
Issue:
`state` field name is `validationState` ,  in `OpenshiftProviderCreateForm.tsx` we set `validationMsg` instead, making `validationState` == `undefined`, and `Cannot read properties of undefined (reading 'type')`