### PR TITLE
:lady_beetle: Fix provider-and-secret validtion

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/validateOpenshiftURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/validateOpenshiftURL.ts
@@ -12,19 +12,19 @@ export const validateOpenshiftURL = (url: string | number): ValidationMsg => {
   if (trimmedUrl === '') {
     return {
       type: 'default',
-      msg: 'The URL of the Openshift Virtualization API endpoint, for example: https:example.com:6443 .',
+      msg: 'The URL of the Openshift Virtualization API endpoint, for example: https://example.com:6443 .',
     };
   }
 
   if (!isValidURL) {
     return {
       type: 'error',
-      msg: 'The URL is invalid. URL should include the schema, for example: https:example.com:6443 .',
+      msg: 'The URL is invalid. URL should include the schema, for example: https://example.com:6443 .',
     };
   }
 
   return {
     type: 'success',
-    msg: 'The URL of the Openshift Virtualization API endpoint, for example: https:example.com:6443 .',
+    msg: 'The URL of the Openshift Virtualization API endpoint, for example: https://example.com:6443 .',
   };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
@@ -21,7 +21,6 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
         'regionName',
         'projectName',
         'domainName',
-        'cacert',
         'insecureSkipVerify',
       ];
       break;
@@ -34,19 +33,11 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
           'regionName',
           'projectName',
           'domainName',
-          'cacert',
           'insecureSkipVerify',
         ];
       } else {
         requiredFields = ['token', 'userID', 'projectID', 'regionName'];
-        validateFields = [
-          'token',
-          'userID',
-          'projectID',
-          'regionName',
-          'cacert',
-          'insecureSkipVerify',
-        ];
+        validateFields = ['token', 'userID', 'projectID', 'regionName', 'insecureSkipVerify'];
       }
       break;
     case 'applicationcredential':
@@ -66,7 +57,6 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
           'regionName',
           'projectName',
           'domainName',
-          'cacert',
           'insecureSkipVerify',
         ];
       } else {
@@ -81,7 +71,6 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
           'applicationCredentialSecret',
           'regionName',
           'projectName',
-          'cacert',
           'insecureSkipVerify',
         ];
       }
@@ -94,6 +83,12 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
 
   if (missingRequiredFields.length > 0) {
     return { type: 'error', msg: `missing required fields [${missingRequiredFields.join(', ')}]` };
+  }
+
+  // Add ca cert validation if not insecureSkipVerify
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.['insecureSkipVerify'] || '');
+  if (insecureSkipVerify !== 'true') {
+    validateFields.push('cacert');
   }
 
   for (const id of validateFields) {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretValidator.ts
@@ -9,7 +9,13 @@ import { ovirtSecretFieldValidator } from './ovirtSecretFieldValidator';
 
 export function ovirtSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
   const requiredFields = ['user', 'password'];
-  const validateFields = ['user', 'password', 'insecureSkipVerify', 'cacert'];
+  const validateFields = ['user', 'password', 'insecureSkipVerify'];
+
+  // Add ca cert validation if not insecureSkipVerify
+  const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
+  if (insecureSkipVerify !== 'true') {
+    validateFields.push('cacert');
+  }
 
   const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
   if (missingRequiredFields.length > 0) {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
@@ -9,16 +9,29 @@ export function providerAndSecretValidator(
   provider: V1beta1Provider,
   secret: IoK8sApiCoreV1Secret,
 ): ValidationMsg {
+  const type = provider?.spec?.type || '';
+
+  const secretValidation = secretValidator(type, secret);
   const providerValidation = providerValidator(provider);
-  if (providerValidation) {
+
+  // Test for validation errors
+  if (providerValidation?.type === 'error') {
     return providerValidation;
   }
 
-  const type = provider?.spec?.type || '';
-  const secretValidation = secretValidator(type, secret);
-  if (secretValidation) {
+  if (secretValidation?.type === 'error') {
     return secretValidation;
   }
 
-  return null;
+  // Test for validation warning
+  if (providerValidation?.type === 'warning') {
+    return providerValidation;
+  }
+
+  if (secretValidation?.type === 'warning') {
+    return secretValidation;
+  }
+
+  // Return provider validation
+  return providerValidation;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereSecretValidator.ts
@@ -9,7 +9,13 @@ import { vsphereSecretFieldValidator } from './vsphereSecretFieldValidator';
 
 export function vsphereSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
   const requiredFields = ['user', 'password'];
-  const validateFields = ['user', 'password', 'insecureSkipVerify', 'cacert'];
+  const validateFields = ['user', 'password', 'insecureSkipVerify'];
+
+  // Add ca cert validation if not insecureSkipVerify
+  const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
+  if (insecureSkipVerify !== 'true') {
+    validateFields.push('cacert');
+  }
 
   const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
   if (missingRequiredFields.length > 0) {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -22,7 +22,7 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
     validation: {
       url: {
         type: 'default',
-        msg: 'The URL of the Openshift Virtualization API endpoint, for example: https:example.com:6443 .',
+        msg: 'The URL of the Openshift Virtualization API endpoint, for example: https://example.com:6443 .',
       },
     },
   };


### PR DESCRIPTION
Fix the way validation is done for a whole provider, e.g secret+provider processing:

  - [x] Fix type in openshift example `http:url `=> `http://url`
  - [x] Add missing validation for new ca cert and insecureSkipValidation in openshift validation
  - [x] When processing a whole provider eturn errors, if not found warnings and only then the defatult values 