### PR TITLE
Clean selected source when applying new filter

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/states/PlanCreatePageStore.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/states/PlanCreatePageStore.ts
@@ -52,9 +52,9 @@ export function planCreatePageReducer(
 ): typeof planCreatePageInitialState {
   switch (action.type) {
     case SET_NAME_FILTER:
-      return { ...state, nameFilter: action.payload };
+      return { ...state, nameFilter: action.payload, selectedProviderUID: '', selectedVMs: [] };
     case UPDATE_TYPE_FILTERS:
-      return { ...state, typeFilters: action.payload };
+      return { ...state, typeFilters: action.payload, selectedProviderUID: '', selectedVMs: [] };
     case SELECT_PROVIDER:
       return { ...state, selectedProviderUID: action.payload, selectedVMs: [] };
     case UPDATE_SELECTED_VMS:


### PR DESCRIPTION
Issue:
When a provider is selected, and a user apply a filter, the filter will not apply until the user de select the current provider manually.

Fix:
When a filter is changed the provider gets de selected automatically