### PR TITLE
:soap: Show only ready providers for source of migration

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -37,12 +37,15 @@ export const PlanCreatePage: React.FC<{
     planCreatePageInitialState,
   );
 
-  const [providers] = useK8sWatchResource<V1beta1Provider[]>({
+  const [allProviders] = useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,
     namespaced: true,
     isList: true,
     namespace,
   });
+
+  // Get the ready providers (note: currently forklift does not allow filter be status.phase)
+  const providers = allProviders.filter((p) => p?.status?.phase === 'Ready');
 
   const defaultNamespace = process?.env?.DEFAULT_NAMESPACE || 'default';
 


### PR DESCRIPTION
Issue:
we show all providers as a posible source provider, we should only show providers that makes sense to migrate from.

Fix:
show only "ready" provider

Note:
providers do not support filtering by phase, the filtering is done on the frontend side.