### PR TITLE
:soap: Get initial state of new plan form from state

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -2,6 +2,7 @@ import React, { useReducer } from 'react';
 import { useHistory } from 'react-router';
 import { getResourceUrl } from 'src/modules/Providers/utils';
 import { MigrationAction } from 'src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction';
+import { useCreateVmMigrationData } from 'src/modules/Providers/views/migrate';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelGroupVersionKind, ProviderModelRef, V1beta1Provider } from '@kubev2v/types';
@@ -32,10 +33,16 @@ export const PlanCreatePage: React.FC<{
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
   const history = useHistory();
-  const [filterState, filterDispatch] = useReducer(
-    planCreatePageReducer,
-    planCreatePageInitialState,
-  );
+
+  // Get optional initial state context
+  const { data } = useCreateVmMigrationData();
+
+  // Init form state
+  const [filterState, filterDispatch] = useReducer(planCreatePageReducer, {
+    ...planCreatePageInitialState,
+    selectedProviderUID: data?.provider?.metadata?.uid,
+    selectedVMs: data?.selectedVms,
+  });
 
   const [allProviders] = useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,


### PR DESCRIPTION
Issue:
When clicking back from selecting target provider, we get a clean select source form, we should get the pre selected data.

Fix:
Init the select source form using the context.

Caveat: 
No mechanism to clean the context yet, may result in pre-selected form when not needed.