### PR TITLE
:lady_beetle: openshift-validator-should-not-return-null

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
@@ -24,5 +24,5 @@ export function vsphereProviderValidator(provider: V1beta1Provider): ValidationM
     return { type: 'error', msg: 'invalided sdkEndpoint, can be vcenter or esxi' };
   }
 
-  return null;
+  return { type: 'default' };
 }


### PR DESCRIPTION
Issue:
Validators are expected to return a validation struct

Fix:
return a "defatult" validation struct, instead of null