### PR TITLE
:soap: Better header page sanity

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/PageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/PageHeadings.tsx
@@ -25,7 +25,7 @@ export const PageHeadings: React.FC<PageHeadingsProps> = ({
   actions,
 }) => {
   const status = data?.['status']?.phase;
-  const groupVersionKind = data && getGroupVersionKindForResource(data);
+  const groupVersionKind = data?.kind && getGroupVersionKindForResource(data);
 
   return (
     <div className="co-m-nav-title co-m-nav-title--detail forklift-page-headings">


### PR DESCRIPTION
sanity check before `getGroupVersionKindForResource` should test for `kind` in `data`, and not just `data`