### PR TITLE
:feet: Show pods on overview tab instead of pods tab

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -64,7 +64,6 @@
   "Conditions": "Conditions",
   "Confirm": "Confirm",
   "Connection Failed": "Connection Failed",
-  "Controller": "Controller",
   "Controller CPU limit": "Controller CPU limit",
   "Controller Memory limit": "Controller Memory limit",
   "Controls the interval at which a new snapshot is requested prior to initiating a warm migration. The default value is 60 minutes.": "Controls the interval at which a new snapshot is requested prior to initiating a warm migration. The default value is 60 minutes.",

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/OverviewPage.tsx
@@ -10,7 +10,6 @@ import { getOperatorPhase } from '../../utils/helpers/getOperatorPhase';
 
 import OperatorStatus from './components/OperatorStatus';
 import { ShowWelcomeCardButton } from './components/ShowWelcomeCardButton';
-import ForkliftControllerPodsTab from './tabs/Pods/ForkliftControllerPodsTab';
 import { HeaderTitle } from './components';
 import {
   ForkliftControllerDetailsTab,
@@ -38,11 +37,6 @@ export const OverviewPage: React.FC<OverviewPageProps> = () => {
       href: 'metrics',
       name: t('Metrics'),
       component: ForkliftControllerMetricsTabWrapper,
-    },
-    {
-      href: 'pods',
-      name: t('Pods'),
-      component: ForkliftControllerPodsTabWrapper,
     },
   ];
 
@@ -108,14 +102,6 @@ const ForkliftControllerMetricsTabWrapper: React.FC = () => {
 
   return (
     <ForkliftControllerMetricsTab obj={forkliftController} loaded={loaded} loadError={loadError} />
-  );
-};
-
-const ForkliftControllerPodsTabWrapper: React.FC = () => {
-  const [forkliftController, loaded, loadError] = useK8sWatchForkliftController();
-
-  return (
-    <ForkliftControllerPodsTab obj={forkliftController} loaded={loaded} loadError={loadError} />
   );
 };
 

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/ControllerCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/ControllerCard.tsx
@@ -20,12 +20,12 @@ export const ControllerCard: FC<ControllerCardProps> = ({ obj }) => {
     namespaced: true,
     isList: true,
     namespace: obj?.metadata?.namespace,
-    selector: { matchLabels: { app: 'forklift', 'control-plane': 'controller-manager' } },
+    selector: { matchLabels: { app: 'forklift' } },
   });
 
   return (
     <Card>
-      <CardTitle className="forklift-title">{t('Controller')}</CardTitle>
+      <CardTitle className="forklift-title">{t('Pods')}</CardTitle>
       <Suspend obj={pods} loaded={loaded} loadError={loadError}>
         <CardBody>
           <PodsTable pods={pods} />


### PR DESCRIPTION
Add a pods section to the overview for quick inspection of pods state and logs.

Screenshot:
![pods-in-overview-tab](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f2df71d9-0b61-40c9-9895-ffe87f6d6eef)
