### PR TITLE
:lady_beetle: Add yaml example for network map

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/dynamic-plugin.ts
@@ -11,6 +11,7 @@ import type { ConsolePluginMetadata } from '@openshift-console/dynamic-plugin-sd
 export const exposedModules: ConsolePluginMetadata['exposedModules'] = {
   NetworkMapsListPage: './modules/NetworkMaps/views/list/NetworkMapsListPage',
   NetworkMapDetailsPage: './modules/NetworkMaps/views/details/NetworkMapDetailsPage',
+  yamlTemplates: './modules/NetworkMaps/yamlTemplates',
 };
 
 export const extensions: EncodedExtension[] = [
@@ -58,4 +59,14 @@ export const extensions: EncodedExtension[] = [
       ...NetworkMapModel,
     },
   } as EncodedExtension<ModelMetadata>,
+
+  {
+    type: 'console.yaml-template',
+    properties: {
+      name: 'default',
+      model: NetworkMapModelGroupVersionKind,
+      ...NetworkMapModel,
+      template: { $codeRef: 'yamlTemplates.defaultYamlTemplate' },
+    },
+  },
 ];

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/yamlTemplates/defaultYamlTemplate.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/yamlTemplates/defaultYamlTemplate.ts
@@ -1,0 +1,20 @@
+import { Map as ImmutableMap } from 'immutable';
+
+import { NetworkMapModel } from '@kubev2v/types';
+
+export const NetworkMapModelYAMLTemplates = ImmutableMap().setIn(
+  ['default'],
+  `
+apiVersion: ${NetworkMapModel.apiGroup}/${NetworkMapModel.apiVersion}
+kind: ${NetworkMapModel.kind}
+metadata:
+  name: example
+spec:
+  map: []
+  provider:
+    source: {}
+    destination: {}
+`,
+);
+
+export const defaultYamlTemplate = NetworkMapModelYAMLTemplates.getIn(['default']);

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/yamlTemplates/index.ts
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/yamlTemplates/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './defaultYamlTemplate';
+// @endindex


### PR DESCRIPTION
Issue:
Default YAML example for NetworkMap resource is not valid

Fix:
Add a custom valide YAML example

Screenshot:
![netmap-yaml](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/8dd63025-218a-4e58-a832-5c4da2d4fa43)
