### PR TITLE
:bug: Remove extra primary button in create plan page

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -131,6 +131,7 @@ export const PlanCreatePage: React.FC<{
                 filterDispatch({ type: 'UPDATE_SELECTED_VMS', payload: selectedVms })
               }
               initialSelectedIds={filterState.selectedVMs.map((vm) => vm.vm.id)}
+              showActions={false}
             />
           </>
         )}

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
@@ -11,8 +11,9 @@ export const ProviderVirtualMachinesList: React.FC<{
   namespace: string;
   onSelect?: (selectedIds: VmData[]) => void;
   initialSelectedIds?: string[];
+  showActions: boolean;
   className?: string;
-}> = ({ title, name, namespace, onSelect, initialSelectedIds, className }) => {
+}> = ({ title, name, namespace, onSelect, initialSelectedIds, showActions, className }) => {
   const [provider, providerLoaded, providerLoadError] = useK8sWatchResource<V1beta1Provider>({
     groupVersionKind: ProviderModelGroupVersionKind,
     namespaced: true,
@@ -31,6 +32,7 @@ export const ProviderVirtualMachinesList: React.FC<{
       loadError={providerLoadError}
       onSelect={onSelect}
       initialSelectedIds={initialSelectedIds}
+      showActions={showActions}
       className={className}
     />
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
@@ -95,6 +95,7 @@ export const OVirtVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = 
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => (
   <ProviderVirtualMachinesList
@@ -107,6 +108,7 @@ export const OVirtVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = 
     pageId="OVirtVirtualMachinesList"
     onSelect={onSelect}
     initialSelectedIds={initialSelectedIds}
+    showActions={showActions}
     className={className}
   />
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
@@ -80,6 +80,7 @@ export const OpenShiftVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => (
   <ProviderVirtualMachinesList
@@ -92,6 +93,7 @@ export const OpenShiftVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
     pageId="OpenShiftVirtualMachinesList"
     onSelect={onSelect}
     initialSelectedIds={initialSelectedIds}
+    showActions={showActions}
     className={className}
   />
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OpenStackVirtualMachinesList.tsx
@@ -111,6 +111,7 @@ export const OpenStackVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => (
   <ProviderVirtualMachinesList
@@ -123,6 +124,7 @@ export const OpenStackVirtualMachinesList: React.FC<ProviderVirtualMachinesProps
     pageId="OpenStackVirtualMachinesList"
     onSelect={onSelect}
     initialSelectedIds={initialSelectedIds}
+    showActions={showActions}
     className={className}
   />
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
@@ -49,6 +49,7 @@ export const OvaVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => (
   <ProviderVirtualMachinesList
@@ -61,6 +62,7 @@ export const OvaVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> = ({
     pageId="OvaVirtualMachinesList"
     onSelect={onSelect}
     initialSelectedIds={initialSelectedIds}
+    showActions={showActions}
     className={className}
   />
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
@@ -23,6 +23,7 @@ export interface ProviderVirtualMachinesProps extends RouteComponentProps {
   loadError?: unknown;
   onSelect?: (selectedVMs: VmData[]) => void;
   initialSelectedIds?: string[];
+  showActions: boolean;
   className?: string;
 }
 
@@ -58,6 +59,7 @@ export const ProviderVirtualMachines: React.FC<{ name: string; namespace: string
         obj={obj}
         loaded={providerLoaded}
         loadError={providerLoadError}
+        showActions={true}
       />
     </>
   );
@@ -70,6 +72,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => {
   switch (obj?.provider?.spec?.type) {
@@ -82,6 +85,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
           loadError={loadError}
           onSelect={onSelect}
           initialSelectedIds={initialSelectedIds}
+          showActions={showActions}
           className={className}
         />
       );
@@ -94,6 +98,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
           loadError={loadError}
           onSelect={onSelect}
           initialSelectedIds={initialSelectedIds}
+          showActions={showActions}
           className={className}
         />
       );
@@ -106,6 +111,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
           loadError={loadError}
           onSelect={onSelect}
           initialSelectedIds={initialSelectedIds}
+          showActions={showActions}
           className={className}
         />
       );
@@ -118,6 +124,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
           loadError={loadError}
           onSelect={onSelect}
           initialSelectedIds={initialSelectedIds}
+          showActions={showActions}
           className={className}
         />
       );
@@ -130,6 +137,7 @@ export const ProviderVirtualMachinesListWrapper: React.FC<ProviderVirtualMachine
           loadError={loadError}
           onSelect={onSelect}
           initialSelectedIds={initialSelectedIds}
+          showActions={showActions}
           className={className}
         />
       );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -83,6 +83,7 @@ export const VSphereVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> 
   loadError,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => (
   <ProviderVirtualMachinesList
@@ -95,6 +96,7 @@ export const VSphereVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> 
     pageId="VSphereVirtualMachinesList"
     onSelect={onSelect}
     initialSelectedIds={initialSelectedIds}
+    showActions={showActions}
     className={className}
   />
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -33,6 +33,7 @@ export interface ProviderVirtualMachinesListProps extends RouteComponentProps {
   pageId: string;
   onSelect?: (selectedVMs: VmData[]) => void;
   initialSelectedIds?: string[];
+  showActions: boolean;
   className?: string;
 }
 
@@ -48,6 +49,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   pageId,
   onSelect,
   initialSelectedIds,
+  showActions,
   className,
 }) => {
   const { t } = useForkliftTranslation();
@@ -93,7 +95,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
         features: EnumFilter,
       }}
       extraSupportedMatchers={[concernsMatcher, featuresMatcher]}
-      GlobalActionToolbarItems={actions}
+      GlobalActionToolbarItems={showActions ? actions : undefined}
       toId={toId}
       onSelect={onSelectedIds}
       selectedIds={selectedIds}


### PR DESCRIPTION
Ref: #945

Issue:
in the create plan page, we have 2 primary buttons to do migrations

Screenshot:
Before:
![before-button](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/b050afee-bda9-4165-92d2-904665311dc0)

Top button:
![top-migration-button](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/41b0a98d-3a86-4268-89bc-5948f04bde5a)

Bottom button:
![bottom-button](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/b7998ccf-97d7-4be3-85f4-d988db18b16f)
