### PR TITLE
:soap: Hide unimplemented plan tabs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/PlanDetailsPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/PlanDetailsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 
 import { Suspend } from './components';
-import { PlanDetails, PlanHooks, PlanMappings, PlanVirtualMachines, PlanYAML } from './tabs';
+import { PlanDetails, PlanYAML } from './tabs';
 
 import './PlanDetailsPage.style.css';
 
@@ -44,6 +44,7 @@ const PlanDetailsPage_: React.FC<{
       name: t('YAML'),
       component: () => <PlanYAML plan={obj} loaded={loaded} loadError={loadError} />,
     },
+    /*
     {
       href: 'vms',
       name: t('Virtual Machines'),
@@ -59,6 +60,7 @@ const PlanDetailsPage_: React.FC<{
       name: t('Hooks'),
       component: () => <PlanHooks plan={obj} loaded={loaded} loadError={loadError} />,
     },
+    */
   ];
 
   return (


### PR DESCRIPTION
Issue:
We are ready to create the first build of 2.6 :tada: 
Some tabs in Plan details page are still un implemented.

Fix:
Hide the un implemented tabs until they are ready.

Screenshot:
Before:
![screenshot-localhost_9000-2024 02 22-18_32_21](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/1b6081e5-46be-48c0-a8d0-d8b47df16a2e)


After:
![screenshot-localhost_9000-2024 02 22-18_27_17](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/b5cc2699-8cb3-4e89-a7eb-950ce0983af3)
