### PR TITLE
:feet: Allow to fetch CA from URL for all providers

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
@@ -53,7 +53,7 @@ export const CertificateUpload: FC<CertificateUploadProps> = ({
             <FlexItem>
               <Button
                 className="forklift-certificate-upload-margin"
-                isDisabled={isDisabled}
+                isDisabled={isDisabled || !url?.trim().startsWith('https://')}
                 variant="secondary"
                 onClick={() =>
                   showModal(

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ModalHOC } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
@@ -55,12 +54,12 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
       );
     case 'vsphere':
       return (
-        <ModalHOC>
+        <>
           <VSphereProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
 
           <EditProviderSectionHeading text={t('Provider credentials')} />
           <VSphereCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
-        </ModalHOC>
+        </>
       );
     case 'ova':
       return (

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react';
 import { Base64 } from 'js-base64';
+import { ModalHOC } from 'src/modules/Providers/modals';
 import { validateK8sName, ValidationMsg } from 'src/modules/Providers/utils';
 import { SelectableCard } from 'src/modules/Providers/utils/components/Galerry/SelectableCard';
 import { SelectableGallery } from 'src/modules/Providers/utils/components/Galerry/SelectableGallery';
@@ -84,7 +85,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
   };
 
   return (
-    <>
+    <ModalHOC>
       <div className="forklift-create-provider-edit-section">
         <EditProviderSectionHeading text={t('Provider details')} />
 
@@ -144,7 +145,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
           onNewSecretChange={onNewSecretChange}
         />
       </div>
-    </>
+    </ModalHOC>
   );
 };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/CredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/CredentialsSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ModalHOC } from 'src/modules/Providers/modals';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -40,11 +41,13 @@ export const CredentialsSection: React.FC<CredentialsProps> = (props) => {
   }
 
   return (
-    <CredentialsSection_
-      name={provider?.spec?.secret?.name}
-      namespace={provider?.spec?.secret?.namespace}
-      type={provider?.spec?.type}
-    />
+    <ModalHOC>
+      <CredentialsSection_
+        name={provider?.spec?.secret?.name}
+        namespace={provider?.spec?.secret?.namespace}
+        type={provider?.spec?.type}
+      />
+    </ModalHOC>
   );
 };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useReducer } from 'react';
 import { Base64 } from 'js-base64';
 import { openshiftSecretFieldValidator, safeBase64Decode } from 'src/modules/Providers/utils';
+import { CertificateUpload } from 'src/modules/Providers/utils/components/CertificateUpload';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import {
   Button,
   Divider,
-  FileUpload,
   Form,
   FormGroup,
   Popover,
@@ -22,6 +22,7 @@ import { EditComponentProps } from '../BaseCredentialsSection';
 export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
+  const url = safeBase64Decode(secret?.data?.url || '');
   const token = safeBase64Decode(secret?.data?.token || '');
   const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
   const cacert = safeBase64Decode(secret?.data?.cacert || '');
@@ -190,7 +191,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         helperTextInvalid={state.validation.cacert.msg}
         validated={state.validation.cacert.type}
       >
-        <FileUpload
+        <CertificateUpload
           id="cacert"
           type="text"
           filenamePlaceholder="Drag and drop a file or upload one"
@@ -200,6 +201,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
+          url={url}
           isDisabled={insecureSkipVerify}
         />
       </FormGroup>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -1,17 +1,10 @@
 import React, { useCallback, useReducer } from 'react';
 import { Base64 } from 'js-base64';
 import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Providers/utils';
+import { CertificateUpload } from 'src/modules/Providers/utils/components/CertificateUpload';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import {
-  Divider,
-  FileUpload,
-  Form,
-  FormGroup,
-  Popover,
-  Radio,
-  Switch,
-} from '@patternfly/react-core';
+import { Divider, Form, FormGroup, Popover, Radio, Switch } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 import { EditComponentProps } from '../BaseCredentialsSection';
@@ -50,6 +43,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     </ForkliftTrans>
   );
 
+  const url = safeBase64Decode(secret?.data?.url || '');
   const authType = safeBase64Decode(secret?.data?.authType || '');
   const username = safeBase64Decode(secret?.data?.username || '');
   const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
@@ -288,7 +282,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         validated={state.validation.cacert}
         helperTextInvalid={cacertHelperTextMsgs.error}
       >
-        <FileUpload
+        <CertificateUpload
           id="cacert"
           type="text"
           filenamePlaceholder="Drag and drop a file or upload one"
@@ -298,6 +292,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
+          url={url}
           isDisabled={insecureSkipVerify}
         />
       </FormGroup>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useReducer } from 'react';
 import { Base64 } from 'js-base64';
 import { ovirtSecretFieldValidator, safeBase64Decode } from 'src/modules/Providers/utils';
+import { CertificateUpload } from 'src/modules/Providers/utils/components/CertificateUpload';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import {
   Button,
   Divider,
-  FileUpload,
   Form,
   FormGroup,
   Popover,
@@ -23,6 +23,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
   const { t } = useForkliftTranslation();
 
   const user = safeBase64Decode(secret?.data?.user || '');
+  const url = safeBase64Decode(secret?.data?.url || '');
   const password = safeBase64Decode(secret?.data?.password || '');
   const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
   const cacert = safeBase64Decode(secret?.data?.cacert || '');
@@ -216,7 +217,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
         helperTextInvalid={state.validation.cacert.msg}
         validated={state.validation.cacert.type}
       >
-        <FileUpload
+        <CertificateUpload
           id="cacert"
           type="text"
           filenamePlaceholder="Drag and drop a file or upload one"
@@ -226,6 +227,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
+          url={url}
           isDisabled={insecureSkipVerify}
         />
       </FormGroup>


### PR DESCRIPTION
Allow to fetch CA from URL for all providers

in #924 we added the option to fetch CA from URL to `vSphere` provider, this PR adds the option to `Openshift`, `Openstack` and `Ovirt` providers.

Screenshot:
![fetch-ca-from-url](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3f01093d-0cd7-4b22-8eb3-dc6f2c8d03ab)

Ref #911