### PR TITLE
:lady_beetle: Don't fail when certificate is not valid

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/hooks/useTlsCertificate.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/hooks/useTlsCertificate.ts
@@ -37,8 +37,17 @@ export const toColonSeparatedHex = (hexString: string) =>
  * @param pemEncodedCert valid PEM encoded certificate
  * @returns SHA1 thumbprint
  */
-export const calculateThumbprint = (pemEncodedCert: string) =>
-  toColonSeparatedHex(KJUR.crypto.Util.hashHex(pemtohex(pemEncodedCert), 'sha1'));
+export const calculateThumbprint = (pemEncodedCert: string) => {
+  let thumbprint: string;
+
+  try {
+    thumbprint = toColonSeparatedHex(KJUR.crypto.Util.hashHex(pemtohex(pemEncodedCert), 'sha1'));
+  } catch {
+    thumbprint = '';
+  }
+
+  return thumbprint;
+};
 
 /**
  * @param url URL param for the tls-certificate endpoint


### PR DESCRIPTION
Issue:
we use `pemtohex` on strings that may not be valid `pem`

FIx:
add a `try` `catch` around the problematic call