### PR TITLE
:lady_beetle: Match is missing in console route

### DIFF
--- a/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
+++ b/packages/legacy/src/Plans/components/VMMigrationDetails.tsx
@@ -67,6 +67,7 @@ import { MustGatherBtn } from 'legacy/src/common/components/MustGatherBtn';
 import { VMNameWithPowerState } from 'legacy/src/common/components/VMNameWithPowerState';
 import { PLANS_REFERENCE } from 'legacy/src/common/constants';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { matchPath, useLocation } from 'react-router-dom';
 
 export interface IPlanMatchParams {
   url: string;
@@ -93,7 +94,13 @@ export type VMMigrationDetailsProps = {
   };
 };
 
-export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps> = ({ match }) => {
+export const VMMigrationDetails: React.FunctionComponent<VMMigrationDetailsProps> = () => {
+  // path: ['/mtv/plans/ns/:ns/:planName'],
+  const { pathname } = useLocation();
+  const match = matchPath<{ planName: string; ns: string }>(pathname, {
+    path: '/mtv/plans/ns/:ns/:planName',
+  });
+
   const resourceNamespace = match?.params?.ns;
   const plansQuery = usePlansQuery(resourceNamespace);
   const plan = plansQuery.data?.items.find((item) => item.metadata.name === match?.params.planName);

--- a/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
+++ b/packages/legacy/src/Plans/components/Wizard/PlanWizard.tsx
@@ -12,6 +12,7 @@ import {
   WizardStepFunctionType,
 } from '@patternfly/react-core';
 import { Redirect, RouteComponentProps, useHistory, useRouteMatch } from 'react-router-dom';
+import { matchPath, useLocation } from 'react-router-dom';
 import { UseQueryResult } from 'react-query';
 import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 import { useFormField, useFormState } from '@migtools/lib-ui';
@@ -157,7 +158,14 @@ const usePlanWizardFormState = (
 
 export type PlanWizardFormState = ReturnType<typeof usePlanWizardFormState>; // ✨ Magic
 
-export const PlanWizard: React.FunctionComponent<RouteComponentProps<{ ns: string }>> = (props) => {
+export const PlanWizard: React.FunctionComponent<RouteComponentProps<{ ns: string }>> = () => {
+  // path: ['/mtv/plans/ns/:ns/:planName/edit', '/mtv/plans/ns/:ns/:planName/duplicate'],
+  const { pathname } = useLocation();
+  const match = matchPath<{ planName: string; ns: string }>(pathname, {
+    path: '/mtv/plans/ns/:ns/:planName',
+  });
+  const props = { match };
+
   // namespace is mandatory in all paths: create, edit, duplicate
   const prefillPlanNamespace = props.match?.params?.ns;
   const history = useHistory();

--- a/packages/legacy/src/common/components/MustGatherBtn.tsx
+++ b/packages/legacy/src/common/components/MustGatherBtn.tsx
@@ -28,6 +28,10 @@ export const MustGatherBtn: React.FunctionComponent<IMustGatherBtn> = ({
     notifyDownloadFailed,
   } = React.useContext(MustGatherContext);
 
+  if (!withNs) {
+    return <></>;
+  }
+
   const namespacedName = withNs(displayName, planUid, type);
   const mustGather = latestAssociatedMustGather(namespacedName);
 


### PR DESCRIPTION
Issue:
In OCP 4.15 we don't have `match`  param in the props

Fix:
Add the `match` data using `matchPath` and `useLocation` temporatily, until the bug in OCP is fixed.

Ref:
https://issues.redhat.com/browse/OCPBUGS-30273