### PR TITLE
:lady_beetle: Dont cut mapping dropdown

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
@@ -72,6 +72,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
                 isDisabled={!isEditable}
                 aria-labelledby=""
                 isGrouped
+                menuAppendTo={() => document.body}
               >
                 <SelectGroup label={generalSourcesLabel} key="generalSources">
                   {isEditable ? toSelectedOptions(sources, noSourcesLabel) : null}
@@ -94,6 +95,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
                 isOpen={isTrgOpen}
                 isDisabled={!isEditable}
                 aria-labelledby=""
+                menuAppendTo={() => document.body}
               >
                 {destinations?.map((label) => (
                   <SelectOption value={label} key={label} />


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/976

Issue:
when opening a drop-down in mappings tab, the drop-down is cut off

Screeshot:
Before:
![mapping-tab-selection-is-cut](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/0f3511d5-7571-4e13-b2b1-d974d8c9e19f)

After:
![mapping-tab-selection-is-not-cut](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/10bce742-1fe8-49ee-bb89-eaba77b4056e)
