### PR TITLE
:lady_beetle: Set spacing in mapping tab title

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/PlanDetailsPage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/PlanDetailsPage.style.css
@@ -94,3 +94,8 @@ padding-bottom: var(--pf-global--spacer--lg);
   color: var(--pf-c-button--m-plain--Color);
   margin-left: var(--pf-global--spacer--sm);
 }
+
+.forklift-section-mappings-edit {
+  padding-top: var(--pf-global--spacer--md);
+  padding-bottom: var(--pf-global--spacer--sm);
+}

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappings.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SectionHeading } from 'src/components/headers/SectionHeading';
 import { useOpenShiftNetworks, useSourceNetworks } from 'src/modules/Providers/hooks/useNetworks';
 import { useOpenShiftStorages, useSourceStorages } from 'src/modules/Providers/hooks/useStorages';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -13,7 +14,7 @@ import {
   V1beta1StorageMap,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { PageSection, Title } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core';
 
 import { PlanDetailsTabProps } from '../../PlanDetailsPage';
 
@@ -32,9 +33,7 @@ export const PlanMappings: React.FC<PlanDetailsTabProps> = ({ plan, loaded, load
     <>
       <div>
         <PageSection variant="light">
-          <Title headingLevel={'h1'}>{t('Mappings')}</Title>
-        </PageSection>
-        <PageSection variant="light" className="forklift-page-section--info">
+          <SectionHeading text={t('Mappings')} />
           <PlanMappingsInitSection plan={plan} loaded={loaded} loadError={loadError} />
         </PageSection>
       </div>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
@@ -654,7 +654,7 @@ export const PlanMappingsSection: React.FC<PlanMappingsSectionProps> = ({
           </Button>
         </FlexItem>
       </Flex>
-      <HelperText>
+      <HelperText className="forklift-section-mappings-edit">
         <HelperTextItem variant="indeterminate">
           {t(
             'Click the update mappings button to save your changes, button is disabled until a change is detected.',


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/978

Issue:
Uneven spacing in mapping tab

Screenshot:
Before:
![uneven-spacing](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/09295ef0-35c2-465c-b34c-ad1ab512ba34)

After:
![with-spacing](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/af8c020e-08c0-43f5-9cbb-178a7d0d963b)
