### PR TITLE
:lady_beetle: Fix uneven spacing in mappings tab view mode

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
@@ -570,7 +570,7 @@ export const PlanMappingsSection: React.FC<PlanMappingsSectionProps> = ({
                 {t('Edit mappings')}
               </Button>
               {DisableEditMappings ? (
-                <HelperText>
+                <HelperText className="forklift-section-mappings-edit">
                   <HelperTextItem variant="indeterminate">
                     {t(
                       'The edit mappings button is disabled if the plan started running and at least one virtual machine was migrated successfully.',


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/980

Issue:
Uneven spacing in mapping tab in view mode

Ref: #978 - addressing uneven spacing in edit mode

Screenshot:
Before:
![uneven-spacing](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3113133d-73b1-4144-a14a-2e277eff4437)


After:
![even-spacing](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c4c6ce2f-5852-4bf4-83d8-d678b616bc7d)
