### PR TITLE
:lady_beetle:  Different validation for esxi

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/VSphereEditURLModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderURL/VSphereEditURLModal.tsx
@@ -4,14 +4,25 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import { ProviderModel } from '@kubev2v/types';
 import { ModalVariant } from '@patternfly/react-core';
 
-import { validateVCenterURL } from '../../utils';
-import { EditModal } from '../EditModal';
+import { validateEsxiURL, validateVCenterURL } from '../../utils';
+import { EditModal, ValidationHookType } from '../EditModal';
 
 import { patchProviderURL } from './utils/patchProviderURL';
 import { EditProviderURLModalProps } from './EditProviderURLModal';
 
 export const VSphereEditURLModal: React.FC<EditProviderURLModalProps> = (props) => {
   const { t } = useForkliftTranslation();
+  const provider = props.resource;
+
+  let validationHook: ValidationHookType;
+
+  // VCenter of ESXi
+  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
+  if (sdkEndpoint === 'esxi') {
+    validationHook = validateEsxiURL;
+  } else {
+    validationHook = validateVCenterURL;
+  }
 
   const ModalBody = (
     <ForkliftTrans>
@@ -38,7 +49,7 @@ export const VSphereEditURLModal: React.FC<EditProviderURLModalProps> = (props) 
         'The URL of the vCenter API endpoint, for example: https://vCenter-host-example.com/sdk .',
       )}
       onConfirmHook={patchProviderURL}
-      validationHook={validateVCenterURL}
+      validationHook={validationHook}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
@@ -19,11 +19,11 @@ const PROTOCOL = '(https?:\\/\\/)';
 const IPV4 = '((?:[0-9]{1,3}\\.){3}[0-9]{1,3})';
 const HOSTNAME = '([a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_\\.]+)';
 const PORT = '(:[0-9]+)?';
-const PATH = '(\\/[^ ]*)*';
+const PATH = '((\\/[^ ]*)*)?';
 const QUERY_PARAMS = '(\\?[a-zA-Z0-9=&_]*)?';
 
 const URL_REGEX = new RegExp(
-  `^${PROTOCOL}((${IPV4})|(${HOSTNAME}))((${PORT})(${PATH})?(${QUERY_PARAMS})?)?$`,
+  `^${PROTOCOL}((${IPV4})|(${HOSTNAME}))((${PORT})(${PATH})(${QUERY_PARAMS})?)?$`,
 );
 
 // validate NFS mount NFS_SERVER:EXPORTED_DIRECTORY

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
@@ -10,8 +10,9 @@ export function providerAndSecretValidator(
   secret: IoK8sApiCoreV1Secret,
 ): ValidationMsg {
   const type = provider?.spec?.type || '';
+  const subType = provider?.spec?.settings?.['sdkEndpoint'] || '';
 
-  const secretValidation = secretValidator(type, secret);
+  const secretValidation = secretValidator(type, subType, secret);
   const providerValidation = providerValidator(provider);
 
   // Test for validation errors

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/secretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/secretValidator.ts
@@ -5,9 +5,15 @@ import { ValidationMsg } from '../common';
 import { openshiftSecretValidator } from './openshift/openshiftSecretValidator';
 import { openstackSecretValidator } from './openstack/openstackSecretValidator';
 import { ovirtSecretValidator } from './ovirt/ovirtSecretValidator';
-import { vsphereSecretValidator } from './vsphere/vsphereSecretValidator';
+import { esxiSecretValidator, vcenterSecretValidator } from './vsphere';
 
-export function secretValidator(type: string, secret: IoK8sApiCoreV1Secret): ValidationMsg {
+export type SecretSubType = 'esxi' | 'vcenter';
+
+export function secretValidator(
+  type: string,
+  subType: SecretSubType,
+  secret: IoK8sApiCoreV1Secret,
+): ValidationMsg {
   let validationError: ValidationMsg;
 
   switch (type) {
@@ -21,7 +27,11 @@ export function secretValidator(type: string, secret: IoK8sApiCoreV1Secret): Val
       validationError = ovirtSecretValidator(secret);
       break;
     case 'vsphere':
-      validationError = vsphereSecretValidator(secret);
+      if (subType === 'esxi') {
+        validationError = esxiSecretValidator(secret);
+      } else {
+        validationError = vcenterSecretValidator(secret);
+      }
       break;
     case 'ova':
       validationError = { type: 'default' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
@@ -1,0 +1,99 @@
+import { validateNoSpaces, validatePublicCert, ValidationMsg } from '../../common';
+
+/**
+ * Validates form input fields based on their id.
+ *
+ * @param {string} id - The ID of the form field.
+ * @param {string} value - The value of the form field.
+ *
+ * @return {Validation} - The validation state of the form field. Can be one of the following:
+ * 'default' - The default state of the form field, used when the field is empty or a value has not been entered yet.
+ * 'success' - The field's value has passed validation.
+ * 'error' - The field's value has failed validation.
+ * 'warning' - The field's value has passed validation but does not fit the standard format, it's the user's choice if to accept that value.
+ */
+export const esxiSecretFieldValidator = (id: string, value: string): ValidationMsg => {
+  const trimmedValue = value?.trim() || '';
+
+  let validationState: ValidationMsg;
+
+  switch (id) {
+    case 'user':
+      validationState = validateUser(trimmedValue);
+      break;
+    case 'password':
+      validationState = validatePassword(trimmedValue);
+      break;
+    case 'insecureSkipVerify':
+      validationState = { type: 'default', msg: 'Migrate without validating a CA certificate' };
+      break;
+    case 'cacert':
+      validationState = validateCacert(trimmedValue);
+      break;
+    default:
+      validationState = { type: 'default' };
+      break;
+  }
+
+  return validationState;
+};
+
+const validateUser = (value: string): ValidationMsg => {
+  const noSpaces = validateNoSpaces(value);
+
+  if (value === '') {
+    return {
+      type: 'error',
+      msg: 'A username and domain for the ESXi API endpoint, for example: user . [required]',
+    };
+  }
+
+  if (!noSpaces) {
+    return { type: 'error', msg: 'Invalid username, spaces are not allowed' };
+  }
+
+  return {
+    type: 'success',
+    msg: 'A username and domain for the ESXi API endpoint, for example: user .',
+  };
+};
+
+const validatePassword = (value: string): ValidationMsg => {
+  const valid = validateNoSpaces(value);
+
+  if (value === '') {
+    return {
+      type: 'error',
+      msg: 'A user password for connecting to the ESXi API endpoint. [required]',
+    };
+  }
+
+  if (valid) {
+    return { type: 'success', msg: 'A user password for connecting to the ESXi API endpoint.' };
+  }
+
+  return { type: 'error', msg: 'Invalid password, spaces are not allowed' };
+};
+
+const validateCacert = (value: string): ValidationMsg => {
+  const valid = validatePublicCert(value);
+
+  if (value === '') {
+    return {
+      type: 'default',
+      msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
+    };
+  }
+
+  if (valid) {
+    return {
+      type: 'success',
+      msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
+    };
+  }
+
+  return {
+    type: 'error',
+    msg: 'Invalid CA certificate, certificate must be in a valid PEM encoded X.509 format.',
+  };
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretValidator.ts
@@ -5,9 +5,9 @@ import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
 import { missingKeysInSecretData } from '../../../helpers';
 import { ValidationMsg } from '../../common';
 
-import { vsphereSecretFieldValidator } from './vsphereSecretFieldValidator';
+import { esxiSecretFieldValidator } from './esxiSecretFieldValidator';
 
-export function vsphereSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
+export function esxiSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
   const requiredFields = ['user', 'password'];
   const validateFields = ['user', 'password', 'insecureSkipVerify'];
 
@@ -25,7 +25,7 @@ export function vsphereSecretValidator(secret: IoK8sApiCoreV1Secret): Validation
   for (const id of validateFields) {
     const value = Base64.decode(secret?.data?.[id] || '');
 
-    const validation = vsphereSecretFieldValidator(id, value);
+    const validation = esxiSecretFieldValidator(id, value);
 
     if (validation.type === 'error') {
       return validation;

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/index.ts
@@ -1,7 +1,10 @@
 // @index(['./*.tsx', './*.ts', /__/g], f => `export * from '${f.path}';`)
+export * from './esxiSecretFieldValidator';
+export * from './esxiSecretValidator';
+export * from './validateEsxiURL';
 export * from './validateVCenterURL';
 export * from './validateVDDKImage';
+export * from './vcenterSecretFieldValidator';
+export * from './vcenterSecretValidator';
 export * from './vsphereProviderValidator';
-export * from './vsphereSecretFieldValidator';
-export * from './vsphereSecretValidator';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
@@ -1,6 +1,6 @@
 import { validateURL, ValidationMsg } from '../../common';
 
-export const validateVCenterURL = (url: string | number): ValidationMsg => {
+export const validateEsxiURL = (url: string | number): ValidationMsg => {
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };
@@ -12,7 +12,7 @@ export const validateVCenterURL = (url: string | number): ValidationMsg => {
   if (trimmedUrl === '') {
     return {
       type: 'error',
-      msg: 'The URL is required, URL of the vSphere API endpoint for example: https://host-example.com/sdk .',
+      msg: 'The URL is required, URL of the ESXi API endpoint for example: https://host-example.com/sdk .',
     };
   }
 
@@ -31,6 +31,6 @@ export const validateVCenterURL = (url: string | number): ValidationMsg => {
 
   return {
     type: 'success',
-    msg: 'The URL of the vSphere API endpoint for example: https://host-example.com/sdk .',
+    msg: 'The URL of the ESXi API endpoint for example: https://host-example.com/sdk .',
   };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
@@ -17,8 +17,8 @@ import {
  * 'error' - The field's value has failed validation.
  * 'warning' - The field's value has passed validation but does not fit the standard format, it's the user's choice if to accept that value.
  */
-export const vsphereSecretFieldValidator = (id: string, value: string): ValidationMsg => {
-  const trimmedValue = value.trim();
+export const vcenterSecretFieldValidator = (id: string, value: string): ValidationMsg => {
+  const trimmedValue = value?.trim() || '';
 
   let validationState: ValidationMsg;
 
@@ -49,7 +49,7 @@ const validateUser = (value: string): ValidationMsg => {
   if (value === '') {
     return {
       type: 'error',
-      msg: 'A username and domain for the vSphere API endpoint, for example: user@vsphere.local. [required]',
+      msg: 'A username and domain for the vCenter API endpoint, for example: user@vsphere.local. [required]',
     };
   }
 
@@ -68,7 +68,7 @@ const validateUser = (value: string): ValidationMsg => {
 
   return {
     type: 'success',
-    msg: 'A username and domain for the vSphere API endpoint, for example: user@vsphere.local.',
+    msg: 'A username and domain for the vCenter API endpoint, for example: user@vsphere.local.',
   };
 };
 
@@ -78,12 +78,12 @@ const validatePassword = (value: string): ValidationMsg => {
   if (value === '') {
     return {
       type: 'error',
-      msg: 'A user password for connecting to the vSphere API endpoint. [required]',
+      msg: 'A user password for connecting to the vCenter API endpoint. [required]',
     };
   }
 
   if (valid) {
-    return { type: 'success', msg: 'A user password for connecting to the vSphere API endpoint.' };
+    return { type: 'success', msg: 'A user password for connecting to the vCenter API endpoint.' };
   }
 
   return { type: 'error', msg: 'Invalid password, spaces are not allowed' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretValidator.ts
@@ -1,0 +1,36 @@
+import { Base64 } from 'js-base64';
+
+import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
+
+import { missingKeysInSecretData } from '../../../helpers';
+import { ValidationMsg } from '../../common';
+
+import { vcenterSecretFieldValidator } from './vcenterSecretFieldValidator';
+
+export function vcenterSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
+  const requiredFields = ['user', 'password'];
+  const validateFields = ['user', 'password', 'insecureSkipVerify'];
+
+  // Add ca cert validation if not insecureSkipVerify
+  const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
+  if (insecureSkipVerify !== 'true') {
+    validateFields.push('cacert');
+  }
+
+  const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
+  if (missingRequiredFields.length > 0) {
+    return { type: 'error', msg: `missing required fields [${missingRequiredFields.join(', ')}]` };
+  }
+
+  for (const id of validateFields) {
+    const value = Base64.decode(secret?.data?.[id] || '');
+
+    const validation = vcenterSecretFieldValidator(id, value);
+
+    if (validation.type === 'error') {
+      return validation;
+    }
+  }
+
+  return { type: 'default' };
+}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
+  EsxiCredentialsEdit,
   OpenshiftCredentialsEdit,
   OpenstackCredentialsEdit,
   OvirtCredentialsEdit,
-  VSphereCredentialsEdit,
+  VCenterCredentialsEdit,
 } from '../../details';
 
 import { EditProviderSectionHeading } from './EditProviderSectionHeading';
@@ -24,7 +25,10 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  switch (newProvider?.spec?.type) {
+  const type = newProvider?.spec?.type || '';
+  const subType = newProvider?.spec?.settings?.['sdkEndpoint'] || '';
+
+  switch (type) {
     case 'openstack':
       return (
         <>
@@ -53,14 +57,26 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
         </>
       );
     case 'vsphere':
-      return (
-        <>
-          <VSphereProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+      switch (subType) {
+        case 'esxi':
+          return (
+            <>
+              <VSphereProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
 
-          <EditProviderSectionHeading text={t('Provider credentials')} />
-          <VSphereCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
-        </>
-      );
+              <EditProviderSectionHeading text={t('Provider credentials')} />
+              <EsxiCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
+            </>
+          );
+        default:
+          return (
+            <>
+              <VSphereProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+
+              <EditProviderSectionHeading text={t('Provider credentials')} />
+              <VCenterCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />
+            </>
+          );
+      }
     case 'ova':
       return (
         <>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VSphereProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VSphereProviderCreateForm.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useReducer } from 'react';
-import { validateVCenterURL, validateVDDKImage } from 'src/modules/Providers/utils';
+import {
+  validateEsxiURL,
+  validateVCenterURL,
+  validateVDDKImage,
+  ValidationMsg,
+} from 'src/modules/Providers/utils';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { ExternalLink } from '@kubev2v/common';
@@ -99,6 +104,20 @@ export const VSphereProviderCreateForm: React.FC<VSphereProviderCreateFormProps>
       }
 
       if (id == 'sdkEndpoint') {
+        const sdkEndpoint = trimmedValue || undefined;
+
+        let validationState: ValidationMsg;
+
+        // Revalidate URL - VCenter of ESXi
+        const trimmedURL = provider?.spec?.url?.trim() || '';
+        if (sdkEndpoint === 'esxi') {
+          validationState = validateEsxiURL(trimmedURL);
+        } else {
+          validationState = validateVCenterURL(trimmedURL);
+        }
+
+        dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: 'url', validationState } });
+
         onChange({
           ...provider,
           spec: {
@@ -107,14 +126,22 @@ export const VSphereProviderCreateForm: React.FC<VSphereProviderCreateFormProps>
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),
-              sdkEndpoint: trimmedValue || undefined,
+              sdkEndpoint: sdkEndpoint,
             },
           },
         });
       }
 
       if (id === 'url') {
-        const validationState = validateVCenterURL(trimmedValue);
+        let validationState: ValidationMsg;
+
+        // Validate URL - VCenter of ESXi
+        const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
+        if (sdkEndpoint === 'esxi') {
+          validationState = validateEsxiURL(trimmedValue);
+        } else {
+          validationState = validateVCenterURL(trimmedValue);
+        }
 
         dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: 'url', validationState } });
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/EsxiCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/EsxiCredentialsSection.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
 import { ModalHOC } from 'src/modules/Providers/modals';
-import { vsphereSecretValidator } from 'src/modules/Providers/utils';
+import { esxiSecretValidator } from 'src/modules/Providers/utils';
 
 import {
   BaseCredentialsSection,
   BaseCredentialsSectionProps,
 } from './components/BaseCredentialsSection';
-import { VSphereCredentialsEdit } from './components/edit/VSphereCredentialsEdit';
+import { EsxiCredentialsEdit } from './components/edit/EsxiCredentialsEdit';
 import { VSphereCredentialsList } from './components/list/VSphereCredentialsList';
 
-export type VSphereCredentialsSectionProps = Omit<
+export type EsxiCredentialsSectionProps = Omit<
   BaseCredentialsSectionProps,
   'ListComponent' | 'EditComponent' | 'validator'
 >;
 
-export const VSphereCredentialsSection: React.FC<VSphereCredentialsSectionProps> = (props) => (
+export const EsxiCredentialsSection: React.FC<EsxiCredentialsSectionProps> = (props) => (
   <ModalHOC>
     <BaseCredentialsSection
       {...props}
-      validator={vsphereSecretValidator}
+      validator={esxiSecretValidator}
       ListComponent={VSphereCredentialsList}
-      EditComponent={VSphereCredentialsEdit}
+      EditComponent={EsxiCredentialsEdit}
     />
   </ModalHOC>
 );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/VCenterCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/VCenterCredentialsSection.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ModalHOC } from 'src/modules/Providers/modals';
+import { vcenterSecretValidator } from 'src/modules/Providers/utils';
+
+import {
+  BaseCredentialsSection,
+  BaseCredentialsSectionProps,
+} from './components/BaseCredentialsSection';
+import { VCenterCredentialsEdit } from './components/edit/VCenterCredentialsEdit';
+import { VSphereCredentialsList } from './components/list/VSphereCredentialsList';
+
+export type VCenterCredentialsSectionProps = Omit<
+  BaseCredentialsSectionProps,
+  'ListComponent' | 'EditComponent' | 'validator'
+>;
+
+export const VCenterCredentialsSection: React.FC<VCenterCredentialsSectionProps> = (props) => (
+  <ModalHOC>
+    <BaseCredentialsSection
+      {...props}
+      validator={vcenterSecretValidator}
+      ListComponent={VSphereCredentialsList}
+      EditComponent={VCenterCredentialsEdit}
+    />
+  </ModalHOC>
+);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useReducer } from 'react';
 import { Base64 } from 'js-base64';
-import { safeBase64Decode, vsphereSecretFieldValidator } from 'src/modules/Providers/utils';
+import { esxiSecretFieldValidator, safeBase64Decode } from 'src/modules/Providers/utils';
 import { CertificateUpload } from 'src/modules/Providers/utils/components/CertificateUpload';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
@@ -19,7 +19,7 @@ import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 import { EditComponentProps } from '../BaseCredentialsSection';
 
-export const VSphereCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
+export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
   const user = safeBase64Decode(secret?.data?.user || '');
@@ -55,14 +55,8 @@ export const VSphereCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
   const initialState = {
     passwordHidden: true,
     validation: {
-      user: {
-        type: 'default',
-        msg: 'A username and domain for the vSphere API endpoint, for example: user@vsphere.local.',
-      },
-      password: {
-        type: 'default',
-        msg: 'A user password for connecting to the vSphere API endpoint.',
-      },
+      user: esxiSecretFieldValidator('user', secret?.data?.user),
+      password: esxiSecretFieldValidator('password', secret?.data?.password),
       insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
       cacert: {
         type: 'default',
@@ -92,7 +86,7 @@ export const VSphereCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
 
   const handleChange = useCallback(
     (id, value) => {
-      const validationState = vsphereSecretFieldValidator(id, value);
+      const validationState = esxiSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
       // don't trim fields that allow spaces

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -1,0 +1,221 @@
+import React, { useCallback, useReducer } from 'react';
+import { Base64 } from 'js-base64';
+import { safeBase64Decode, vcenterSecretFieldValidator } from 'src/modules/Providers/utils';
+import { CertificateUpload } from 'src/modules/Providers/utils/components/CertificateUpload';
+import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
+
+import {
+  Button,
+  Divider,
+  Form,
+  FormGroup,
+  Popover,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
+import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
+import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+
+import { EditComponentProps } from '../BaseCredentialsSection';
+
+export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
+  const { t } = useForkliftTranslation();
+
+  const user = safeBase64Decode(secret?.data?.user || '');
+  const url = safeBase64Decode(secret?.data?.url || '');
+  const password = safeBase64Decode(secret?.data?.password || '');
+  const cacert = safeBase64Decode(secret?.data?.cacert || '');
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
+
+  const insecureSkipVerifyHelperTextPopover = (
+    <ForkliftTrans>
+      <p>
+        Select <strong>Skip certificate validation</strong> to skip certificate verification, which
+        proceeds with an insecure migration and then the certificate is not required. Insecure
+        migration means that the transferred data is sent over an insecure connection and
+        potentially sensitive data could be exposed.
+      </p>
+    </ForkliftTrans>
+  );
+
+  const cacertHelperTextPopover = (
+    <ForkliftTrans>
+      <p>
+        Use the CA certificate of the Manager unless it was replaced by a third-party certificate,
+        in which case enter the Manager Apache CA certificate.
+      </p>
+      <p>When left empty the system CA certificate is used.</p>
+      <p>
+        The certificate is not verified when <strong>Skip certificate validation</strong> is set.
+      </p>
+    </ForkliftTrans>
+  );
+
+  const initialState = {
+    passwordHidden: true,
+    validation: {
+      user: vcenterSecretFieldValidator('user', secret?.data?.user),
+      password: vcenterSecretFieldValidator('password', secret?.data?.password),
+      insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
+      cacert: {
+        type: 'default',
+        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
+      },
+    },
+  };
+
+  const reducer = (state, action) => {
+    switch (action.type) {
+      case 'SET_FIELD_VALIDATED':
+        return {
+          ...state,
+          validation: {
+            ...state.validation,
+            [action.payload.field]: action.payload.validationState,
+          },
+        };
+      case 'TOGGLE_PASSWORD_HIDDEN':
+        return { ...state, passwordHidden: !state.passwordHidden };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const handleChange = useCallback(
+    (id, value) => {
+      const validationState = vcenterSecretFieldValidator(id, value);
+      dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
+
+      // don't trim fields that allow spaces
+      const encodedValue = ['cacert'].includes(id)
+        ? Base64.encode(value)
+        : Base64.encode(value.trim());
+
+      onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
+    },
+    [secret, onChange],
+  );
+
+  const togglePasswordHidden = () => {
+    dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
+  };
+
+  return (
+    <Form isWidthLimited className="forklift-section-secret-edit">
+      <FormGroup
+        label={t('Username')}
+        isRequired
+        fieldId="username"
+        helperText={state.validation.user.msg}
+        helperTextInvalid={state.validation.user.msg}
+        validated={state.validation.user.type}
+      >
+        <TextInput
+          isRequired
+          type="text"
+          id="username"
+          name="username"
+          onChange={(value) => handleChange('user', value)}
+          value={user}
+          validated={state.validation.user.type}
+        />
+      </FormGroup>
+      <FormGroup
+        label={t('Password')}
+        isRequired
+        fieldId="password"
+        helperText={state.validation.password.msg}
+        helperTextInvalid={state.validation.password.msg}
+        validated={state.validation.password.type}
+      >
+        <TextInput
+          className="pf-u-w-75"
+          isRequired
+          type={state.passwordHidden ? 'password' : 'text'}
+          aria-label="Password input"
+          onChange={(value) => handleChange('password', value)}
+          value={password}
+          validated={state.validation.password.type}
+        />
+        <Button
+          variant="control"
+          onClick={togglePasswordHidden}
+          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+        >
+          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+        </Button>
+      </FormGroup>
+
+      <Divider />
+
+      <FormGroup
+        label={t('Skip certificate validation')}
+        labelIcon={
+          <Popover
+            headerContent={t('Skip certificate validation')}
+            bodyContent={insecureSkipVerifyHelperTextPopover}
+            alertSeverityVariant="info"
+          >
+            <button
+              type="button"
+              onClick={(e) => e.preventDefault()}
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        }
+        fieldId="insecureSkipVerify"
+        validated={state.validation.insecureSkipVerify.type}
+        helperTextInvalid={state.validation.insecureSkipVerify.msg}
+      >
+        <Switch
+          className="forklift-section-secret-edit-switch"
+          id="insecureSkipVerify"
+          name="insecureSkipVerify"
+          label={t('Skip certificate validation')}
+          isChecked={insecureSkipVerify}
+          hasCheckIcon
+          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+        />
+      </FormGroup>
+
+      <FormGroup
+        label={t('CA certificate')}
+        labelIcon={
+          <Popover
+            headerContent={t('CA certificate')}
+            bodyContent={cacertHelperTextPopover}
+            alertSeverityVariant="info"
+          >
+            <button
+              type="button"
+              onClick={(e) => e.preventDefault()}
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        }
+        fieldId="cacert"
+        helperText={state.validation.cacert.msg}
+        helperTextInvalid={state.validation.cacert.msg}
+        validated={state.validation.cacert.type}
+      >
+        <CertificateUpload
+          id="cacert"
+          url={url}
+          value={cacert}
+          validated={state.validation.cacert.type}
+          onDataChange={(value) => handleChange('cacert', value)}
+          onTextChange={(value) => handleChange('cacert', value)}
+          onClearClick={() => handleChange('cacert', '')}
+          isDisabled={insecureSkipVerify}
+        />
+      </FormGroup>
+    </Form>
+  );
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/index.ts
@@ -1,8 +1,9 @@
 // @index('./*', f => `export * from '${f.path}';`)
+export * from './EsxiCredentialsEdit';
 export * from './OpenshiftCredentialsEdit';
 export * from './OpenstackCredentialsEdit';
 export * from './OpenstackCredentialsEditFormGroups';
 export * from './OvirtCredentialsEdit';
 export * from './patchSecretData';
-export * from './VSphereCredentialsEdit';
+export * from './VCenterCredentialsEdit';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/index.ts
@@ -1,9 +1,10 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
 export * from './components';
 export * from './CredentialsSection';
+export * from './EsxiCredentialsSection';
 export * from './MaskedData';
 export * from './OpenshiftCredentialsSection';
 export * from './OpenstackCredentialsSection';
 export * from './OvirtCredentialsSection';
-export * from './VSphereCredentialsSection';
+export * from './VCenterCredentialsSection';
 // @endindex


### PR DESCRIPTION
Ref #967

Issue:
There is domain warning for root username when provider is VMware and Endpoint type is ESXi on MTV, which is not expected because the username of ESXi host doesn’t have domain

Screenshots:
Before:
![esxi-username-false-validator](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/6318ef5d-4aa2-4fd1-b10f-a3609b6ac48a)

After:
![esxi-username-validator](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c6a45a7f-323d-46e4-9104-4164ee643298)
