### PR TITLE
:soap: Rename start button to start migration

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
@@ -41,7 +41,7 @@ export const DetailsSectionInternal: React.FC<DetailsSectionProps> = ({ obj }) =
             variant="primary"
             onClick={() => showModal(<PlanStartMigrationModal resource={obj} model={PlanModel} />)}
           >
-            {t('Start')}
+            {t('Start migration')}
           </Button>
         </div>
       </FlexItem>


### PR DESCRIPTION
 Rename start button to start migration

Screenshot:
![start-button](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/97f27db4-83b1-477b-9dc0-41aec96f31ce)
