### PR TITLE
Fix docker/login-action

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
The password is stored in a secret QUAY_TOKEN (to our defense, it's called "token" in quay.io)