### PR TITLE
:lady_beetle:  Reset dataChanged when entering Edit mode for the Credentials section

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
@@ -93,6 +93,9 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
         return { ...state, reveal: !state.reveal };
       case 'TOGGLE_EDIT':
         return { ...state, edit: !state.edit };
+      case 'RESET_DATA_CHANGED': {
+        return { ...state, dataChanged: false };
+      }
       case 'SET_NEW_SECRET': {
         const dataChanged = isSecretDataChanged(secret, action.payload);
         const validationError = validator(action.payload);
@@ -127,6 +130,11 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
     dispatch({ type: 'TOGGLE_REVEAL' });
   }
 
+  // mark data as unchanged, i.e. current staged secret data is equal to saved secret data
+  function resetDataChanged() {
+    dispatch({ type: 'RESET_DATA_CHANGED' });
+  }
+
   // Handle user edits
   function onNewSecretChange(newValue: IoK8sApiCoreV1Secret) {
     // update staged secret with new value
@@ -150,6 +158,7 @@ export const BaseCredentialsSection: React.FC<BaseCredentialsSectionProps> = ({
       await patchSecretData(state.newSecret, true);
 
       setIsLoading(false);
+      resetDataChanged();
       toggleEdit();
     } catch (err) {
       dispatch({


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/789

Fixing a bug by resetting the `dataChanged` flag, whenever entering the edit mode for the Credentials section page.

### Before
[Screencast from 2024-03-21 18-21-30.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/1c5623b8-21b7-4aaf-ade3-24d12cff907c)

### After
[Screencast from 2024-03-21 18-23-53.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/80bd3b74-7ed1-4547-93b2-a4192dea0c0d)


