### PR TITLE
:lady_beetle: Fix missing source mappings for the OVA provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
@@ -270,7 +270,8 @@ export const PlanMappingsSection: React.FC<PlanMappingsSectionProps> = ({
         (obj.providerType === 'vsphere' && vsphereFindObj(obj, next.source)) ||
         (obj.providerType === 'openstack' && openstackFindObj(obj, next.source)) ||
         (obj.providerType === 'openshift' &&
-          openshiftFindObj(obj as OpenShiftNetworkAttachmentDefinition, next.source)),
+          openshiftFindObj(obj as OpenShiftNetworkAttachmentDefinition, next.source)) ||
+        (obj.providerType === 'ova' && ovaFindObj(obj, next.source)),
     );
 
     const nextTargetIndex = targetNetworks.findIndex(
@@ -381,6 +382,10 @@ export const PlanMappingsSection: React.FC<PlanMappingsSectionProps> = ({
     nextName: string,
   ) => {
     return `${obj.namespace}/${obj.name}` === nextName || obj.name === nextName;
+  };
+
+  const ovaFindObj = (obj, nextName: string) => {
+    return obj.path === nextName || obj.name === nextName;
   };
 
   const createReplacedNetworkMap = (

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
@@ -53,6 +53,9 @@ export const mapSourceNetworksIdsToLabels = (
         case 'vsphere': {
           return [net.id, net.name];
         }
+        case 'ova': {
+          return [net.id, net.name];
+        }
         default: {
           return undefined;
         }
@@ -79,6 +82,9 @@ export const mapSourceStoragesIdsToLabels = (
           return [storage.id, storage.path ?? storage.name];
         }
         case 'vsphere': {
+          return [storage.id, storage.name];
+        }
+        case 'ova': {
           return [storage.id, storage.name];
         }
         default: {

--- a/packages/forklift-console-plugin/src/modules/Providers/hooks/useNetworks.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/hooks/useNetworks.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import {
   OpenShiftNetworkAttachmentDefinition,
   OpenstackNetwork,
+  OvaNetwork,
   OVirtNetwork,
   ProviderType,
   V1beta1Provider,
@@ -15,7 +16,8 @@ export type InventoryNetwork =
   | OpenShiftNetworkAttachmentDefinition
   | OpenstackNetwork
   | OVirtNetwork
-  | VSphereNetwork;
+  | VSphereNetwork
+  | OvaNetwork;
 
 export const useSourceNetworks = (
   provider: V1beta1Provider,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/createInitialState.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/createInitialState.ts
@@ -137,7 +137,7 @@ export const createInitialState = ({
       sourceStorageLabelToId: {},
       storageIdsUsedBySelectedVms: ['ovirt', 'openstack'].includes(sourceProvider.spec?.type)
         ? []
-        : getStoragesUsedBySelectedVms(selectedVms, []),
+        : getStoragesUsedBySelectedVms({}, selectedVms, []),
       namespacesUsedBySelectedVms:
         sourceProvider.spec?.type === 'openshift'
           ? getNamespacesUsedBySelectedVms(selectedVms)

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getNetworksUsedBySelectedVMs.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getNetworksUsedBySelectedVMs.ts
@@ -44,6 +44,9 @@ export const toNetworksOrProfiles = (vm) => {
         ) ?? []
       );
     }
+    case 'ova': {
+      return vm?.networks?.map((network) => Object.values(network)[0]) ?? [];
+    }
     default:
       return [];
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getStoragesUsedBySelectedVMs.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getStoragesUsedBySelectedVMs.ts
@@ -1,9 +1,14 @@
+import { Draft } from 'immer';
+
 import { OpenstackVolume, OVirtDisk } from '@kubev2v/types';
 
 import { VmData } from '../../details';
 
 // based on packages legacy/src/Plans/components/Wizard/helpers.tsx
 export const getStoragesUsedBySelectedVms = (
+  sourceStorageLabelToId: Draft<{
+    [label: string]: string;
+  }>,
   selectedVMs: VmData[],
   disks: (OVirtDisk | OpenstackVolume)[],
 ): string[] => {
@@ -30,6 +35,9 @@ export const getStoragesUsedBySelectedVms = (
               );
               const storageDomainIds = vmDisks?.map((disk) => disk?.storageDomain);
               return storageDomainIds;
+            }
+            case 'ova': {
+              return [Object.values(sourceStorageLabelToId)[0]];
             }
             default:
               return [];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/mapSourceToLabels.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/mapSourceToLabels.ts
@@ -19,6 +19,9 @@ export const mapSourceNetworksToLabels = (
         case 'vsphere': {
           return [net.name, net.id];
         }
+        case 'ova': {
+          return [net.name, net.id];
+        }
         default: {
           return undefined;
         }
@@ -45,6 +48,9 @@ export const mapSourceStoragesToLabels = (
           return [storage.path ?? storage.name, storage.id];
         }
         case 'vsphere': {
+          return [storage.name, storage.id];
+        }
+        case 'ova': {
           return [storage.name, storage.id];
         }
         default: {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -276,7 +276,11 @@ const handlers: {
     } = draft;
     existingResources.disks = disks;
 
-    calculatedOnce.storageIdsUsedBySelectedVms = getStoragesUsedBySelectedVms(selectedVms, disks);
+    calculatedOnce.storageIdsUsedBySelectedVms = getStoragesUsedBySelectedVms(
+      draft.calculatedOnce.sourceStorageLabelToId,
+      selectedVms,
+      disks,
+    );
     recalculateStorages(draft);
   },
   [SET_EXISTING_NET_MAPS](


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/973

Add missing source mappings (network and storage) for the OVA provider.
Fix that in all places (fast create plan, plan creation wizard, mappings  tab).

### Screencasts
[Screencast from 2024-03-26 07-05-08.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/7f8af7b4-2a07-4f2b-a299-03c49ff9cb25)

[Screencast from 2024-03-26 07-08-06.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/4ea0de82-45cd-4335-a594-d4319a878225)

