### PR TITLE
:lady_beetle: Avoid displaying a re-generated warning while creating a new mapping

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/helpers.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/helpers.ts
@@ -144,6 +144,7 @@ export const recalculateStorages = (draft) => {
   executeStorageMappingValidation(draft);
   if (
     storageMappings &&
+    storageMappings.length !== 0 &&
     !areMappingsEqual(storageMappings, draft.calculatedPerNamespace.storageMappings)
   ) {
     addIfMissing<StorageAlerts>(STORAGE_MAPPING_REGENERATED, draft.alerts.storageMappings.warnings);
@@ -159,6 +160,7 @@ export const recalculateNetworks = (draft) => {
   executeNetworkMappingValidation(draft);
   if (
     networkMappings &&
+    networkMappings.length !== 0 &&
     !areMappingsEqual(networkMappings, draft.calculatedPerNamespace.networkMappings)
   ) {
     addIfMissing<NetworkAlerts>(NETWORK_MAPPING_REGENERATED, draft.alerts.networkMappings.warnings);


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/975

### Screencast
[Screencast from 2024-03-26 09-44-37.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/2fdcf9c3-8b9b-45ae-b4be-da266f86fffa)

