### PR TITLE
:lady_beetle: Openstack resources identified by labels

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
@@ -51,7 +51,7 @@ export const calculateNetworks = (
     .sort((a, b) => universalComparator(a, b, 'en'))
     .map((label) => {
       const usedBySelectedVms = networkIdsUsedBySelectedVms.some(
-        (id) => id === sourceNetworkLabelToId[label],
+        (id) => id === sourceNetworkLabelToId[label] || id === label,
       );
       return {
         label,
@@ -119,7 +119,7 @@ export const calculateStorages = (
     .sort((a, b) => universalComparator(a, b, 'en'))
     .map((label) => {
       const usedBySelectedVms = storageIdsUsedBySelectedVms.some(
-        (id) => id === sourceStorageLabelToId[label],
+        (id) => id === sourceStorageLabelToId[label] || id === label,
       );
       return {
         label,


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1015

Openstack resources identified by labels

Screenshot:
Before:
[Screencast from 2024-03-26 11-11-58.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/9b643f64-6932-41d4-bc3f-acdb9b10dabb)

After:
[Screencast from 2024-03-26 11-11-19.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/6ad31515-cae9-4843-b255-f06cd248150f)
