### PR TITLE
:lady_beetle:  If one item missing invalidate sum of resources

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/OpenshiftPlanResources.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/OpenshiftPlanResources.tsx
@@ -35,6 +35,9 @@ export const OpenshiftPlanResources: React.FC<{ planInventory: OpenshiftVM[] }> 
     { cpuCount: 0, memoryMB: 0 },
   );
 
+  const missingCPUInfo = planInventory.find(({ object }) => getK8sCPU(object) === '0');
+  const missingMemoryInfo = planInventory.find(({ object }) => getK8sVMMemory(object) === '0Mi');
+
   return (
     <PageSection variant="light">
       <SectionHeading text={t('Calculated resources')} />
@@ -56,15 +59,15 @@ export const OpenshiftPlanResources: React.FC<{ planInventory: OpenshiftVM[] }> 
             <Th width={10}>
               <strong>{t('Total CPU count:')}</strong>
             </Th>
-            <Td width={10}>{totalResources.cpuCount || '-'} Cores</Td>
-            <Td width={10}>{totalResourcesRunning.cpuCount || '-'} Cores</Td>
+            <Td width={10}>{missingCPUInfo ? '-' : `${totalResources.cpuCount} Cores`}</Td>
+            <Td width={10}>{missingCPUInfo ? '-' : `${totalResourcesRunning.cpuCount} Cores`}</Td>
           </Tr>
           <Tr>
             <Th width={10}>
               <strong>{t('Total memory:')}</strong>
             </Th>
-            <Td width={10}>{totalResources.memoryMB || '-'} MB</Td>
-            <Td width={10}>{totalResourcesRunning.memoryMB || '-'} MB</Td>
+            <Td width={10}>{missingMemoryInfo ? '-' : `${totalResources.memoryMB} MB`}</Td>
+            <Td width={10}>{missingMemoryInfo ? '-' : `${totalResourcesRunning.memoryMB} MB`}</Td>
           </Tr>
         </Tbody>
       </TableComposable>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/OpenstackPlanResources.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/OpenstackPlanResources.tsx
@@ -34,15 +34,15 @@ export const OpenstackPlanResources: React.FC<{ planInventory: OpenstackVM[] }> 
             <Th width={10}>
               <strong>{t('Total CPU count:')}</strong>
             </Th>
-            <Td width={10}>- Cores</Td>
-            <Td width={10}>- Cores</Td>
+            <Td width={10}>-</Td>
+            <Td width={10}>-</Td>
           </Tr>
           <Tr>
             <Th width={10}>
               <strong>{t('Total memory:')}</strong>
             </Th>
-            <Td width={10}>- MB</Td>
-            <Td width={10}>- MB</Td>
+            <Td width={10}>-</Td>
+            <Td width={10}>-</Td>
           </Tr>
         </Tbody>
       </TableComposable>


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1030

Issue:
In plan resources, if one OCP vm is missing information, invalidate the sum
In OCP vm resources sum, we may miss one or more vms, in this case, we need to invalidate the all sum.

Fix:
Invalidate sum if one item is missing