### PR TITLE
:lady_beetle: Fix few issues with field validations in the vSphere create form

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/safeBase64Decode.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/safeBase64Decode.ts
@@ -4,6 +4,6 @@ export function safeBase64Decode(value: string) {
   try {
     return Base64.decode(value);
   } catch {
-    return '';
+    return undefined;
   }
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretFieldValidator.ts
@@ -12,7 +12,7 @@ import { validateNoSpaces, validatePublicCert, ValidationMsg } from '../../commo
  * 'error' - The field's value has failed validation.
  */
 export const openstackSecretFieldValidator = (id: string, value: string): ValidationMsg => {
-  const trimmedValue = value.trim();
+  const trimmedValue = value?.trim();
 
   let validationState: ValidationMsg;
 

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
@@ -13,7 +13,7 @@ import { validateNoSpaces, validatePublicCert, ValidationMsg } from '../../commo
  * 'warning' - The field's value has passed validation but does not fit the standard format, it's the user's choice if to accept that value.
  */
 export const esxiSecretFieldValidator = (id: string, value: string): ValidationMsg => {
-  const trimmedValue = value?.trim() || '';
+  const trimmedValue = value?.trim();
 
   let validationState: ValidationMsg;
 
@@ -41,6 +41,13 @@ export const esxiSecretFieldValidator = (id: string, value: string): ValidationM
 const validateUser = (value: string): ValidationMsg => {
   const noSpaces = validateNoSpaces(value);
 
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A username and domain for the ESXi API endpoint, for example: user . [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -60,6 +67,13 @@ const validateUser = (value: string): ValidationMsg => {
 
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A user password for connecting to the ESXi API endpoint. [required]',
+    };
+  }
 
   if (value === '') {
     return {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
@@ -1,6 +1,13 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateEsxiURL = (url: string | number): ValidationMsg => {
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The URL is required, URL of the ESXi API endpoint for example: https://host-example.com/sdk .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVCenterURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVCenterURL.ts
@@ -1,6 +1,13 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateVCenterURL = (url: string | number): ValidationMsg => {
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The URL is required, URL of the vCenter API endpoint for example: https://host-example.com/sdk .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -1,6 +1,12 @@
 import { validateContainerImage, ValidationMsg } from '../../common';
 
 export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => {
+  if (vddkImage === undefined)
+    return {
+      msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
+      type: 'default',
+    };
+
   // Sanity check
   if (typeof vddkImage !== 'string') {
     return { type: 'error', msg: 'VDDK image is not a string' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
@@ -18,7 +18,7 @@ import {
  * 'warning' - The field's value has passed validation but does not fit the standard format, it's the user's choice if to accept that value.
  */
 export const vcenterSecretFieldValidator = (id: string, value: string): ValidationMsg => {
-  const trimmedValue = value?.trim() || '';
+  const trimmedValue = value?.trim();
 
   let validationState: ValidationMsg;
 
@@ -45,6 +45,13 @@ export const vcenterSecretFieldValidator = (id: string, value: string): Validati
 
 const validateUser = (value: string): ValidationMsg => {
   const noSpaces = validateNoSpaces(value);
+
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A username and domain for the vCenter API endpoint, for example: user@vsphere.local. [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -74,6 +81,13 @@ const validateUser = (value: string): ValidationMsg => {
 
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A user password for connecting to the vCenter API endpoint. [required]',
+    };
+  }
 
   if (value === '') {
     return {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -21,8 +21,8 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  const url = provider?.spec?.url || '';
-  const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'] || '';
+  const url = provider?.spec?.url;
+  const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'];
   const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
 
   const vddkHelperTextPopover = (
@@ -44,14 +44,8 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
 
   const initialState = {
     validation: {
-      url: {
-        msg: 'The URL of the ESXi API endpoint for example: https://host-example.com/sdk .',
-        type: 'default',
-      },
-      vddkInitImage: {
-        type: 'default',
-        msg: 'VMware Virtual Disk Development Kit (VDDK) image, for example: quay.io/kubev2v/vddk:latest .',
-      },
+      url: validateEsxiURL(url),
+      vddkInitImage: validateVDDKImage(vddkInitImage),
     },
   };
 
@@ -74,7 +68,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
 
   const handleChange = useCallback(
     (id, value) => {
-      const trimmedValue = value.trim();
+      const trimmedValue = value?.trim();
 
       if (id == 'vddkInitImage') {
         const validationState = validateVDDKImage(trimmedValue);
@@ -87,8 +81,6 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
         onChange({
           ...provider,
           spec: {
-            type: provider.spec.type,
-            url: provider.spec.url,
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),
@@ -101,17 +93,9 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
       if (id == 'sdkEndpoint') {
         const sdkEndpoint = trimmedValue || undefined;
 
-        // Revalidate URL - VCenter or ESXi
-        const trimmedURL = provider?.spec?.url?.trim() || '';
-        const validationState = validateEsxiURL(trimmedURL);
-
-        dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: 'url', validationState } });
-
         onChange({
           ...provider,
           spec: {
-            type: provider.spec.type,
-            url: provider.spec.url,
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -21,9 +21,9 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
 }) => {
   const { t } = useForkliftTranslation();
 
-  const url = provider?.spec?.url || '';
-  const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'] || '';
-  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
+  const url = provider?.spec?.url;
+  const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'];
+  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'];
 
   const vddkHelperTextPopover = (
     <ForkliftTrans>
@@ -44,14 +44,8 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
 
   const initialState = {
     validation: {
-      url: {
-        msg: 'The URL of the vCenter API endpoint for example: https://host-example.com/sdk .',
-        type: 'default',
-      },
-      vddkInitImage: {
-        type: 'default',
-        msg: 'VMware Virtual Disk Development Kit (VDDK) image, for example: quay.io/kubev2v/vddk:latest .',
-      },
+      url: validateVCenterURL(url),
+      vddkInitImage: validateVDDKImage(vddkInitImage),
     },
   };
 
@@ -74,7 +68,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
 
   const handleChange = useCallback(
     (id, value) => {
-      const trimmedValue = value.trim();
+      const trimmedValue = value?.trim();
 
       if (id == 'vddkInitImage') {
         const validationState = validateVDDKImage(trimmedValue);
@@ -87,8 +81,6 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
         onChange({
           ...provider,
           spec: {
-            type: provider.spec.type,
-            url: provider.spec.url,
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),
@@ -101,17 +93,9 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
       if (id == 'sdkEndpoint') {
         const sdkEndpoint = trimmedValue || undefined;
 
-        // Revalidate URL - VCenter or ESXi
-        const trimmedURL = provider?.spec?.url?.trim() || '';
-        const validationState = validateVCenterURL(trimmedURL);
-
-        dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: 'url', validationState } });
-
         onChange({
           ...provider,
           spec: {
-            type: provider.spec.type,
-            url: provider.spec.url,
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -22,9 +22,9 @@ import { EditComponentProps } from '../BaseCredentialsSection';
 export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
-  const user = safeBase64Decode(secret?.data?.user || '');
-  const url = safeBase64Decode(secret?.data?.url || '');
-  const password = safeBase64Decode(secret?.data?.password || '');
+  const user = safeBase64Decode(secret?.data?.user);
+  const password = safeBase64Decode(secret?.data?.password);
+  const url = safeBase64Decode(secret?.data?.url);
   const cacert = safeBase64Decode(secret?.data?.cacert || '');
   const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
 
@@ -58,10 +58,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
       user: esxiSecretFieldValidator('user', user),
       password: esxiSecretFieldValidator('password', password),
       insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
-      cacert: {
-        type: 'default',
-        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
-      },
+      cacert: esxiSecretFieldValidator('cacert', cacert),
     },
   };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -22,9 +22,9 @@ import { EditComponentProps } from '../BaseCredentialsSection';
 export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
-  const user = safeBase64Decode(secret?.data?.user || '');
-  const url = safeBase64Decode(secret?.data?.url || '');
-  const password = safeBase64Decode(secret?.data?.password || '');
+  const user = safeBase64Decode(secret?.data?.user);
+  const password = safeBase64Decode(secret?.data?.password);
+  const url = safeBase64Decode(secret?.data?.url);
   const cacert = safeBase64Decode(secret?.data?.cacert || '');
   const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
 
@@ -58,10 +58,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
       user: vcenterSecretFieldValidator('user', user),
       password: vcenterSecretFieldValidator('password', password),
       insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
-      cacert: {
-        type: 'default',
-        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
-      },
+      cacert: vcenterSecretFieldValidator('cacert', cacert),
     },
   };
 


### PR DESCRIPTION
Fix few issues in `vSphere` create form regarding fields validations and specifically when switching between endpoint types.

This is a follow up for
https://github.com/kubev2v/forklift-console-plugin/pull/1033 and https://github.com/kubev2v/forklift-console-plugin/pull/1034.

The fix includes:
1. The initial help text for an empty `user`, `password` fields can't be set to an error validation type.
2. When switching between endpoint types (vCenter <-> ESXi), the fields value should be kept while re-validation of the fields based on the new endpoint type should be done. This was not the case prior to this fix.

### Screencasts

## Before


[Screencast from 2024-03-28 14-38-05.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/1b0a48e0-8e5b-4322-8634-7257958c7f30)


[Screencast from 2024-03-28 14-33-33.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/4325095a-68dd-48b2-8f3c-592eb7416e6a)




## After
[Screencast from 2024-03-28 14-52-20.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/4b070ab0-6dae-4e3d-9402-82fb77093ec5)

[Screencast from 2024-03-28 14-54-24.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/a1b1c145-5a58-4ad5-bb41-de7f2055e200)

