### PR TITLE
Enforce setting the cacert field for secure providers

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftSecretValidator.ts
@@ -2,6 +2,7 @@ import { Base64 } from 'js-base64';
 
 import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
 
+import { missingKeysInSecretData } from '../../../helpers';
 import { ValidationMsg } from '../../common';
 
 import { openshiftSecretFieldValidator } from './openshiftSecretFieldValidator';
@@ -10,6 +11,33 @@ export function openshiftSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
   const url = secret?.data?.url || '';
   const token = secret?.data?.token || '';
 
+  // required fields
+  const requiredFields = [];
+
+  // Validate fields
+  const validateFields = ['user', 'token', 'insecureSkipVerify'];
+
+  // Add ca cert validation if not insecureSkipVerify
+  const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
+  if (insecureSkipVerify !== 'true') {
+    validateFields.push('cacert');
+    requiredFields.push('cacert');
+  }
+
+  const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
+  if (missingRequiredFields.length > 0) {
+    return { type: 'error', msg: `missing required fields [${missingRequiredFields.join(', ')}]` };
+  }
+
+  for (const id of validateFields) {
+    const value = Base64.decode(secret?.data?.[id] || '');
+
+    const validation = openshiftSecretFieldValidator(id, value);
+
+    if (validation.type === 'error') {
+      return validation;
+    }
+  }
   // Empty URL + token is valid as host providers
   if (url === '' && token === '') {
     return { type: 'default' };
@@ -23,25 +51,6 @@ export function openshiftSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
   // If we have token, url is required
   if (url === '' && token !== '') {
     return { type: 'error', msg: `Missing required fields [url]` };
-  }
-
-  // Validate fields
-  const validateFields = ['user', 'token', 'insecureSkipVerify'];
-
-  // Add ca cert validation if not insecureSkipVerify
-  const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
-  if (insecureSkipVerify !== 'true') {
-    validateFields.push('cacert');
-  }
-
-  for (const id of validateFields) {
-    const value = Base64.decode(secret?.data?.[id] || '');
-
-    const validation = openshiftSecretFieldValidator(id, value);
-
-    if (validation.type === 'error') {
-      return validation;
-    }
   }
 
   return { type: 'default' };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
@@ -79,16 +79,17 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
       return { type: 'error', msg: 'invalid authType' };
   }
 
-  const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
-
-  if (missingRequiredFields.length > 0) {
-    return { type: 'error', msg: `missing required fields [${missingRequiredFields.join(', ')}]` };
-  }
-
   // Add ca cert validation if not insecureSkipVerify
   const insecureSkipVerify = safeBase64Decode(secret?.data?.['insecureSkipVerify'] || '');
   if (insecureSkipVerify !== 'true') {
     validateFields.push('cacert');
+    requiredFields.push('cacert');
+  }
+
+  const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);
+
+  if (missingRequiredFields.length > 0) {
+    return { type: 'error', msg: `missing required fields [${missingRequiredFields.join(', ')}]` };
   }
 
   for (const id of validateFields) {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretValidator.ts
@@ -15,6 +15,7 @@ export function ovirtSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMs
   const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
   if (insecureSkipVerify !== 'true') {
     validateFields.push('cacert');
+    requiredFields.push('cacert');
   }
 
   const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretValidator.ts
@@ -15,6 +15,7 @@ export function esxiSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg
   const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
   if (insecureSkipVerify !== 'true') {
     validateFields.push('cacert');
+    requiredFields.push('cacert');
   }
 
   const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretValidator.ts
@@ -15,6 +15,7 @@ export function vcenterSecretValidator(secret: IoK8sApiCoreV1Secret): Validation
   const insecureSkipVerify = Base64.decode(secret?.data?.['insecureSkipVerify'] || '');
   if (insecureSkipVerify !== 'true') {
     validateFields.push('cacert');
+    requiredFields.push('cacert');
   }
 
   const missingRequiredFields = missingKeysInSecretData(secret, requiredFields);


### PR DESCRIPTION
Fix a bug in which the cacert field was not required if `insecureSkipVerify` is set to false, i.e. provider is secure.
This is reproduced for all providers.

![Screenshot from 2024-03-28 16-55-17](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/4f6dc5e3-b3c2-4a1b-ac6b-d534eeb5e2c1)
