### PR TITLE
 🐞 migrations may not have an owner

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
@@ -120,7 +120,7 @@ export const MigrationVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => 
 
   const planMigrations = (
     migrations && migrationLoaded && !migrationLoadError ? migrations : []
-  ).filter((m) => m.metadata.ownerReferences[0].uid === plan.metadata.uid);
+  ).filter((m) => m?.metadata?.ownerReferences?.[0]?.uid === plan.metadata.uid);
 
   planMigrations?.sort(
     (a, b) =>


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1039

migrations may not have an owner

the vm list page for plans may creash if we have a migration without an owner