### PR TITLE
:lady_beetle: Support validation for the openStack CA certificate field

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -142,7 +142,6 @@
   "Error": "Error",
   "Error: Insecure Skip Verify must be a boolean value.": "Error: Insecure Skip Verify must be a boolean value.",
   "Error: Name is required and must be a unique within a namespace and valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).": "Error: Name is required and must be a unique within a namespace and valid Kubernetes name (i.e., must contain no more than 253 characters, consists of lower case alphanumeric characters , '-' or '.' and starts and ends with an alphanumeric character).",
-  "Error: The format of the provided CA certificate is invalid. Ensure the CA certificate format is valid.": "Error: The format of the provided CA certificate is invalid. Ensure the CA certificate format is valid.",
   "Error: this field must be set to a boolean value.": "Error: this field must be set to a boolean value.",
   "ESXi": "ESXi",
   "Expiration date": "Expiration date",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -26,15 +26,6 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     successAndNotSkipped: t("The provider's CA certificate will be validated."),
   };
 
-  const cacertHelperTextMsgs = {
-    error: t(
-      'Error: The format of the provided CA certificate is invalid. Ensure the CA certificate format is valid.',
-    ),
-    success: t(
-      'A CA certificate to be trusted when connecting to the OpenStack Identity (Keystone) endpoint. Ensure the CA certificate format is valid. To use a CA certificate, drag the file to the text box or browse for it. To use the system CA certificate, leave the field empty.',
-    ),
-  };
-
   const insecureSkipVerifyHelperTextPopover = (
     <ForkliftTrans>
       Note: If <strong>Skip certificate validation</strong> is selected, migrations from this
@@ -278,16 +269,16 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
             : t('CA certificate - leave empty to use system CA certificates')
         }
         fieldId="cacert"
-        helperText={cacertHelperTextMsgs.success}
-        validated={state.validation.cacert}
-        helperTextInvalid={cacertHelperTextMsgs.error}
+        helperText={state.validation.cacert.msg}
+        validated={state.validation.cacert.type}
+        helperTextInvalid={state.validation.cacert.msg}
       >
         <CertificateUpload
           id="cacert"
           type="text"
           filenamePlaceholder="Drag and drop a file or upload one"
           value={cacert}
-          validated={state.validation.cacert}
+          validated={state.validation.cacert.type}
           onDataChange={(value) => handleChange('cacert', value)}
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1043

Fix a bug for supporting field validation of the CA certificate field for the openStack provider.

## Before

![Screenshot from 2024-03-28 22-04-29](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/891ad8f2-7d63-4a02-ab69-f8d80b4c0963)


## After
![Screenshot from 2024-03-28 22-05-18](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/791c20fa-668d-4983-89ec-0c85a3709d64)
