### PR TITLE
:lady_beetle: Avoid wrapping VM concern lables into more than one line

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMConcernsCellRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/VMConcernsCellRenderer.tsx
@@ -28,7 +28,7 @@ export const VMConcernsCellRenderer: React.FC<VMCellProps> = ({ data }) => {
 
   return (
     <TableCell>
-      <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+      <Flex spaceItems={{ default: 'spaceItemsNone' }} flexWrap={{ default: 'nowrap' }}>
         {['Critical', 'Information', 'Warning'].map((category) => (
           <FlexItem key={category}>
             <ConcernPopover category={category} concerns={groupedConcerns[category] || []} />


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1025

Wrap the VM concern labels in provider VMs tab and Plan create VMs modal into one line.

# Screeshots

[Screencast from 2024-04-01 16-56-13.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/2676824b-4470-4d3d-8cda-a7f6236f8ba6)
[Screencast from 2024-04-01 16-56-45.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/2fc476e6-0057-4de6-883f-810469ed293a)
