### PR TITLE
:lady_beetle:  Fix status and action when plan succedded

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -302,6 +302,7 @@
   "Plan name": "Plan name",
   "Plan running": "Plan running",
   "Plane not ready": "Plane not ready",
+  "Plane Succeeded": "Plane Succeeded",
   "Plans": "Plans",
   "Plans for virtualization": "Plans for virtualization",
   "Please choose a NetworkAttachmentDefinition for data transfer.": "Please choose a NetworkAttachmentDefinition for data transfer.",

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
@@ -74,7 +74,10 @@ export const canPlanStart = (plan: V1beta1Plan) => {
   const conditions = getConditions(plan);
 
   return (
-    conditions?.includes('Ready') && !conditions?.includes('Executing') && !plan?.spec?.archived
+    conditions?.includes('Ready') &&
+    !conditions?.includes('Executing') &&
+    !conditions?.includes('Succeeded') &&
+    !plan?.spec?.archived
   );
 };
 
@@ -88,6 +91,12 @@ export const isPlanExecuting = (plan: V1beta1Plan) => {
   const conditions = getConditions(plan);
 
   return conditions?.includes('Executing');
+};
+
+export const isPlanSucceeded = (plan: V1beta1Plan) => {
+  const conditions = getConditions(plan);
+
+  return conditions?.includes('Succeeded');
 };
 
 const getConditions = (obj: V1beta1Plan) =>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -5,75 +5,17 @@ import ProvidersCreateVmMigrationPage from 'src/modules/Providers/views/migrate/
 import { startCreate } from 'src/modules/Providers/views/migrate/reducer/actions';
 import { useFetchEffects } from 'src/modules/Providers/views/migrate/useFetchEffects';
 import { useSaveEffect } from 'src/modules/Providers/views/migrate/useSaveEffect';
-import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
+import { ForkliftTrans } from 'src/utils/i18n';
 
 import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, PageSection, Title, Wizard } from '@patternfly/react-core';
 
-import { findProviderByID, PlanCreateForm, ProviderVirtualMachinesList } from './components';
-import {
-  PlanCreatePageActionTypes,
-  planCreatePageInitialState,
-  planCreatePageReducer,
-  PlanCreatePageState,
-} from './states';
+import { findProviderByID } from './components';
+import { planCreatePageInitialState, planCreatePageReducer } from './states';
+import { SelectSourceProvider } from './steps';
 
 import './PlanCreatePage.style.css';
-
-export const PlanCreatePage_: React.FC<{
-  namespace: string;
-  filterState: PlanCreatePageState;
-  filterDispatch: React.Dispatch<PlanCreatePageActionTypes>;
-  providers: V1beta1Provider[];
-  selectedProvider: V1beta1Provider;
-}> = ({ filterState, filterDispatch, providers, selectedProvider }) => {
-  const { t } = useForkliftTranslation();
-
-  // Get the ready providers (note: currently forklift does not allow filter be status.phase)
-  const readyProviders = providers.filter((p) => p?.status?.phase === 'Ready');
-
-  const filteredProviders = readyProviders.filter(
-    (provider) =>
-      provider.metadata.name.toLowerCase().includes(filterState.nameFilter.toLowerCase()) &&
-      (filterState.typeFilters.length === 0 ||
-        filterState.typeFilters.includes(provider.spec.type)),
-  );
-
-  const selectedProviderName = selectedProvider?.metadata?.name;
-  const selectedProviderNamespace = selectedProvider?.metadata?.namespace;
-
-  return (
-    <>
-      <Title headingLevel="h2">{t('Select source provider')}</Title>
-
-      <PlanCreateForm
-        providers={filteredProviders}
-        filterState={filterState}
-        filterDispatch={filterDispatch}
-      />
-
-      {filterState.selectedProviderUID && (
-        <>
-          <Title headingLevel="h2" className="forklift--create-plan--title">
-            {t('Select virtual machines')}
-          </Title>
-
-          <ProviderVirtualMachinesList
-            title=""
-            name={selectedProviderName}
-            namespace={selectedProviderNamespace}
-            onSelect={(selectedVms) =>
-              filterDispatch({ type: 'UPDATE_SELECTED_VMS', payload: selectedVms })
-            }
-            initialSelectedIds={filterState.selectedVMs.map((vm) => vm.vm.id)}
-            showActions={false}
-          />
-        </>
-      )}
-    </>
-  );
-};
 
 export const PlanCreatePage: React.FC<{ namespace: string }> = ({ namespace }) => {
   // Get optional initial state context
@@ -111,7 +53,7 @@ export const PlanCreatePage: React.FC<{ namespace: string }> = ({ namespace }) =
       id: 'step-1',
       name: 'Select source provider',
       component: (
-        <PlanCreatePage_
+        <SelectSourceProvider
           namespace={namespace}
           filterState={filterState}
           filterDispatch={filterDispatch}

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/CreateMigrationPlan/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/CreateMigrationPlan/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+
+// @endindex

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/SelectSourceProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/SelectSourceProvider.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useForkliftTranslation } from 'src/utils/i18n';
+
+import { V1beta1Provider } from '@kubev2v/types';
+import { Title } from '@patternfly/react-core';
+
+import { PlanCreatePageActionTypes, PlanCreatePageState } from '../../states';
+
+import { PlanCreateForm, ProviderVirtualMachinesList } from './../../components';
+
+export const SelectSourceProvider: React.FC<{
+  namespace: string;
+  filterState: PlanCreatePageState;
+  filterDispatch: React.Dispatch<PlanCreatePageActionTypes>;
+  providers: V1beta1Provider[];
+  selectedProvider: V1beta1Provider;
+}> = ({ filterState, filterDispatch, providers, selectedProvider }) => {
+  const { t } = useForkliftTranslation();
+
+  // Get the ready providers (note: currently forklift does not allow filter be status.phase)
+  const readyProviders = providers.filter((p) => p?.status?.phase === 'Ready');
+
+  const filteredProviders = readyProviders.filter(
+    (provider) =>
+      provider.metadata.name.toLowerCase().includes(filterState.nameFilter.toLowerCase()) &&
+      (filterState.typeFilters.length === 0 ||
+        filterState.typeFilters.includes(provider.spec.type)),
+  );
+
+  const selectedProviderName = selectedProvider?.metadata?.name;
+  const selectedProviderNamespace = selectedProvider?.metadata?.namespace;
+
+  return (
+    <>
+      <Title headingLevel="h2">{t('Select source provider')}</Title>
+
+      <PlanCreateForm
+        providers={filteredProviders}
+        filterState={filterState}
+        filterDispatch={filterDispatch}
+      />
+
+      {filterState.selectedProviderUID && (
+        <>
+          <Title headingLevel="h2" className="forklift--create-plan--title">
+            {t('Select virtual machines')}
+          </Title>
+
+          <ProviderVirtualMachinesList
+            title=""
+            name={selectedProviderName}
+            namespace={selectedProviderNamespace}
+            onSelect={(selectedVms) =>
+              filterDispatch({ type: 'UPDATE_SELECTED_VMS', payload: selectedVms })
+            }
+            initialSelectedIds={filterState.selectedVMs.map((vm) => vm.vm.id)}
+            showActions={false}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './SelectSourceProvider';
+// @endindex

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './SelectSourceProvider';
+// @endindex

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/DetailsSection/DetailsSection.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { PlanStartMigrationModal } from 'src/modules/Plans/modals';
-import { canPlanReStart, canPlanStart, isPlanExecuting } from 'src/modules/Plans/utils';
+import {
+  canPlanReStart,
+  canPlanStart,
+  isPlanExecuting,
+  isPlanSucceeded,
+} from 'src/modules/Plans/utils';
 import { ModalHOC, useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -34,6 +39,7 @@ export const DetailsSectionInternal: React.FC<DetailsSectionProps> = ({ obj }) =
   const canStart = canPlanStart(obj);
   const canReStart = canPlanReStart(obj);
   const isExecuting = isPlanExecuting(obj);
+  const isSucceeded = isPlanSucceeded(obj);
 
   const buttonStartLabel = canReStart ? t('Restart migration') : t('Start migration');
   const buttonStartIcon = canReStart ? (
@@ -45,7 +51,14 @@ export const DetailsSectionInternal: React.FC<DetailsSectionProps> = ({ obj }) =
   const canNotRunIcon = (
     <StartIcon color="gray" className="forklift-page-section--details-start-button__icon" />
   );
-  const canNotRunLabel = isExecuting ? t('Plan running') : t('Plane not ready');
+  let canNotRunLabel: string;
+  if (isExecuting) {
+    canNotRunLabel = t('Plan running');
+  } else if (isSucceeded) {
+    canNotRunLabel = t('Plane Succeeded');
+  } else {
+    canNotRunLabel = t('Plane not ready');
+  }
 
   return (
     <>


### PR DESCRIPTION
Issue:
when succeeded "start" action is available

Fix:
when succeeded don't allow "start" action
when succeeded show "succeeded" note

Screenshot:
![screenshot-localhost_9000-2024 04 02-10_44_36](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/e1c8201e-3086-4ea5-b793-08040470cc2a)
