### PR TITLE
Allow to remove faile vms from plan

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
@@ -75,7 +75,8 @@ export const PlanVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => {
   const extendedProps = {
     ...props,
     toId: (item: VMData) => item?.specVM?.id,
-    canSelect: (item: VMData) => item?.statusVM?.started === undefined,
+    canSelect: (item: VMData) =>
+      item?.statusVM?.started === undefined || item?.statusVM?.error !== undefined,
     onSelect: setSelectedIds,
     selectedIds: selectedIds,
     GlobalActionToolbarItems: actions,

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/PlanVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/PlanVirtualMachines.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
+import { isPlanExecuting } from 'src/modules/Plans/utils';
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { ModalHOC } from 'src/modules/Providers/modals';
 
@@ -21,12 +22,12 @@ export interface PlanVirtualMachinesProps extends RouteComponentProps {
 }
 
 const PlanVirtualMachines_: React.FC<PlanVirtualMachinesProps> = (props) => {
-  const migration = props?.obj?.plan?.status?.migration.vms;
+  const plan = props?.obj.plan;
 
-  if (migration === undefined) {
-    return <PlanVirtualMachinesList {...props} />;
-  } else {
+  if (isPlanExecuting(plan)) {
     return <MigrationVirtualMachinesList {...props} />;
+  } else {
+    return <PlanVirtualMachinesList {...props} />;
   }
 };
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/128

Issue:
Add support for removing failed VMs from a completed/partially-failed plan

Screenshot:
[Screencast from 2024-04-02 11-40-31.webm](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/355af752-501f-48e4-bfd2-bd67d9263e3c)
