### PR TITLE
:lady_beetle:  Validate secret text instead of base64 text

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -55,8 +55,8 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
   const initialState = {
     passwordHidden: true,
     validation: {
-      user: esxiSecretFieldValidator('user', secret?.data?.user),
-      password: esxiSecretFieldValidator('password', secret?.data?.password),
+      user: esxiSecretFieldValidator('user', user),
+      password: esxiSecretFieldValidator('password', password),
       insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
       cacert: {
         type: 'default',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -55,8 +55,8 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
   const initialState = {
     passwordHidden: true,
     validation: {
-      user: vcenterSecretFieldValidator('user', secret?.data?.user),
-      password: vcenterSecretFieldValidator('password', secret?.data?.password),
+      user: vcenterSecretFieldValidator('user', user),
+      password: vcenterSecretFieldValidator('password', password),
       insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
       cacert: {
         type: 'default',


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1041

Issue:
validation of secret data that is base64 text

Fix:
validate the decoded value