### PR TITLE
:lady_beetle: Avoid exception in PlanPageHeadings if plan conditions are not loaded

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
@@ -30,7 +30,7 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
   const criticalCondition =
     loaded &&
     !error &&
-    plan?.status?.conditions.find((condition) => condition?.category === 'Critical');
+    plan?.status?.conditions?.find((condition) => condition?.category === 'Critical');
 
   if (criticalCondition) {
     alerts.push(


### PR DESCRIPTION
Avoid a NPE generated in `PlanPageHeadings` when entering one of the Plan tabs while the Plan conditions (`plan.status.conditions`) data is not fetched yet from backend.

Not 100% reproducible.
For reproducing:  quickly switch between the plans list to one of the plan's tabs.