### PR TITLE
:lady_beetle: Fis suspense

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/Suspend.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/Suspend.tsx
@@ -24,15 +24,13 @@ export type SuspendProps = {
  * @returns {JSX.Element} The JSX element containing the children or a loading indicator.
  */
 export const Suspend: React.FC<SuspendProps> = ({ obj, loaded, loadError, children }) => {
+  if (obj && loaded && !loadError) {
+    return <>{children}</>;
+  }
+
   return (
-    <React.Suspense
-      fallback={
-        <Bullseye>
-          <Loading />
-        </Bullseye>
-      }
-    >
-      {obj && loaded && !loadError && children}
-    </React.Suspense>
+    <Bullseye>
+      <Loading />
+    </Bullseye>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/PlanResources.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Resources/PlanResources.tsx
@@ -14,8 +14,9 @@ import {
   VSphereVM,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { Bullseye } from '@patternfly/react-core';
 
-import { Suspend } from '../../components';
+import { Loading, Suspend } from '../../components';
 
 import { OpenshiftPlanResources } from './OpenshiftPlanResources';
 import { OpenstackPlanResources } from './OpenstackPlanResources';
@@ -34,7 +35,7 @@ export const PlanResources: React.FC<{ name: string; namespace: string }> = ({
     namespace,
   });
 
-  const [provider] = useK8sWatchResource<V1beta1Provider>({
+  const [provider, providerLoaded, providerLodeError] = useK8sWatchResource<V1beta1Provider>({
     groupVersionKind: ProviderModelGroupVersionKind,
     namespaced: true,
     name: plan?.spec?.provider?.source?.name,
@@ -44,7 +45,7 @@ export const PlanResources: React.FC<{ name: string; namespace: string }> = ({
   const inventoryOptions: UseProviderInventoryParams = {
     provider: provider,
     subPath: 'vms?detail=4',
-    disabled: !loaded || loadError,
+    disabled: !loaded || loadError || !providerLoaded || providerLodeError,
   };
 
   const {
@@ -90,6 +91,10 @@ export const PlanResources: React.FC<{ name: string; namespace: string }> = ({
         </Suspend>
       );
     default:
-      return <></>;
+      return (
+        <Bullseye>
+          <Loading></Loading>
+        </Bullseye>
+      );
   }
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Details/ProviderDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { RouteComponentProps } from 'react-router-dom';
 import { SectionHeading } from 'src/components/headers/SectionHeading';
+import { Loading } from 'src/modules/Plans/views/details';
 import { useGetDeleteAndEditAccessReview, useProviderInventory } from 'src/modules/Providers/hooks';
 import { getResourceUrl, ProviderData } from 'src/modules/Providers/utils';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
@@ -14,7 +15,7 @@ import {
   V1beta1Provider,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Alert, PageSection } from '@patternfly/react-core';
+import { Alert, Bullseye, PageSection } from '@patternfly/react-core';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 
 import {
@@ -37,7 +38,11 @@ export const ProviderDetails: React.FC<ProviderDetailsProps> = ({ obj, loaded, l
   const { provider, inventory } = obj;
 
   if (!loaded || loadError || !provider?.metadata?.name) {
-    return <></>;
+    return (
+      <Bullseye>
+        <Loading />
+      </Bullseye>
+    );
   }
 
   const providerURL = getResourceUrl({


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1064

Issue:
When data is loading, plan details page show empty page instead of loading indicator