### PR TITLE
:lady_beetle:  Check provider type before assuming vm use glance

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
@@ -76,6 +76,7 @@ export const calculateStorages = (
   draft: Draft<CreateVmMigrationPageState>,
 ): Partial<CreateVmMigrationPageState['calculatedPerNamespace']> => {
   const {
+    receivedAsParams: { sourceProvider },
     existingResources,
     underConstruction: { plan },
     calculatedOnce: { sourceStorageLabelToId, storageIdsUsedBySelectedVms },
@@ -121,7 +122,7 @@ export const calculateStorages = (
       let usedBySelectedVms = storageIdsUsedBySelectedVms.some(
         (id) => id === sourceStorageLabelToId[label] || id === label,
       );
-      if (label === 'glance') {
+      if (label === 'glance' && sourceProvider?.spec?.type === 'openstack') {
         usedBySelectedVms = true;
       }
       return {


### PR DESCRIPTION
Issue:
We assume all vms use "glance" storage, but this is true only for vms running on "openstack" provider

Fix:
Check provider type before assuming "glance" is used by the vm