### PR TITLE
:lady_beetle: Allow to edit pod network as source

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/hooks/useNetworks.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/hooks/useNetworks.ts
@@ -12,6 +12,17 @@ import {
 
 import useProviderInventory from './useProviderInventory';
 
+const podNetwork: InventoryNetwork = {
+  providerType: 'openshift',
+  object: undefined,
+  uid: 'pod',
+  version: '',
+  namespace: '',
+  name: 'Pod network',
+  selfLink: '',
+  id: 'pod',
+};
+
 export type InventoryNetwork =
   | OpenShiftNetworkAttachmentDefinition
   | OpenstackNetwork
@@ -33,13 +44,17 @@ export const useSourceNetworks = (
     disabled: !provider,
   });
 
-  const typedNetworks = useMemo(
-    () =>
-      Array.isArray(networks)
-        ? networks.map((net) => ({ ...net, providerType } as InventoryNetwork))
-        : [],
-    [networks],
-  );
+  const typedNetworks = useMemo(() => {
+    const networksList = Array.isArray(networks)
+      ? networks.map((net) => ({ ...net, providerType } as InventoryNetwork))
+      : [];
+
+    if (Array.isArray(networks) && provider?.spec?.type === 'openshift') {
+      networksList.push(podNetwork);
+    }
+
+    return networksList;
+  }, [networks]);
 
   return [typedNetworks, loading, error];
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -337,9 +337,12 @@ const handlers: {
     // triggered by the user
     flow.editingDone = true;
     netMap.spec.map = networkMappings.map(({ source, destination }) => ({
-      source: {
-        id: sourceNetworkLabelToId[source],
-      },
+      source:
+        sourceNetworkLabelToId[source] === 'pod'
+          ? { type: 'pod' }
+          : {
+              id: sourceNetworkLabelToId[source],
+            },
       destination:
         destination === POD_NETWORK
           ? { type: 'pod' }


### PR DESCRIPTION
Issue:
Network mapping create and edit does not allow to add and edit "pod" networks for OCP sources.

Fix:
Allow to add and edit "pod" network for OCP sources