### PR TITLE
:lady_beetle: When calculating progress, catch all disk transfer piplines

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
@@ -47,7 +47,9 @@ const cellRenderers: Record<string, React.FC<PlanVMsCellProps>> = {
     return <Timestamp timestamp={value} />;
   },
   transfer: (props: PlanVMsCellProps) => {
-    const diskTransfer = props.data.statusVM?.pipeline.find((p) => p?.name === 'DiskTransfer');
+    const diskTransfer = props.data.statusVM?.pipeline.find((p) =>
+      p?.name?.startsWith('DiskTransfer'),
+    );
     const annotations: { unit: string } = diskTransfer?.annotations as undefined;
 
     return annotations?.unit ? (


### PR DESCRIPTION
Issue:
we currently look for disk transfer progress on piplines with the name "DiskTransfer", but we now have other disk transfer options like "DiskTransferV2v"

Fix:
catch all "DiskTransfer..." piplines