### PR TITLE
:lady_beetle: Refine glance used only on image based vms

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
@@ -76,7 +76,6 @@ export const calculateStorages = (
   draft: Draft<CreateVmMigrationPageState>,
 ): Partial<CreateVmMigrationPageState['calculatedPerNamespace']> => {
   const {
-    receivedAsParams: { sourceProvider },
     existingResources,
     underConstruction: { plan },
     calculatedOnce: { sourceStorageLabelToId, storageIdsUsedBySelectedVms },
@@ -119,12 +118,9 @@ export const calculateStorages = (
   const generatedSourceStorages = Object.keys(sourceStorageLabelToId)
     .sort((a, b) => universalComparator(a, b, 'en'))
     .map((label) => {
-      let usedBySelectedVms = storageIdsUsedBySelectedVms.some(
+      const usedBySelectedVms = storageIdsUsedBySelectedVms.some(
         (id) => id === sourceStorageLabelToId[label] || id === label,
       );
-      if (label === 'glance' && sourceProvider?.spec?.type === 'openstack') {
-        usedBySelectedVms = true;
-      }
       return {
         label,
         usedBySelectedVms,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getStoragesUsedBySelectedVMs.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/getStoragesUsedBySelectedVMs.ts
@@ -27,6 +27,11 @@ export const getStoragesUsedBySelectedVms = (
                   (disks as OpenstackVolume[]).find((disk) => disk.id === av.ID),
                 ) ?? [];
               const volumeTypeIds = vmDisks.map((disk) => disk?.volumeType);
+
+              if (vm?.imageID) {
+                volumeTypeIds.push('glance');
+              }
+
               return volumeTypeIds;
             }
             case 'ovirt': {


### PR DESCRIPTION
Issue:
When creating a plan for volume based OpenStack VMs, it enforces mapping glance to a OCP storage though the VMs are not using the glance.
It's better to not enforce mapping glance for OpenStack VMs that are not using it.

Fix:
check for `imageID != null` before adding `glance`