### PR TITLE
:lady_beetle: fix-remove-alerts

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/helpers.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/helpers.ts
@@ -255,7 +255,7 @@ export const addIfMissing = <T>(key: T, keys: T[]) => {
 export const removeIfPresent = <T>(key: T, keys: T[]) => {
   console.warn('removeIfPresent', key, keys);
   const index = keys?.findIndex((k) => k === key);
-  if (!index || index === -1) {
+  if (index === undefined || index === -1) {
     return;
   }
   keys.splice(index, 1);


### PR DESCRIPTION
Issue:
When creating a plan, errors about mappings are not removed when fixed

Fix:
Remove errors when fixed