### PR TITLE
:lady_beetle: Clean vddk image before saving

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -20,9 +20,11 @@ import { EditModal, EditModalProps, OnConfirmHookType } from '../EditModal';
 const onConfirm: OnConfirmHookType = async ({ resource, model, newValue: value }) => {
   const provider = resource as V1beta1Provider;
   const currentSettings = provider?.spec?.settings as object;
+  const vddkInitImage: string = value as string;
+
   const settings = {
     ...currentSettings,
-    vddkInitImage: value || undefined,
+    vddkInitImage: vddkInitImage?.trim() || undefined,
   };
 
   const op = provider?.spec?.settings ? 'replace' : 'add';


### PR DESCRIPTION
Issue:
When patching vmware providers vddkInitImage, we allow spaces before and after the container image URL.

Fix:
Remove white-spaces before patching.