### PR TITLE
:robot:  Fixing the Codecov failures

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Test coverage
         uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
 
   e2e:
     name: Run e2e tests


### PR DESCRIPTION
The following codecov failure is often reproduced:
   ` Error: Codecov: Failed to properly upload: The process '/home/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255`
   
Based on https://github.com/codecov/codecov-action/issues/1359, just avoid failing the CI if Codecov fails, till they will find a resolution.