### PR TITLE
Disable plane edit providers

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -37,7 +37,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <DescriptionList
         columnModifier={{
-          default: '1Col',
+          default: '2Col',
         }}
       >
         <DetailsItem

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -1,17 +1,12 @@
 import React, { useReducer } from 'react';
 import { Suspend } from 'src/modules/Plans/views/details/components';
+import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import {
-  PlanModel,
-  ProviderModelGroupVersionKind,
-  V1beta1Plan,
-  V1beta1Provider,
-} from '@kubev2v/types';
-import { k8sUpdate, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, DescriptionList, Flex, FlexItem, Spinner } from '@patternfly/react-core';
+import { ProviderModelGroupVersionKind, V1beta1Plan, V1beta1Provider } from '@kubev2v/types';
+import { ResourceLink, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { DescriptionList } from '@patternfly/react-core';
 
-import { ProvidersEdit } from './components';
 import { providersSectionReducer, ProvidersSectionState } from './state';
 
 const initialState: ProvidersSectionState = {
@@ -38,75 +33,39 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     namespace: obj.metadata.namespace,
   });
 
-  const targetProviders = providers.filter((p) => ['openshift'].includes(p?.spec?.type));
-
-  const onUpdate = async () => {
-    dispatch({ type: 'SET_UPDATING', payload: true });
-    await k8sUpdate({ model: PlanModel, data: state.plan });
-  };
-
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
-      <Flex className="forklift-network-map__details-tab--update-button">
-        <FlexItem>
-          <Button
-            variant="primary"
-            onClick={onUpdate}
-            isDisabled={!state.hasChanges || state.updating}
-            icon={state.updating ? <Spinner size="sm" /> : undefined}
-          >
-            {t('Update providers')}
-          </Button>
-        </FlexItem>
-
-        <FlexItem>
-          <Button
-            variant="secondary"
-            onClick={() => dispatch({ type: 'INIT', payload: obj })}
-            isDisabled={!state.hasChanges || state.updating}
-          >
-            {t('Cancel')}
-          </Button>
-        </FlexItem>
-      </Flex>
-
       <DescriptionList
         columnModifier={{
           default: '1Col',
         }}
       >
-        <ProvidersEdit
-          providers={providers}
-          selectedProviderName={state.plan?.spec?.provider?.source?.name}
-          label={t('Source provider')}
-          placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_SOURCE_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
+        <DetailsItem
+          title={t('Source provider')}
+          content={
+            <ResourceLink
+              inline
+              name={state.plan?.spec?.provider?.source?.name}
+              namespace={state.plan?.spec?.provider?.source?.namespace}
+              groupVersionKind={ProviderModelGroupVersionKind}
+            />
           }
-          invalidLabel={t('The chosen provider is no longer available.')}
-          mode={state.sourceProviderMode}
-          helpContent="source provider"
-          setMode={() => dispatch({ type: 'SET_SOURCE_PROVIDER_MODE', payload: 'edit' })}
+          helpContent={'source provider'}
+          crumbs={['spec', 'providers', 'source']}
         />
 
-        <ProvidersEdit
-          providers={targetProviders}
-          selectedProviderName={state.plan?.spec?.provider?.destination?.name}
-          label={t('Target provider')}
-          placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_TARGET_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
+        <DetailsItem
+          title={t('Target provider')}
+          content={
+            <ResourceLink
+              inline
+              name={state.plan?.spec?.provider?.destination?.name}
+              namespace={state.plan?.spec?.provider?.destination?.namespace}
+              groupVersionKind={ProviderModelGroupVersionKind}
+            />
           }
-          invalidLabel={t('The chosen provider is no longer available.')}
-          mode={state.targetProviderMode}
-          helpContent="Target provider"
-          setMode={() => dispatch({ type: 'SET_TARGET_PROVIDER_MODE', payload: 'edit' })}
+          helpContent={'destination provider'}
+          crumbs={['spec', 'providers', 'destination']}
         />
       </DescriptionList>
     </Suspend>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
@@ -45,7 +45,6 @@ export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, p
   return (
     <>
       <DescriptionList
-        className="forklift-page-section--details-status"
         columnModifier={{
           default: '2Col',
         }}


### PR DESCRIPTION
Ref:
https://github.com/kubev2v/forklift-console-plugin/issues/1095
https://github.com/kubev2v/forklift-console-plugin/issues/1063

Issue:
Editing plans providers changes the plan in a way it's a new plan, no need to allow users to change the plan providers.

Screeshot:
Before:
![screenshot-localhost_9000-2024 04 11-15_05_39](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/7877125b-3e2d-4e38-967d-455728cdecc4)

After:
![screenshot-localhost_9000-2024 04 11-15_04_26](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3ddc97a2-3de3-4dc6-9483-70c043a34d66)
