### PR TITLE
Align start plan with other buttons labels

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
@@ -21,7 +21,7 @@ export const ActionsCell = ({ data }: CellProps) => {
 
   const isWarmAndExecuting = plan?.spec?.warm && isPlanExecuting(plan);
 
-  const buttonStartLabel = canReStart ? t('Restart') : t('start');
+  const buttonStartLabel = canReStart ? t('Restart') : t('Start');
 
   return (
     <Flex flex={{ default: 'flex_3' }} flexWrap={{ default: 'nowrap' }}>


### PR DESCRIPTION
Typo of missing capital letter of the start plan button.