### PR TITLE
:feet: Update plan phase options

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/utils/constants/plan-status.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/constants/plan-status.ts
@@ -1,5 +1,17 @@
-export const PLAN_STATUS: Record<string, string> = {
+import { PlanPhase } from '../types';
+
+// Creating a record to map each phase to itself
+export const planPhases: Record<string, PlanPhase> = {
+  Error: 'Error',
+  vmError: 'vmError',
+  Unknown: 'Unknown',
+  Archiving: 'Archiving',
+  Archived: 'Archived',
+  Failed: 'Failed',
+  Canceled: 'Canceled',
+  Succeeded: 'Succeeded',
+  Running: 'Running',
   Ready: 'Ready',
-  'Not Ready': 'Not Ready',
-  Critical: 'Critical',
+  Warning: 'Warning',
+  NotReady: 'NotReady',
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/PlansListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/PlansListPage.tsx
@@ -11,7 +11,7 @@ import { HelperText, HelperTextItem } from '@patternfly/react-core';
 
 import { PlansAddButton } from '../../componenets';
 import PlansEmptyState from '../../componenets/PlansEmptyState';
-import { getPlanPhase, PLAN_STATUS, PlanData } from '../../utils';
+import { getPlanPhase, PlanData, planPhases } from '../../utils';
 
 import PlanRow from './PlanRow';
 
@@ -80,7 +80,7 @@ export const fieldsMetadataFactory: ResourceFieldFactory = (t) => [
       type: 'enum',
       primary: true,
       placeholderLabel: t('Status'),
-      values: EnumToTuple(PLAN_STATUS),
+      values: EnumToTuple(planPhases),
     },
     sortable: true,
   },


### PR DESCRIPTION
Issue:
The values of status filtering don't include 'Succeeded' or 'Failed'

Fix:
Update the filter to allow all phases

Screenshot:
![filter-by-plan-phases](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/b117dc68-e489-48ea-acd5-ae5a575982f4)


