### PR TITLE
Use dynamic validations for providers fields

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/validateOpenshiftURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/validateOpenshiftURL.ts
@@ -1,12 +1,20 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateOpenshiftURL = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The URL of the Openshift Virtualization API endpoint, for example: https://example.com:6443 .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateURL(trimmedUrl);
 
   if (trimmedUrl === '') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretFieldValidator.ts
@@ -67,6 +67,14 @@ export const openstackSecretFieldValidator = (id: string, value: string): Valida
 const validateUsername = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A username for connecting to the OpenStack Identity (Keystone) endpoint. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -86,6 +94,14 @@ const validateUsername = (value: string): ValidationMsg => {
 
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A user password for connecting to the OpenStack Identity (Keystone) endpoint. [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -107,6 +123,14 @@ const validatePassword = (value: string): ValidationMsg => {
 const validateRegionName = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack region name. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -123,6 +147,14 @@ const validateRegionName = (value: string): ValidationMsg => {
 
 const validateProjectName = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack project name. [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -141,6 +173,14 @@ const validateProjectName = (value: string): ValidationMsg => {
 const validateDomainName = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack domain name. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -158,6 +198,14 @@ const validateDomainName = (value: string): ValidationMsg => {
 const validateToken = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack token for authentication using a user name. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -174,6 +222,14 @@ const validateToken = (value: string): ValidationMsg => {
 
 const validateUserID = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A user ID for connecting to the OpenStack Identity (Keystone) endpoint. [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -195,6 +251,14 @@ const validateUserID = (value: string): ValidationMsg => {
 const validateProjectID = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack project ID. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -211,6 +275,14 @@ const validateProjectID = (value: string): ValidationMsg => {
 
 const validateApplicationCredentialID = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
+
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack application credential ID needed for the application credential authentication. [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -232,6 +304,14 @@ const validateApplicationCredentialID = (value: string): ValidationMsg => {
 const validateApplicationCredentialSecret = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack application credential Secret needed for the application credential authentication. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -252,6 +332,14 @@ const validateApplicationCredentialSecret = (value: string): ValidationMsg => {
 const validateApplicationCredentialName = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'OpenStack application credential name needed for application credential authentication. [required]',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -270,19 +358,24 @@ const validateApplicationCredentialName = (value: string): ValidationMsg => {
 };
 
 const validateInsecureSkipVerify = (value: string): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return { type: 'default', msg: 'Migrate without validating a CA certificate' };
+  }
+
   const valid = ['true', 'false', ''].includes(value);
 
   if (valid) {
     return { type: 'success', msg: 'Migrate without validating a CA certificate' };
   }
 
-  return { type: 'error', msg: 'Invalid skip verify flag, must be true or false' };
+  return { type: 'error', msg: 'Invalid Skip certificate validation value, must be true or false' };
 };
 
 const validateCacert = (value: string): ValidationMsg => {
   const valid = validatePublicCert(value);
 
-  if (value === '') {
+  if (value === undefined || value === '') {
     return {
       type: 'default',
       msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/openstackSecretValidator.ts
@@ -86,7 +86,7 @@ export function openstackSecretValidator(secret: IoK8sApiCoreV1Secret): Validati
   }
 
   // Add ca cert validation if not insecureSkipVerify
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.['insecureSkipVerify'] || '');
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.['insecureSkipVerify']);
   if (insecureSkipVerify !== 'true') {
     validateFields.push('cacert');
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/validateOpenstackURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openstack/validateOpenstackURL.ts
@@ -1,13 +1,28 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateOpenstackURL = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The URL is required, URL of the OpenStack Identity (Keystone) API endpoint, for example: https://identity_service.com:5000/v3 .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateURL(trimmedUrl);
+
+  if (trimmedUrl === '') {
+    return {
+      type: 'error',
+      msg: 'The URL is required, URL of the OpenStack Identity (Keystone) API endpoint, for example: https://identity_service.com:5000/v3 .',
+    };
+  }
 
   if (!isValidURL) {
     return {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ova/validateOvaNfsPath.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ova/validateOvaNfsPath.ts
@@ -1,12 +1,20 @@
 import { validateNFSMount, ValidationMsg } from '../../common';
 
 export const validateOvaNfsPath = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The NFS shared directory containing the Open Virtual Appliance (OVA) files, for example: 10.10.0.10:/ova .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateNFSMount(trimmedUrl);
 
   if (trimmedUrl === '') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/ovirtSecretFieldValidator.ts
@@ -18,7 +18,7 @@ import {
  * 'error' - The field's value has failed validation.
  */
 export const ovirtSecretFieldValidator = (id: string, value: string): ValidationMsg => {
-  const trimmedValue = value.trim();
+  const trimmedValue = value?.trim();
 
   let validationState: ValidationMsg;
 
@@ -30,7 +30,7 @@ export const ovirtSecretFieldValidator = (id: string, value: string): Validation
       validationState = validatePassword(trimmedValue);
       break;
     case 'insecureSkipVerify':
-      validationState = { type: 'default', msg: 'Migrate without validating a CA certificate' };
+      validationState = validateInsecureSkipVerify(trimmedValue);
       break;
     case 'cacert':
       validationState = validateCacert(trimmedValue);
@@ -45,6 +45,14 @@ export const ovirtSecretFieldValidator = (id: string, value: string): Validation
 
 const validateUser = (value: string): ValidationMsg => {
   const noSpaces = validateNoSpaces(value);
+
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'A username for connecting to the Red Hat Virtualization Manager (RHVM) API endpoint, for example: name@internal . [required]',
+    };
+  }
 
   if (value === '') {
     return {
@@ -75,6 +83,14 @@ const validateUser = (value: string): ValidationMsg => {
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return {
+      type: 'default',
+      msg: 'User name password is required, user password for connecting to the Red Hat Virtualization Manager (RHVM) API endpoint.',
+    };
+  }
+
   if (value === '') {
     return {
       type: 'error',
@@ -95,7 +111,8 @@ const validatePassword = (value: string): ValidationMsg => {
 const validateCacert = (value: string): ValidationMsg => {
   const valid = validatePublicCert(value);
 
-  if (value === '') {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined || value === '') {
     return {
       type: 'default',
       msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
@@ -113,4 +130,19 @@ const validateCacert = (value: string): ValidationMsg => {
     type: 'error',
     msg: 'Invalid CA certificate, certificate must be in a valid PEM encoded X.509 format.',
   };
+};
+
+const validateInsecureSkipVerify = (value: string): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return { type: 'default', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  const valid = ['true', 'false', ''].includes(value);
+
+  if (valid) {
+    return { type: 'success', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  return { type: 'error', msg: 'Invalid Skip certificate validation value, must be true or false' };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/validateOvirtURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/ovirt/validateOvirtURL.ts
@@ -1,12 +1,20 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateOvirtURL = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (url === undefined) {
+    return {
+      type: 'default',
+      msg: 'The URL of the Red Hat Virtualization Manager (RHVM) API endpoint, for example: https://rhv-host-example.com/ovirt-engine/api .',
+    };
+  }
+
   // Sanity check
   if (typeof url !== 'string') {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateURL(trimmedUrl);
 
   if (trimmedUrl === '') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/esxiSecretFieldValidator.ts
@@ -25,7 +25,7 @@ export const esxiSecretFieldValidator = (id: string, value: string): ValidationM
       validationState = validatePassword(trimmedValue);
       break;
     case 'insecureSkipVerify':
-      validationState = { type: 'default', msg: 'Migrate without validating a CA certificate' };
+      validationState = validateInsecureSkipVerify(trimmedValue);
       break;
     case 'cacert':
       validationState = validateCacert(trimmedValue);
@@ -41,6 +41,7 @@ export const esxiSecretFieldValidator = (id: string, value: string): ValidationM
 const validateUser = (value: string): ValidationMsg => {
   const noSpaces = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (value === undefined) {
     return {
       type: 'default',
@@ -68,6 +69,7 @@ const validateUser = (value: string): ValidationMsg => {
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (value === undefined) {
     return {
       type: 'default',
@@ -89,10 +91,25 @@ const validatePassword = (value: string): ValidationMsg => {
   return { type: 'error', msg: 'Invalid password, spaces are not allowed' };
 };
 
+const validateInsecureSkipVerify = (value: string): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return { type: 'default', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  const valid = ['true', 'false', ''].includes(value);
+
+  if (valid) {
+    return { type: 'success', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  return { type: 'error', msg: 'Invalid Skip certificate validation value, must be true or false' };
+};
+
 const validateCacert = (value: string): ValidationMsg => {
   const valid = validatePublicCert(value);
 
-  if (value === '') {
+  if (value === undefined || value === '') {
     return {
       type: 'default',
       msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateEsxiURL.ts
@@ -1,6 +1,7 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateEsxiURL = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (url === undefined) {
     return {
       type: 'default',
@@ -13,7 +14,7 @@ export const validateEsxiURL = (url: string | number): ValidationMsg => {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateURL(trimmedUrl);
 
   if (trimmedUrl === '') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVCenterURL.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVCenterURL.ts
@@ -1,6 +1,7 @@
 import { validateURL, ValidationMsg } from '../../common';
 
 export const validateVCenterURL = (url: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (url === undefined) {
     return {
       type: 'default',
@@ -13,7 +14,7 @@ export const validateVCenterURL = (url: string | number): ValidationMsg => {
     return { type: 'error', msg: 'URL is not a string' };
   }
 
-  const trimmedUrl: string = url.toString().trim();
+  const trimmedUrl: string = url.trim();
   const isValidURL = validateURL(trimmedUrl);
 
   if (trimmedUrl === '') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -1,6 +1,7 @@
 import { validateContainerImage, ValidationMsg } from '../../common';
 
 export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (vddkImage === undefined)
     return {
       msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
@@ -12,7 +13,7 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
     return { type: 'error', msg: 'VDDK image is not a string' };
   }
 
-  const trimmedVddkImage: string = vddkImage.toString().trim();
+  const trimmedVddkImage: string = vddkImage.trim();
   const isValidTrimmedVddkImage = validateContainerImage(trimmedVddkImage);
 
   if (trimmedVddkImage === '')

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vcenterSecretFieldValidator.ts
@@ -30,7 +30,7 @@ export const vcenterSecretFieldValidator = (id: string, value: string): Validati
       validationState = validatePassword(trimmedValue);
       break;
     case 'insecureSkipVerify':
-      validationState = { type: 'default', msg: 'Migrate without validating a CA certificate' };
+      validationState = validateInsecureSkipVerify(trimmedValue);
       break;
     case 'cacert':
       validationState = validateCacert(trimmedValue);
@@ -46,6 +46,7 @@ export const vcenterSecretFieldValidator = (id: string, value: string): Validati
 const validateUser = (value: string): ValidationMsg => {
   const noSpaces = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (value === undefined) {
     return {
       type: 'default',
@@ -82,6 +83,7 @@ const validateUser = (value: string): ValidationMsg => {
 const validatePassword = (value: string): ValidationMsg => {
   const valid = validateNoSpaces(value);
 
+  // For a newly opened form where the field is not set yet, set the validation type to default.
   if (value === undefined) {
     return {
       type: 'default',
@@ -106,7 +108,7 @@ const validatePassword = (value: string): ValidationMsg => {
 const validateCacert = (value: string): ValidationMsg => {
   const valid = validatePublicCert(value);
 
-  if (value === '') {
+  if (value === undefined || value === '') {
     return {
       type: 'default',
       msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
@@ -124,4 +126,19 @@ const validateCacert = (value: string): ValidationMsg => {
     type: 'error',
     msg: 'Invalid CA certificate, certificate must be in a valid PEM encoded X.509 format.',
   };
+};
+
+const validateInsecureSkipVerify = (value: string): ValidationMsg => {
+  // For a newly opened form where the field is not set yet, set the validation type to default.
+  if (value === undefined) {
+    return { type: 'default', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  const valid = ['true', 'false', ''].includes(value);
+
+  if (valid) {
+    return { type: 'success', msg: 'Migrate without validating a CA certificate' };
+  }
+
+  return { type: 'error', msg: 'Invalid Skip certificate validation value, must be true or false' };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -23,7 +23,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
 
   const url = provider?.spec?.url;
   const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'];
-  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'] || '';
+  const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'];
 
   const vddkHelperTextPopover = (
     <ForkliftTrans>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
@@ -16,12 +16,11 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
+  const url = provider?.spec?.url;
+
   const initialState = {
     validation: {
-      url: {
-        type: 'default',
-        msg: 'The NFS shared directory containing the Open Virtual Appliance (OVA) files, for example: 10.10.0.10:/ova .',
-      },
+      url: validateOvaNfsPath(url),
     },
   };
 
@@ -44,7 +43,7 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
 
   const handleChange = useCallback(
     (id, value) => {
-      const trimmedValue = value.trim();
+      const trimmedValue = value?.trim();
 
       if (id === 'url') {
         const validationState = validateOvaNfsPath(trimmedValue);
@@ -72,7 +71,7 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
           id="url"
           name="url"
           isRequired
-          value={provider?.spec?.url || ''}
+          value={url || ''}
           validated={state.validation.url.type}
           onChange={(value) => handleChange('url', value)}
         />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -16,14 +16,11 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
 }) => {
   const { t } = useForkliftTranslation();
 
-  const url = provider?.spec?.url || '';
+  const url = provider?.spec?.url;
 
   const initialState = {
     validation: {
-      url: {
-        type: 'default',
-        msg: 'The URL of the Openshift Virtualization API endpoint, for example: https://example.com:6443 .',
-      },
+      url: validateOpenshiftURL(url),
     },
   };
 
@@ -48,7 +45,7 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
     (id, value) => {
       if (id !== 'url') return;
 
-      const trimmedUrl: string = value.toString().trim();
+      const trimmedUrl: string = value?.toString().trim();
       const validationState = validateOpenshiftURL(trimmedUrl);
 
       dispatch({

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
@@ -16,12 +16,11 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
 }) => {
   const { t } = useForkliftTranslation();
 
+  const url = provider?.spec?.url;
+
   const initialState = {
     validation: {
-      url: {
-        type: 'default',
-        msg: 'The URL of the OpenStack Identity (Keystone) API endpoint, for example: https://identity_service.com:5000/v3 .',
-      },
+      url: validateOpenstackURL(url),
     },
   };
 
@@ -46,7 +45,7 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
     (id, value) => {
       if (id !== 'url') return;
 
-      const trimmedURL: string = value.trim();
+      const trimmedURL: string = value?.trim();
       const validationState = validateOpenstackURL(trimmedURL);
 
       dispatch({
@@ -74,7 +73,7 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
           type="text"
           id="url"
           name="url"
-          value={provider?.spec?.url || ''}
+          value={url || ''}
           validated={state.validation.url.type}
           onChange={(value) => handleChange('url', value)}
         />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
@@ -16,12 +16,11 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
 }) => {
   const { t } = useForkliftTranslation();
 
+  const url = provider?.spec?.url;
+
   const initialState = {
     validation: {
-      url: {
-        type: 'default',
-        msg: 'The URL of the Red Hat Virtualization Manager (RHVM) API endpoint, for example: https://rhv-host-example.com/ovirt-engine/api .',
-      },
+      url: validateOvirtURL(url),
     },
   };
 
@@ -46,7 +45,7 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
     (id, value) => {
       if (id !== 'url') return;
 
-      const trimmedValue: string = value.trim();
+      const trimmedValue: string = value?.trim();
       const validationState = validateOvirtURL(trimmedValue);
 
       dispatch({
@@ -74,7 +73,7 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
           type="text"
           id="url"
           name="url"
-          value={provider?.spec?.url || ''}
+          value={url || ''}
           validated={state.validation.url.type}
           onChange={(value) => handleChange('url', value)}
         />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -25,8 +25,8 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
   const user = safeBase64Decode(secret?.data?.user);
   const password = safeBase64Decode(secret?.data?.password);
   const url = safeBase64Decode(secret?.data?.url);
-  const cacert = safeBase64Decode(secret?.data?.cacert || '');
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
+  const cacert = safeBase64Decode(secret?.data?.cacert);
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify);
 
   const insecureSkipVerifyHelperTextPopover = (
     <ForkliftTrans>
@@ -57,7 +57,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
     validation: {
       user: esxiSecretFieldValidator('user', user),
       password: esxiSecretFieldValidator('password', password),
-      insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
+      insecureSkipVerify: esxiSecretFieldValidator('insecureSkipVerify', insecureSkipVerify),
       cacert: esxiSecretFieldValidator('cacert', cacert),
     },
   };
@@ -88,8 +88,8 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
 
       // don't trim fields that allow spaces
       const encodedValue = ['cacert'].includes(id)
-        ? Base64.encode(value)
-        : Base64.encode(value.trim());
+        ? Base64.encode(value || '')
+        : Base64.encode(value?.trim() || '');
 
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
@@ -174,7 +174,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           id="insecureSkipVerify"
           name="insecureSkipVerify"
           label={t('Skip certificate validation')}
-          isChecked={insecureSkipVerify}
+          isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
           onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
         />
@@ -210,7 +210,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           onDataChange={(value) => handleChange('cacert', value)}
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}
-          isDisabled={insecureSkipVerify}
+          isDisabled={insecureSkipVerify === 'true'}
         />
       </FormGroup>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -22,10 +22,10 @@ import { EditComponentProps } from '../BaseCredentialsSection';
 export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
-  const url = safeBase64Decode(secret?.data?.url || '');
-  const token = safeBase64Decode(secret?.data?.token || '');
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
-  const cacert = safeBase64Decode(secret?.data?.cacert || '');
+  const url = safeBase64Decode(secret?.data?.url);
+  const token = safeBase64Decode(secret?.data?.token);
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify);
+  const cacert = safeBase64Decode(secret?.data?.cacert);
 
   const insecureSkipVerifyHelperTextPopover = (
     <ForkliftTrans>
@@ -54,15 +54,9 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
   const initialState = {
     passwordHidden: true,
     validation: {
-      token: {
-        type: 'default',
-        msg: 'A service account token, required for authenticating the the connection to the API server.',
-      },
-      insecureSkipVerify: { type: 'default', msg: 'Migrate without validating a CA certificate' },
-      cacert: {
-        type: 'default',
-        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
-      },
+      token: openshiftSecretFieldValidator('token', token),
+      insecureSkipVerify: openshiftSecretFieldValidator('insecureSkipVerify', insecureSkipVerify),
+      cacert: openshiftSecretFieldValidator('cacert', cacert),
     },
   };
 
@@ -93,8 +87,8 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
 
       // don't trim fields that allow spaces
       const encodedValue = ['cacert'].includes(id)
-        ? Base64.encode(value)
-        : Base64.encode(value.trim());
+        ? Base64.encode(value || '')
+        : Base64.encode(value?.trim() || '');
 
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
@@ -155,15 +149,14 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         }
         fieldId="insecureSkipVerify"
         validated={state.validation.insecureSkipVerify.type}
-        helperText={state.validation.insecureSkipVerify.msg}
         helperTextInvalid={state.validation.insecureSkipVerify.msg}
       >
         <Switch
           className="forklift-section-secret-edit-switch"
           id="insecureSkipVerify"
           name="insecureSkipVerify"
-          label={t('Migrate without validating a CA certificate')}
-          isChecked={insecureSkipVerify}
+          label={t('Skip certificate validation')}
+          isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
           onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
         />
@@ -202,7 +195,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
           url={url}
-          isDisabled={insecureSkipVerify}
+          isDisabled={insecureSkipVerify === 'true'}
         />
       </FormGroup>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -34,11 +34,11 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     </ForkliftTrans>
   );
 
-  const url = safeBase64Decode(secret?.data?.url || '');
-  const authType = safeBase64Decode(secret?.data?.authType || '');
-  const username = safeBase64Decode(secret?.data?.username || '');
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
-  const cacert = safeBase64Decode(secret?.data?.cacert || '');
+  const url = safeBase64Decode(secret?.data?.url);
+  const authType = safeBase64Decode(secret?.data?.authType);
+  const username = safeBase64Decode(secret?.data?.username);
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify);
+  const cacert = safeBase64Decode(secret?.data?.cacert);
 
   let authenticationType:
     | 'passwordSecretFields'
@@ -74,11 +74,8 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
   const initialState = {
     authenticationType: authenticationType,
     validation: {
-      cacert: {
-        type: 'default',
-        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
-      },
-      insecureSkipVerify: { type: 'default', msg: 'Migrate without validating a CA certificate' },
+      cacert: openstackSecretFieldValidator('cacert', cacert),
+      insecureSkipVerify: openstackSecretFieldValidator('insecureSkipVerify', insecureSkipVerify),
     },
   };
 
@@ -112,8 +109,8 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
 
       // don't trim fields that allow spaces
       const encodedValue = ['cacert'].includes(id)
-        ? Base64.encode(value)
-        : Base64.encode(value.trim());
+        ? Base64.encode(value || '')
+        : Base64.encode(value?.trim() || '');
 
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
@@ -139,8 +136,8 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
             data: {
               ...secret.data,
               ['authType']: Base64.encode('token'),
-              userID: '',
-              username: '',
+              userID: undefined,
+              username: undefined,
             },
           });
           break;
@@ -152,8 +149,8 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
             data: {
               ...secret.data,
               ['authType']: Base64.encode('applicationcredential'),
-              applicationCredentialID: '',
-              username: '',
+              applicationCredentialID: undefined,
+              username: undefined,
             },
           });
           break;
@@ -257,14 +254,14 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           label={insecureSkipVerifyHelperTextMsgs.successAndSkipped}
           labelOff={insecureSkipVerifyHelperTextMsgs.successAndNotSkipped}
           aria-label={insecureSkipVerifyHelperTextMsgs.successAndSkipped}
-          isChecked={insecureSkipVerify}
+          isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
           onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
         />
       </FormGroup>
       <FormGroup
         label={
-          insecureSkipVerify
+          insecureSkipVerify === 'true'
             ? t("CA certificate - disabled when 'Skip certificate validation' is selected")
             : t('CA certificate - leave empty to use system CA certificates')
         }
@@ -284,7 +281,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
           url={url}
-          isDisabled={insecureSkipVerify}
+          isDisabled={insecureSkipVerify === 'true'}
         />
       </FormGroup>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
@@ -15,36 +15,28 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
 }) => {
   const { t } = useForkliftTranslation();
 
-  const applicationCredentialName = safeBase64Decode(secret?.data?.applicationCredentialName || '');
-  const applicationCredentialSecret = safeBase64Decode(
-    secret?.data?.applicationCredentialSecret || '',
-  );
-  const username = safeBase64Decode(secret?.data?.username || '');
-  const regionName = safeBase64Decode(secret?.data?.regionName || '');
-  const projectName = safeBase64Decode(secret?.data?.projectName || '');
-  const domainName = safeBase64Decode(secret?.data?.domainName || '');
+  const applicationCredentialName = safeBase64Decode(secret?.data?.applicationCredentialName);
+  const applicationCredentialSecret = safeBase64Decode(secret?.data?.applicationCredentialSecret);
+  const username = safeBase64Decode(secret?.data?.username);
+  const regionName = safeBase64Decode(secret?.data?.regionName);
+  const projectName = safeBase64Decode(secret?.data?.projectName);
+  const domainName = safeBase64Decode(secret?.data?.domainName);
 
   const initialState = {
     passwordHidden: true,
     validation: {
-      applicationCredentialName: {
-        type: 'default',
-        msg: 'OpenStack application credential name needed for application credential authentication.',
-      },
-      applicationCredentialSecret: {
-        type: 'default',
-        msg: 'OpenStack application credential Secret needed for the application credential authentication.',
-      },
-      username: {
-        type: 'default',
-        msg: 'A username for connecting to the OpenStack Identity (Keystone) endpoint.',
-      },
-      regionName: { type: 'default', msg: 'OpenStack region name.' },
-      projectName: {
-        type: 'default',
-        msg: 'OpenStack application credential name needed for application credential authentication.',
-      },
-      domainName: { type: 'default', msg: 'OpenStack domain name.' },
+      applicationCredentialName: openstackSecretFieldValidator(
+        'applicationCredentialName',
+        applicationCredentialName,
+      ),
+      applicationCredentialSecret: openstackSecretFieldValidator(
+        'applicationCredentialSecret',
+        applicationCredentialSecret,
+      ),
+      username: openstackSecretFieldValidator('username', username),
+      regionName: openstackSecretFieldValidator('regionName', regionName),
+      projectName: openstackSecretFieldValidator('projectName', projectName),
+      domainName: openstackSecretFieldValidator('domainName', domainName),
     },
   };
 
@@ -73,7 +65,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       const validationState = openstackSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
-      const encodedValue = Base64.encode(value.trim());
+      const encodedValue = Base64.encode(value?.trim() || '');
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
     [secret, onChange],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
@@ -15,26 +15,24 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
 }) => {
   const { t } = useForkliftTranslation();
 
-  const applicationCredentialID = safeBase64Decode(secret?.data?.applicationCredentialID || '');
-  const applicationCredentialSecret = safeBase64Decode(
-    secret?.data?.applicationCredentialSecret || '',
-  );
-  const regionName = safeBase64Decode(secret?.data?.regionName || '');
-  const projectName = safeBase64Decode(secret?.data?.projectName || '');
+  const applicationCredentialID = safeBase64Decode(secret?.data?.applicationCredentialID);
+  const applicationCredentialSecret = safeBase64Decode(secret?.data?.applicationCredentialSecret);
+  const regionName = safeBase64Decode(secret?.data?.regionName);
+  const projectName = safeBase64Decode(secret?.data?.projectName);
 
   const initialState = {
     passwordHidden: true,
     validation: {
-      applicationCredentialID: {
-        type: 'default',
-        msg: 'OpenStack application credential ID needed for the application credential authentication.',
-      },
-      applicationCredentialSecret: {
-        type: 'default',
-        msg: 'OpenStack application credential Secret needed for the application credential authentication.',
-      },
-      regionName: { type: 'default', msg: 'OpenStack region name.' },
-      projectName: { type: 'default', msg: 'OpenStack project name.' },
+      applicationCredentialID: openstackSecretFieldValidator(
+        'applicationCredentialID',
+        applicationCredentialID,
+      ),
+      applicationCredentialSecret: openstackSecretFieldValidator(
+        'applicationCredentialSecret',
+        applicationCredentialSecret,
+      ),
+      regionName: openstackSecretFieldValidator('regionName', regionName),
+      projectName: openstackSecretFieldValidator('projectName', projectName),
     },
   };
 
@@ -63,7 +61,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
       const validationState = openstackSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
-      const encodedValue = Base64.encode(value.trim());
+      const encodedValue = Base64.encode(value?.trim() || '');
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
     [secret, onChange],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
@@ -15,26 +15,20 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  const username = safeBase64Decode(secret?.data?.username || '');
-  const password = safeBase64Decode(secret?.data?.password || '');
-  const regionName = safeBase64Decode(secret?.data?.regionName || '');
-  const projectName = safeBase64Decode(secret?.data?.projectName || '');
-  const domainName = safeBase64Decode(secret?.data?.domainName || '');
+  const username = safeBase64Decode(secret?.data?.username);
+  const password = safeBase64Decode(secret?.data?.password);
+  const regionName = safeBase64Decode(secret?.data?.regionName);
+  const projectName = safeBase64Decode(secret?.data?.projectName);
+  const domainName = safeBase64Decode(secret?.data?.domainName);
 
   const initialState = {
     passwordHidden: true,
     validation: {
-      username: {
-        type: 'default',
-        msg: 'A username for connecting to the OpenStack Identity (Keystone) endpoint.',
-      },
-      password: {
-        type: 'default',
-        msg: 'A user password for connecting to the OpenStack Identity (Keystone) endpoint.',
-      },
-      regionName: { type: 'default', msg: 'OpenStack region name.' },
-      projectName: { type: 'default', msg: 'OpenStack project name.' },
-      domainName: { type: 'default', msg: 'OpenStack domain name.' },
+      username: openstackSecretFieldValidator('username', username),
+      password: openstackSecretFieldValidator('password', password),
+      regionName: openstackSecretFieldValidator('regionName', regionName),
+      projectName: openstackSecretFieldValidator('projectName', projectName),
+      domainName: openstackSecretFieldValidator('domainName', domainName),
     },
   };
 
@@ -63,7 +57,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       const validationState = openstackSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
-      const encodedValue = Base64.encode(value.trim());
+      const encodedValue = Base64.encode(value?.trim() || '');
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
     [secret, onChange],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
@@ -15,21 +15,18 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
 }) => {
   const { t } = useForkliftTranslation();
 
-  const token = safeBase64Decode(secret?.data?.token || '');
-  const userID = safeBase64Decode(secret?.data?.userID || '');
-  const projectID = safeBase64Decode(secret?.data?.projectID || '');
-  const regionName = safeBase64Decode(secret?.data?.regionName || '');
+  const token = safeBase64Decode(secret?.data?.token);
+  const userID = safeBase64Decode(secret?.data?.userID);
+  const projectID = safeBase64Decode(secret?.data?.projectID);
+  const regionName = safeBase64Decode(secret?.data?.regionName);
 
   const initialState = {
     passwordHidden: true,
     validation: {
-      token: { type: 'default', msg: 'OpenStack token for authentication using a user name.' },
-      userID: {
-        type: 'default',
-        msg: 'A user ID for connecting to the OpenStack Identity (Keystone) endpoint.',
-      },
-      projectID: { type: 'default', msg: 'OpenStack project ID.' },
-      regionName: { type: 'default', msg: 'OpenStack region name.' },
+      token: openstackSecretFieldValidator('token', token),
+      userID: openstackSecretFieldValidator('userID', userID),
+      projectID: openstackSecretFieldValidator('projectID', projectID),
+      regionName: openstackSecretFieldValidator('regionName', regionName),
     },
   };
 
@@ -57,7 +54,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
       const validationState = openstackSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
-      const encodedValue = Base64.encode(value.trim());
+      const encodedValue = Base64.encode(value?.trim() || '');
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
     [secret, onChange],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
@@ -15,23 +15,20 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
 }) => {
   const { t } = useForkliftTranslation();
 
-  const token = safeBase64Decode(secret?.data?.token || '');
-  const username = safeBase64Decode(secret?.data?.username || '');
-  const regionName = safeBase64Decode(secret?.data?.regionName || '');
-  const projectName = safeBase64Decode(secret?.data?.projectName || '');
-  const domainName = safeBase64Decode(secret?.data?.domainName || '');
+  const token = safeBase64Decode(secret?.data?.token);
+  const username = safeBase64Decode(secret?.data?.username);
+  const regionName = safeBase64Decode(secret?.data?.regionName);
+  const projectName = safeBase64Decode(secret?.data?.projectName);
+  const domainName = safeBase64Decode(secret?.data?.domainName);
 
   const initialState = {
     passwordHidden: true,
     validation: {
-      token: { type: 'default', msg: 'OpenStack token for authentication using a user name.' },
-      username: {
-        type: 'default',
-        msg: 'A username for connecting to the OpenStack Identity (Keystone) endpoint.',
-      },
-      regionName: { type: 'default', msg: 'OpenStack region name.' },
-      projectName: { type: 'default', msg: 'OpenStack project name.' },
-      domainName: { type: 'default', msg: 'OpenStack domain name.' },
+      token: openstackSecretFieldValidator('token', token),
+      username: openstackSecretFieldValidator('username', username),
+      regionName: openstackSecretFieldValidator('regionName', regionName),
+      projectName: openstackSecretFieldValidator('projectName', projectName),
+      domainName: openstackSecretFieldValidator('domainName', domainName),
     },
   };
 
@@ -59,7 +56,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       const validationState = openstackSecretFieldValidator(id, value);
       dispatch({ type: 'SET_FIELD_VALIDATED', payload: { field: id, validationState } });
 
-      const encodedValue = Base64.encode(value.trim());
+      const encodedValue = Base64.encode(value?.trim() || '');
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
     [secret, onChange],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -22,11 +22,11 @@ import { EditComponentProps } from '../BaseCredentialsSection';
 export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onChange }) => {
   const { t } = useForkliftTranslation();
 
-  const user = safeBase64Decode(secret?.data?.user || '');
-  const url = safeBase64Decode(secret?.data?.url || '');
-  const password = safeBase64Decode(secret?.data?.password || '');
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
-  const cacert = safeBase64Decode(secret?.data?.cacert || '');
+  const url = safeBase64Decode(secret?.data?.url);
+  const user = safeBase64Decode(secret?.data?.user);
+  const password = safeBase64Decode(secret?.data?.password);
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify);
+  const cacert = safeBase64Decode(secret?.data?.cacert);
 
   const insecureSkipVerifyHelperTextPopover = (
     <ForkliftTrans>
@@ -57,19 +57,10 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
   const initialState = {
     passwordHidden: true,
     validation: {
-      user: {
-        type: 'default',
-        msg: 'A username for connecting to the Red Hat Virtualization Manager (RHVM) API endpoint, for example: name@internal .',
-      },
-      password: {
-        type: 'default',
-        msg: 'A user password for connecting to the Red Hat Virtualization Manager (RHVM) API endpoint.',
-      },
-      insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
-      cacert: {
-        type: 'default',
-        msg: 'The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.',
-      },
+      user: ovirtSecretFieldValidator('user', user),
+      password: ovirtSecretFieldValidator('password', password),
+      insecureSkipVerify: ovirtSecretFieldValidator('insecureSkipVerify', insecureSkipVerify),
+      cacert: ovirtSecretFieldValidator('cacert', cacert),
     },
   };
 
@@ -103,8 +94,8 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
 
       // don't trim fields that allow spaces
       const encodedValue = ['cacert'].includes(id)
-        ? Base64.encode(value)
-        : Base64.encode(value.trim());
+        ? Base64.encode(value || '')
+        : Base64.encode(value?.trim() || '');
 
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
@@ -131,7 +122,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           id="user"
           name="user"
           value={user}
-          validated={state.validation.user}
+          validated={state.validation.user.type}
           onChange={(value) => handleChange('user', value)}
         />
       </FormGroup>
@@ -189,7 +180,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           id="insecureSkipVerify"
           name="insecureSkipVerify"
           label={t('Skip certificate validation')}
-          isChecked={insecureSkipVerify}
+          isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
           onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
         />
@@ -228,7 +219,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           onClearClick={() => handleChange('cacert', '')}
           browseButtonText="Upload"
           url={url}
-          isDisabled={insecureSkipVerify}
+          isDisabled={insecureSkipVerify === 'true'}
         />
       </FormGroup>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -25,8 +25,8 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
   const user = safeBase64Decode(secret?.data?.user);
   const password = safeBase64Decode(secret?.data?.password);
   const url = safeBase64Decode(secret?.data?.url);
-  const cacert = safeBase64Decode(secret?.data?.cacert || '');
-  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify || '') === 'true';
+  const cacert = safeBase64Decode(secret?.data?.cacert);
+  const insecureSkipVerify = safeBase64Decode(secret?.data?.insecureSkipVerify);
 
   const insecureSkipVerifyHelperTextPopover = (
     <ForkliftTrans>
@@ -57,7 +57,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
     validation: {
       user: vcenterSecretFieldValidator('user', user),
       password: vcenterSecretFieldValidator('password', password),
-      insecureSkipVerify: { type: 'default', msg: 'Skip certificate validation' },
+      insecureSkipVerify: vcenterSecretFieldValidator('insecureSkipVerify', insecureSkipVerify),
       cacert: vcenterSecretFieldValidator('cacert', cacert),
     },
   };
@@ -88,8 +88,8 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
 
       // don't trim fields that allow spaces
       const encodedValue = ['cacert'].includes(id)
-        ? Base64.encode(value)
-        : Base64.encode(value.trim());
+        ? Base64.encode(value || '')
+        : Base64.encode(value?.trim() || '');
 
       onChange({ ...secret, data: { ...secret.data, [id]: encodedValue } });
     },
@@ -174,7 +174,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
           id="insecureSkipVerify"
           name="insecureSkipVerify"
           label={t('Skip certificate validation')}
-          isChecked={insecureSkipVerify}
+          isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
           onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
         />
@@ -210,7 +210,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
           onDataChange={(value) => handleChange('cacert', value)}
           onTextChange={(value) => handleChange('cacert', value)}
           onClearClick={() => handleChange('cacert', '')}
-          isDisabled={insecureSkipVerify}
+          isDisabled={insecureSkipVerify === 'true'}
         />
       </FormGroup>
     </Form>


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1059

Replace all static providers fields initial validations with dynamic ones,  based on the providers validators (See [ ../Providers/utils/validators/provider/](https://github.com/kubev2v/forklift-console-plugin/tree/main/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider)).

This fix all providers for both create and edit credentials dialogs.