### PR TITLE
:soap: If must gather settings is default value of -1 show default

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
@@ -63,7 +63,13 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
           <DetailsItem
             title={'Must gather cleanup after (hours)'}
             showHelpIconNextToTitle={true}
-            content={mustGatherAPICleanupMaxAge || <span className="text-muted">{'Disabled'}</span>}
+            content={
+              mustGatherAPICleanupMaxAge && mustGatherAPICleanupMaxAge !== '-1' ? (
+                mustGatherAPICleanupMaxAge
+              ) : (
+                <span className="text-muted">{'Disabled'}</span>
+              )
+            }
             moreInfoLink={
               'https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options'
             }


### PR DESCRIPTION
In overview page settings card we show 'Must gather cleanup after (hours)' value, when the value is -1, it means the value it `default`

Screenshots:
Before
![default-must-gather-settings-raw-value](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/69e2f689-2a88-4fdb-aa8a-f8252f705589)

After
![default-must-gather-settings](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/97ab0b8a-2c54-4fc2-b7e3-d0f4e0d7d0c7)
