### PR TITLE
:feet: Enhance the DetailsItem component to enable both hyperlink and edit

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
@@ -132,21 +132,24 @@ export const DescriptionTitle: React.FC<{ title: string }> = ({ title }) => (
 );
 
 /**
- * Component for displaying an inline link button with editable content.
+ * Component for displaying an editable content in the following format:
+ * The content field's element and next to that appears a press-able inline
+ * link edit button with the pencil icon, for triggering the onEdit callback.
  *
  * @component
- * @param {ReactNode} content - The content of the button.
+ * @param {ReactNode} content - The field's content element.
  * @param {Function} onEdit - Function to be called when the button is clicked.
  */
-export const EditableContentButton: React.FC<{ content: ReactNode; onEdit: () => void }> = ({
-  content,
-  onEdit,
-}) => (
-  <Button variant="link" isInline onClick={onEdit}>
-    <DescriptionListDescription>
-      {content} <Pencil className="forklift-page-details-edit-pencil" />
-    </DescriptionListDescription>
-  </Button>
+export const EditableContentButton: React.FC<{
+  content: ReactNode;
+  onEdit: () => void;
+}> = ({ content, onEdit }) => (
+  <DescriptionListDescription>
+    {content}
+    <Button variant="link" isInline onClick={onEdit}>
+      <Pencil className="forklift-page-details-edit-pencil" />
+    </Button>
+  </DescriptionListDescription>
 );
 
 /**


### PR DESCRIPTION
References:
https://github.com/kubev2v/forklift-console-plugin/issues/1106
https://github.com/kubev2v/forklift-console-plugin/issues/1124

Up till now the `DetailsItem` component supported 2 modes:
1. A non editable content (w/o hyperlink).
2. An editable content while both content and pencil icon are an inline button for triggering the `onEdit` callback.

This PR enhances the `DetailsItem` component by replacing the editable mode style (2) such that only the pencil icon is an inline button for triggering the `onEdit` callback, while the field's context element is now separated from the edit button and can be used as read only text element, a hyperlink button etc.

### Screencast of 2 examples for the editable mode usage (readable text and hyperlink)
[Screencast from 2024-04-24 17-44-09.webm](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/e4832e15-954a-40d4-a443-4141535348e4)


### Future enhancement: 
We can consider adding a 'Edit' label next to the pencil icon:

### pencil icon with a label
![Screenshot from 2024-04-18 21-33-05](https://github.com/kubev2v/forklift-console-plugin/assets/18169498/e39b7847-52ad-42aa-8386-44ded5a5a79f)
