### PR TITLE
:lady_beetle:  Allow to choose NADs from default namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
@@ -103,7 +103,7 @@ export const mapTargetNetworksIdsToLabels = (
   plan: V1beta1Plan,
 ): { [label: string]: string } => {
   const tuples: [string, string][] = targets
-    .filter(({ namespace }) => namespace === plan.spec.targetNamespace)
+    .filter(({ namespace }) => namespace === plan.spec.targetNamespace || namespace === 'default')
     .map((net) => [net.uid, net.name]);
 
   tuples.push(['pod', POD_NETWORK]);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
@@ -38,7 +38,7 @@ export const calculateNetworks = (
 
   const targetNetworkNameToUid = Object.fromEntries(
     existingResources.targetNetworks
-      .filter(({ namespace }) => namespace === plan.spec.targetNamespace)
+      .filter(({ namespace }) => namespace === plan.spec.targetNamespace || namespace === 'default')
       .map((net) => [net.name, net.uid]),
   );
   const targetNetworkLabels = [


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1121

Issue:
VMs will have access to NADs in the 'default' namespace, but we only let users select NADs from the destination namespace

Fix:
When presenting the available NADs show also NADs from the default namespace

Screenshots:
Before
![screenshot-localhost_9000-2024 05 02-20_40_33](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/6311cef9-4429-4e87-b4d9-06ddb136c998)

After:
![screenshot-localhost_9000-2024 05 02-20_39_35](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/9e77963c-2c70-406e-bc9f-2cfc4a714bc8)
