### PR TITLE
:robot: Use bearer auth for remote ocp

### DIFF
--- a/ci/configure/openshift.sh
+++ b/ci/configure/openshift.sh
@@ -54,8 +54,8 @@ function setup_bridge_for_openshift_oauth () {
     BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
     BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 
-    BRIDGE_K8S_AUTH="openshift"
-    BRIDGE_USER_AUTH="openshift"
+    BRIDGE_K8S_AUTH="bearer-token"
+    BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
 
     if oc_available_loggedin; then
         BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client-dev"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30630,7 +30630,7 @@
     },
     "packages/forklift-console-plugin": {
       "name": "@kubev2v/forklift-console-plugin",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubev2v/common": "*",


### PR DESCRIPTION
The bridge application has problems supporting openshift authentication, use bearer auth for remote ocp

Ref: https://github.com/openshift/console/pull/13720