### PR TITLE
🐞 Migration Plan (UI) - select VM from the list takes ~3-5sec

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useProviderInventory } from 'src/modules/Providers/hooks';
 import { ProviderVirtualMachinesListWrapper, VmData } from 'src/modules/Providers/views';
+import { useInventoryVms } from 'src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms';
 
-import { ProviderInventory, ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
+import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 export const ProviderVirtualMachinesList: React.FC<{
@@ -21,8 +21,8 @@ export const ProviderVirtualMachinesList: React.FC<{
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
-  const obj = { provider, inventory };
+  const [vmData, vmDataLoading] = useInventoryVms({ provider }, providerLoaded, providerLoadError);
+  const obj = { provider, vmData, vmDataLoading: vmDataLoading || vmData?.length === 0 };
 
   return (
     <ProviderVirtualMachinesListWrapper

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/MemoizedProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/MemoizedProviderVirtualMachinesList.tsx
@@ -1,0 +1,41 @@
+import React, { memo } from 'react';
+import { VmData } from 'src/modules/Providers/views';
+
+import { ProviderVirtualMachinesList } from '../../components/ProvidersVirtualMachinesList';
+
+export interface ProviderVirtualMachinesListProps {
+  title: string;
+  name: string;
+  namespace: string;
+  onSelect: (selectedVms: VmData[]) => void;
+  initialSelectedIds: string[];
+  showActions: boolean;
+}
+
+export const MemoizedProviderVirtualMachinesList = memo(
+  ({
+    title,
+    name,
+    namespace,
+    onSelect,
+    initialSelectedIds,
+    showActions,
+  }: ProviderVirtualMachinesListProps) => {
+    return (
+      <ProviderVirtualMachinesList
+        title={title}
+        name={name}
+        namespace={namespace}
+        onSelect={onSelect}
+        initialSelectedIds={initialSelectedIds}
+        showActions={showActions}
+      />
+    );
+  },
+  (prevProps, nextProps) => {
+    // Only re-render if selectedProviderName, selectedProviderNamespace
+    return prevProps.name === nextProps.name && prevProps.namespace === nextProps.namespace;
+  },
+);
+
+MemoizedProviderVirtualMachinesList.displayName = 'MemoizedProviderVirtualMachinesList';

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/SelectSourceProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/steps/SelectSourceProvider/SelectSourceProvider.tsx
@@ -6,7 +6,8 @@ import { Title } from '@patternfly/react-core';
 
 import { PlanCreatePageActionTypes, PlanCreatePageState } from '../../states';
 
-import { PlanCreateForm, ProviderVirtualMachinesList } from './../../components';
+import { PlanCreateForm } from './../../components';
+import { MemoizedProviderVirtualMachinesList } from './MemoizedProviderVirtualMachinesList';
 
 export const SelectSourceProvider: React.FC<{
   namespace: string;
@@ -46,7 +47,7 @@ export const SelectSourceProvider: React.FC<{
             {t('Select virtual machines')}
           </Title>
 
-          <ProviderVirtualMachinesList
+          <MemoizedProviderVirtualMachinesList
             title=""
             name={selectedProviderName}
             namespace={selectedProviderNamespace}

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/types/ProviderData.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/types/ProviderData.ts
@@ -1,9 +1,14 @@
 import { ProviderInventory, V1beta1Provider } from '@kubev2v/types';
 
+import { VmData } from '../../views';
+
 import { ProvidersPermissionStatus } from './ProvidersPermissionStatus';
 
 export interface ProviderData {
   provider?: V1beta1Provider;
   inventory?: ProviderInventory;
+  inventoryLoading?: boolean;
+  vmData?: VmData[];
+  vmDataLoading?: boolean;
   permissions?: ProvidersPermissionStatus;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/ProviderVirtualMachines.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { useProviderInventory } from 'src/modules/Providers/hooks';
 import { ProviderData } from 'src/modules/Providers/utils';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import { ProviderInventory, ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
+import { ProviderModelGroupVersionKind, V1beta1Provider } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, PageSection } from '@patternfly/react-core';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 
+import { useInventoryVms } from './utils/useInventoryVms';
 import { VmData } from './components';
 import { OpenShiftVirtualMachinesList } from './OpenShiftVirtualMachinesList';
 import { OpenStackVirtualMachinesList } from './OpenStackVirtualMachinesList';
@@ -40,13 +40,13 @@ export const ProviderVirtualMachines: React.FC<{ name: string; namespace: string
     namespace,
   });
 
-  const { inventory } = useProviderInventory<ProviderInventory>({ provider });
-  const obj = { provider, inventory };
+  const [vmData, vmDataLoading] = useInventoryVms({ provider }, providerLoaded, providerLoadError);
+  const obj = { provider, vmData, vmDataLoading };
 
   return (
     <>
       <PageSection variant="light" className="forklift-page-section--info">
-        {inventory?.vmCount > 0 && (
+        {vmData?.length > 0 && (
           <Alert
             customIcon={<BellIcon />}
             variant="info"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -17,8 +17,6 @@ import {
 } from '@kubev2v/common';
 import { Concern } from '@kubev2v/types';
 
-import { useInventoryVms } from '../utils/useInventoryVms';
-
 import { ConcernsTable } from './ConcernsTable';
 import { MigrationAction } from './MigrationAction';
 import { VmData } from './VMCellProps';
@@ -42,8 +40,6 @@ export const toId = (item: VmData) => item.vm.id;
 export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> = ({
   title,
   obj,
-  loaded,
-  loadError,
   cellMapper,
   fieldsMetadataFactory,
   pageId,
@@ -54,14 +50,12 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
 }) => {
   const { t } = useForkliftTranslation();
   const [page, setPage] = useState(1);
-
-  const initialSelectedIds_ = initialSelectedIds || [];
-
-  const [selectedIds, setSelectedIds] = useState(initialSelectedIds_);
-  const [expandedIds, setExpandedIds] = useState([]);
   const [userSettings] = useState(() => loadUserSettings({ pageId }));
 
-  const [vmData, loading] = useInventoryVms(obj, loaded, loadError);
+  const initialSelectedIds_ = initialSelectedIds || [];
+  const initialExpandedIds_ = [];
+  const { vmData, vmDataLoading } = obj;
+
   const actions: FC<GlobalActionWithSelection<VmData>>[] = [
     ({ selectedIds }) => (
       <MigrationAction
@@ -74,8 +68,6 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   ];
 
   const onSelectedIds = (selectedIds: string[]) => {
-    setSelectedIds(selectedIds);
-
     if (onSelect) {
       const selectedVms = vmData.filter((data) => selectedIds.includes(toId(data)));
       onSelect(selectedVms);
@@ -86,7 +78,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
     <StandardPageWithSelection
       className={className}
       data-testid="vm-list"
-      dataSource={[vmData || [], !loading, null]}
+      dataSource={[vmData || [], !vmDataLoading, null]}
       CellMapper={cellMapper}
       fieldsMetadata={fieldsMetadataFactory(t)}
       namespace={obj?.provider?.metadata?.namespace}
@@ -100,11 +92,10 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
       GlobalActionToolbarItems={showActions ? actions : undefined}
       toId={toId}
       onSelect={onSelectedIds}
-      selectedIds={selectedIds}
+      selectedIds={initialSelectedIds_}
       page={page}
       setPage={setPage}
-      expandedIds={expandedIds}
-      onExpand={setExpandedIds}
+      expandedIds={initialExpandedIds_}
       ExpandedComponent={ConcernsTable}
     />
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
@@ -16,19 +16,15 @@ import { VmData } from '../components';
  * @returns {Array} tuple containing: the data, loading status and load error (if any)
  */
 export const useInventoryVms = (
-  { provider, inventory }: ProviderData,
+  { provider }: ProviderData,
   providerLoaded: boolean,
   providerLoadError: unknown,
 ): [VmData[], boolean, Error] => {
-  const largeInventory = inventory?.vmCount > 1000;
-  const customTimeoutAndInterval = largeInventory ? 250000 : undefined;
   const validProvider = providerLoaded && !providerLoadError && provider;
 
   const inventoryOptions: UseProviderInventoryParams = {
     provider: validProvider,
     subPath: 'vms?detail=4',
-    fetchTimeout: customTimeoutAndInterval,
-    interval: customTimeoutAndInterval,
   };
 
   const {


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1143

Issue
While creating a migration plan and reaching the "Select VMs" screen, it takes ~3-5 seconds from clicking the selected VM till it is marked with "V"

Fix:
  - [x] memo the list of vms in the create plan wizrd component so it will not re render unless the provider changes
  - [x] get only the initial selected vms from parent component and then select vms inside the table component, instead on the caller component
  - [x] get inventory once, in the parent component and pass the vms to the child instead of calling the vms list in both parent and child compnents