### PR TITLE
:lady_beetle: Dont sort on filter change

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/useInventoryVms.tsx
@@ -25,6 +25,7 @@ export const useInventoryVms = (
   const inventoryOptions: UseProviderInventoryParams = {
     provider: validProvider,
     subPath: 'vms?detail=4',
+    interval: 180000,
   };
 
   const {


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1152

Issue:
When items are above 10k , filtering become slow

Fix:
Dont sort when filtering.