### PR TITLE
:robot: add https:// before the route we get automatically

### DIFF
--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -16,8 +16,8 @@ CONSOLE_PORT=${CONSOLE_PORT:-9000}
 # Look for forklift routes
 if oc_available_loggedin; then
     routes=$(oc get routes -A -o template --template='{{range .items}}{{.spec.host}}{{"\n"}}{{end}}' 2>/dev/null || true)
-    INVENTORY_SERVER_HOST=${INVENTORY_SERVER_HOST:-$(echo "$routes" | grep forklift-inventory)}
-    SERVICES_API_SERVER_HOST=${SERVICES_API_SERVER_HOST:-$(echo "$routes" | grep forklift-services)}
+    INVENTORY_SERVER_HOST=https://${INVENTORY_SERVER_HOST:-$(echo "$routes" | grep forklift-inventory)}
+    SERVICES_API_SERVER_HOST=https://${SERVICES_API_SERVER_HOST:-$(echo "$routes" | grep forklift-services)}
 fi
 
 # Default to localhost if no route found


### PR DESCRIPTION
When CI is detecting the inventory route automatically, it does not add the protocol to the URL

This PR adds the missing `https://`