### PR TITLE
🐞 Not possible to use values other than predefined values for VMs in flight

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditMaxVMInFlightModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditMaxVMInFlightModal.tsx
@@ -6,34 +6,30 @@ import { ForkliftControllerModel } from '@kubev2v/types';
 import { ModalVariant } from '@patternfly/react-core';
 
 import { EditSettingsModalProps } from './EditSettingsModalProps';
-import SettingsSelectInput from './SettingsSelectInput';
-
-// Define the options
-const options = [
-  { key: 2, name: 2, description: 'Very low concurrent VM migrations' },
-  { key: 10, name: 10, description: 'Low concurrent VM migrations' },
-  { key: 20, name: 20, description: 'Moderate concurrent VM migrations' },
-  { key: 50, name: 50, description: 'High concurrent VM migrations' },
-  { key: 100, name: 100, description: 'Very high concurrent VM migrations' },
-];
+import SettingsNumberInput from './SettingsNumberInput';
 
 /**
- * MaxVMInFlightSelect component.
- * Wraps the SettingsSelectInput component with pre-defined options.
+ * MaxVMInFlightNumberInput component.
+ * Wraps the SettingsNumberInput component with pre-defined default value.
  *
  * @param {ModalInputComponentProps} props - Properties passed to the component
  * @returns {JSX.Element}
  */
-const MaxVMInFlightSelect: ModalInputComponentType = (props) => {
-  return <SettingsSelectInput {...props} options={options} />;
+const MaxVMInFlightNumberInput: ModalInputComponentType = (props) => {
+  return <SettingsNumberInput {...props} />;
 };
 
 export const EditMaxVMInFlightModal: React.FC<EditSettingsModalProps> = (props) => {
   const { t } = useForkliftTranslation();
 
+  // Set default value to 20
+  const resource = props.resource;
+  resource.spec['controller_max_vm_inflight'] = resource.spec['controller_max_vm_inflight'] || 20;
+
   return (
     <EditModal
       {...props}
+      resource={resource}
       jsonPath={'spec.controller_max_vm_inflight'}
       title={props?.title || t('Edit Maximum concurrent VM migrations')}
       label={props?.label || t('Maximum concurrent VM migrations')}
@@ -43,7 +39,7 @@ export const EditMaxVMInFlightModal: React.FC<EditSettingsModalProps> = (props) 
       helperText={t(
         'Please enter the maximum number of concurrent VM migrations, if empty default value will be used.',
       )}
-      InputComponent={MaxVMInFlightSelect}
+      InputComponent={MaxVMInFlightNumberInput}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsNumberInput.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsNumberInput.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { NumberInput } from '@patternfly/react-core';
+
+import { SettingsSelectInputProps } from './SettingsSelectInput';
+
+export const SettingsNumberInput: React.FC<SettingsSelectInputProps> = ({
+  value: value_ = 0,
+  onChange,
+}) => {
+  const [value, setValue] = React.useState<number | ''>(parseInt(value_.toString()));
+
+  const setNewValue = (newValue: number) => {
+    setValue(newValue);
+    onChange(newValue.toString());
+  };
+
+  const onUserMinus = () => {
+    const newValue = (value || 0) - 1;
+    setNewValue(newValue);
+  };
+
+  const onUserPlus = () => {
+    const newValue = (value || 0) + 1;
+    setNewValue(newValue);
+  };
+
+  const onUserChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const value = (event.target as HTMLInputElement).value;
+    const newValue = value === '' ? value : +value;
+    setNewValue(newValue || 0);
+  };
+
+  // Render the Select component with dynamically created SelectOption children
+  return (
+    <NumberInput
+      value={value}
+      onMinus={onUserMinus}
+      onChange={onUserChange}
+      onPlus={onUserPlus}
+      inputName="input"
+      inputAriaLabel="number input"
+      minusBtnAriaLabel="minus"
+      plusBtnAriaLabel="plus"
+    />
+  );
+};
+
+export default SettingsNumberInput;

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsSelectInput.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsSelectInput.tsx
@@ -21,10 +21,10 @@ interface Option {
  * @property {(value: string) => void} onChange - Function to call when the value changes
  * @property {Option[]} options - The options to present to the user
  */
-interface SettingsSelectInputProps {
+export interface SettingsSelectInputProps {
   value: number | string;
   onChange: (value: number | string) => void;
-  options: Option[];
+  options?: Option[];
 }
 
 /**

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/index.ts
@@ -6,5 +6,6 @@ export * from './EditMaxVMInFlightModal';
 export * from './EditPreCopyIntervalModal';
 export * from './EditSettingsModalProps';
 export * from './EditSnapshotPoolingIntervalModal';
+export * from './SettingsNumberInput';
 export * from './SettingsSelectInput';
 // @endindex


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1131

Issue:
In the console plugin for MTV the available settings for maximum VMs in flight is 2,10,20, and more.
I would like to at least have 1 and 5 as well to reduce load on our demo environment.

Fix:
use numeric input