### PR TITLE
🐞 Plans -> details tab -> settings section, no title when data is missing

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
@@ -6,8 +6,6 @@ import { ProviderModelGroupVersionKind, V1beta1Plan, V1beta1Provider } from '@ku
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList } from '@patternfly/react-core';
 
-import { Suspend } from '../Suspend';
-
 import {
   PreserveClusterCpuModelDetailsItem,
   PreserveStaticIPsDetailsItem,
@@ -28,20 +26,19 @@ export type SettingsSectionProps = {
 };
 
 export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, permissions }) => {
-  const [sourceProvider, loaded, loadError] = useK8sWatchResource<V1beta1Provider>({
+  const [sourceProvider] = useK8sWatchResource<V1beta1Provider>({
     groupVersionKind: ProviderModelGroupVersionKind,
     namespaced: true,
     name: obj?.spec?.provider?.source?.name,
     namespace: obj?.spec?.provider?.source?.namespace,
   });
 
-  const [destinationProvider, destinationLoaded, destinationLoadError] =
-    useK8sWatchResource<V1beta1Provider>({
-      groupVersionKind: ProviderModelGroupVersionKind,
-      namespaced: true,
-      name: obj?.spec?.provider?.destination?.name,
-      namespace: obj?.spec?.provider?.destination?.namespace,
-    });
+  const [destinationProvider] = useK8sWatchResource<V1beta1Provider>({
+    groupVersionKind: ProviderModelGroupVersionKind,
+    namespaced: true,
+    name: obj?.spec?.provider?.destination?.name,
+    namespace: obj?.spec?.provider?.destination?.namespace,
+  });
 
   return (
     <>
@@ -54,39 +51,23 @@ export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, p
           <WarmDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
 
-        <Suspend
-          obj={destinationProvider}
-          loaded={destinationLoaded}
-          loadError={destinationLoadError}
-        >
-          <TransferNetworkDetailsItem
-            resource={obj}
-            canPatch={permissions.canPatch}
-            destinationProvider={destinationProvider}
-          />
-        </Suspend>
+        <TransferNetworkDetailsItem
+          resource={obj}
+          canPatch={permissions.canPatch}
+          destinationProvider={destinationProvider}
+        />
 
-        <Suspend
-          obj={destinationProvider}
-          loaded={destinationLoaded}
-          loadError={destinationLoadError}
-        >
-          <TargetNamespaceDetailsItem
-            resource={obj}
-            canPatch={permissions.canPatch}
-            destinationProvider={destinationProvider}
-          />
-        </Suspend>
+        <TargetNamespaceDetailsItem
+          resource={obj}
+          canPatch={permissions.canPatch}
+          destinationProvider={destinationProvider}
+        />
 
         {['ovirt'].includes(sourceProvider?.spec?.type) && (
-          <Suspend obj={sourceProvider} loaded={loaded} loadError={loadError}>
-            <PreserveClusterCpuModelDetailsItem resource={obj} canPatch={permissions.canPatch} />
-          </Suspend>
+          <PreserveClusterCpuModelDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
         {['vsphere'].includes(sourceProvider?.spec?.type) && (
-          <Suspend obj={sourceProvider} loaded={loaded} loadError={loadError}>
-            <PreserveStaticIPsDetailsItem resource={obj} canPatch={permissions.canPatch} />
-          </Suspend>
+          <PreserveStaticIPsDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
       </DescriptionList>
     </>


### PR DESCRIPTION
Issue:
while data is loaded in plans details tab, settings section, we see the loading dots without showing the title of the details item.

Fix:
don't check for loaded and error, when showing the item titles

Screenshot:
before:
![missing-data](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/82830109-781a-47da-8eb2-773eba3d90a5)

after:
![missing-data-after](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d79ad922-1beb-4808-b3fb-59a2565e90e9)
