### PR TITLE
Add pvc information for a vm in extended view

### DIFF
--- a/packages/eslint-plugin/cspell.wordlist.txt
+++ b/packages/eslint-plugin/cspell.wordlist.txt
@@ -81,3 +81,5 @@ esxi
 KJUR
 millicores
 inputgroup
+pvc
+pvcs

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -19,6 +19,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
   const conditions = props.resourceData.statusVM?.conditions;
   const pods = props.resourceData.pods;
   const jobs = props.resourceData.jobs;
+  const pvcs = props.resourceData.pvcs;
   const vmCreated = pipeline.find(
     (p) => p?.name === 'VirtualMachineCreation' && p?.phase === 'Completed',
   );
@@ -114,6 +115,37 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
                       </FlexItem>
                       <FlexItem>
                         <Status status={getJobPhase(job)}></Status>
+                      </FlexItem>
+                    </Flex>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </>
+      )}
+
+      {(pvcs || []).length > 0 && (
+        <>
+          <SectionHeading
+            text={'PersistentVolumeClaims'}
+            className="forklift-page-plan-details-vm-status__section-header"
+          />
+          <TableComposable aria-label="Expandable table" variant="compact">
+            <Tbody>
+              {(pvcs || []).map((pvc) => (
+                <Tr key={pvc.metadata.uid}>
+                  <Td>
+                    <Flex>
+                      <FlexItem>
+                        <ResourceLink
+                          groupVersionKind={{ version: 'v1', kind: 'PersistentVolumeClaim' }}
+                          name={pvc?.metadata?.name}
+                          namespace={pvc?.metadata?.namespace}
+                        />
+                      </FlexItem>
+                      <FlexItem>
+                        <Status status={pvc.status.phase}></Status>
                       </FlexItem>
                     </Flex>
                   </Td>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
@@ -53,6 +53,7 @@ export const PlanVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => {
     statusVM: vmDict[m.id],
     pods: [],
     jobs: [],
+    pvcs: [],
     targetNamespace: plan?.spec?.targetNamespace,
   }));
 

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
@@ -1,5 +1,6 @@
 import {
   IoK8sApiBatchV1Job,
+  IoK8sApiCoreV1PersistentVolumeClaim,
   IoK8sApiCoreV1Pod,
   V1beta1PlanSpecVms,
   V1beta1PlanStatusMigrationVms,
@@ -10,5 +11,6 @@ export type VMData = {
   statusVM?: V1beta1PlanStatusMigrationVms;
   pods: IoK8sApiCoreV1Pod[];
   jobs: IoK8sApiBatchV1Job[];
+  pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
   targetNamespace: string;
 };


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1128

Issue:
Issues concerning PVC population don't have a debugging link in the UI

Fix:
Add a link for the migration PVCs

Screenshot:
Before:
![without-pvc](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c6700417-8d95-47ab-943f-2fcdaa5755dc)

After:
![with-pvc](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/a64c0d96-6f9c-4dc1-8f5d-23ecd6c95d6b)

