### PR TITLE
🐾 Plan -> vm list don't show plan status conditions

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesRow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ResourceField, RowProps } from '@kubev2v/common';
 import { Td } from '@kubev2v/common';
 
-import { PlanVMsCellProps } from '../components';
+import { ConditionsCellRenderer, PlanVMsCellProps } from '../components';
 import { NameCellRenderer } from '../components/NameCellRenderer';
 import { VMData } from '../types';
 
@@ -33,6 +33,7 @@ const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdPro
 
 const cellRenderers: Record<string, React.FC<PlanVMsCellProps>> = {
   name: NameCellRenderer,
+  conditions: ConditionsCellRenderer,
 };
 
 interface RenderTdProps {

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/ConditionsCellRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/ConditionsCellRenderer.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { TableCell } from 'src/modules/Providers/utils';
+
+import { YellowExclamationTriangleIcon } from '@openshift-console/dynamic-plugin-sdk';
+import { Label, Level, LevelItem } from '@patternfly/react-core';
+
+import { PlanVMsCellProps } from './PlanVMsCellProps';
+
+export const ConditionsCellRenderer: React.FC<PlanVMsCellProps> = ({ data }) => {
+  const condition = data?.conditions?.[0];
+  if (!condition) {
+    return <></>;
+  }
+
+  return (
+    <TableCell>
+      <Level hasGutter>
+        <LevelItem>
+          <Label isCompact color="orange" icon={<YellowExclamationTriangleIcon />}>
+            {condition.category}
+          </Label>
+        </LevelItem>
+        <LevelItem>{condition.message}</LevelItem>
+      </Level>
+    </TableCell>
+  );
+};

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/index.ts
@@ -1,4 +1,5 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './ConditionsCellRenderer';
 export * from './MigrationVMsCancelButton';
 export * from './NameCellRenderer';
 export * from './PlanVMsCellProps';

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
@@ -3,6 +3,7 @@ import {
   IoK8sApiCoreV1PersistentVolumeClaim,
   IoK8sApiCoreV1Pod,
   V1beta1PlanSpecVms,
+  V1beta1PlanStatusConditions,
   V1beta1PlanStatusMigrationVms,
 } from '@kubev2v/types';
 
@@ -12,5 +13,6 @@ export type VMData = {
   pods: IoK8sApiCoreV1Pod[];
   jobs: IoK8sApiBatchV1Job[];
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
+  conditions?: V1beta1PlanStatusConditions[];
   targetNamespace: string;
 };


### PR DESCRIPTION
Ref: #1126 

Issue:
Plan conditions include information about VM specific issues, we do not show this information

Fix:
Extract the vm specific information from the plan conditions and shoe it in the vm list

Screenshots:
Before:
![vm-no-condition](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f0b62b70-c49d-448a-b3ac-cc81b3f15b7d)

After:
![vm-condition](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/7b76604e-f5ae-4030-819e-ebc18bfda9c3)
