### PR TITLE
:lady_beetle: Save network map target namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -7,6 +7,7 @@ import {
 } from 'src/modules/Providers/hooks/useNetworks';
 import { MappingList } from 'src/modules/Providers/views/migrate/components/MappingList';
 import { Mapping } from 'src/modules/Providers/views/migrate/types';
+import { updateNetworkMapDestination } from 'src/modules/Providers/views/migrate/useSaveEffect';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
@@ -64,7 +65,10 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
 
   const onUpdate = async () => {
     dispatch({ type: 'SET_UPDATING', payload: true });
-    await k8sUpdate({ model: NetworkMapModel, data: state.networkMap });
+    await k8sUpdate({
+      model: NetworkMapModel,
+      data: updateNetworkMapDestination(state.networkMap),
+    });
     dispatch({ type: 'SET_UPDATING', payload: false });
   };
 
@@ -162,7 +166,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
             isDisabled={!state.hasChanges || state.updating}
             icon={state.updating ? <Spinner size="sm" /> : undefined}
           >
-            {t('Update providers')}
+            {t('Update mappings')}
           </Button>
         </FlexItem>
 

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react';
 import { Suspend } from 'src/modules/Plans/views/details/components';
+import { updateNetworkMapDestination } from 'src/modules/Providers/views/migrate/useSaveEffect';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import {
@@ -42,7 +43,10 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
 
   const onUpdate = async () => {
     dispatch({ type: 'SET_UPDATING', payload: true });
-    await k8sUpdate({ model: NetworkMapModel, data: state.networkMap });
+    await k8sUpdate({
+      model: NetworkMapModel,
+      data: updateNetworkMapDestination(state.networkMap),
+    });
   };
 
   return (

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/mapMappingsIdsToLabels.tsx
@@ -104,7 +104,7 @@ export const mapTargetNetworksIdsToLabels = (
 ): { [label: string]: string } => {
   const tuples: [string, string][] = targets
     .filter(({ namespace }) => namespace === plan.spec.targetNamespace || namespace === 'default')
-    .map((net) => [net.uid, net.name]);
+    .map((net) => [net.uid, `${net.namespace}/${net.name}`]);
 
   tuples.push(['pod', POD_NETWORK]);
   const labelToId = resolveCollisions(tuples);

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/patchPlanMappingsData.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/patchPlanMappingsData.ts
@@ -30,7 +30,7 @@ export async function patchPlanMappingsData(
       {
         op: 'replace',
         path: '/spec/map',
-        value: updatedNetwork,
+        value: updateNetworkMapSpecMapDestination(updatedNetwork),
       },
     ],
   });
@@ -46,4 +46,25 @@ export async function patchPlanMappingsData(
       },
     ],
   });
+}
+
+/**
+ * Updates the destination name and namespace in the network map entries.
+ * If the destination name contains a '/', it splits the name into two parts.
+ * The first part becomes the new namespace, and the second part becomes the new name.
+ *
+ * @param {NetworkMap} networkMap - The network map object to update.
+ * @returns {NetworkMap} The updated network map object.
+ */
+export function updateNetworkMapSpecMapDestination(
+  networkMaps: V1beta1NetworkMapSpecMap[],
+): V1beta1NetworkMapSpecMap[] {
+  networkMaps?.forEach((entry) => {
+    const parts = entry.destination.name.split('/');
+    if (parts.length === 2) {
+      entry.destination.namespace = parts[0];
+      entry.destination.name = parts[1];
+    }
+  });
+  return networkMaps;
 }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/calculateMappings.ts
@@ -39,7 +39,7 @@ export const calculateNetworks = (
   const targetNetworkNameToUid = Object.fromEntries(
     existingResources.targetNetworks
       .filter(({ namespace }) => namespace === plan.spec.targetNamespace || namespace === 'default')
-      .map((net) => [net.name, net.uid]),
+      .map((net) => [`${net.namespace}/${net.name}`, net.uid]),
   );
   const targetNetworkLabels = [
     POD_NETWORK,

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -155,7 +155,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
             isDisabled={!state.hasChanges || state.updating}
             icon={state.updating ? <Spinner size="sm" /> : undefined}
           >
-            {t('Update providers')}
+            {t('Update mappings')}
           </Button>
         </FlexItem>
 


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1171

Issue:
when creating and patching multus network destinations we don't keep the network definition CR namespace

Fix:
keep the network namespace

