### PR TITLE
:lady_beetle: Hide PreserveStaticIPsDetailsItem in 2.6.

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
@@ -10,7 +10,6 @@ import { Suspend } from '../Suspend';
 
 import {
   PreserveClusterCpuModelDetailsItem,
-  PreserveStaticIPsDetailsItem,
   TargetNamespaceDetailsItem,
   TransferNetworkDetailsItem,
   WarmDetailsItem,
@@ -81,11 +80,6 @@ export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, p
         {['ovirt'].includes(sourceProvider?.spec?.type) && (
           <Suspend obj={sourceProvider} loaded={loaded} loadError={loadError}>
             <PreserveClusterCpuModelDetailsItem resource={obj} canPatch={permissions.canPatch} />
-          </Suspend>
-        )}
-        {['vsphere'].includes(sourceProvider?.spec?.type) && (
-          <Suspend obj={sourceProvider} loaded={loaded} loadError={loadError}>
-            <PreserveStaticIPsDetailsItem resource={obj} canPatch={permissions.canPatch} />
           </Suspend>
         )}
       </DescriptionList>


### PR DESCRIPTION
Issue:
PreserveStaticIPs will not be available in 2.6.2

Fix:
Remove the PreserveStaticIPs option from UI

Screenshots:
Before:
![reseve-ip](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/dcbfebd1-25e4-4b3c-83b1-e23fd9f8674b)


After:
![hide-reseve-ip](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3737511a-7cf4-4365-b30d-0124da686368)
