### PR TITLE
:lady_beetle: Check for empty name when extracting namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/patchPlanMappingsData.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/patchPlanMappingsData.ts
@@ -60,8 +60,8 @@ export function updateNetworkMapSpecMapDestination(
   networkMaps: V1beta1NetworkMapSpecMap[],
 ): V1beta1NetworkMapSpecMap[] {
   networkMaps?.forEach((entry) => {
-    const parts = entry.destination.name.split('/');
-    if (parts.length === 2) {
+    const parts = entry?.destination?.name?.split('/');
+    if (parts?.length === 2) {
       entry.destination.namespace = parts[0];
       entry.destination.name = parts[1];
     }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
@@ -123,8 +123,8 @@ export function updateNetworkMapDestination(networkMap: V1beta1NetworkMap): V1be
   const networkMapCopy = deepCopy(networkMap);
 
   networkMapCopy.spec.map?.forEach((entry) => {
-    const parts = entry.destination.name.split('/');
-    if (parts.length === 2) {
+    const parts = entry?.destination?.name?.split('/');
+    if (parts?.length === 2) {
       entry.destination.namespace = parts[0];
       entry.destination.name = parts[1];
     }


### PR DESCRIPTION
Issue:
network mapping name can be `null`, split by `\` will fail for null values,

Fix:
Test for null before trying to do splig