### PR TITLE
:soap: Hide empty conditions sections

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -156,34 +156,38 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
         </>
       )}
 
-      <SectionHeading
-        text={'Conditions'}
-        className="forklift-page-plan-details-vm-status__section-header"
-      />
-      <TableComposable aria-label="Expandable table" variant="compact">
-        <Thead>
-          <Tr>
-            <Th width={10}>{t('Type')}</Th>
-            <Th width={10}>{t('Status')}</Th>
-            <Th width={20}>{t('Updated')}</Th>
-            <Th width={10}>{t('Reason')}</Th>
-            <Th> {t('Message')}</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          {(conditions || []).map((condition) => (
-            <Tr key={condition.type}>
-              <Td>{condition.type}</Td>
-              <Td>{getStatusLabel(condition.status)}</Td>
-              <Td>
-                <Timestamp timestamp={condition.lastTransitionTime} />
-              </Td>
-              <Td>{condition.reason}</Td>
-              <Td modifier="truncate">{condition?.message || '-'}</Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
+      {(conditions || []).length > 0 && (
+        <>
+          <SectionHeading
+            text={'Conditions'}
+            className="forklift-page-plan-details-vm-status__section-header"
+          />
+          <TableComposable aria-label="Expandable table" variant="compact">
+            <Thead>
+              <Tr>
+                <Th width={10}>{t('Type')}</Th>
+                <Th width={10}>{t('Status')}</Th>
+                <Th width={20}>{t('Updated')}</Th>
+                <Th width={10}>{t('Reason')}</Th>
+                <Th> {t('Message')}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {(conditions || []).map((condition) => (
+                <Tr key={condition.type}>
+                  <Td>{condition.type}</Td>
+                  <Td>{getStatusLabel(condition.status)}</Td>
+                  <Td>
+                    <Timestamp timestamp={condition.lastTransitionTime} />
+                  </Td>
+                  <Td>{condition.reason}</Td>
+                  <Td modifier="truncate">{condition?.message || '-'}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </>
+      )}
 
       <SectionHeading
         text={'Pipeline'}


### PR DESCRIPTION
Issue:
in plans details view, vms tab, we show the conditions section even when empty

Fix:
hide the conditions section when empty

Screenshots:
Before:
![with-conditions](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/56aab774-cf7c-4256-a445-88361d133e43)

After:
![no-conditions](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/e7a40891-1fbc-4422-8c3b-c8614fca0d44)
