### PR TITLE
:cleanup: Dont compile storiebook files when building the common package

### DIFF
--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -25,6 +25,7 @@
   },
 
   "include": ["./src/**/*"],
+  "exclude": ["./src/components-stories/**/*", "./src/components-stories/*"],
 
   "ts-node": {
     "files": true,


### PR DESCRIPTION
Issue:
We build the storybook files on each build, but we only use them when running storybook

Fix:
Build the storybook files only for storybook