### PR TITLE
:lady_beetle: Warn on manual hooks in plan

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useReducer } from 'react';
 import { Base64 } from 'js-base64';
 import SectionHeading from 'src/components/headers/SectionHeading';
+import { AlertMessageForModals } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
@@ -27,7 +28,7 @@ import { onUpdatePlanHooks } from './utils';
 export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name, namespace }) => {
   const { t } = useForkliftTranslation();
 
-  const [plan, preHookResource, postHookResource, loaded, loadError] = usePlanHooks(
+  const [plan, preHookResource, postHookResource, loaded, loadError, warning] = usePlanHooks(
     name,
     namespace,
   );
@@ -95,6 +96,24 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
   return (
     <Suspend obj={plan} loaded={loaded} loadError={loadError}>
       {state.alertMessage && <PageSection variant="light">{state.alertMessage}</PageSection>}
+
+      {warning && (
+        <PageSection
+          variant="light"
+          className="forklift-page-plan-details-vm-status__section-actions"
+        >
+          <AlertMessageForModals
+            variant="warning"
+            title={'The plan hooks were manually configured'}
+            message={
+              <>
+                <p>Warning: {warning},</p>
+                <p>updating the hooks will override the current configuration.</p>
+              </>
+            }
+          />
+        </PageSection>
+      )}
 
       <PageSection
         variant="light"

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/hooks/usePlanHooks.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/hooks/usePlanHooks.ts
@@ -28,5 +28,43 @@ export const usePlanHooks = (name: string, namespace: string) => {
   const postHookResource = hookRecourses.find((h) => h.metadata.name === postHook?.hook?.name);
   const preHookResource = hookRecourses.find((h) => h.metadata.name === preHook?.hook?.name);
 
-  return [plan, preHookResource, postHookResource, loaded, loadError];
+  // Check for unsupported hooks
+  const warning = validateHooks(plan);
+
+  return [plan, preHookResource, postHookResource, loaded, loadError, warning];
 };
+
+/**
+ * Validates that there is only one 'PostHook' and one 'PreHook' defined
+ * and that the exact same hooks are defined on all VMs in the plan.
+ *
+ * @param {V1beta1Plan} plan - The plan object containing VM specifications.
+ * @returns {string} - Returns a warning string.
+ */
+function validateHooks(plan: V1beta1Plan): string {
+  if (!plan?.spec?.vms) {
+    return;
+  }
+
+  const hooksOnFirstVM = plan.spec.vms[0]?.hooks || [];
+
+  const hasMultiplePostHook = hooksOnFirstVM.filter((h) => h.step === 'PostHook').length > 1;
+  const hasMultiplePreHook = hooksOnFirstVM.filter((h) => h.step === 'PreHook').length > 1;
+
+  if (hasMultiplePostHook || hasMultiplePreHook) {
+    return 'the plan is configured with more then one hook per step';
+  }
+
+  const sortedFirstVMHooks = hooksOnFirstVM.sort((a, b) => a.step.localeCompare(b.step));
+
+  const sameHooks = plan.spec.vms.every((vm) => {
+    const sortedVMHooks = (vm.hooks || []).sort((a, b) => a.step.localeCompare(b.step));
+    return JSON.stringify(sortedFirstVMHooks) === JSON.stringify(sortedVMHooks);
+  });
+
+  if (!sameHooks) {
+    return 'the plan is configured with different hooks for different virtual machines';
+  }
+
+  return;
+}

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/components/AlertMessageForModals.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/components/AlertMessageForModals.tsx
@@ -4,11 +4,12 @@ import { Alert } from '@patternfly/react-core';
 
 import './alerts.style.css';
 
-export const AlertMessageForModals: React.FC<{ title: string; message: string }> = ({
-  title,
-  message,
-}) => (
-  <Alert className="co-alert forklift-alert--margin-top" isInline variant="danger" title={title}>
+export const AlertMessageForModals: React.FC<{
+  title: string;
+  message: React.ReactNode | string;
+  variant?: 'default' | 'danger' | 'success' | 'warning' | 'info';
+}> = ({ title, message, variant = 'danger' }) => (
+  <Alert className="co-alert forklift-alert--margin-top" isInline variant={variant} title={title}>
     {message}
   </Alert>
 );


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1199

Issue:
A user may create a valid plan with unsupported hooks settings.

Fix:
Warn users before editing hooks in the UI, that the current settings is not supported by the UI, and the current unsupported settings will be overwritten and lost if the user edit the hooks using the UI.

Screenshot:
![hooks-warning](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f4883876-05e6-449c-b8ad-201cece74975)
