### PR TITLE
:feet: Update to PF5 - part II - onClick event handler

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/actions/NetworkMapActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/actions/NetworkMapActionsDropdownItems.tsx
@@ -21,15 +21,15 @@ export const NetworkMapActionsDropdownItems = ({ data }: NetworkMapActionsDropdo
     namespace: networkMap?.metadata?.namespace,
   });
 
+  const onClick = () => {
+    showModal(<DeleteModal resource={networkMap} model={NetworkMapModel} />);
+  };
+
   return [
     <DropdownItemLink key="EditNetworkMapping" href={networkMapURL}>
       {t('Edit NetworkMap')}
     </DropdownItemLink>,
-    <DropdownItem
-      key="delete"
-      isDisabled={!data?.permissions?.canDelete}
-      onClick={() => showModal(<DeleteModal resource={networkMap} model={NetworkMapModel} />)}
-    >
+    <DropdownItem key="delete" isDisabled={!data?.permissions?.canDelete} onClick={onClick}>
       {t('Delete NetworkMap')}
     </DropdownItem>,
   ];

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/componenets/NetworkMapsAddButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/componenets/NetworkMapsAddButton.tsx
@@ -19,12 +19,12 @@ export const NetworkMapsAddButton: React.FC<{ namespace: string; dataTestId?: st
     namespaced: namespace !== undefined,
   });
 
+  const onClick = () => {
+    history.push(`${NetworkMapsListURL}/~new`);
+  };
+
   return (
-    <Button
-      data-testid={dataTestId}
-      variant="primary"
-      onClick={() => history.push(`${NetworkMapsListURL}/~new`)}
-    >
+    <Button data-testid={dataTestId} variant="primary" onClick={onClick}>
       {t('Create NetworkMap')}
     </Button>
   );

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -156,6 +156,10 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
     });
   };
 
+  const onClick = () => {
+    dispatch({ type: 'INIT', payload: obj });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -173,7 +177,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
         <FlexItem>
           <Button
             variant="secondary"
-            onClick={() => dispatch({ type: 'INIT', payload: obj })}
+            onClick={onClick}
             isDisabled={!state.hasChanges || state.updating}
           >
             {t('Cancel')}

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -49,6 +49,10 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     });
   };
 
+  const onClick = () => {
+    dispatch({ type: 'INIT', payload: obj });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -66,7 +70,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
         <FlexItem>
           <Button
             variant="secondary"
-            onClick={() => dispatch({ type: 'INIT', payload: obj })}
+            onClick={onClick}
             isDisabled={!state.hasChanges || state.updating}
           >
             {t('Cancel')}

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/ShowWelcomeCardButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/components/ShowWelcomeCardButton.tsx
@@ -10,15 +10,16 @@ export const ShowWelcomeCardButton: React.FC = () => {
   // Set and use context data for the overview page state
   const { setData } = useCreateOverviewContext();
   const { data: { hideWelcomeCardByContext } = {} } = useCreateOverviewContext();
+  const onClick = () => {
+    setData({ hideWelcomeCardByContext: false });
+  };
 
   if (!hideWelcomeCardByContext) return null;
 
   return (
     <Label
       color="purple"
-      onClick={() => {
-        setData({ hideWelcomeCardByContext: false });
-      }}
+      onClick={onClick}
       onClose={() => null}
       style={{ cursor: 'pointer' }}
       data-testid="show-welcome-card"

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/MigrationsChartCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/MigrationsChartCard.tsx
@@ -72,6 +72,11 @@ export const MigrationsChartCard: React.FC<MigrationsCardProps> = () => {
     ...migrationsDataPoints.succeeded.map((m) => m.value),
   );
 
+  const handleTimeRangeSelectedFactory = (timeRange: TimeRangeOptions) => () => {
+    onToggle();
+    setSelectedTimeRange(timeRange);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -85,28 +90,19 @@ export const MigrationsChartCard: React.FC<MigrationsCardProps> = () => {
             isPlain
             dropdownItems={[
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last7Days);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last7Days)}
                 key="7days"
               >
                 {t('7 days')}
               </DropdownItem>,
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last31Days);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last31Days)}
                 key="31days"
               >
                 {t('31 days')}
               </DropdownItem>,
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last24H);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last24H)}
                 key="24hours"
               >
                 {t('24 hours')}

--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/VmMigrationsChartCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Metrics/cards/VmMigrationsChartCard.tsx
@@ -94,6 +94,11 @@ export const VmMigrationsChartCard: React.FC<MigrationsCardProps> = () => {
     ...VmMigrationsDataPoints.succeeded.map((m) => m.value),
   );
 
+  const handleTimeRangeSelectedFactory = (timeRange: TimeRangeOptions) => () => {
+    onToggle();
+    setSelectedTimeRange(timeRange);
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -107,28 +112,19 @@ export const VmMigrationsChartCard: React.FC<MigrationsCardProps> = () => {
             isPlain
             dropdownItems={[
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last7Days);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last7Days)}
                 key="7days"
               >
                 {t('7 days')}
               </DropdownItem>,
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last31Days);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last31Days)}
                 key="31days"
               >
                 {t('31 days')}
               </DropdownItem>,
               <DropdownItem
-                onClick={() => {
-                  onToggle();
-                  setSelectedTimeRange(TimeRangeOptions.Last24H);
-                }}
+                onClick={handleTimeRangeSelectedFactory(TimeRangeOptions.Last24H)}
                 key="24hours"
               >
                 {t('24 hours')}

--- a/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
@@ -36,35 +36,45 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
 
   const buttonStartLabel = canReStart ? t('Restart migration') : t('Start migration');
 
+  const onClickPlanStart = () => {
+    showModal(
+      <PlanStartMigrationModal resource={plan} model={PlanModel} title={buttonStartLabel} />,
+    );
+  };
+
+  const onClickPlanCutover = () => {
+    showModal(<PlanCutoverMigrationModal resource={plan} />);
+  };
+
+  const onClickDuplicate = () => {
+    showModal(<DuplicateModal resource={plan} model={PlanModel} />);
+  };
+
+  const onClickArchive = () => {
+    showModal(<ArchiveModal resource={plan} model={PlanModel} />);
+  };
+
+  const onClickPlanDelete = () => {
+    showModal(<PlanDeleteModal resource={plan} model={PlanModel} />);
+  };
+
   return [
     <DropdownItemLink key="EditPlan" href={planURL}>
       {t('Edit Plan')}
     </DropdownItemLink>,
 
-    <DropdownItem
-      key="start"
-      isDisabled={!canStart}
-      onClick={() =>
-        showModal(
-          <PlanStartMigrationModal resource={plan} model={PlanModel} title={buttonStartLabel} />,
-        )
-      }
-    >
+    <DropdownItem key="start" isDisabled={!canStart} onClick={onClickPlanStart}>
       {buttonStartLabel}
     </DropdownItem>,
 
-    <DropdownItem
-      key="cutover"
-      isDisabled={!isWarmAndExecuting}
-      onClick={() => showModal(<PlanCutoverMigrationModal resource={plan} />)}
-    >
+    <DropdownItem key="cutover" isDisabled={!isWarmAndExecuting} onClick={onClickPlanCutover}>
       {t('Cutover')}
     </DropdownItem>,
 
     <DropdownItem
       key="duplicate"
       isDisabled={!data?.permissions?.canDelete}
-      onClick={() => showModal(<DuplicateModal resource={plan} model={PlanModel} />)}
+      onClick={onClickDuplicate}
     >
       {t('Duplicate Plan')}
     </DropdownItem>,
@@ -72,7 +82,7 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
     <DropdownItem
       key="archive"
       isDisabled={!data?.permissions?.canDelete || ['Archived', 'Archiving'].includes(phase)}
-      onClick={() => showModal(<ArchiveModal resource={plan} model={PlanModel} />)}
+      onClick={onClickArchive}
     >
       {t('Archive Plan')}
     </DropdownItem>,
@@ -80,7 +90,7 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
     <DropdownItem
       key="delete"
       isDisabled={!data?.permissions?.canDelete}
-      onClick={() => showModal(<PlanDeleteModal resource={plan} model={PlanModel} />)}
+      onClick={onClickPlanDelete}
     >
       {t('Delete Plan')}
     </DropdownItem>,

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
@@ -50,6 +50,10 @@ export const MappingListItem: FC<MappingListItemProps> = ({
   const [isSrcOpen, setToggleSrcOpen] = useToggle(false);
   const [isTrgOpen, setToggleTrgOpen] = useToggle(false);
 
+  const onClick = () => {
+    deleteMapping({ source, destination });
+  };
+
   return (
     <DataListItem aria-labelledby="">
       <DataListItemRow>
@@ -111,7 +115,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
             aria-labelledby=""
           >
             <Button
-              onClick={() => deleteMapping({ source, destination })}
+              onClick={onClick}
               variant="plain"
               aria-label={t('Delete mapping')}
               key="delete-action"

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
@@ -58,21 +58,16 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
     );
   }
 
+  const onClick = () => {
+    showModal(
+      <PlanStartMigrationModal resource={plan} model={PlanModel} title={buttonStartLabel} />,
+    );
+  };
+
   const actions = (
     <Level hasGutter>
       {canStart && (
-        <Button
-          variant="primary"
-          onClick={() =>
-            showModal(
-              <PlanStartMigrationModal
-                resource={plan}
-                model={PlanModel}
-                title={buttonStartLabel}
-              />,
-            )
-          }
-        >
+        <Button variant="primary" onClick={onClick}>
           <Level hasGutter>
             <>
               <LevelItem>{buttonStartIcon}</LevelItem>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
@@ -50,6 +50,13 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
     onUpdatePlanHooks({ plan, preHookResource, postHookResource, dispatch, state });
   }
 
+  const onClick = () => {
+    dispatch({
+      type: 'INIT',
+      payload: initialState(plan, preHookResource, postHookResource),
+    });
+  };
+
   const HooksTabAction = (
     <>
       <Flex>
@@ -65,16 +72,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
         </FlexItem>
 
         <FlexItem>
-          <Button
-            variant="secondary"
-            isDisabled={!state.hasChanges}
-            onClick={() =>
-              dispatch({
-                type: 'INIT',
-                payload: initialState(plan, preHookResource, postHookResource),
-              })
-            }
-          >
+          <Button variant="secondary" isDisabled={!state.hasChanges} onClick={onClick}>
             {t('Cancel')}
           </Button>
         </FlexItem>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
@@ -13,16 +13,13 @@ export const MigrationVMsCancelButton: FC<{
 }> = ({ selectedIds, migration }) => {
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
+  const onClick = () => {
+    showModal(<MigrationVMsCancelModal migration={migration} selected={selectedIds} />);
+  };
 
   return (
     <ToolbarItem>
-      <Button
-        variant="secondary"
-        onClick={() =>
-          showModal(<MigrationVMsCancelModal migration={migration} selected={selectedIds} />)
-        }
-        isDisabled={!selectedIds?.length}
-      >
+      <Button variant="secondary" onClick={onClick} isDisabled={!selectedIds?.length}>
         {t('Cancel virtual machines')}
       </Button>
     </ToolbarItem>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
@@ -14,13 +14,13 @@ export const PlanVMsDeleteButton: FC<{
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
+  const onClick = () => {
+    showModal(<PlanVMsDeleteModal plan={plan} selected={selectedIds} />);
+  };
+
   return (
     <ToolbarItem>
-      <Button
-        variant="secondary"
-        onClick={() => showModal(<PlanVMsDeleteModal plan={plan} selected={selectedIds} />)}
-        isDisabled={selectedIds?.length < 1}
-      >
+      <Button variant="secondary" onClick={onClick} isDisabled={selectedIds?.length < 1}>
         {t('Remove virtual machines')}
       </Button>
     </ToolbarItem>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
@@ -28,25 +28,23 @@ export const ActionsCell = ({ data }: CellProps) => {
   const buttonStartIcon = canReStart ? <ReStartIcon /> : <StartIcon />;
   const buttonCutoverIcon = <CutoverIcon />;
 
+  const onClickPlanStartMigration = () => {
+    showModal(
+      <PlanStartMigrationModal resource={data.obj} model={PlanModel} title={buttonStartLabel} />,
+    );
+  };
+
+  const onClickPlanCutoverMigration = () => {
+    showModal(<PlanCutoverMigrationModal resource={data.obj} />);
+  };
+
   return (
     <Flex flex={{ default: 'flex_3' }} flexWrap={{ default: 'nowrap' }}>
       <FlexItem grow={{ default: 'grow' }}></FlexItem>
 
       {canStart && (
         <FlexItem align={{ default: 'alignRight' }}>
-          <Button
-            variant="secondary"
-            icon={buttonStartIcon}
-            onClick={() =>
-              showModal(
-                <PlanStartMigrationModal
-                  resource={data.obj}
-                  model={PlanModel}
-                  title={buttonStartLabel}
-                />,
-              )
-            }
-          >
+          <Button variant="secondary" icon={buttonStartIcon} onClick={onClickPlanStartMigration}>
             {buttonStartLabel}
           </Button>
         </FlexItem>
@@ -57,7 +55,7 @@ export const ActionsCell = ({ data }: CellProps) => {
           <Button
             variant="secondary"
             icon={buttonCutoverIcon}
-            onClick={() => showModal(<PlanCutoverMigrationModal resource={data.obj} />)}
+            onClick={onClickPlanCutoverMigration}
           >
             {t('Cutover')}
           </Button>

--- a/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdownItems.tsx
@@ -20,6 +20,10 @@ export const ProviderActionsDropdownItems = ({ data }: ProviderActionsDropdownIt
     namespace: provider?.metadata?.namespace,
   });
 
+  const onClick = () => {
+    showModal(<DeleteModal resource={provider} model={ProviderModel} />);
+  };
+
   return [
     <DropdownItemLink key="EditProvider" href={providerURL}>
       {t('Edit Provider')}
@@ -30,11 +34,7 @@ export const ProviderActionsDropdownItems = ({ data }: ProviderActionsDropdownIt
     <DropdownItemLink key="MigratePlan" href={`${providerURL}/vms`}>
       {t('Migrate')}
     </DropdownItemLink>,
-    <DropdownItem
-      key="delete"
-      isDisabled={!data?.permissions?.canDelete}
-      onClick={() => showModal(<DeleteModal resource={provider} model={ProviderModel} />)}
-    >
+    <DropdownItem key="delete" isDisabled={!data?.permissions?.canDelete} onClick={onClick}>
       {t('Delete Provider')}
     </DropdownItem>,
   ];

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -104,6 +104,10 @@ export const EditModal: React.FC<EditModalProps> = ({
     }
   }, [resource, value]);
 
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
+
   /**
    * LabelIcon is a (?) icon that triggers a Popover component when clicked.
    */
@@ -112,7 +116,7 @@ export const EditModal: React.FC<EditModalProps> = ({
       <button
         type="button"
         aria-label="More info for field"
-        onClick={(e) => e.preventDefault()}
+        onClick={onClick}
         aria-describedby="modal-with-form-form-field"
         className="pf-c-form__group-label-help"
       >

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
@@ -34,6 +34,12 @@ export const CertificateUpload: FC<CertificateUploadProps> = ({
   const { showModal } = useModal();
   const { t } = useForkliftTranslation();
   const isText = !type || type === 'text';
+  const onClick = () => {
+    showModal(
+      <FetchCertificateModal url={url} handleSave={onTextChange} existingCert={String(value)} />,
+    );
+  };
+
   return (
     <>
       <FileUpload
@@ -55,15 +61,7 @@ export const CertificateUpload: FC<CertificateUploadProps> = ({
                 className="forklift-certificate-upload-margin"
                 isDisabled={isDisabled || !url?.trim().startsWith('https://')}
                 variant="secondary"
-                onClick={() =>
-                  showModal(
-                    <FetchCertificateModal
-                      url={url}
-                      handleSave={onTextChange}
-                      existingCert={String(value)}
-                    />,
-                  )
-                }
+                onClick={onClick}
               >
                 {t('Fetch certificate from URL')}
               </Button>

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/FetchCertificateModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/FetchCertificateModal.tsx
@@ -21,6 +21,12 @@ export const FetchCertificateModal: FC<{
   const success = !loading && !fetchError && !certError;
   const hasThumbprintChanged =
     existingCert && success && thumbprint !== calculateThumbprint(existingCert);
+
+  const onClick = () => {
+    handleSave(certificate);
+    toggleModal();
+  };
+
   return (
     <Modal
       title={t('Verify certificate')}
@@ -33,10 +39,7 @@ export const FetchCertificateModal: FC<{
         <Button
           key="confirm"
           variant="primary"
-          onClick={() => {
-            handleSave(certificate);
-            toggleModal();
-          }}
+          onClick={onClick}
           isDisabled={!success || !isTrusted}
         >
           {t('Confirm')}

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
@@ -108,50 +108,52 @@ export const DescriptionTitleWithHelp: React.FC<{
   crumbs,
   moreInfoLabel = 'More info:',
   moreInfoLink,
-}) => (
-  <DescriptionListTermHelpText>
-    {showHelpIconNextToTitle ? <label>{title} &nbsp;</label> : null}
-    <Popover
-      headerContent={<div>{title}</div>}
-      bodyContent={
-        <Flex direction={{ default: 'column' }}>
-          <FlexItem>{helpContent}</FlexItem>
+}) => {
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
 
-          {moreInfoLink && (
-            <FlexItem>
-              {moreInfoLabel}{' '}
-              <ExternalLink href={moreInfoLink} isInline hideIcon>
-                <Truncate content={moreInfoLink} />
-              </ExternalLink>
-            </FlexItem>
-          )}
+  return (
+    <DescriptionListTermHelpText>
+      {showHelpIconNextToTitle ? <label>{title} &nbsp;</label> : null}
+      <Popover
+        headerContent={<div>{title}</div>}
+        bodyContent={
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem>{helpContent}</FlexItem>
 
-          {crumbs && crumbs.length > 0 && (
-            <FlexItem>
-              <Breadcrumb>
-                {crumbs.map((c) => (
-                  <BreadcrumbItem key={c}>{c}</BreadcrumbItem>
-                ))}
-              </Breadcrumb>
-            </FlexItem>
-          )}
-        </Flex>
-      }
-    >
-      {showHelpIconNextToTitle ? (
-        <button
-          type="button"
-          onClick={(e) => e.preventDefault()}
-          className="pf-c-form__group-label-help"
-        >
-          <HelpIcon />
-        </button>
-      ) : (
-        <DescriptionListTermHelpTextButton> {title} </DescriptionListTermHelpTextButton>
-      )}
-    </Popover>
-  </DescriptionListTermHelpText>
-);
+            {moreInfoLink && (
+              <FlexItem>
+                {moreInfoLabel}{' '}
+                <ExternalLink href={moreInfoLink} isInline hideIcon>
+                  <Truncate content={moreInfoLink} />
+                </ExternalLink>
+              </FlexItem>
+            )}
+
+            {crumbs && crumbs.length > 0 && (
+              <FlexItem>
+                <Breadcrumb>
+                  {crumbs.map((c) => (
+                    <BreadcrumbItem key={c}>{c}</BreadcrumbItem>
+                  ))}
+                </Breadcrumb>
+              </FlexItem>
+            )}
+          </Flex>
+        }
+      >
+        {showHelpIconNextToTitle ? (
+          <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
+            <HelpIcon />
+          </button>
+        ) : (
+          <DescriptionListTermHelpTextButton> {title} </DescriptionListTermHelpTextButton>
+        )}
+      </Popover>
+    </DescriptionListTermHelpText>
+  );
+};
 
 /**
  * Component for displaying title without a popover.

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -211,6 +211,10 @@ export const ProvidersCreatePage: React.FC<{
     namespace: namespace,
   });
 
+  const onClick = () => {
+    history.push(providersListURL);
+  };
+
   return (
     <div>
       <PageSection variant="light">
@@ -272,7 +276,7 @@ export const ProvidersCreatePage: React.FC<{
             </Button>
           </FlexItem>
           <FlexItem>
-            <Button onClick={() => history.push(providersListURL)} variant="secondary">
+            <Button onClick={onClick} variant="secondary">
               {t('Cancel')}
             </Button>
           </FlexItem>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -117,6 +117,10 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
     [provider],
   );
 
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -172,11 +176,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
             bodyContent={vddkHelperTextPopover}
             alertSeverityVariant="info"
           >
-            <button
-              type="button"
-              onClick={(e) => e.preventDefault()}
-              className="pf-c-form__group-label-help"
-            >
+            <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
               <HelpIcon />
             </button>
           </Popover>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -117,6 +117,10 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
     [provider],
   );
 
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -172,11 +176,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
             bodyContent={vddkHelperTextPopover}
             alertSeverityVariant="info"
           >
-            <button
-              type="button"
-              onClick={(e) => e.preventDefault()}
-              className="pf-c-form__group-label-help"
-            >
+            <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
               <HelpIcon />
             </button>
           </Popover>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -93,6 +93,16 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  const onClickEventPreventDef: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (
+    event,
+  ) => {
+    event.preventDefault();
+  };
+
+  const onClickTogglePassword = () => {
+    togglePasswordHidden();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -132,7 +142,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
         />
         <Button
           variant="control"
-          onClick={togglePasswordHidden}
+          onClick={onClickTogglePassword}
           aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
         >
           {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
@@ -151,7 +161,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />
@@ -183,7 +193,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -93,6 +93,16 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   }
 
+  const onClickEventPreventDef: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (
+    event,
+  ) => {
+    event.preventDefault();
+  };
+
+  const onClickTogglePassword = () => {
+    togglePasswordHidden();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -114,7 +124,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         />
         <Button
           variant="control"
-          onClick={() => togglePasswordHidden()}
+          onClick={onClickTogglePassword}
           aria-label={state.passwordHidden ? 'Show token' : 'Hide token'}
         >
           {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
@@ -133,7 +143,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />
@@ -165,7 +175,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -160,6 +160,10 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     [secret],
   );
 
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -235,11 +239,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
             bodyContent={<div>{insecureSkipVerifyHelperTextPopover}</div>}
             alertSeverityVariant="info"
           >
-            <button
-              type="button"
-              onClick={(e) => e.preventDefault()}
-              className="pf-c-form__group-label-help"
-            >
+            <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
               <HelpIcon />
             </button>
           </Popover>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -99,6 +99,16 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  const onClickEventPreventDef: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (
+    event,
+  ) => {
+    event.preventDefault();
+  };
+
+  const onClickTogglePassword = () => {
+    togglePasswordHidden();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -138,7 +148,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
         />
         <Button
           variant="control"
-          onClick={() => togglePasswordHidden()}
+          onClick={onClickTogglePassword}
           aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
         >
           {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
@@ -157,7 +167,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />
@@ -189,7 +199,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           >
             <button
               type="button"
-              onClick={(e) => e.preventDefault()}
+              onClick={onClickEventPreventDef}
               className="pf-c-form__group-label-help"
             >
               <HelpIcon />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -93,6 +93,10 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  const onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void = (event) => {
+    event.preventDefault();
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -149,11 +153,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
             bodyContent={insecureSkipVerifyHelperTextPopover}
             alertSeverityVariant="info"
           >
-            <button
-              type="button"
-              onClick={(e) => e.preventDefault()}
-              className="pf-c-form__group-label-help"
-            >
+            <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
               <HelpIcon />
             </button>
           </Popover>
@@ -181,11 +181,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
             bodyContent={cacertHelperTextPopover}
             alertSeverityVariant="info"
           >
-            <button
-              type="button"
-              onClick={(e) => e.preventDefault()}
-              className="pf-c-form__group-label-help"
-            >
+            <button type="button" onClick={onClick} className="pf-c-form__group-label-help">
               <HelpIcon />
             </button>
           </Popover>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/SelectNetworkButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/SelectNetworkButton.tsx
@@ -33,18 +33,13 @@ export const SelectNetworkButton: FC<{
 }> = ({ selectedIds, provider, hostsData }) => {
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
+  const onClick = () => {
+    showModal(<VSphereNetworkModal provider={provider} data={hostsData} selected={selectedIds} />);
+  };
 
   return (
     <ToolbarItem>
-      <Button
-        variant="secondary"
-        onClick={() =>
-          showModal(
-            <VSphereNetworkModal provider={provider} data={hostsData} selected={selectedIds} />,
-          )
-        }
-        isDisabled={!selectedIds?.length}
-      >
+      <Button variant="secondary" onClick={onClick} isDisabled={!selectedIds?.length}>
         {t('Select migration network')}
       </Button>
     </ToolbarItem>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Networks/ProviderNetworks.tsx
@@ -49,6 +49,9 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
     isDefault: `${net.namespace}/${net.name}` === defaultNetwork,
     config: JSON.parse(net?.object?.spec?.config || '{}') as CnoConfig,
   }));
+  const onClick = () => {
+    showModal(<EditProviderDefaultTransferNetwork resource={provider} />);
+  };
 
   return (
     <div>
@@ -57,11 +60,7 @@ const ProviderNetworks_: React.FC<ProviderNetworksProps> = ({ obj }) => {
 
         {permissions.canPatch && (
           <div className="forklift-page-provider-networks-button">
-            <Button
-              key="editTransferNetwork"
-              variant="secondary"
-              onClick={() => showModal(<EditProviderDefaultTransferNetwork resource={provider} />)}
-            >
+            <Button key="editTransferNetwork" variant="secondary" onClick={onClick}>
               {t('Set default transfer network')}
             </Button>
           </div>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/MigrationAction.tsx
@@ -23,16 +23,14 @@ export const MigrationAction: FC<{
     namespaced: namespace !== undefined,
   });
   const { setData } = useCreateVmMigrationData();
+  const onClick = () => {
+    setData({ selectedVms, provider });
+    history.push(`${planListURL}/~new`);
+  };
+
   return (
     <ToolbarItem className={className}>
-      <Button
-        variant="primary"
-        onClick={() => {
-          setData({ selectedVms, provider });
-          history.push(`${planListURL}/~new`);
-        }}
-        isDisabled={!selectedVms?.length}
-      >
+      <Button variant="primary" onClick={onClick} isDisabled={!selectedVms?.length}>
         {t('Create migration plan')}
       </Button>
     </ToolbarItem>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersAddButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProvidersAddButton.tsx
@@ -19,12 +19,12 @@ export const ProvidersAddButton: React.FC<{ namespace: string; dataTestId?: stri
     namespaced: namespace !== undefined,
   });
 
+  const onClick = () => {
+    history.push(`${providersListURL}/~new`);
+  };
+
   return (
-    <Button
-      data-testid={dataTestId}
-      variant="primary"
-      onClick={() => history.push(`${providersListURL}/~new`)}
-    >
+    <Button data-testid={dataTestId} variant="primary" onClick={onClick}>
       {t('Create Provider')}
     </Button>
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
@@ -52,6 +52,10 @@ export const MappingListItem: FC<MappingListItemProps> = ({
   const { t } = useForkliftTranslation();
   const [isSrcOpen, setToggleSrcOpen] = useToggle(false);
   const [isTrgOpen, setToggleTrgOpen] = useToggle(false);
+  const onClick = () => {
+    deleteMapping({ source, destination });
+  };
+
   return (
     <DataListItem aria-labelledby="">
       <DataListItemRow>
@@ -114,7 +118,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
           aria-labelledby=""
         >
           <Button
-            onClick={() => deleteMapping({ source, destination })}
+            onClick={onClick}
             variant="plain"
             aria-label={t('Delete mapping')}
             key="delete-action"

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/actions/StorageMapActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/actions/StorageMapActionsDropdownItems.tsx
@@ -21,15 +21,15 @@ export const StorageMapActionsDropdownItems = ({ data }: StorageMapActionsDropdo
     namespace: StorageMap?.metadata?.namespace,
   });
 
+  const onClick = () => {
+    showModal(<DeleteModal resource={StorageMap} model={StorageMapModel} />);
+  };
+
   return [
     <DropdownItemLink key="EditStorageMapping" href={StorageMapURL}>
       {t('Edit StorageMap')}
     </DropdownItemLink>,
-    <DropdownItem
-      key="delete"
-      isDisabled={!data?.permissions?.canDelete}
-      onClick={() => showModal(<DeleteModal resource={StorageMap} model={StorageMapModel} />)}
-    >
+    <DropdownItem key="delete" isDisabled={!data?.permissions?.canDelete} onClick={onClick}>
       {t('Delete StorageMap')}
     </DropdownItem>,
   ];

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/componenets/StorageMapsAddButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/componenets/StorageMapsAddButton.tsx
@@ -19,12 +19,12 @@ export const StorageMapsAddButton: React.FC<{ namespace: string; dataTestId?: st
     namespaced: namespace !== undefined,
   });
 
+  const onClick = () => {
+    history.push(`${StorageMapsListURL}/~new`);
+  };
+
   return (
-    <Button
-      data-testid={dataTestId}
-      variant="primary"
-      onClick={() => history.push(`${StorageMapsListURL}/~new`)}
-    >
+    <Button data-testid={dataTestId} variant="primary" onClick={onClick}>
       {t('Create StorageMap')}
     </Button>
   );

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -145,6 +145,10 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
     });
   };
 
+  const onClick = () => {
+    dispatch({ type: 'INIT', payload: obj });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -162,7 +166,7 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
         <FlexItem>
           <Button
             variant="secondary"
-            onClick={() => dispatch({ type: 'INIT', payload: obj })}
+            onClick={onClick}
             isDisabled={!state.hasChanges || state.updating}
           >
             {t('Cancel')}

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -45,6 +45,10 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     await k8sUpdate({ model: StorageMapModel, data: state.StorageMap });
   };
 
+  const onClick = () => {
+    dispatch({ type: 'INIT', payload: obj });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -62,7 +66,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
         <FlexItem>
           <Button
             variant="secondary"
-            onClick={() => dispatch({ type: 'INIT', payload: obj })}
+            onClick={onClick}
             isDisabled={!state.hasChanges || state.updating}
           >
             {t('Cancel')}


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1098

Include 2 changes:
1.  Seems like `onClick` event handler parameters were not changed  in PF5.
      But to be on the safe side and avoid uncaught PF 4 -> PF 5 migration errors, this PR typed (i.e.  (add type to function 
      signature) all  `onClick` callback appearances which include the event parameter.
2. As an enhancement for code readability, named most of `onClick` callback appearances (when possible).