### PR TITLE
:feet: Error when vddk init image is empty

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -410,6 +410,7 @@
   "Show archived": "Show archived",
   "Show the welcome card": "Show the welcome card",
   "Skip certificate validation": "Skip certificate validation",
+  "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.": "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.",
   "Snapshot polling interval (seconds)": "Snapshot polling interval (seconds)",
   "Something is wrong, the data was not loaded due to an error, please try to reload the page.": "Something is wrong, the data was not loaded due to an error, please try to reload the page.",
   "Something is wrong, the secret was not loaded, please try to reload the page.": "Something is wrong, the secret was not loaded, please try to reload the page.",

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -77,7 +77,7 @@ export const EditModal: React.FC<EditModalProps> = ({
       const validationResult = validationHook(value);
       setValidation(validationResult);
     }
-  }, []);
+  }, [validationHook]);
 
   /**
    * Handles value change.
@@ -112,7 +112,7 @@ export const EditModal: React.FC<EditModalProps> = ({
         <AlertMessageForModals title={t('Error')} message={err.message || err.toString()} />,
       );
     }
-  }, [resource, value]);
+  }, [resource, value, onConfirmHook]);
 
   /**
    * LabelIcon is a (?) icon that triggers a Popover component when clicked.

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/index.ts
@@ -1,3 +1,5 @@
 // @index('./*.tsx', f => `export * from '${f.path}';`)
 export * from './EditProviderVDDKImage';
+export * from './onEmptyVddkConfirm';
+export * from './onVddkConfirm';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onEmptyVddkConfirm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onEmptyVddkConfirm.tsx
@@ -1,0 +1,62 @@
+import { V1beta1Provider } from '@kubev2v/types';
+import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+import { OnConfirmHookType } from '../EditModal';
+
+/**
+ * Handles the confirmation action for editing a resource annotations.
+ * Delete the vddkInitImage settings in the resource's spec.
+ *
+ * @param {Object} options - Options for the confirmation action.
+ * @param {Object} options.resource - The resource to be modified.
+ * @param {Object} options.model - The model associated with the resource.
+ * @returns {Promise<Object>} - The modified resource.
+ */
+export const onEmptyVddkConfirm: OnConfirmHookType = async ({ resource, model }) => {
+  const provider = resource as V1beta1Provider;
+  let op: string;
+
+  // Patch settings
+  const currentSettings = (provider?.spec?.settings || {}) as object;
+  const settings = {
+    ...currentSettings,
+    vddkInitImage: undefined,
+  };
+
+  op = Object.keys(currentSettings).length ? 'replace' : 'add';
+
+  await k8sPatch({
+    model: model,
+    resource: resource,
+    data: [
+      {
+        op,
+        path: '/spec/settings',
+        value: settings,
+      },
+    ],
+  });
+
+  // Patch annotations
+  const currentAnnotations = (provider?.metadata?.annotations || {}) as object;
+  const annotations = {
+    ...currentAnnotations,
+    'forklift.konveyor.io/empty-vddk-init-image': 'yes',
+  };
+
+  op = Object.keys(currentAnnotations).length ? 'replace' : 'add';
+
+  const obj = await k8sPatch({
+    model: model,
+    resource: resource,
+    data: [
+      {
+        op,
+        path: '/metadata/annotations',
+        value: annotations,
+      },
+    ],
+  });
+
+  return obj;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onVddkConfirm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onVddkConfirm.tsx
@@ -1,0 +1,64 @@
+import { V1beta1Provider } from '@kubev2v/types';
+import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+
+import { OnConfirmHookType } from '../EditModal';
+
+/**
+ * Handles the confirmation action for editing a resource annotations.
+ * Adds or updates the vddkInitImage settings in the resource's spec.
+ *
+ * @param {Object} options - Options for the confirmation action.
+ * @param {Object} options.resource - The resource to be modified.
+ * @param {Object} options.model - The model associated with the resource.
+ * @param {any} options.newValue - The new value for the 'vddkInitImage' spec settings.
+ * @returns {Promise<Object>} - The modified resource.
+ */
+export const onVddkConfirm: OnConfirmHookType = async ({ resource, model, newValue: value }) => {
+  const provider = resource as V1beta1Provider;
+  const vddkInitImage: string = value as string;
+  let op: string;
+
+  // Patch settings
+  const currentSettings = provider?.spec?.settings as object;
+  const settings = {
+    ...currentSettings,
+    vddkInitImage: vddkInitImage?.trim() || undefined,
+  };
+
+  op = provider?.spec?.settings ? 'replace' : 'add';
+
+  await k8sPatch({
+    model: model,
+    resource: resource,
+    data: [
+      {
+        op,
+        path: '/spec/settings',
+        value: Object.keys(settings).length === 0 ? undefined : settings,
+      },
+    ],
+  });
+
+  // Patch annotations
+  const currentAnnotations = provider?.metadata?.annotations as object;
+  const annotations = {
+    ...currentAnnotations,
+    'forklift.konveyor.io/empty-vddk-init-image': undefined,
+  };
+
+  op = provider?.spec?.settings ? 'replace' : 'add';
+
+  const obj = await k8sPatch({
+    model: model,
+    resource: resource,
+    data: [
+      {
+        op,
+        path: '/metadata/annotations',
+        value: Object.keys(annotations).length === 0 ? undefined : annotations,
+      },
+    ],
+  });
+
+  return obj;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
@@ -3,10 +3,10 @@ import { ForkliftTrans } from 'src/utils';
 
 import { ExternalLink } from '@kubev2v/common';
 
-const CREATE_VDDK_HELP_LINK =
+export const CREATE_VDDK_HELP_LINK =
   'https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
 
-export const VDDKHelperText = (
+export const VDDKHelperText: React.FC = () => (
   <ForkliftTrans>
     <p>VMware Virtual Disk Development Kit (VDDK) image.</p>
     <br />
@@ -18,24 +18,18 @@ export const VDDKHelperText = (
     <br />
 
     <p>
-      To make use of this feature, you download the VMware Virtual Disk Development Kit (VDDK),
-      build a VDDK image, and push the VDDK image to your image registry.{' '}
+      It is strongly recommended to create a VDDK init image to accelerate migrations. For more
+      information, see{' '}
+      <ExternalLink isInline href={CREATE_VDDK_HELP_LINK}>
+        Creating VDDK image
+      </ExternalLink>
+      .
     </p>
-    <br />
+  </ForkliftTrans>
+);
 
-    <p>
-      The VDDK package contains symbolic links, therefore, the procedure of creating a VDDK image
-      must be performed on a file system that preserves symbolic links (symlinks).
-    </p>
-    <br />
-
-    <p>
-      The format of the URL of the VMware Virtual Disk Development Kit (VDDK) image should include a
-      registry, project, image name, and optionally a version, for example:{' '}
-      <strong>quay.io/kubev2v/vddk:latest</strong>.
-    </p>
-    <br />
-
+export const VDDKHelperTextShort: React.FC = () => (
+  <ForkliftTrans>
     <p>
       It is strongly recommended to create a VDDK init image to accelerate migrations. For more
       information, see{' '}

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -19,7 +19,7 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
   if (trimmedVddkImage === '')
     return {
       msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
-      type: 'warning',
+      type: 'error',
     };
 
   if (!isValidTrimmedVddkImage) {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.style.css
@@ -41,3 +41,11 @@
   font-size: small;
   padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
+
+.forklift-section-provider-edit-vddk-input {
+  padding-top: var(--pf-global--spacer--sm);
+}
+
+.forklift-section-provider-edit-vddk-checkbox {
+  padding-top: var(--pf-global--spacer--sm);
+}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -89,14 +89,10 @@ export const ProvidersCreatePage: React.FC<{
       }
       case 'SET_NEW_PROVIDER': {
         const value = action.payload as V1beta1Provider;
-        let validationError: ValidationMsg = { type: 'default' };
+        let validationError = providerAndSecretValidator(value, state.newSecret);
 
         if (providerNames.includes(value?.metadata?.name)) {
           validationError = { type: 'error', msg: 'Provider name is not unique' };
-        }
-
-        if (!value?.metadata?.name) {
-          validationError = { type: 'error', msg: 'Missing provider name' };
         }
 
         // Sync secret with new URL
@@ -104,11 +100,6 @@ export const ProvidersCreatePage: React.FC<{
           ...state.newSecret,
           data: { ...state.newSecret.data, url: Base64.encode(value?.spec?.url || '') },
         };
-
-        validationError =
-          validationError.type === 'error'
-            ? validationError
-            : providerAndSecretValidator(value, updatedSecret);
 
         return {
           ...state,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -1,10 +1,15 @@
 import React, { useCallback, useReducer } from 'react';
-import { validateVCenterURL, validateVDDKImage, VDDKHelperText } from 'src/modules/Providers/utils';
+import {
+  validateVCenterURL,
+  validateVDDKImage,
+  VDDKHelperText,
+  VDDKHelperTextShort,
+} from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
-import { Form, Popover, Radio, TextInput } from '@patternfly/react-core';
+import { Checkbox, Form, Hint, HintBody, Popover, Radio, TextInput } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 export interface VCenterProviderCreateFormProps {
@@ -19,6 +24,8 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
   const { t } = useForkliftTranslation();
 
   const url = provider?.spec?.url;
+  const emptyVddkInitImage =
+    provider?.metadata?.annotations?.['forklift.konveyor.io/empty-vddk-init-image'];
   const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'];
   const sdkEndpoint = provider?.spec?.settings?.['sdkEndpoint'];
 
@@ -50,6 +57,29 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
     (id, value) => {
       const trimmedValue = value?.trim();
 
+      if (id == 'emptyVddkInitImage') {
+        const vddValidationState = validateVDDKImage(provider?.spec?.settings?.vddkInitImage);
+        const initVddkValidationState = validateVDDKImage(undefined);
+        const validationState =
+          trimmedValue === 'yes' ? initVddkValidationState : vddValidationState;
+
+        dispatch({
+          type: 'SET_FIELD_VALIDATED',
+          payload: { field: 'vddkInitImage', validationState },
+        });
+
+        onChange({
+          ...provider,
+          metadata: {
+            ...provider?.metadata,
+            annotations: {
+              ...(provider?.metadata?.annotations as object),
+              'forklift.konveyor.io/empty-vddk-init-image': trimmedValue || undefined,
+            },
+          },
+        });
+      }
+
       if (id == 'vddkInitImage') {
         const validationState = validateVDDKImage(trimmedValue);
 
@@ -64,7 +94,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
             ...provider?.spec,
             settings: {
               ...(provider?.spec?.settings as object),
-              vddkInitImage: trimmedValue || undefined,
+              vddkInitImage: trimmedValue,
             },
           },
         });
@@ -145,7 +175,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
         fieldId="vddkInitImage"
         helperText={state.validation.vddkInitImage.msg}
         helperTextInvalid={state.validation.vddkInitImage.msg}
-        validated={state.validation.vddkInitImage.type}
+        validated={emptyVddkInitImage === 'yes' ? 'default' : state.validation.vddkInitImage.type}
         labelIcon={
           <Popover
             headerContent={t('VDDK init image')}
@@ -162,14 +192,34 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
           </Popover>
         }
       >
-        <TextInput
-          type="text"
-          id="vddkInitImage"
-          name="vddkInitImage"
-          value={vddkInitImage}
-          validated={state.validation.vddkInitImage.type}
-          onChange={(value) => handleChange('vddkInitImage', value)}
-        />
+        <Hint>
+          <HintBody>
+            <VDDKHelperTextShort />
+            <Checkbox
+              className="forklift-section-provider-edit-vddk-checkbox"
+              label={t(
+                'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.',
+              )}
+              isChecked={emptyVddkInitImage === 'yes'}
+              onChange={(value) => handleChange('emptyVddkInitImage', value ? 'yes' : undefined)}
+              id="emptyVddkInitImage"
+              name="emptyVddkInitImage"
+            />
+          </HintBody>
+        </Hint>
+        <div className="forklift-section-provider-edit-vddk-input">
+          <TextInput
+            type="text"
+            id="vddkInitImage"
+            name="vddkInitImage"
+            isDisabled={emptyVddkInitImage === 'yes'}
+            value={emptyVddkInitImage === 'yes' ? '' : vddkInitImage}
+            validated={
+              emptyVddkInitImage === 'yes' ? 'default' : state.validation.vddkInitImage.type
+            }
+            onChange={(value) => handleChange('vddkInitImage', value)}
+          />
+        </div>
       </FormGroupWithHelpText>
     </Form>
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createProvider.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/utils/createProvider.ts
@@ -41,6 +41,22 @@ export async function createProvider(provider: V1beta1Provider, secret: IoK8sApi
     newProvider = provider;
   }
 
+  // Remove empty settings
+  for (const key in newProvider?.spec?.settings) {
+    // if spec.settings.* is '' replace with undefined
+    if (newProvider.spec.settings[key] === '') {
+      newProvider.spec.settings[key] = undefined;
+    }
+  }
+
+  // Remove vddkInitImage when emptyVddkInitImage flag is on
+  const emptyVddkInitImage =
+    provider?.metadata?.annotations?.['forklift.konveyor.io/empty-vddk-init-image'];
+
+  if (emptyVddkInitImage === 'yes' && provider?.spec?.settings?.['vddkInitImage']) {
+    provider.spec.settings['vddkInitImage'] = undefined;
+  }
+
   const obj = await k8sCreate({
     model: ProviderModel,
     data: newProvider,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/ProviderDetailsPage.style.css
@@ -46,3 +46,11 @@
   font-size: small;
   padding-top: var(--pf-c-form__helper-text--MarginTop);
 }
+
+.forklift-section-provider-edit-vddk-checkbox {
+  padding-top: var(--pf-global--spacer--sm);
+}
+
+.forklift-section-provider-empty-vddk-label-text {
+  padding-left: var(--pf-global--spacer--xs);
+}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { EditProviderVDDKImage, useModal } from 'src/modules/Providers/modals';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
+import { YellowExclamationTriangleIcon } from '@openshift-console/dynamic-plugin-sdk';
+import { Label } from '@patternfly/react-core';
+
 import { DetailsItem } from '../../../../../utils';
 
 import { ProviderDetailsItemProps } from './ProviderDetailsItem';
@@ -34,7 +37,10 @@ export const VDDKDetailsItem: React.FC<ProviderDetailsItemProps> = ({
       title={t('VDDK init image')}
       content={
         provider?.spec?.settings?.['vddkInitImage'] || (
-          <span className="text-muted">{t('Empty')}</span>
+          <Label isCompact color={'orange'}>
+            <YellowExclamationTriangleIcon />
+            <span className="forklift-section-provider-empty-vddk-label-text">{t('Empty')}</span>
+          </Label>
         )
       }
       moreInfoLink={moreInfoLink ?? defaultMoreInfoLink}


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1206

Issue:
When creating and editing a vmware provider it's easy to leave the vddk container image empty

Fix:
Add a checkbox for users to confirm they want an empty image

  - [x] Error field and form if image is empty, edit and create provider
  - [x] Allow to override empty image error using a checkbox, edit and create provider
  - [x] In details page, make empty image a warning
 
Screenshots:
![create-vddk-image-empty](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3d7d49e6-1caa-4c3c-9a8f-a496bdc042c5)
![create-vddk-image](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/424be3b7-bfa7-481c-8e1a-038b87389889)
![details-vddk-image-empty](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c31899e4-8525-4c90-b000-eefa4fad8b74)
![edit-vddk-image-empty](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/cb143a34-ab58-420b-80ea-12bd1569383a)
![edit-vddk-image](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f66543c6-3076-42b8-9bd1-8fa0b30a2cfb)
