### PR TITLE
:soap: Show completed pipeline tasks

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -1,5 +1,6 @@
 {
   "{{Canceled}} canceled": "{{Canceled}} canceled",
+  "{{completed}} / {{total}}": "{{completed}} / {{total}}",
   "{{dateLabel}} Failed: {{value}}": "{{dateLabel}} Failed: {{value}}",
   "{{dateLabel}} Running: {{value}}": "{{dateLabel}} Running: {{value}}",
   "{{dateLabel}} Succeeded: {{value}}": "{{dateLabel}} Succeeded: {{value}}",
@@ -66,6 +67,7 @@
   "Click the update mappings button to save your changes, button is disabled until a change is detected.": "Click the update mappings button to save your changes, button is disabled until a change is detected.",
   "Cluster": "Cluster",
   "Clusters": "Clusters",
+  "Completed {{completed}} of {{total}} {{name}} tasks": "Completed {{completed}} of {{total}} {{name}} tasks",
   "Completed at": "Completed at",
   "Concern": "Concern",
   "Concerns": "Concerns",
@@ -474,7 +476,6 @@
   "Token": "Token",
   "Total CPU count:": "Total CPU count:",
   "Total memory:": "Total memory:",
-  "Total of {{length}} {{name}} tasks": "Total of {{length}} {{name}} tasks",
   "Total virtual machines": "Total virtual machines",
   "Total: {{length}}": "Total: {{length}}",
   "Transfer Network": "Transfer Network",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -4,7 +4,7 @@ import { useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { RowProps, TableComposable, Tbody, Td, Th, Thead, Tr } from '@kubev2v/common';
-import { IoK8sApiBatchV1Job } from '@kubev2v/types';
+import { IoK8sApiBatchV1Job, V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
 import { ResourceLink, Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/Status';
 import {
@@ -234,10 +234,10 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
               <Td>
                 {p?.tasks?.length > 0 && (
                   <Tooltip
-                    content={t('Total of {{length}} {{name}} tasks', {
-                      length: p.tasks.length,
-                      name: p?.name,
-                    })}
+                    content={t(
+                      'Completed {{completed}} of {{total}} {{name}} tasks',
+                      getPipelineTasks(p),
+                    )}
                   >
                     <Button
                       className="forklift-page-plan-details-vm-tasks"
@@ -246,7 +246,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
                         showModal(<PipelineTasksModal name={p?.name} tasks={p.tasks} />)
                       }
                     >
-                      <TaskIcon /> {p.tasks.length}
+                      <TaskIcon /> {t('{{completed}} / {{total}}', getPipelineTasks(p))}
                     </Button>
                   </Tooltip>
                 )}
@@ -278,4 +278,11 @@ const getJobPhase = (job: IoK8sApiBatchV1Job) => {
   }
 
   return 'Pending';
+};
+
+const getPipelineTasks = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
+  const tasks = pipeline?.tasks || [];
+  const tasksCompleted = tasks.filter((c) => c.phase === 'Completed');
+
+  return { total: tasks.length, completed: tasksCompleted.length, name: pipeline.name };
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PipelineTasksModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PipelineTasksModal.tsx
@@ -35,15 +35,15 @@ export const PipelineTasksModal: React.FC<PipelineTasksModalProps> = ({ name, ta
           </Tr>
         </Thead>
         <Tbody>
-          {(tasks || []).map((p) => (
-            <Tr key={p?.name}>
-              <Td>{p?.name}</Td>
-              <Td>{p?.phase}</Td>
-              <Td>{getTransferProgress(p)}</Td>
+          {(tasks || []).map((t) => (
+            <Tr key={t?.name}>
+              <Td>{t?.name}</Td>
+              <Td>{t?.phase}</Td>
+              <Td>{getTaskProgress(t)}</Td>
               <Td>
-                <Timestamp timestamp={p?.started} />
+                <Timestamp timestamp={t?.started} />
               </Td>
-              <Td>{p?.error?.reasons}</Td>
+              <Td>{t?.error?.reasons}</Td>
             </Tr>
           ))}
         </Tbody>
@@ -52,15 +52,15 @@ export const PipelineTasksModal: React.FC<PipelineTasksModalProps> = ({ name, ta
   );
 };
 
-const getTransferProgress = (diskTransfer) => {
-  if (!diskTransfer || !diskTransfer?.progress) {
+const getTaskProgress = (task) => {
+  if (!task || !task?.progress) {
     return { completed: '-', total: '-' };
   }
 
-  const { completed, total } = diskTransfer.progress;
+  const { completed, total } = task.progress;
 
   const completeString = completed !== undefined ? completed : '-';
   const totalString = total !== undefined ? total : '-';
 
-  return `${completeString} / ${totalString} ${diskTransfer.annotations?.unit || '-'}`;
+  return `${completeString} / ${totalString} ${task.annotations?.unit || '-'}`;
 };


### PR DESCRIPTION
In migration vms list, in the extended view, we show the pipeline tasks

Issue:
we only show the total tasks, we can show also the completed tasks

Screenshots:
Before:
![task-only-total](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/96de0a9a-67e7-4fbf-8832-2724bfcb3f0e)

After:
![task-complete-of-total](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/14409472-e30a-4fd1-b98a-5ee8641ed915)
