### PR TITLE
:lady_beetle: Don't let user edit empty vddk image without empty flag

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -10,7 +10,7 @@ import { validateVDDKImage } from '../../utils/validators';
 import { EditModal, EditModalProps } from '../EditModal';
 
 import { onEmptyVddkConfirm } from './onEmptyVddkConfirm';
-import { onVddkConfirm } from './onVddkConfirm';
+import { onNoneEmptyVddkConfirm } from './onNoneEmptyVddkConfirm';
 
 export type EditProviderVDDKImageProps = Modify<
   EditModalProps,
@@ -67,8 +67,8 @@ export const EditProviderVDDKImage: React.FC<EditProviderVDDKImageProps> = (prop
       label={props?.label || t('VDDK init image')}
       model={ProviderModel}
       body={body}
-      validationHook={isEmptyImage ? validateEmptyVDDKImage : validateVDDKImage}
-      onConfirmHook={isEmptyImage ? onEmptyVddkConfirm : onVddkConfirm}
+      validationHook={isEmptyImage ? validateEmptyVDDKImage : validateNoneEmptyVDDKImage}
+      onConfirmHook={isEmptyImage ? onEmptyVddkConfirm : onNoneEmptyVddkConfirm}
       InputComponent={isEmptyImage ? EmptyVddkTextInput : VddkTextInput}
     />
   );
@@ -89,3 +89,6 @@ const EmptyVddkTextInput: React.FC = () => (
 
 // Validation of empty vddk image
 const validateEmptyVDDKImage = () => validateVDDKImage(undefined);
+
+// Validation of none empty vddk image, make sure it's not undefined
+const validateNoneEmptyVDDKImage = (value) => validateVDDKImage(value || '');

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/index.ts
@@ -1,5 +1,5 @@
 // @index('./*.tsx', f => `export * from '${f.path}';`)
 export * from './EditProviderVDDKImage';
 export * from './onEmptyVddkConfirm';
-export * from './onVddkConfirm';
+export * from './onNoneEmptyVddkConfirm';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onNoneEmptyVddkConfirm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/onNoneEmptyVddkConfirm.tsx
@@ -13,7 +13,11 @@ import { OnConfirmHookType } from '../EditModal';
  * @param {any} options.newValue - The new value for the 'vddkInitImage' spec settings.
  * @returns {Promise<Object>} - The modified resource.
  */
-export const onVddkConfirm: OnConfirmHookType = async ({ resource, model, newValue: value }) => {
+export const onNoneEmptyVddkConfirm: OnConfirmHookType = async ({
+  resource,
+  model,
+  newValue: value,
+}) => {
   const provider = resource as V1beta1Provider;
   const vddkInitImage: string = value as string;
   let op: string;


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1212

Issue:
When user edit an empty VDDK image, they can remove the empty flag, without adding a valid image

Fix:
Validate that the image is not empty when editing a VDDK image

Screenshot:
Before:
https://github.com/kubev2v/forklift-console-plugin/assets/2181522/606c3f6d-6007-4dc6-a342-2233fe98ceba

After:
https://github.com/kubev2v/forklift-console-plugin/assets/2181522/78fe0093-278a-4089-9aed-1f232c7bbcf5

