### PR TITLE
:lady_beetle: Filter network options in vmware provider host

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useCallback, useReducer, useState } from 'react';
+import { FilterableSelect } from 'src/components';
 import { AlertMessageForModals, useModal } from 'src/modules/Providers/modals';
 import { validateNoSpaces } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -8,11 +9,11 @@ import { NetworkAdapters, V1beta1Provider } from '@kubev2v/types';
 import {
   Button,
   Form,
+  HelperText,
+  HelperTextItem,
   Modal,
   ModalVariant,
-  Select,
-  SelectOption,
-  SelectVariant,
+  Text,
   TextInput,
 } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
@@ -203,27 +204,26 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
 
       <Form id="modal-with-form-form">
         <FormGroupWithHelpText label="Network" isRequired fieldId="network">
-          <Select
-            variant={SelectVariant.single}
-            placeholderText="Select a network"
+          <FilterableSelect
+            placeholder="Select a network"
             aria-label="Select Network"
-            onToggle={onSelectToggle}
-            onSelect={onSelect}
-            selections={
-              state.network ? `${state.network.name} - ${state.network.ipAddress}` : undefined
-            }
-            isOpen={state.isSelectOpen}
-            menuAppendTo={() => document.body}
-          >
-            {networkOptions.map((option) => (
-              <SelectOption
-                isDisabled={option.disabled}
-                key={option.key}
-                value={option.label}
-                description={option.description}
-              />
-            ))}
-          </Select>
+            onSelect={(value) => onSelect(null, value)}
+            value={state.network ? `${state.network.name} - ${state.network.ipAddress}` : undefined}
+            selectOptions={networkOptions.map((option) => ({
+              itemId: option.label,
+              isDisabled: option.disabled,
+              children: (
+                <>
+                  <Text>{option.label}</Text>
+                  {option.description && (
+                    <HelperText>
+                      <HelperTextItem variant="indeterminate">{option.description}</HelperTextItem>
+                    </HelperText>
+                  )}
+                </>
+              ),
+            }))}
+          />
         </FormGroupWithHelpText>
 
         {endpointType !== 'esxi' && (


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1132

Issue:
In ESXi host network selection, when lots of options avalable no way to search for a network
We need better component then simple drop down, because lots of options may be available, making it hard to choose

Fix:
Use a filtered selection component

Screenshots:
Before:
https://github.com/kubev2v/forklift-console-plugin/assets/2181522/7538261e-9f2c-49c2-b557-07bce58212f9

After:
https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d2ca1425-9bb0-48ee-9478-4c3f933dbb80

