### PR TITLE
:lady_beetle: Set loading when changing provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/ProvidersVirtualMachinesList.tsx
@@ -25,7 +25,7 @@ export const ProviderVirtualMachinesList: React.FC<{
   });
 
   const [vmData, vmDataLoading] = useInventoryVms({ provider }, providerLoaded, providerLoadError);
-  const obj = { provider, vmData, vmDataLoading: vmDataLoading || vmData?.length === 0 };
+  const obj = { provider, vmData, vmDataLoading: vmDataLoading };
 
   return (
     <ProviderVirtualMachinesListWrapper

--- a/packages/forklift-console-plugin/src/modules/Providers/hooks/useProviderInventory.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/hooks/useProviderInventory.ts
@@ -77,6 +77,8 @@ export const useProviderInventory = <T>({
 
   // Fetch data from API
   useEffect(() => {
+    setLoading(true);
+
     const fetchData = async () => {
       if (disabled) {
         return;


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1236

Issue:
when creating a plan using wizard and choosing a provider with no vms, vm table gets stuck on loading

Screenshot:
Before:
![vm-list-loading](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/95b83710-4ff8-4081-8350-3c38c110a7cf)
After:
![vm-list-empty](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/3dd67bf4-c9ec-4e1b-93dd-0d24d221a3c0)
