### PR TITLE
:lady_beetle: Dont spellcheck none spellable texts

### DIFF
--- a/packages/common/src/components-stories/FormGroupWithHelpText.stories.tsx
+++ b/packages/common/src/components-stories/FormGroupWithHelpText.stories.tsx
@@ -25,7 +25,16 @@ export const DefaultValidatedHelpText: Story = {
   args: {
     label: 'Username',
     isRequired: true,
-    children: <TextInput isRequired type="text" name="user" value="myName" validated="default" />,
+    children: (
+      <TextInput
+        spellCheck="false"
+        isRequired
+        type="text"
+        name="user"
+        value="myName"
+        validated="default"
+      />
+    ),
     helperText: 'This is a help text',
     helperTextInvalid: 'This is a help text for an invalid case',
     validated: 'default',
@@ -39,7 +48,16 @@ export const SuccessValidatedHelpText: Story = {
   args: {
     label: 'Username',
     isRequired: true,
-    children: <TextInput isRequired type="text" name="user" value="myName" validated="success" />,
+    children: (
+      <TextInput
+        spellCheck="false"
+        isRequired
+        type="text"
+        name="user"
+        value="myName"
+        validated="success"
+      />
+    ),
     helperText: 'This is a help text',
     helperTextInvalid: 'This is a help text for an invalid case',
     validated: 'success',
@@ -53,7 +71,16 @@ export const WarningValidatedHelpText: Story = {
   args: {
     label: 'Username',
     isRequired: true,
-    children: <TextInput isRequired type="text" name="user" value="my%Name" validated="warning" />,
+    children: (
+      <TextInput
+        spellCheck="false"
+        isRequired
+        type="text"
+        name="user"
+        value="my%Name"
+        validated="warning"
+      />
+    ),
     helperText: 'This is a warning help text indicating that a % char is not recommended',
     helperTextInvalid: 'This is a help text for an invalid case',
     validated: 'warning',
@@ -67,7 +94,16 @@ export const ErrorValidatedHelpText: Story = {
   args: {
     label: 'Username',
     isRequired: true,
-    children: <TextInput isRequired type="text" name="user" value="my Name" validated="error" />,
+    children: (
+      <TextInput
+        spellCheck="false"
+        isRequired
+        type="text"
+        name="user"
+        value="my Name"
+        validated="error"
+      />
+    ),
     helperText: 'This is a help text',
     helperTextInvalid:
       'This is an error help text indicating that an invalid space char is not allowed',
@@ -82,7 +118,16 @@ export const ErrorValidatedUndefinedHelpText: Story = {
   args: {
     label: 'Username',
     isRequired: true,
-    children: <TextInput isRequired type="text" name="user" value="my Name" validated="error" />,
+    children: (
+      <TextInput
+        spellCheck="false"
+        isRequired
+        type="text"
+        name="user"
+        value="my Name"
+        validated="error"
+      />
+    ),
     helperText: 'This is a help text',
     helperTextInvalid: undefined,
     validated: 'error',

--- a/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
+++ b/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
@@ -232,6 +232,7 @@ export const FilterableSelect: React.FunctionComponent<FilterableSelectProps> = 
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
+          spellCheck="false"
           value={inputValue}
           onClick={onToggleClick}
           onChange={onTextInputChange}

--- a/packages/forklift-console-plugin/src/components/InputList/LazyTextInput.tsx
+++ b/packages/forklift-console-plugin/src/components/InputList/LazyTextInput.tsx
@@ -53,6 +53,7 @@ export const LazyTextInput: React.FunctionComponent<LazyTextInputProps> = ({
 
   return (
     <TextInput
+      spellCheck="false"
       value={value}
       type={type}
       onChange={(value) => setValue(value)}

--- a/packages/forklift-console-plugin/src/modules/Plans/modals/DuplicateModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/modals/DuplicateModal.tsx
@@ -232,6 +232,7 @@ export const DuplicateModal: React.FC<DuplicateModalProps> = ({ title, resource,
                 )}
               >
                 <TextInput
+                  spellCheck="false"
                   validated={newNameValidation}
                   value={newName}
                   id="name"

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
@@ -138,6 +138,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
             <>
               <FormGroupWithHelpText label="Hook runner image" isRequired fieldId="pre-hook-image">
                 <TextInput
+                  spellCheck="false"
                   value={state.preHook?.spec?.image}
                   type="url"
                   onChange={(value) => dispatch({ type: 'PRE_HOOK_IMAGE', payload: value })}
@@ -187,6 +188,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
             <>
               <FormGroupWithHelpText label="Hook runner image" isRequired fieldId="post-hook-image">
                 <TextInput
+                  spellCheck="false"
                   value={state.postHook?.spec?.image}
                   type="url"
                   onChange={(value) => dispatch({ type: 'POST_HOOK_IMAGE', payload: value })}

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -142,6 +142,7 @@ export const EditModal: React.FC<EditModalProps> = ({
     <InputComponent value={value} onChange={(value) => handleValueChange(value)} />
   ) : (
     <TextInput
+      spellCheck="false"
       id="modal-with-form-form-field"
       name="modal-with-form-form-field"
       value={value}

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -80,6 +80,7 @@ const VddkTextInput = undefined;
 // EmptyVddkTextInput is a mock input item for the empty vddk image string
 const EmptyVddkTextInput: React.FC = () => (
   <TextInput
+    spellCheck="false"
     id="modal-with-form-form-field"
     name="modal-with-form-form-field"
     isDisabled={true}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -163,6 +163,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
         validated={state.validation.url.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="url"
@@ -208,6 +209,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
         </Hint>
         <div className="forklift-section-provider-edit-vddk-input">
           <TextInput
+            spellCheck="false"
             type="text"
             id="vddkInitImage"
             name="vddkInitImage"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
@@ -68,6 +68,7 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
         helperTextInvalid={state.validation.url.msg}
       >
         <TextInput
+          spellCheck="false"
           type="text"
           id="url"
           name="url"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -69,6 +69,7 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
         helperTextInvalid={state.validation.url.msg}
       >
         <TextInput
+          spellCheck="false"
           type="text"
           id="url"
           name="url"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
@@ -70,6 +70,7 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
         validated={state.validation.url.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="url"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
@@ -70,6 +70,7 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
         helperTextInvalid={state.validation.url.msg}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="url"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -125,6 +125,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
               validated={state.validation.name.type}
             >
               <TextInput
+                spellCheck="false"
                 isRequired
                 type="text"
                 id="k8sName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -164,6 +164,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
         validated={state.validation.url.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="url"
@@ -209,6 +210,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
         </Hint>
         <div className="forklift-section-provider-edit-vddk-input">
           <TextInput
+            spellCheck="false"
             type="text"
             id="vddkInitImage"
             name="vddkInitImage"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/FieldWithClipboardCopy.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/FieldWithClipboardCopy.tsx
@@ -31,7 +31,7 @@ export const FieldWithClipboardCopy: React.FC<ShowFieldWithClipboardCopyProps> =
           <div>{t('{{label}} field is missing from the secret data.', { label: field.label })}</div>
         }
       >
-        <TextInput value="No value" type="text" isDisabled />
+        <TextInput spellCheck="false" value="No value" type="text" isDisabled />
       </Tooltip>
     );
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/MaskedField.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/MaskedField.tsx
@@ -6,5 +6,7 @@ import { TextInput } from '@patternfly/react-core';
  * Show a readable masked (hidden) field value.
  */
 export const MaskedField: React.FC = () => {
-  return <TextInput value="&bull;&bull;&bull;&bull;&bull;" type="text" isDisabled />;
+  return (
+    <TextInput spellCheck="false" value="&bull;&bull;&bull;&bull;&bull;" type="text" isDisabled />
+  );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -114,6 +114,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
         validated={state.validation.user.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="username"
@@ -132,6 +133,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
         validated={state.validation.password.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -114,6 +114,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         validated={state.validation.token.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
@@ -87,6 +87,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.applicationCredentialName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="applicationCredentialName"
@@ -106,6 +107,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.applicationCredentialSecret.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
@@ -133,6 +135,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.username.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="username"
@@ -152,6 +155,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.regionName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="regionName"
@@ -171,6 +175,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.projectName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="projectName"
@@ -190,6 +195,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         validated={state.validation.domainName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="domainName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
@@ -83,6 +83,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
         validated={state.validation.applicationCredentialID.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="applicationCredentialID"
@@ -102,6 +103,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
         validated={state.validation.applicationCredentialSecret.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
@@ -129,6 +131,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
         validated={state.validation.regionName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="regionName"
@@ -148,6 +151,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
         validated={state.validation.projectName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="projectName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
@@ -79,6 +79,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         validated={state.validation.username.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="username"
@@ -98,6 +99,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         validated={state.validation.password.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
@@ -124,6 +126,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         validated={state.validation.regionName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="regionName"
@@ -143,6 +146,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         validated={state.validation.projectName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="projectName"
@@ -162,6 +166,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         validated={state.validation.domainName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="domainName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
@@ -76,6 +76,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
         validated={state.validation.token.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
@@ -103,6 +104,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
         validated={state.validation.userID.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="userID"
@@ -122,6 +124,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
         validated={state.validation.projectID.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="projectID"
@@ -141,6 +144,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
         validated={state.validation.regionName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="regionName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
@@ -78,6 +78,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         validated={state.validation.token.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
@@ -105,6 +106,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         validated={state.validation.username.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="username"
@@ -124,6 +126,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         validated={state.validation.regionName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="regionName"
@@ -143,6 +146,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         validated={state.validation.projectName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="projectName"
@@ -162,6 +166,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         validated={state.validation.domainName.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="domainName"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -120,6 +120,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
         validated={state.validation.user.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="user"
@@ -138,6 +139,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
         validated={state.validation.password.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -108,6 +108,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
         validated={state.validation.user.type}
       >
         <TextInput
+          spellCheck="false"
           isRequired
           type="text"
           id="username"
@@ -126,6 +127,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
         validated={state.validation.password.type}
       >
         <TextInput
+          spellCheck="false"
           className="pf-u-w-75"
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
@@ -237,6 +237,7 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
               validated={state.validation.username}
             >
               <TextInput
+                spellCheck="false"
                 isRequired
                 type="text"
                 id="username"
@@ -254,6 +255,7 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
               validated={state.validation.password}
             >
               <TextInput
+                spellCheck="false"
                 className="forklift-host-modal-input-secret"
                 isRequired
                 type={state.passwordHidden ? 'password' : 'text'}

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
@@ -166,6 +166,7 @@ export const PlansCreateForm = ({
               )}
             >
               <TextInput
+                spellCheck="false"
                 isRequired
                 type="text"
                 id="planName"


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1239

Issue:
We spell check all our text inputs, most of our text inputs do not require spell checking

Fix:
Remove spellchecking for inputs that are not spellable.

Screenshots:
Before:
![with-spellcheck](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/f34fad50-5c33-40fd-a4d7-38a667969357)

After:
![no-spellcheck](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/ff9ee306-8c02-4213-ae41-151be1ea48ad)
