### PR TITLE
🐞 Dont focus on input texts when edit modal open

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -161,7 +161,7 @@ export const EditModal: React.FC<EditModalProps> = ({
     >
       {t('Save')}
     </Button>,
-    <Button key="cancel" variant="secondary" onClick={toggleModal}>
+    <Button key="cancel" variant="secondary" onClick={toggleModal} autoFocus>
       {t('Cancel')}
     </Button>,
   ];


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1240

Issue:
Text inputs are auto focused when input modal is open

Screenshot:
Before:
![focused-input](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/d6cdc01e-fe95-4fec-89b0-930c3382cc1f)

After:
![un-focused-input](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c2cb1082-5d8e-491f-a33f-ceb4792738a2)
