### PR TITLE
:feet: Add an unselect hint to selected gallary card

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -73,6 +73,8 @@
   "Click the update credentials button to save your changes, button is disabled until a change is detected.": "Click the update credentials button to save your changes, button is disabled until a change is detected.",
   "Click the update hooks button to save your changes, button is disabled until a change is detected.": "Click the update hooks button to save your changes, button is disabled until a change is detected.",
   "Click the update mappings button to save your changes, button is disabled until a change is detected.": "Click the update mappings button to save your changes, button is disabled until a change is detected.",
+  "Click to select a different provider from the list.": "Click to select a different provider from the list.",
+  "Click to unselect.": "Click to unselect.",
   "Cluster": "Cluster",
   "Clusters": "Clusters",
   "Completed {{completed}} of {{total}} {{name}} tasks": "Completed {{completed}} of {{total}} {{name}} tasks",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/PlanCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/PlanCreateForm.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { SelectableCard } from 'src/modules/Providers/utils/components/Gallery/SelectableCard';
 import { SelectableGallery } from 'src/modules/Providers/utils/components/Gallery/SelectableGallery';
 import { VmData } from 'src/modules/Providers/views';
+import { useForkliftTranslation } from 'src/utils';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
-import { Flex, FlexItem, Form } from '@patternfly/react-core';
+import { Flex, FlexItem, Form, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 
 import { PlanCreatePageState } from '../states';
 
@@ -31,6 +32,8 @@ export const PlanCreateForm: React.FC<PlanCreateFormProps> = ({
   filterState,
   filterDispatch,
 }) => {
+  const { t } = useForkliftTranslation();
+
   const providerCardItems = createProviderCardItems(providers);
 
   const onChange = (id: string) => {
@@ -57,6 +60,19 @@ export const PlanCreateForm: React.FC<PlanCreateFormProps> = ({
                   onChange={() => onChange('')}
                   isSelected
                   isCompact
+                  content={
+                    <Tooltip
+                      content={
+                        <div>{t('Click to select a different provider from the list.')}</div>
+                      }
+                    >
+                      <HelperText>
+                        <HelperTextItem variant="indeterminate">
+                          {t('Click to unselect.')}
+                        </HelperTextItem>
+                      </HelperText>
+                    </Tooltip>
+                  }
                 />
               </FlexItem>
             </Flex>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -8,7 +8,15 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
 import { IoK8sApiCoreV1Secret, ProviderType, V1beta1Provider } from '@kubev2v/types';
-import { Flex, FlexItem, Form, TextInput } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  Form,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  Tooltip,
+} from '@patternfly/react-core';
 
 import { EditProvider } from './EditProvider';
 import { EditProviderSectionHeading } from './EditProviderSectionHeading';
@@ -101,6 +109,19 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
                     onChange={() => handleTypeChange(null)}
                     isSelected
                     isCompact
+                    content={
+                      <Tooltip
+                        content={
+                          <div>{t('Click to select a different provider from the list.')}</div>
+                        }
+                      >
+                        <HelperText>
+                          <HelperTextItem variant="indeterminate">
+                            {t('Click to unselect.')}
+                          </HelperTextItem>
+                        </HelperText>
+                      </Tooltip>
+                    }
                   />
                 </FlexItem>
               </Flex>


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1244

In gallery view when we select one card we don't explicitly say that clicking this card will un select it.

Screenshots:
Before:
![without-hint](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/911f754e-c252-4603-83f9-5bb340dc9548)

After:
![with-hint](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/25393df5-d0e2-4205-bb3e-c2f1855666a2)
