### PR TITLE
:lady_beetle: Add true and false staus icons

### DIFF
--- a/packages/forklift-console-plugin/src/components/status/StatusIcon.tsx
+++ b/packages/forklift-console-plugin/src/components/status/StatusIcon.tsx
@@ -6,6 +6,8 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
   InfoCircleIcon,
+  MinusCircleIcon,
+  PlusCircleIcon,
 } from '@patternfly/react-icons';
 import { BanIcon } from '@patternfly/react-icons/dist/esm/icons/ban-icon';
 import { ClipboardListIcon } from '@patternfly/react-icons/dist/esm/icons/clipboard-list-icon';
@@ -95,6 +97,12 @@ export const StatusIcon: React.FC<{ phase: string }> = ({ phase }) => {
 
     case 'PipelineNotStarted':
       return <NotStartedIcon />;
+
+    case 'True':
+      return <PlusCircleIcon />;
+
+    case 'False':
+      return <MinusCircleIcon />;
 
     default:
       return <>-</>;


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1251

Issue:
conditions status has "true" and "false" as values, we do not assign an icon to this values

Fix:
assign plus and minus icons to true and false

Screenshots:
Before:
![no-icon](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/c472917a-4e99-45ae-a652-ce7a5712afad)

After:
![true-icon](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/5855d039-9473-40de-890a-d3b261fabc91)
