### PR TITLE
:lady_beetle: Make host default network label gray

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -113,6 +113,7 @@
   "Dates are compared in UTC. End of the interval is included.": "Dates are compared in UTC. End of the interval is included.",
   "Dedicated CPU": "Dedicated CPU",
   "Default": "Default",
+  "Default network": "Default network",
   "Default Transfer Network": "Default Transfer Network",
   "Defines the CPU limits allocated to the main container in the controller pod. The default value is 500 milliCPU.": "Defines the CPU limits allocated to the main container in the controller pod. The default value is 500 milliCPU.",
   "Delete": "Delete",

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/NetworkCellRenderer.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/components/NetworkCellRenderer.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { TableCell } from 'src/modules/Providers/utils';
+import { useForkliftTranslation } from 'src/utils';
 
-import { Button, Popover } from '@patternfly/react-core';
+import { Button, HelperText, HelperTextItem, Popover } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -21,6 +22,8 @@ const statusIcons = {
 
 // Define cell renderer for 'network'
 export const NetworkCellRenderer: React.FC<HostCellProps> = (props) => {
+  const { t } = useForkliftTranslation();
+
   const host = props?.data?.host;
   const name = props?.data?.networkAdapter?.name;
   const ip = props?.data?.networkAdapter?.ipAddress;
@@ -30,9 +33,16 @@ export const NetworkCellRenderer: React.FC<HostCellProps> = (props) => {
 
   const hostStatus = determineHostStatus(host);
   const statusIcon = statusIcons[hostStatus.status.toLowerCase()];
+
+  const defaultNetworkLabel = (
+    <HelperText>
+      <HelperTextItem variant="indeterminate">{t('Default network')}</HelperTextItem>
+    </HelperText>
+  );
+
   let cellContent = (
     <>
-      {statusIcon} {name ? `${name} - ${cidr}` : '(default)'}
+      {statusIcon} {name ? `${name} - ${cidr}` : defaultNetworkLabel}
     </>
   );
 


### PR DESCRIPTION
Issue:
the label for default network (default) uses "regular item" color, it should have "default value" color

Fix:
make the default network color gray

Screenshots:
Before:
![black-default-network](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/ba64127b-95f2-43a9-82d0-e9c80fde6764)

After:
![gray-default-network](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/767ac75b-c682-4249-a009-3fefeadf1dfa)
