### PR TITLE
:lady_beetle: Don't use namespace for owner refs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/utils/helpers/onSaveHost.ts
@@ -137,7 +137,6 @@ async function processHostSecretPair(
             apiVersion: 'forklift.konveyor.io/v1beta1',
             kind: 'Provider',
             name: provider.metadata.name,
-            namespace: provider.metadata.namespace,
             uid: provider.metadata.uid,
           },
         ],

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useSaveEffect.ts
@@ -47,6 +47,11 @@ const createPlan = async (
 };
 
 const addOwnerRef = async (model: K8sModel, resource, ownerReferences) => {
+  const cleanOwnerReferences = ownerReferences.map((ref) => ({
+    ...ref,
+    namespace: undefined,
+  }));
+
   return await k8sPatch({
     model,
     resource,
@@ -54,7 +59,7 @@ const addOwnerRef = async (model: K8sModel, resource, ownerReferences) => {
       {
         op: 'add',
         path: '/metadata/ownerReferences',
-        value: ownerReferences,
+        value: cleanOwnerReferences,
       },
     ],
   });


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1254

When setting ownerRefs don't send the namespace