### PR TITLE
:lady_beetle: Set initial plan target namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/createInitialState.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/createInitialState.ts
@@ -52,7 +52,7 @@ export const createInitialState = ({
             source: getObjectRef(sourceProvider),
             destination: undefined,
           },
-          targetNamespace: undefined,
+          targetNamespace: namespace,
           vms: selectedVms.map((data) => ({
             name: data.name,
             namespace: data.namespace,


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1257

Issue:
Initial target namespace may be empty on plan wizard

Fix:
set the initial namespace to be the plan namespace