### PR TITLE
:lady_beetle: Use custom create label when editint vmware boot disk

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -106,6 +106,7 @@
   "Credentials": "Credentials",
   "Critical": "Critical",
   "Critical concerns": "Critical concerns",
+  "Custom path:": "Custom path:",
   "Cutover": "Cutover",
   "Data centers": "Data centers",
   "Data is loading, please wait.": "Data is loading, please wait.",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/EditRootDisk.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditRootDisk/EditRootDisk.tsx
@@ -72,6 +72,7 @@ const RootDiskInputFactory: () => ModalInputComponentType = () => {
         onSelect={onChange}
         canCreate
         placeholder={t('First root device')}
+        createNewOptionLabel={t('Custom path:')}
       ></FilterableSelect>
     );
   };


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1261

Use custom create label when editint vmware boot disk

"Create new option" -> "Custom path"

Screenshots:
Before:
![screenshot-localhost_9000-2024 07 07-16_39_56](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/009ac552-0a1c-45b1-8188-25a80d06e5a8)


After:
![screenshot-localhost_9000-2024 07 07-16_36_54](https://github.com/kubev2v/forklift-console-plugin/assets/2181522/859331a1-4269-4c63-a10c-9af4dfc25179)
