### PR TITLE
🐞 [UI] max_vm_inflight parameter is not setting

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditMaxVMInFlightModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditMaxVMInFlightModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EditModal, ModalInputComponentType } from 'src/modules/Providers/modals';
+import { defaultOnConfirmWithIntValue } from 'src/modules/Providers/modals/EditModal/utils/defaultOnConfirm';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ForkliftControllerModel } from '@kubev2v/types';
@@ -40,6 +41,7 @@ export const EditMaxVMInFlightModal: React.FC<EditSettingsModalProps> = (props) 
         'Please enter the maximum number of concurrent VM migrations, if empty default value will be used.',
       )}
       InputComponent={MaxVMInFlightNumberInput}
+      onConfirmHook={defaultOnConfirmWithIntValue}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditPreCopyIntervalModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditPreCopyIntervalModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EditModal, ModalInputComponentType } from 'src/modules/Providers/modals';
+import { defaultOnConfirmWithIntValue } from 'src/modules/Providers/modals/EditModal/utils/defaultOnConfirm';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ForkliftControllerModel } from '@kubev2v/types';
@@ -43,6 +44,7 @@ export const EditPreCopyIntervalModal: React.FC<EditSettingsModalProps> = (props
         'Please enter the interval in minutes for precopy, if empty default value will be used.',
       )}
       InputComponent={PrecopyIntervalSelect}
+      onConfirmHook={defaultOnConfirmWithIntValue}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/EditSnapshotPoolingIntervalModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/EditSnapshotPoolingIntervalModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EditModal, ModalInputComponentType } from 'src/modules/Providers/modals';
+import { defaultOnConfirmWithIntValue } from 'src/modules/Providers/modals/EditModal/utils/defaultOnConfirm';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ForkliftControllerModel } from '@kubev2v/types';
@@ -43,6 +44,7 @@ export const EditSnapshotPoolingIntervalModal: React.FC<EditSettingsModalProps> 
         'Please enter the interval in seconds for snapshot pooling, if empty default value will be used.',
       )}
       InputComponent={SnapshotPoolingIntervalSelect}
+      onConfirmHook={defaultOnConfirmWithIntValue}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/utils/defaultOnConfirm.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/utils/defaultOnConfirm.ts
@@ -1,11 +1,14 @@
 import { getValueByJsonPath, jsonPathToPatch } from 'src/modules/Providers/utils';
 
-import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
+import { k8sPatch, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
+/**
+ * Patches a Kubernetes resource with a new value.
+ */
 export const defaultOnConfirm = async ({ resource, jsonPath, model, newValue: value }) => {
   const op = getValueByJsonPath(resource, jsonPath) ? 'replace' : 'add';
 
-  await k8sPatch({
+  return await k8sPatch<K8sResourceCommon>({
     model: model,
     resource: resource,
     data: [
@@ -16,4 +19,15 @@ export const defaultOnConfirm = async ({ resource, jsonPath, model, newValue: va
       },
     ],
   });
+};
+
+/**
+ * Wraps the defaultOnConfirm method to convert the newValue from string to int before patching.
+ */
+export const defaultOnConfirmWithIntValue = async ({ resource, jsonPath, model, newValue }) => {
+  // Convert the newValue from string to int
+  const intValue = parseInt(newValue.toString(), 10);
+
+  // Call the original method with the converted value
+  return await defaultOnConfirm({ resource, jsonPath, model, newValue: intValue });
 };


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1267

Issue:
While trying to change 'max_vm_inflight' parameter from the UI, nothing happens.

The forklift-controller pod isn't restarted and 'MAX_VM_INFLIGHT' doesn't exist in 'oc describe pod forklift-controller-xxxxx'.

The issue is that the parameter is set as a string and not as a number.

Fix:
send integer instead of strings to the backend