### PR TITLE
:feet:  Update to PF5 - part II - onChange event handler

### DIFF
--- a/packages/common/src/components/Filter/AutocompleteFilter.tsx
+++ b/packages/common/src/components/Filter/AutocompleteFilter.tsx
@@ -71,7 +71,7 @@ export const AutocompleteFilter = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value, isPlaceholder) => {
+  ) => void = (_event, value, isPlaceholder) => {
     if (isPlaceholder) {
       return;
     }

--- a/packages/common/src/components/Filter/DateFilter.tsx
+++ b/packages/common/src/components/Filter/DateFilter.tsx
@@ -33,7 +33,10 @@ export const DateFilter = ({
     onFilterUpdate([...validFilters.filter((d) => d !== option)]);
   };
 
-  const onDateChange = (even: FormEvent<HTMLInputElement>, value: string) => {
+  const onDateChange: (event: FormEvent<HTMLInputElement>, value: string, date?: Date) => void = (
+    _event,
+    value,
+  ) => {
     // require full format "YYYY-MM-DD" although partial date is also accepted
     // i.e. YYYY-MM gets parsed as YYYY-MM-01 and results in auto completing the date
     // unfortunately due to auto-complete user cannot delete the date char after char

--- a/packages/common/src/components/Filter/DateRangeFilter.tsx
+++ b/packages/common/src/components/Filter/DateRangeFilter.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import React, { useState } from 'react';
 import { DateTime } from 'luxon';
 
 import {
@@ -63,7 +63,11 @@ export const DateRangeFilter = ({
     onFilterUpdate([...validFilters.filter((range) => range !== target)]);
   };
 
-  const onFromDateChange = (even: FormEvent<HTMLInputElement>, value: string) => {
+  const onFromDateChange: (
+    event: React.FormEvent<HTMLInputElement>,
+    value: string,
+    date?: Date,
+  ) => void = (_event, value) => {
     //see DateFilter onDateChange
     if (value?.length === 10 && isValidDate(value)) {
       setFrom(parseISOtoJSDate(value));
@@ -71,7 +75,11 @@ export const DateRangeFilter = ({
     }
   };
 
-  const onToDateChange = (even: FormEvent<HTMLInputElement>, value: string) => {
+  const onToDateChange: (
+    event: React.FormEvent<HTMLInputElement>,
+    value: string,
+    date?: Date,
+  ) => void = (_event, value) => {
     //see DateFilter onDateChange
     if (value?.length === 10 && isValidDate(value)) {
       const newTo = parseISOtoJSDate(value);
@@ -82,6 +90,7 @@ export const DateRangeFilter = ({
       }
     }
   };
+
   return (
     <ToolbarFilter
       key={filterId}

--- a/packages/common/src/components/Filter/EnumFilter.tsx
+++ b/packages/common/src/components/Filter/EnumFilter.tsx
@@ -142,7 +142,7 @@ export const EnumFilter = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value, isPlaceholder) => {
+  ) => void = (_event, value, isPlaceholder) => {
     if (isPlaceholder) {
       return;
     }

--- a/packages/common/src/components/Filter/FreetextFilter.tsx
+++ b/packages/common/src/components/Filter/FreetextFilter.tsx
@@ -31,6 +31,14 @@ export const FreetextFilter = ({
     onFilterUpdate([...selectedFilters, inputValue]);
     setInputValue('');
   };
+
+  const onChange: (event: React.FormEvent<HTMLInputElement>, value: string) => void = (
+    _event,
+    value,
+  ) => {
+    setInputValue(value);
+  };
+
   return (
     <ToolbarFilter
       key={filterId}
@@ -46,9 +54,7 @@ export const FreetextFilter = ({
         <SearchInput
           placeholder={placeholderLabel}
           value={inputValue}
-          onChange={(event, value) => {
-            setInputValue(value);
-          }}
+          onChange={onChange}
           onSearch={onTextInput}
           onClear={() => setInputValue('')}
         />

--- a/packages/common/src/components/Filter/GroupedEnumFilter.tsx
+++ b/packages/common/src/components/Filter/GroupedEnumFilter.tsx
@@ -111,7 +111,7 @@ export const GroupedEnumFilter = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value, isPlaceholder) => {
+  ) => void = (_event, value, isPlaceholder) => {
     if (isPlaceholder) {
       return;
     }

--- a/packages/common/src/components/Filter/SwitchFilter.tsx
+++ b/packages/common/src/components/Filter/SwitchFilter.tsx
@@ -20,12 +20,18 @@ export const SwitchFilter = ({
   onFilterUpdate,
   placeholderLabel,
 }: FilterTypeProps) => {
+  const onChange: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    onFilterUpdate(checked ? [Boolean(checked).toString()] : []);
+  };
+
   return (
     <ToolbarItem>
       <Switch
         label={placeholderLabel}
         isChecked={selectedFilters.length === 1 && selectedFilters[0] === 'true'}
-        onChange={(checked) => onFilterUpdate(checked ? [Boolean(checked).toString()] : [])}
+        onChange={onChange}
       />
     </ToolbarItem>
   );

--- a/packages/common/src/components/TableView/ManageColumnsModal.tsx
+++ b/packages/common/src/components/TableView/ManageColumnsModal.tsx
@@ -127,6 +127,12 @@ export const ManageColumnsModal = ({
     onClose();
   };
 
+  type onChangeFactoryType = (
+    id: string,
+  ) => (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (id) => (checked) => onSelect(id, checked);
+
   return (
     <Modal
       title={title}
@@ -177,7 +183,7 @@ export const ManageColumnsModal = ({
                             : isVisible
                         }
                         isDisabled={isIdentity}
-                        onChange={(value) => onSelect(id, value)}
+                        onChange={onChangeFactory(id)}
                         otherControls
                       />
                     </DataListControl>

--- a/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
+++ b/packages/forklift-console-plugin/src/components/FilterableSelect/FilterableSelect.tsx
@@ -143,7 +143,10 @@ export const FilterableSelect: React.FunctionComponent<FilterableSelectProps> = 
    * @param {React.FormEvent<HTMLInputElement>} _event The input event.
    * @param {string} value The new input value.
    */
-  const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
+  const onTextInputChange: (_event: React.FormEvent<HTMLInputElement>, value: string) => void = (
+    _event,
+    value,
+  ) => {
     setInputValue(value);
     setFilterValue(value);
   };

--- a/packages/forklift-console-plugin/src/components/InputList/LazyTextInput.tsx
+++ b/packages/forklift-console-plugin/src/components/InputList/LazyTextInput.tsx
@@ -51,12 +51,18 @@ export const LazyTextInput: React.FunctionComponent<LazyTextInputProps> = ({
     }
   };
 
+  const onChangeText: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    setValue(value);
+  };
+
   return (
     <TextInput
       spellCheck="false"
       value={value}
       type={type}
-      onChange={(value) => setValue(value)}
+      onChange={onChangeText}
       onBlur={handleBlur}
       onKeyDown={handleKeyDown}
       aria-label={ariaLabel}

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -460,8 +460,8 @@ export function StandardPage<T>({
             perPage={itemsPerPage}
             page={currentPage}
             itemCount={filteredData.length}
-            onSetPage={(event, page) => setPage(page)}
-            onPerPageSelect={(event, perPage, page) => {
+            onSetPage={(_event, page) => setPage(page)}
+            onPerPageSelect={(_event, perPage, page) => {
               setPerPage(perPage);
               setPage(page);
             }}

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/components/MapsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/components/MapsEdit.tsx
@@ -86,7 +86,7 @@ export const MapsEdit: React.FC<MapsEditProps> = ({
 export type MapsEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;
   label: string;
   placeHolderLabel: string;
   invalidLabel: string;

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -53,6 +53,24 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     dispatch({ type: 'INIT', payload: obj });
   };
 
+  const onChangeSource: (value: string, event: React.FormEvent<HTMLSelectElement>) => void = (
+    value,
+  ) => {
+    dispatch({
+      type: 'SET_SOURCE_PROVIDER',
+      payload: providers.find((p) => p?.metadata?.name === value),
+    });
+  };
+
+  const onChangeTarget: (value: string, event: React.FormEvent<HTMLSelectElement>) => void = (
+    value,
+  ) => {
+    dispatch({
+      type: 'SET_TARGET_PROVIDER',
+      payload: providers.find((p) => p?.metadata?.name === value),
+    });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -88,12 +106,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
           selectedProviderName={state.networkMap?.spec?.provider?.source?.name}
           label={t('Source provider')}
           placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_SOURCE_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
-          }
+          onChange={onChangeSource}
           invalidLabel={t('The chosen provider is no longer available.')}
           mode={state.sourceProviderMode}
           helpContent="source provider"
@@ -105,12 +118,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
           selectedProviderName={state.networkMap?.spec?.provider?.destination?.name}
           label={t('Target provider')}
           placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_TARGET_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
-          }
+          onChange={onChangeTarget}
           invalidLabel={t('The chosen provider is no longer available.')}
           mode={state.targetProviderMode}
           helpContent="Target provider"

--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -85,7 +85,7 @@ const ProviderOption = (provider, index) => (
 export type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;
   label: string;
   placeHolderLabel: string;
   invalidLabel: string;

--- a/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsNumberInput.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/modal/SettingsNumberInput.tsx
@@ -25,7 +25,7 @@ export const SettingsNumberInput: React.FC<SettingsSelectInputProps> = ({
     setNewValue(newValue);
   };
 
-  const onUserChange = (event: React.FormEvent<HTMLInputElement>) => {
+  const onUserChange: (event: React.FormEvent<HTMLInputElement>) => void = (event) => {
     const value = (event.target as HTMLInputElement).value;
     const newValue = value === '' ? value : +value;
     setNewValue(newValue || 0);

--- a/packages/forklift-console-plugin/src/modules/Plans/modals/DuplicateModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/modals/DuplicateModal.tsx
@@ -96,9 +96,9 @@ export const DuplicateModal: React.FC<DuplicateModalProps> = ({ title, resource,
     setNewNameValidation('success');
   };
 
-  const onChange = (name: string) => {
-    validateName(name);
-    setNewName(name);
+  const onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (value) => {
+    validateName(value);
+    setNewName(value);
   };
 
   const onDuplicate = useCallback(async () => {

--- a/packages/forklift-console-plugin/src/modules/Plans/modals/PlanCutoverMigrationModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/modals/PlanCutoverMigrationModal.tsx
@@ -59,10 +59,14 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
     setCutoverDate(migrationCutoverDate);
   }, [lastMigration]);
 
-  const onDateChange = (inputDate, newDate: string) => {
+  const onDateChange: (
+    event: React.FormEvent<HTMLInputElement>,
+    value: string,
+    date?: Date,
+  ) => void = (_event, value) => {
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 
-    const [year, month, day] = newDate.split('-').map((num: string) => parseInt(num, 10));
+    const [year, month, day] = value.split('-').map((num: string) => parseInt(num, 10));
 
     updatedFromDate.setFullYear(year);
     updatedFromDate.setMonth(month - 1);
@@ -71,7 +75,14 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
     setCutoverDate(updatedFromDate.toISOString());
   };
 
-  const onTimeChange = (_event, _time, hour: number, minute: number) => {
+  const onTimeChange: (
+    event: React.FormEvent<HTMLInputElement>,
+    time: string,
+    hour?: number,
+    minute?: number,
+    seconds?: number,
+    isValid?: boolean,
+  ) => void = (_event, _time, hour, minute) => {
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 
     updatedFromDate.setHours(hour);

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SearchInputProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/components/SearchInputProvider.tsx
@@ -23,12 +23,19 @@ export const SearchInputProvider: React.FunctionComponent<SearchInputProviderPro
     filterDispatch({ type: 'SET_NAME_FILTER', payload: value });
   };
 
+  const onChange: (event: React.FormEvent<HTMLInputElement>, value: string) => void = (
+    _event,
+    value,
+  ) => {
+    updateNameFilter(value);
+  };
+
   return (
     <div className="forklift--create-plan--search-input-provider">
       <SearchInput
         placeholder={t('Filter provider')}
         value={filterState.nameFilter}
-        onChange={(_, value) => updateNameFilter(value)}
+        onChange={onChange}
         onClear={() => updateNameFilter('')}
       />
     </div>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/MappingListItem.tsx
@@ -59,7 +59,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value: string, isPlaceholder) => {
+  ) => void = (_event, value: string, isPlaceholder) => {
     !isPlaceholder &&
       replaceMapping({
         current: { source, destination },
@@ -71,7 +71,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value: string) => {
+  ) => void = (_event, value: string) => {
     replaceMapping({
       current: { source, destination },
       next: { source, destination: value },

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -85,7 +85,7 @@ const ProviderOption = (provider, index) => (
 export type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;
   label: string;
   placeHolderLabel: string;
   invalidLabel: string;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
@@ -39,8 +39,10 @@ interface SwitchRendererProps {
 
 const PreserveClusterCpuModelInputFactory: () => ModalInputComponentType = () => {
   const SwitchRenderer: React.FC<SwitchRendererProps> = ({ value, onChange }) => {
-    const onChangeInternal = (v) => {
-      onChange(v ? 'true' : 'false');
+    const onChangeInternal: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+      checked,
+    ) => {
+      onChange(checked ? 'true' : 'false');
     };
 
     return (

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanPreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
@@ -41,8 +41,10 @@ const PreserveStaticIPsInputFactory: () => ModalInputComponentType = () => {
   const { t } = useForkliftTranslation();
 
   const SwitchRenderer: React.FC<SwitchRendererProps> = ({ value, onChange }) => {
-    const onChangeInternal = (v) => {
-      onChange(v ? 'true' : 'false');
+    const onChangeInternal: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+      checked,
+    ) => {
+      onChange(checked ? 'true' : 'false');
     };
 
     return (

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanWarm/EditPlanWarm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditPlanWarm/EditPlanWarm.tsx
@@ -39,8 +39,10 @@ interface SwitchRendererProps {
 
 const WarmInputFactory: () => ModalInputComponentType = () => {
   const SwitchRenderer: React.FC<SwitchRendererProps> = ({ value, onChange }) => {
-    const onChangeInternal = (v) => {
-      onChange(v ? 'true' : 'false');
+    const onChangeInternal: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+      checked,
+    ) => {
+      onChange(checked ? 'true' : 'false');
     };
 
     return (

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
@@ -91,6 +91,45 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
     </>
   );
 
+  const onChangePreHookSet: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    dispatch({ type: 'PRE_HOOK_SET', payload: checked });
+  };
+
+  const onChangePostHookSet: (
+    checked: boolean,
+    event: React.FormEvent<HTMLInputElement>,
+  ) => void = (checked) => {
+    dispatch({ type: 'POST_HOOK_SET', payload: checked });
+  };
+
+  const onChangePreHookImage: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    dispatch({ type: 'PRE_HOOK_IMAGE', payload: value });
+  };
+
+  const onChangePreHookPlaybook: (
+    value: string,
+    event: React.FormEvent<HTMLInputElement>,
+  ) => void = (value) => {
+    dispatch({ type: 'PRE_HOOK_PLAYBOOK', payload: value });
+  };
+
+  const onChangePostHookImage: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    dispatch({ type: 'POST_HOOK_IMAGE', payload: value });
+  };
+
+  const onChangePostHookPlaybook: (
+    value: string,
+    event: React.FormEvent<HTMLInputElement>,
+  ) => void = (value) => {
+    dispatch({ type: 'POST_HOOK_PLAYBOOK', payload: value });
+  };
+
   return (
     <Suspend obj={plan} loaded={loaded} loadError={loadError}>
       {state.alertMessage && <PageSection variant="light">{state.alertMessage}</PageSection>}
@@ -130,7 +169,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
               label="Enable pre migration hook"
               labelOff="Do not enable a pre migration hook"
               isChecked={state.preHookSet}
-              onChange={(value) => dispatch({ type: 'PRE_HOOK_SET', payload: value })}
+              onChange={onChangePreHookSet}
             />
           </FormGroupWithHelpText>
 
@@ -141,7 +180,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
                   spellCheck="false"
                   value={state.preHook?.spec?.image}
                   type="url"
-                  onChange={(value) => dispatch({ type: 'PRE_HOOK_IMAGE', payload: value })}
+                  onChange={onChangePreHookImage}
                   aria-label="pre hook image"
                 />
                 <HelperText>
@@ -155,7 +194,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
                 <CodeEditor
                   language="yaml"
                   value={Base64.decode(state.preHook?.spec?.playbook || '')}
-                  onChange={(value) => dispatch({ type: 'PRE_HOOK_PLAYBOOK', payload: value })}
+                  onChange={onChangePreHookPlaybook}
                   minHeight="400px"
                   showMiniMap={false}
                 />
@@ -180,7 +219,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
               label="Enable post migration hook"
               labelOff="Do not enable a post migration hook"
               isChecked={state.postHookSet}
-              onChange={(value) => dispatch({ type: 'POST_HOOK_SET', payload: value })}
+              onChange={onChangePostHookSet}
             />
           </FormGroupWithHelpText>
 
@@ -191,7 +230,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
                   spellCheck="false"
                   value={state.postHook?.spec?.image}
                   type="url"
-                  onChange={(value) => dispatch({ type: 'POST_HOOK_IMAGE', payload: value })}
+                  onChange={onChangePostHookImage}
                   aria-label="pre hook image"
                 />
                 <HelperText>
@@ -205,7 +244,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
                 <CodeEditor
                   language="yaml"
                   value={Base64.decode(state.postHook?.spec?.playbook || '')}
-                  onChange={(value) => dispatch({ type: 'POST_HOOK_PLAYBOOK', payload: value })}
+                  onChange={onChangePostHookPlaybook}
                   minHeight="400px"
                   showMiniMap={false}
                 />

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditModal/EditModal.tsx
@@ -135,6 +135,10 @@ export const EditModal: React.FC<EditModalProps> = ({
     </Popover>
   );
 
+  const onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (value) => {
+    handleValueChange(value);
+  };
+
   /**
    * InputComponent_ is a higher-order component that renders either the passed-in InputComponent, or a default TextInput,
    */
@@ -146,7 +150,7 @@ export const EditModal: React.FC<EditModalProps> = ({
       id="modal-with-form-form-field"
       name="modal-with-form-form-field"
       value={value}
-      onChange={(value) => handleValueChange(value)}
+      onChange={onChange}
       validated={validation.type}
     />
   );

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -35,6 +35,16 @@ export const EditProviderVDDKImage: React.FC<EditProviderVDDKImageProps> = (prop
 
   const isEmptyImage = emptyImage === 'yes';
 
+  const onChange: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    if (checked) {
+      setEmptyImage('yes');
+    } else {
+      setEmptyImage(undefined);
+    }
+  };
+
   const body = (
     <Hint>
       <HintBody>
@@ -45,13 +55,7 @@ export const EditProviderVDDKImage: React.FC<EditProviderVDDKImageProps> = (prop
             'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.',
           )}
           isChecked={isEmptyImage}
-          onChange={(checked) => {
-            if (checked) {
-              setEmptyImage('yes');
-            } else {
-              setEmptyImage(undefined);
-            }
-          }}
+          onChange={onChange}
           id="emptyVddkInitImage"
           name="emptyVddkInitImage"
         />

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/VerifyCertificate.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/VerifyCertificate.tsx
@@ -26,6 +26,12 @@ export const VerifyCertificate: FC<{
 }> = ({ thumbprint, issuer, validTo, isTrusted, setIsTrusted, hasThumbprintChanged }) => {
   const { t } = useForkliftTranslation();
 
+  const onChange: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    setIsTrusted(checked);
+  };
+
   return (
     <>
       {hasThumbprintChanged && (
@@ -60,7 +66,7 @@ export const VerifyCertificate: FC<{
             id="certificate-check"
             name="certificateCheck"
             isChecked={isTrusted}
-            onChange={setIsTrusted}
+            onChange={onChange}
           />
         </FlexItem>
       </Flex>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -130,6 +130,24 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
     event.preventDefault();
   };
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
+  const onChangEmptyVddk: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('emptyVddkInitImage', checked ? 'yes' : undefined);
+  };
+
+  const onChangeVddk: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('vddkInitImage', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -170,7 +188,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
           name="url"
           value={url}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
 
@@ -201,7 +219,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
                 'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.',
               )}
               isChecked={emptyVddkInitImage === 'yes'}
-              onChange={(value) => handleChange('emptyVddkInitImage', value ? 'yes' : undefined)}
+              onChange={onChangEmptyVddk}
               id="emptyVddkInitImage"
               name="emptyVddkInitImage"
             />
@@ -218,7 +236,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
             validated={
               emptyVddkInitImage === 'yes' ? 'default' : state.validation.vddkInitImage.type
             }
-            onChange={(value) => handleChange('vddkInitImage', value)}
+            onChange={onChangeVddk}
           />
         </div>
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OVAProviderCreateForm.tsx
@@ -57,6 +57,12 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
     [provider],
   );
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -75,7 +81,7 @@ export const OVAProviderCreateForm: React.FC<OVAProviderCreateFormProps> = ({
           isRequired
           value={url || ''}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenshiftProviderCreateForm.tsx
@@ -59,6 +59,12 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
     [provider],
   );
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -75,7 +81,7 @@ export const OpenshiftProviderFormCreate: React.FC<OpenshiftProviderCreateFormPr
           name="url"
           value={url}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OpenstackProviderCreateForm.tsx
@@ -59,6 +59,12 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
     [provider],
   );
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -77,7 +83,7 @@ export const OpenstackProviderCreateForm: React.FC<OpenstackProviderCreateFormPr
           name="url"
           value={url || ''}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/OvirtProviderCreateForm.tsx
@@ -59,6 +59,12 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
     [provider],
   );
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -77,7 +83,7 @@ export const OvirtProviderCreateForm: React.FC<OvirtProviderCreateFormProps> = (
           name="url"
           value={url || ''}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
     </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -93,6 +93,10 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
     onNewProviderChange({ ...newProvider, spec: { ...newProvider?.spec, type: type } });
   };
 
+  const onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (value) => {
+    handleNameChange(value);
+  };
+
   return (
     <ModalHOC>
       <div className="forklift-create-provider-edit-section">
@@ -153,7 +157,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
                 name="name"
                 value={newProvider.metadata.name} // Use the appropriate prop value here
                 validated={state.validation.name.type}
-                onChange={(value) => handleNameChange(value)} // Call the custom handler method
+                onChange={onChange} // Call the custom handler method
               />
             </FormGroupWithHelpText>
           </Form>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -131,6 +131,24 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
     event.preventDefault();
   };
 
+  const onChangeUrl: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('url', value);
+  };
+
+  const onChangEmptyVddk: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('emptyVddkInitImage', checked ? 'yes' : undefined);
+  };
+
+  const onChangeVddk: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('vddkInitImage', value);
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-provider-edit">
       <FormGroupWithHelpText
@@ -171,7 +189,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
           name="url"
           value={url}
           validated={state.validation.url.type}
-          onChange={(value) => handleChange('url', value)}
+          onChange={onChangeUrl}
         />
       </FormGroupWithHelpText>
 
@@ -202,7 +220,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
                 'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration, migration may be slow.',
               )}
               isChecked={emptyVddkInitImage === 'yes'}
-              onChange={(value) => handleChange('emptyVddkInitImage', value ? 'yes' : undefined)}
+              onChange={onChangEmptyVddk}
               id="emptyVddkInitImage"
               name="emptyVddkInitImage"
             />
@@ -219,7 +237,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
             validated={
               emptyVddkInitImage === 'yes' ? 'default' : state.validation.vddkInitImage.type
             }
-            onChange={(value) => handleChange('vddkInitImage', value)}
+            onChange={onChangeVddk}
           />
         </div>
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -103,6 +103,24 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
     togglePasswordHidden();
   };
 
+  const onChangeUser: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('user', value);
+  };
+
+  const onChangePassword: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('password', value);
+  };
+
+  const onChangeInsecure: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('insecureSkipVerify', checked ? 'true' : 'false');
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -119,7 +137,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           type="text"
           id="username"
           name="username"
-          onChange={(value) => handleChange('user', value)}
+          onChange={onChangeUser}
           value={user}
           validated={state.validation.user.type}
         />
@@ -138,7 +156,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
           aria-label="Password input"
-          onChange={(value) => handleChange('password', value)}
+          onChange={onChangePassword}
           value={password}
           validated={state.validation.password.type}
         />
@@ -181,7 +199,7 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
           label={t('Skip certificate validation')}
           isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
-          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+          onChange={onChangeInsecure}
         />
       </FormGroupWithHelpText>
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -103,6 +103,18 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     togglePasswordHidden();
   };
 
+  const onChangeToken: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('token', value);
+  };
+
+  const onChangeInsecure: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('insecureSkipVerify', checked ? 'true' : 'false');
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -119,7 +131,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
           aria-label="Token input"
-          onChange={(value) => handleChange('token', value)}
+          onChange={onChangeToken}
           value={token}
           validated={state.validation.token.type}
         />
@@ -162,7 +174,7 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           label={t('Skip certificate validation')}
           isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
-          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+          onChange={onChangeInsecure}
         />
       </FormGroupWithHelpText>
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEdit.tsx
@@ -164,6 +164,12 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
     event.preventDefault();
   };
 
+  const onChangeInsecure: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('insecureSkipVerify', checked ? 'true' : 'false');
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -257,7 +263,7 @@ export const OpenstackCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
           aria-label={insecureSkipVerifyHelperTextMsgs.successAndSkipped}
           isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
-          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+          onChange={onChangeInsecure}
         />
       </FormGroupWithHelpText>
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
@@ -76,6 +76,13 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  type onChangeFactoryType = (
+    changedField: string,
+  ) => (value: string, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (changedField) => (value) =>
+    handleChange(changedField, value);
+
   return (
     <>
       <FormGroupWithHelpText
@@ -93,7 +100,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="applicationCredentialName"
           name="applicationCredentialName"
           value={applicationCredentialName}
-          onChange={(value) => handleChange('applicationCredentialName', value)}
+          onChange={onChangeFactory('applicationCredentialName')}
           validated={state.validation.applicationCredentialName.type}
         />
       </FormGroupWithHelpText>
@@ -114,7 +121,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="applicationCredentialSecret"
           name="applicationCredentialSecret"
           value={applicationCredentialSecret}
-          onChange={(value) => handleChange('applicationCredentialSecret', value)}
+          onChange={onChangeFactory('applicationCredentialSecret')}
           validated={state.validation.applicationCredentialSecret.type}
         />
         <Button
@@ -141,7 +148,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="username"
           name="username"
           value={username}
-          onChange={(value) => handleChange('username', value)}
+          onChange={onChangeFactory('username')}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -161,7 +168,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="regionName"
           name="regionName"
           value={regionName}
-          onChange={(value) => handleChange('regionName', value)}
+          onChange={onChangeFactory('regionName')}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -181,7 +188,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="projectName"
           name="projectName"
           value={projectName}
-          onChange={(value) => handleChange('projectName', value)}
+          onChange={onChangeFactory('projectName')}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -201,7 +208,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           id="domainName"
           name="domainName"
           value={domainName}
-          onChange={(value) => handleChange('domainName', value)}
+          onChange={onChangeFactory('domainName')}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
@@ -72,6 +72,13 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  type onChangeFactoryType = (
+    changedField: string,
+  ) => (value: string, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (changedField) => (value) =>
+    handleChange(changedField, value);
+
   return (
     <>
       <FormGroupWithHelpText
@@ -89,7 +96,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           id="applicationCredentialID"
           name="applicationCredentialID"
           value={applicationCredentialID}
-          onChange={(value) => handleChange('applicationCredentialID', value)}
+          onChange={onChangeFactory('applicationCredentialID')}
           validated={state.validation.applicationCredentialID.type}
         />
       </FormGroupWithHelpText>
@@ -110,7 +117,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           id="applicationCredentialSecret"
           name="applicationCredentialSecret"
           value={applicationCredentialSecret}
-          onChange={(value) => handleChange('applicationCredentialSecret', value)}
+          onChange={onChangeFactory('applicationCredentialSecret')}
           validated={state.validation.applicationCredentialSecret.type}
         />
         <Button
@@ -137,7 +144,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           id="regionName"
           name="regionName"
           value={regionName}
-          onChange={(value) => handleChange('regionName', value)}
+          onChange={onChangeFactory('regionName')}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -157,7 +164,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           id="projectName"
           name="projectName"
           value={projectName}
-          onChange={(value) => handleChange('projectName', value)}
+          onChange={onChangeFactory('projectName')}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
@@ -68,6 +68,13 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  type onChangeFactoryType = (
+    changedField: string,
+  ) => (value: string, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (changedField) => (value) =>
+    handleChange(changedField, value);
+
   return (
     <>
       <FormGroupWithHelpText
@@ -85,7 +92,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           id="username"
           name="username"
           value={username}
-          onChange={(value) => handleChange('username', value)}
+          onChange={onChangeFactory('username')}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -105,7 +112,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           type={state.passwordHidden ? 'password' : 'text'}
           aria-label="Password input"
           value={password}
-          onChange={(value) => handleChange('password', value)}
+          onChange={onChangeFactory('password')}
           validated={state.validation.password.type}
         />
         <Button
@@ -132,7 +139,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           id="regionName"
           name="regionName"
           value={regionName}
-          onChange={(value) => handleChange('regionName', value)}
+          onChange={onChangeFactory('regionName')}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -152,7 +159,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           id="projectName"
           name="projectName"
           value={projectName}
-          onChange={(value) => handleChange('projectName', value)}
+          onChange={onChangeFactory('projectName')}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -172,7 +179,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           id="domainName"
           name="domainName"
           value={domainName}
-          onChange={(value) => handleChange('domainName', value)}
+          onChange={onChangeFactory('domainName')}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
@@ -65,6 +65,13 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  type onChangeFactoryType = (
+    changedField: string,
+  ) => (value: string, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (changedField) => (value) =>
+    handleChange(changedField, value);
+
   return (
     <>
       <FormGroupWithHelpText
@@ -83,7 +90,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           id="token"
           name="token"
           value={token}
-          onChange={(value) => handleChange('token', value)}
+          onChange={onChangeFactory('token')}
           validated={state.validation.token.type}
         />
         <Button
@@ -110,7 +117,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           id="userID"
           name="userID"
           value={userID}
-          onChange={(value) => handleChange('userID', value)}
+          onChange={onChangeFactory('userID')}
           validated={state.validation.userID.type}
         />
       </FormGroupWithHelpText>
@@ -130,7 +137,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           id="projectID"
           name="projectID"
           value={projectID}
-          onChange={(value) => handleChange('projectID', value)}
+          onChange={onChangeFactory('projectID')}
           validated={state.validation.projectID.type}
         />
       </FormGroupWithHelpText>
@@ -150,7 +157,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           id="regionName"
           name="regionName"
           value={regionName}
-          onChange={(value) => handleChange('regionName', value)}
+          onChange={onChangeFactory('regionName')}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
@@ -67,6 +67,13 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
     dispatch({ type: 'TOGGLE_PASSWORD_HIDDEN' });
   };
 
+  type onChangeFactoryType = (
+    changedField: string,
+  ) => (value: string, event: React.FormEvent<HTMLInputElement>) => void;
+
+  const onChangeFactory: onChangeFactoryType = (changedField) => (value) =>
+    handleChange(changedField, value);
+
   return (
     <>
       <FormGroupWithHelpText
@@ -85,7 +92,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           id="token"
           name="token"
           value={token}
-          onChange={(value) => handleChange('token', value)}
+          onChange={onChangeFactory('token')}
           validated={state.validation.token.type}
         />
         <Button
@@ -112,7 +119,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           id="username"
           name="username"
           value={username}
-          onChange={(value) => handleChange('username', value)}
+          onChange={onChangeFactory('Username')}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -132,7 +139,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           id="regionName"
           name="regionName"
           value={regionName}
-          onChange={(value) => handleChange('regionName', value)}
+          onChange={onChangeFactory('regionName')}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -152,7 +159,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           id="projectName"
           name="projectName"
           value={projectName}
-          onChange={(value) => handleChange('projectName', value)}
+          onChange={onChangeFactory('projectName')}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -172,7 +179,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           id="domainName"
           name="domainName"
           value={domainName}
-          onChange={(value) => handleChange('domainName', value)}
+          onChange={onChangeFactory('domainName')}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -109,6 +109,24 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
     togglePasswordHidden();
   };
 
+  const onChangeUser: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('user', value);
+  };
+
+  const onChangePassword: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('password', value);
+  };
+
+  const onChangeInsecure: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('insecureSkipVerify', checked ? 'true' : 'false');
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -127,7 +145,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           name="user"
           value={user}
           validated={state.validation.user.type}
-          onChange={(value) => handleChange('user', value)}
+          onChange={onChangeUser}
         />
       </FormGroupWithHelpText>
       <FormGroupWithHelpText
@@ -146,7 +164,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           aria-label="Password input"
           value={password}
           validated={state.validation.password.type}
-          onChange={(value) => handleChange('password', value)}
+          onChange={onChangePassword}
         />
         <Button
           variant="control"
@@ -187,7 +205,7 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
           label={t('Skip certificate validation')}
           isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
-          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+          onChange={onChangeInsecure}
         />
       </FormGroupWithHelpText>
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -97,6 +97,24 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
     event.preventDefault();
   };
 
+  const onChangeUser: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('user', value);
+  };
+
+  const onChangePassword: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    handleChange('password', value);
+  };
+
+  const onChangeInsecure: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void = (
+    checked,
+  ) => {
+    handleChange('insecureSkipVerify', checked ? 'true' : 'false');
+  };
+
   return (
     <Form isWidthLimited className="forklift-section-secret-edit">
       <FormGroupWithHelpText
@@ -113,7 +131,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
           type="text"
           id="username"
           name="username"
-          onChange={(value) => handleChange('user', value)}
+          onChange={onChangeUser}
           value={user}
           validated={state.validation.user.type}
         />
@@ -132,7 +150,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
           isRequired
           type={state.passwordHidden ? 'password' : 'text'}
           aria-label="Password input"
-          onChange={(value) => handleChange('password', value)}
+          onChange={onChangePassword}
           value={password}
           validated={state.validation.password.type}
         />
@@ -171,7 +189,7 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
           label={t('Skip certificate validation')}
           isChecked={insecureSkipVerify === 'true'}
           hasCheckIcon
-          onChange={(value) => handleChange('insecureSkipVerify', value ? 'true' : 'false')}
+          onChange={onChangeInsecure}
         />
       </FormGroupWithHelpText>
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
@@ -186,6 +186,18 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
     };
   });
 
+  const onChangUser: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    dispatch({ type: 'SET_USERNAME', payload: value });
+  };
+
+  const onChangePassword: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    dispatch({ type: 'SET_PASSWORD', payload: value });
+  };
+
   return (
     <Modal
       title={t('Select migration network')}
@@ -246,7 +258,7 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
                 type="text"
                 id="username"
                 value={state.username}
-                onChange={(value) => dispatch({ type: 'SET_USERNAME', payload: value })}
+                onChange={onChangUser}
                 validated={state.validation.username}
               />
             </FormGroupWithHelpText>
@@ -265,7 +277,7 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
                 type={state.passwordHidden ? 'password' : 'text'}
                 aria-label="Password input"
                 value={state.password}
-                onChange={(value) => dispatch({ type: 'SET_PASSWORD', payload: value })}
+                onChange={onChangePassword}
                 validated={state.validation.password}
               />
               <Button variant="control" onClick={togglePasswordHidden}>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/MappingListItem.tsx
@@ -62,7 +62,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value: string, isPlaceholder) => {
+  ) => void = (_event, value: string, isPlaceholder) => {
     !isPlaceholder &&
       replaceMapping({
         current: { source, destination },
@@ -74,7 +74,7 @@ export const MappingListItem: FC<MappingListItemProps> = ({
     event: SelectEventType,
     value: SelectValueType,
     isPlaceholder?: boolean,
-  ) => void = (event, value: string) => {
+  ) => void = (_event, value: string) => {
     replaceMapping({
       current: { source, destination },
       next: { source, destination: value },

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
@@ -145,6 +145,19 @@ export const PlansCreateForm = ({
   const networkMessages = buildNetworkMessages(t);
   const storageMessages = buildStorageMessages(t);
 
+  const onChangePlan: (value: string, event: React.FormEvent<HTMLInputElement>) => void = (
+    value,
+  ) => {
+    dispatch(setPlanName(value?.trim() ?? ''));
+  };
+
+  const onChangeTargetProvider: (
+    value: string,
+    event: React.FormEvent<HTMLSelectElement>,
+  ) => void = (value) => {
+    dispatch(setPlanTargetProvider(value));
+  };
+
   return (
     <>
       {children}
@@ -173,7 +186,7 @@ export const PlansCreateForm = ({
                 value={plan.metadata.name}
                 validated={validation.planName}
                 isDisabled={flow.editingDone}
-                onChange={(value) => dispatch(setPlanName(value?.trim() ?? ''))}
+                onChange={onChangePlan}
               />
             </FormGroupWithHelpText>
           </Form>
@@ -228,7 +241,7 @@ export const PlansCreateForm = ({
           >
             <FormSelect
               value={plan.spec.provider?.destination?.name}
-              onChange={(value) => dispatch(setPlanTargetProvider(value))}
+              onChange={onChangeTargetProvider}
               id="targetProvider"
               isDisabled={flow.editingDone}
             >

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/components/MapsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/components/MapsEdit.tsx
@@ -86,7 +86,7 @@ export const MapsEdit: React.FC<MapsEditProps> = ({
 export type MapsEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;
   label: string;
   placeHolderLabel: string;
   invalidLabel: string;

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -49,6 +49,20 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
     dispatch({ type: 'INIT', payload: obj });
   };
 
+  const onChangeSource: (value: string) => void = (value) => {
+    dispatch({
+      type: 'SET_SOURCE_PROVIDER',
+      payload: providers.find((p) => p?.metadata?.name === value),
+    });
+  };
+
+  const onChangeTarget: (value: string) => void = (value) => {
+    dispatch({
+      type: 'SET_TARGET_PROVIDER',
+      payload: providers.find((p) => p?.metadata?.name === value),
+    });
+  };
+
   return (
     <Suspend obj={providers} loaded={providersLoaded} loadError={providersLoadError}>
       <Flex className="forklift-network-map__details-tab--update-button">
@@ -84,12 +98,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
           selectedProviderName={state.StorageMap?.spec?.provider?.source?.name}
           label={t('Source provider')}
           placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_SOURCE_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
-          }
+          onChange={onChangeSource}
           invalidLabel={t('The chosen provider is no longer available.')}
           mode={state.sourceProviderMode}
           helpContent="source provider"
@@ -101,12 +110,7 @@ export const ProvidersSection: React.FC<ProvidersSectionProps> = ({ obj }) => {
           selectedProviderName={state.StorageMap?.spec?.provider?.destination?.name}
           label={t('Target provider')}
           placeHolderLabel={t('Select a provider')}
-          onChange={(value) =>
-            dispatch({
-              type: 'SET_TARGET_PROVIDER',
-              payload: providers.find((p) => p?.metadata?.name === value),
-            })
-          }
+          onChange={onChangeTarget}
           invalidLabel={t('The chosen provider is no longer available.')}
           mode={state.targetProviderMode}
           helpContent="Target provider"

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -85,7 +85,7 @@ export const ProvidersEdit: React.FC<ProvidersEditProps> = ({
 export type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
-  onChange: (value: string) => void;
+  onChange: (value: string, event: React.FormEvent<HTMLSelectElement>) => void;
   label: string;
   placeHolderLabel: string;
   invalidLabel: string;


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1098

For avoiding uncaught PF 4 -> PF 5 migration errors, this PR named and typed (i.e. (add type to function signature) all `onChange` callback appearances which use parameters.