### PR TITLE
Add DV list to extended vm view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4586,9 +4586,9 @@
       "link": true
     },
     "node_modules/@kubev2v/types": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@kubev2v/types/-/types-0.0.17.tgz",
-      "integrity": "sha512-xOT44F19PT4jaRPt6mokilTnkJgE2Of/44ALiD5dFcdh1I7vss+QZ7Qux7G+VJjL/EJ7xBJqoaSLsiEXCELxlw==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@kubev2v/types/-/types-0.0.19.tgz",
+      "integrity": "sha512-V2qRDrRE8ZWx0Ab9wBjlExPPFDXY0jZrDh8yZAeRGwkYXVL2qgcnhA+iWjOjvywfMomTgwYmjIw9I7ZtwxihAA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -34039,7 +34039,7 @@
         "use-immer": "^0.9.0"
       },
       "devDependencies": {
-        "@kubev2v/types": "0.0.17",
+        "@kubev2v/types": "0.0.19",
         "@kubev2v/webpack": "*",
         "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.11",
         "@types/ejs": "^3.0.6",

--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -44,7 +44,7 @@
     "react-router-dom": "5.3.x"
   },
   "devDependencies": {
-    "@kubev2v/types": "0.0.17",
+    "@kubev2v/types": "0.0.19",
     "@kubev2v/webpack": "*",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.11",
     "@types/react": "^17.0.1",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -40,6 +40,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
   const pods = props.resourceData.pods;
   const jobs = props.resourceData.jobs;
   const pvcs = props.resourceData.pvcs;
+  const dvs = props.resourceData.dvs;
   const vmCreated = pipeline.find(
     (p) => p?.name === 'VirtualMachineCreation' && p?.phase === 'Completed',
   );
@@ -192,6 +193,43 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
                   </Td>
                   <Td>
                     <Status status={pvc.status.phase}></Status>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </>
+      )}
+
+      {(dvs || []).length > 0 && (
+        <>
+          <SectionHeading
+            text={'DataVolumes'}
+            className="forklift-page-plan-details-vm-status__section-header"
+          />
+          <TableComposable aria-label="Expandable table" variant="compact">
+            <Thead>
+              <Tr>
+                <Th width={20}>{t('Name')}</Th>
+                <Th>{t('Status')}</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {(dvs || []).map((dv) => (
+                <Tr key={dv.metadata.uid}>
+                  <Td>
+                    <ResourceLink
+                      groupVersionKind={{
+                        version: 'v1beta1',
+                        kind: 'DataVolume',
+                        group: 'cdi.kubevirt.io',
+                      }}
+                      name={dv?.metadata?.name}
+                      namespace={dv?.metadata?.namespace}
+                    />
+                  </Td>
+                  <Td>
+                    <Status status={dv?.status?.phase}></Status>
                   </Td>
                 </Tr>
               ))}

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Plan/PlanVirtualMachinesList.tsx
@@ -76,6 +76,7 @@ export const PlanVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => {
     pods: [],
     jobs: [],
     pvcs: [],
+    dvs: [],
     conditions: conditionsDict[m.id],
     targetNamespace: plan?.spec?.targetNamespace,
   }));

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/types/VMData.ts
@@ -2,6 +2,7 @@ import {
   IoK8sApiBatchV1Job,
   IoK8sApiCoreV1PersistentVolumeClaim,
   IoK8sApiCoreV1Pod,
+  V1beta1DataVolume,
   V1beta1PlanSpecVms,
   V1beta1PlanStatusConditions,
   V1beta1PlanStatusMigrationVms,
@@ -13,6 +14,7 @@ export type VMData = {
   pods: IoK8sApiCoreV1Pod[];
   jobs: IoK8sApiBatchV1Job[];
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
+  dvs: V1beta1DataVolume[];
   conditions?: V1beta1PlanStatusConditions[];
   targetNamespace: string;
 };


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1270

Add DataVolume list to VM extended row in the running plan vms list.

Screenshot:
![with-data-volumes](https://github.com/user-attachments/assets/9c3132fa-4d77-468f-a382-f0a783e3a38b)
