### PR TITLE
:lady_beetle: Make user settings persistante

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/list/NetworkMapsListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/list/NetworkMapsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -103,7 +103,8 @@ const NetworkMapsListPage: React.FC<{
   namespace: string;
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'NetworkMaps' }));
+
+  const userSettings = loadUserSettings({ pageId: 'NetworkMaps' });
 
   const [networkMaps, networkMapsLoaded, networkMapsLoadError] = useK8sWatchResource<
     V1beta1NetworkMap[]

--- a/packages/forklift-console-plugin/src/modules/Overview/hooks/OverviewContextProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/hooks/OverviewContextProvider.tsx
@@ -32,7 +32,7 @@ export const CreateOverviewContextProvider = CreateOverviewContext.Provider;
 export const useOverviewContext = (): CreateOverviewContextType => {
   // use the same approach as useSafetyFirst() hook
   // https://github.com/openshift/console/blob/9d4a9b0a01b2de64b308f8423a325f1fae5f8726/frontend/packages/console-dynamic-plugin-sdk/src/app/components/safety-first.tsx#L10
-  const [userSettings] = useState(() => loadUserSettings({ userSettingsKeySuffix: 'Overview' }));
+  const userSettings = loadUserSettings({ userSettingsKeySuffix: 'Overview' });
   const hideWelcomeCardInitState = userSettings?.welcome?.hideWelcome;
   const [data, setData] = useState<CreateOverviewContextData>({
     hideWelcomeCardByContext: hideWelcomeCardInitState,

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
@@ -223,7 +223,8 @@ export const MigrationVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => 
 
   const [selectedIds, setSelectedIds] = useState([]);
   const [expandedIds, setExpandedIds] = useState([]);
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'PlanVirtualMachines' }));
+
+  const userSettings = loadUserSettings({ pageId: 'PlanVirtualMachines' });
 
   const virtualMachines: V1beta1PlanSpecVms[] = plan?.spec?.vms || [];
   const migrationVirtualMachines: V1beta1PlanStatusMigrationVms[] =

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/PlansListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/PlansListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { ModalHOC } from 'src/modules/Providers/modals';
@@ -133,7 +133,8 @@ const PlansListPage: React.FC<{
   namespace: string;
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'Plans' }));
+
+  const userSettings = loadUserSettings({ pageId: 'Plans' });
 
   const [plans, plansLoaded, plansLoadError] = useK8sWatchResource<V1beta1Plan[]>({
     groupVersionKind: PlanModelGroupVersionKind,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/VSphereHostsList.tsx
@@ -67,7 +67,7 @@ export const VSphereHostsList: FC<ProviderHostsProps> = ({ obj }) => {
   const { namespace } = provider?.metadata || {};
 
   const [selectedIds, setSelectedIds] = useState([]);
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'ProviderHosts' }));
+  const userSettings = loadUserSettings({ pageId: 'ProviderHosts' });
 
   const {
     inventory: hostsInventory,

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import {
   GlobalActionWithSelection,
@@ -49,7 +49,8 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   className,
 }) => {
   const { t } = useForkliftTranslation();
-  const [userSettings] = useState(() => loadUserSettings({ pageId }));
+
+  const userSettings = loadUserSettings({ pageId });
 
   const initialSelectedIds_ = initialSelectedIds || [];
   const initialExpandedIds_ = [];

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import modernizeMigration from 'src/modules/Providers/images/modernizeMigration.svg';
 import { ProviderData, SOURCE_ONLY_PROVIDER_TYPES } from 'src/modules/Providers/utils';
@@ -169,7 +169,8 @@ const ProvidersListPage: React.FC<{
   namespace: string;
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'Providers' }));
+
+  const userSettings = loadUserSettings({ pageId: 'Providers' });
 
   const [providers, providersLoaded, providersLoadError] = useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/list/StorageMapsListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/list/StorageMapsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import StandardPage from 'src/components/page/StandardPage';
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -103,7 +103,8 @@ const StorageMapsListPage: React.FC<{
   namespace: string;
 }> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
-  const [userSettings] = useState(() => loadUserSettings({ pageId: 'StorageMaps' }));
+
+  const userSettings = loadUserSettings({ pageId: 'StorageMaps' });
 
   const [StorageMaps, StorageMapsLoaded, StorageMapsLoadError] = useK8sWatchResource<
     V1beta1StorageMap[]


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1281

Issue:
when table data change, user settings are reset to initial state.

Fix:
don't remember user settings as a component state.

Screenshots:
Before:
https://github.com/user-attachments/assets/9b029c1f-02c7-4f60-81c3-68ae092b5ffd

After:
https://github.com/user-attachments/assets/aca28f6b-9699-4cd9-a465-8adae2e81f8f



