### PR TITLE
:feet:  Add type-ahead text search to EnumFilter

### DIFF
--- a/packages/common/src/components/Filter/EnumFilter.tsx
+++ b/packages/common/src/components/Filter/EnumFilter.tsx
@@ -11,7 +11,7 @@ import {
 
 import { localeCompare, SelectEventType, SelectValueType, ToggleEventType } from '../../utils';
 
-import { FilterTypeProps } from './types';
+import { FilterTypeProps, InlineFilter } from './types';
 
 /**
  * One label may map to multiple enum ids due to translation or by design (i.e. "Unknown")
@@ -117,7 +117,8 @@ export const EnumFilter = ({
   filterId,
   showFilter = true,
   resolvedLanguage,
-}: FilterTypeProps) => {
+  hasInlineFilter = false,
+}: FilterTypeProps & InlineFilter) => {
   const [isExpanded, setExpanded] = useState(false);
   const { uniqueEnumLabels, onUniqueFilterUpdate, selectedUniqueEnumLabels } = useUnique({
     supportedEnumValues,
@@ -136,6 +137,21 @@ export const EnumFilter = ({
     if (typeof label === 'string') {
       onUniqueFilterUpdate([...selectedUniqueEnumLabels, label]);
     }
+  };
+
+  const options = uniqueEnumLabels.map((label) => <SelectOption key={label} value={label} />);
+
+  const onFilter: (
+    event: React.ChangeEvent<HTMLInputElement> | null,
+    textInput: string,
+  ) => React.ReactElement[] | undefined = (_event, textInput) => {
+    if (textInput === '') {
+      return options;
+    }
+    const filtered = options.filter((item) => {
+      return item.key.toString().toLowerCase().includes(textInput.toLowerCase());
+    });
+    return filtered;
   };
 
   const onSelect: (
@@ -170,10 +186,10 @@ export const EnumFilter = ({
         placeholderText={placeholderLabel}
         isOpen={isExpanded}
         onToggle={onToggle}
+        hasInlineFilter={hasInlineFilter}
+        onFilter={onFilter}
       >
-        {uniqueEnumLabels.map((label) => (
-          <SelectOption key={label} value={label} />
-        ))}
+        {options}
       </Select>
     </ToolbarFilter>
   );

--- a/packages/common/src/components/Filter/SearchableEnumFilter.tsx
+++ b/packages/common/src/components/Filter/SearchableEnumFilter.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { EnumFilter } from './EnumFilter';
+import { FilterTypeProps } from './types';
+
+/**
+ * EnumFilter with inline free search text enabled.
+ */
+export const SearchableEnumFilter = (props: FilterTypeProps) => (
+  <EnumFilter {...props} hasInlineFilter={true} />
+);

--- a/packages/common/src/components/Filter/index.ts
+++ b/packages/common/src/components/Filter/index.ts
@@ -5,6 +5,7 @@ export * from './DateRangeFilter';
 export * from './EnumFilter';
 export * from './FreetextFilter';
 export * from './GroupedEnumFilter';
+export * from './SearchableEnumFilter';
 export * from './SearchableGroupedEnumFilter';
 export * from './SwitchFilter';
 export * from './types';

--- a/packages/common/src/components/FilterGroup/matchers.ts
+++ b/packages/common/src/components/FilterGroup/matchers.ts
@@ -8,6 +8,7 @@ import {
   EnumFilter,
   FreetextFilter,
   GroupedEnumFilter,
+  SearchableEnumFilter,
   SearchableGroupedEnumFilter,
   SwitchFilter,
 } from '../Filter';
@@ -100,6 +101,11 @@ const enumMatcher = {
   matchValue: (value: string) => (filter: string) => value === filter,
 };
 
+const searchableEnumMatcher = {
+  filterType: 'searchableEnum',
+  matchValue: enumMatcher.matchValue,
+};
+
 const groupedEnumMatcher = {
   filterType: 'groupedEnum',
   matchValue: enumMatcher.matchValue,
@@ -134,6 +140,7 @@ export const defaultValueMatchers: ValueMatcher[] = [
   autocompleteFilterMatcher,
   freetextMatcher,
   enumMatcher,
+  searchableEnumMatcher,
   groupedEnumMatcher,
   searchableGroupedEnumMatcher,
   sliderMatcher,
@@ -145,10 +152,11 @@ export const defaultSupportedFilters: Record<string, FilterRenderer> = {
   date: DateFilter,
   dateRange: DateRangeFilter,
   enum: EnumFilter,
-  freetext: FreetextFilter,
+  searchableEnum: SearchableEnumFilter,
   groupedEnum: GroupedEnumFilter,
-  slider: SwitchFilter,
   searchableGroupedEnum: SearchableGroupedEnumFilter,
+  freetext: FreetextFilter,
+  slider: SwitchFilter,
   autocomplete: AutocompleteFilter,
 };
 


### PR DESCRIPTION
Add a new filter `SearchableEnumFilter` for supporting typing a head input for the EnumFilter.

**EnumFilter example:**

![Screenshot from 2024-07-30 10-06-59](https://github.com/user-attachments/assets/5f0b204f-1456-43fc-b146-31ca5955073e)

**SearchableEnumFilter example:**
![Screenshot from 2024-07-30 10-06-06](https://github.com/user-attachments/assets/818b0803-5399-4a0b-aced-64761de37159)

