### PR TITLE
VMware - filter VMs by available dynamic enum list of hosts

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 import { VSphereVM } from '@kubev2v/types';
 
-import { concernFilter } from './utils/filters/concernFilter';
+import { concernFilter, hostFilter } from './utils/filters';
 import { ProviderVirtualMachinesList, VmData } from './components';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 import { getVmPowerState, useVSphereInventoryVms } from './utils';
@@ -44,11 +44,8 @@ export const vSphereVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
     label: t('Host'),
     isVisible: true,
     isIdentity: false,
-    filter: {
-      type: 'freetext',
-      placeholderLabel: t('Filter by host'),
-    },
     sortable: true,
+    filter: hostFilter(t),
   },
   {
     resourceFieldId: 'folder',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -12,6 +12,7 @@ import {
   loadUserSettings,
   ResourceFieldFactory,
   RowProps,
+  SearchableEnumFilter,
   SearchableGroupedEnumFilter,
   ValueMatcher,
 } from '@kubev2v/common';
@@ -86,9 +87,10 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
       userSettings={userSettings}
       extraSupportedFilters={{
         concerns: SearchableGroupedEnumFilter,
+        host: SearchableEnumFilter,
         features: EnumFilter,
       }}
-      extraSupportedMatchers={[concernsMatcher, featuresMatcher]}
+      extraSupportedMatchers={[concernsMatcher, hostMatcher, featuresMatcher]}
       GlobalActionToolbarItems={showActions ? actions : undefined}
       toId={toId}
       onSelect={onSelectedIds}
@@ -110,4 +112,9 @@ export const concernsMatcher: ValueMatcher = {
 export const featuresMatcher: ValueMatcher = {
   filterType: 'features',
   matchValue: (features: { [key: string]: boolean }) => (filter: string) => !!features?.[filter],
+};
+
+export const hostMatcher: ValueMatcher = {
+  filterType: 'host',
+  matchValue: (value: string) => (filter: string) => value == filter,
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/hostFilter.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/hostFilter.ts
@@ -1,0 +1,19 @@
+import { EnumValue } from '@kubev2v/common';
+
+/**
+ * This component enables filtering the VMware's virtual machines
+ * by the hostname that they are running on.
+ */
+export const hostFilter = (t: (string) => string) => {
+  return {
+    type: 'host',
+    primary: true,
+    placeholderLabel: t('Host'),
+    dynamicFilter: (items: { hostName: string }[]) => ({
+      values: [
+        ...Array.from(new Set(items.map((item) => item.hostName))) // at this point the list contains unique strings that can be used as ID
+          .map((label: string): EnumValue => ({ id: label, label })),
+      ],
+    }),
+  };
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/index.ts
@@ -1,3 +1,4 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
 export * from './concernFilter';
+export * from './hostFilter';
 // @endindex


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1274

This includes the following changes for the **VMware provider VMs list only**:
1. Set the 'Host' filter to be a primary filter.
2. Display a dynamic list of hosts that the VMs run on as an enum filter to select.
3. Enable selecting any number of hosts from the enum filter list. If none, all VMs are filtered.
3. Enable to type-ahead input for displaying a subset of the enum filter list of hosts.

**Before:**
![Screenshot from 2024-07-30 10-47-13](https://github.com/user-attachments/assets/c330a4eb-08c6-4c1f-bb20-a2e8ef167696)                       
 <br><br><br>                
**After:**

![Screenshot from 2024-07-30 11-30-53](https://github.com/user-attachments/assets/c62d4128-b538-4032-a5e0-049e99f46812)
<br><br>
![Screenshot from 2024-07-30 11-30-24](https://github.com/user-attachments/assets/969484e0-9304-4d73-ac63-83df04300b45)
