### PR TITLE
oVirt - filter VMs by available dynamic enum list of hosts

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 
-import { concernFilter } from './utils/filters/concernFilter';
+import { concernFilter, OvirtHostFiler } from './utils/filters';
 import { ProviderVirtualMachinesList, VmData } from './components';
 import { OVirtVirtualMachinesCells } from './OVirtVirtualMachinesRow';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
@@ -47,11 +47,8 @@ export const oVirtVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
     label: t('Host'),
     isVisible: true,
     isIdentity: false,
-    filter: {
-      type: 'freetext',
-      placeholderLabel: t('Filter by host'),
-    },
     sortable: true,
+    filter: OvirtHostFiler(t),
   },
   {
     resourceFieldId: 'path',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EnumToTuple, ResourceFieldFactory } from '@kubev2v/common';
 import { VSphereVM } from '@kubev2v/types';
 
-import { concernFilter, hostFilter } from './utils/filters';
+import { concernFilter, VsphereHostFilter } from './utils/filters';
 import { ProviderVirtualMachinesList, VmData } from './components';
 import { ProviderVirtualMachinesProps } from './ProviderVirtualMachines';
 import { getVmPowerState, useVSphereInventoryVms } from './utils';
@@ -45,7 +45,7 @@ export const vSphereVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
     isVisible: true,
     isIdentity: false,
     sortable: true,
-    filter: hostFilter(t),
+    filter: VsphereHostFilter(t),
   },
   {
     resourceFieldId: 'folder',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
@@ -1,0 +1,22 @@
+import { EnumValue } from '@kubev2v/common';
+
+const labelToFilterItem = (label: string): EnumValue =>
+  label !== '' ? { id: label, label } : { id: label, label: 'Undefined' };
+
+/**
+ * This component enables filtering the oVirt virtual machines
+ * by the hostname that they are running on.
+ */
+export const OvirtHostFiler = (t: (string) => string) => {
+  return {
+    type: 'host',
+    primary: true,
+    placeholderLabel: t('Host'),
+    dynamicFilter: (items: { vm: { host: string } }[]) => ({
+      values: [
+        ...Array.from(new Set(items.map((item) => item.vm.host))) // at this point the list contains unique strings that can be used as ID
+          .map(labelToFilterItem),
+      ],
+    }),
+  };
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/VsphereHostFilter.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/VsphereHostFilter.ts
@@ -1,10 +1,13 @@
 import { EnumValue } from '@kubev2v/common';
 
+const labelToFilterItem = (label: string): EnumValue =>
+  label !== '' ? { id: label, label } : { id: label, label: 'Undefined' };
+
 /**
  * This component enables filtering the VMware's virtual machines
  * by the hostname that they are running on.
  */
-export const hostFilter = (t: (string) => string) => {
+export const VsphereHostFilter = (t: (string) => string) => {
   return {
     type: 'host',
     primary: true,
@@ -12,7 +15,7 @@ export const hostFilter = (t: (string) => string) => {
     dynamicFilter: (items: { hostName: string }[]) => ({
       values: [
         ...Array.from(new Set(items.map((item) => item.hostName))) // at this point the list contains unique strings that can be used as ID
-          .map((label: string): EnumValue => ({ id: label, label })),
+          .map(labelToFilterItem),
       ],
     }),
   };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/index.ts
@@ -1,4 +1,5 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
 export * from './concernFilter';
-export * from './hostFilter';
+export * from './OvirtHostFilter';
+export * from './VsphereHostFilter';
 // @endindex


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1275

This includes the following changes for the oVirt provider VMs list only:

 1. Set the 'Host' filter to be a primary filter.
 2. Display a dynamic list of hosts that the VMs run on as an enum filter to select.
 3. All VMs that are not assigned to any host, will be filtered out by the "Undefined" option.
 4. Enable selecting any number of hosts from the enum filter list. If none, all VMs are filtered.
 5. Enable to type-ahead input for displaying a subset of the enum filter list of hosts.

**Before:**

![Screenshot from 2024-07-31 00-25-26](https://github.com/user-attachments/assets/1a2ae6e5-de88-414c-bee9-dbcac1c44ac7)
<br><br>

**After:**

![Screenshot from 2024-07-31 00-51-45](https://github.com/user-attachments/assets/59397d6d-8da4-4112-8e7b-6d475c2d9c0a)
<br><br>
![Screenshot from 2024-07-31 00-29-53](https://github.com/user-attachments/assets/45e6d914-df38-4293-8582-3010c74062b9)

