### PR TITLE
:lady_beetle: Handle fetching from inventory for users without a full namespaces access role

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -183,7 +183,7 @@ const ProvidersListPage: React.FC<{
     inventory,
     loading: inventoryLoading,
     error: inventoryError,
-  } = useProvidersInventoryList({});
+  } = useProvidersInventoryList({ namespace });
 
   const permissions = useGetDeleteAndEditAccessReview({
     model: ProviderModel,


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1293

Handle providers fetching from inventory for logged users with limited namespace roles (not kubeadmin), who can only list their namespaces content and don't have get permissions to all namespaces.

Before the fix, when such a user tried to fetch providers inventory data (i.e. display the providers list), regardless to current namespace, the "`inventory server is not reachable`" error was always displayed and inventory data fetching failed.

After this fix, such a user that tries to fetch inventory data under his permitted namespace(s), will succeed to do that and no error is displayed.

## Before:
![Screenshot from 2024-08-18 14-38-01](https://github.com/user-attachments/assets/be9ed032-eb46-419d-bc0b-3b888c1ed4a4)

## After


![Screenshot from 2024-08-18 14-35-00](https://github.com/user-attachments/assets/c2bf37a1-2419-4091-9aeb-61e3b7d7a01a)