### PR TITLE
props.resourceData.statusVM may be null

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
@@ -77,7 +77,7 @@ const cellRenderers: Record<string, React.FC<PlanVMsCellProps>> = {
     );
   },
   status: (props: PlanVMsCellProps) => {
-    const pipeline = props.data.statusVM?.pipeline;
+    const pipeline = props.data.statusVM?.pipeline || [];
     let lastRunningItem: V1beta1PlanStatusMigrationVmsPipeline;
 
     if (pipeline[0]?.phase === 'Pending') {

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -35,8 +35,8 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
   const { t } = useForkliftTranslation();
   const { showModal } = useModal();
 
-  const pipeline = props.resourceData.statusVM?.pipeline;
-  const conditions = props.resourceData.statusVM?.conditions;
+  const pipeline = props.resourceData.statusVM?.pipeline || [];
+  const conditions = props.resourceData.statusVM?.conditions || [];
   const pods = props.resourceData.pods;
   const jobs = props.resourceData.jobs;
   const pvcs = props.resourceData.pvcs;
@@ -238,7 +238,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
         </>
       )}
 
-      {(conditions || []).length > 0 && (
+      {conditions.length > 0 && (
         <>
           <SectionHeading
             text={'Conditions'}
@@ -255,7 +255,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
               </Tr>
             </Thead>
             <Tbody>
-              {(conditions || []).map((condition) => (
+              {conditions.map((condition) => (
                 <Tr key={condition.type}>
                   <Td>{condition.type}</Td>
                   <Td>{getStatusLabel(condition.status)}</Td>


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1308

Issue:
When listing vms in a plan, sometimes the pipeline stats is null

Fix:
Add a fallback to empty list