### PR TITLE
:lady_beetle: Fix k8s API's statuses handing in StandardPage component for retrieving resources

### DIFF
--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -333,7 +333,7 @@ export function StandardPage<T>({
     [filteredData, currentPage, itemsPerPage],
   );
 
-  const errorFetchingData = loaded && error;
+  const errorFetchingData = error;
   const noResults = loaded && !error && sortedData.length == 0;
   const noMatchingResults = loaded && !error && filteredData.length === 0 && sortedData.length > 0;
 
@@ -444,7 +444,7 @@ export function StandardPage<T>({
           toId={toId}
           expandedIds={expandedIds}
         >
-          {!loaded && <Loading key="loading" title={t('Loading')} />}
+          {!loaded && !error && <Loading key="loading" title={t('Loading')} />}
           {errorFetchingData && <ErrorState key="error" title={t('Unable to retrieve data')} />}
           {noResults &&
             (customNoResultsFound ?? (


### PR DESCRIPTION
When calling k8s hook APIs for retrieving resources, the API returns two statuses: 
loaded and error.

See https://github.com/openshift/console/blob/7993fd9f652aac0c4c4f7f83e529a46e799b530c/frontend/packages/console-dynamic-plugin-sdk/src/utils/k8s/hooks/useK8sWatchResources.ts#L144-L163


Based on the code and on debugging, if an error status is returned setting to true, the loaded status is not necessarily set to true as well.

Therefore,  in case of an error when loaded is  false, fixing how we handle it in `StandardPage`  component is required to display an API failure's error message of "`Unable to retrieve data"` in the center of the page instead of keep rendering a `Loading` component.

## An example + screenshots:

 in the edge case scenario of a non admin user that trying to list the "all namespaces" resources, the API returns an error of "`403 Forbidden`" and loaded is returned set to `false`.

The providers page appears as follows before the fix:

![Screenshot from 2024-08-22 15-59-14](https://github.com/user-attachments/assets/5f0ebf19-1f95-419e-9bcf-4f2dc0cd5188)


And after the fix:
![Screenshot from 2024-08-22 16-04-51](https://github.com/user-attachments/assets/afb02dc6-a17d-4a05-964f-eb0ca0aed36c)
