### PR TITLE
:lady_beetle: If Plan finished ignore errors and warnings in plan

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
@@ -7,6 +7,37 @@ export const getPlanPhase = (data: PlanData): PlanPhase => {
 
   if (!plan) return 'Unknown';
 
+  // Check condition type
+  const conditions = getConditions(plan);
+
+  if (!conditions || conditions?.length < 1) {
+    return 'Unknown';
+  }
+
+  // Check for Archived
+  if (plan?.spec?.archived && !conditions.includes('Archived')) {
+    return 'Archiving';
+  }
+
+  if (conditions.includes('Archived')) {
+    return 'Archived';
+  }
+
+  // Check for Succeeded
+  if (conditions.includes('Succeeded')) {
+    return 'Succeeded';
+  }
+
+  // Check for Canceled
+  if (conditions.includes('Canceled')) {
+    return 'Canceled';
+  }
+
+  // CHeck for Running
+  if (conditions.includes('Executing')) {
+    return 'Running';
+  }
+
   // Check condition category
   const isCritical = plan?.status?.conditions?.find(
     (c) => c.category === 'Critical' && c.status === 'True',
@@ -16,32 +47,8 @@ export const getPlanPhase = (data: PlanData): PlanPhase => {
     return 'Error';
   }
 
-  // Check condition category
-  const isWarn = plan?.status?.conditions?.find(
-    (c) => c.category === 'Warn' && c.status === 'True',
-  );
-
   // Check for vm errors
   const vmError = plan?.status?.migration?.vms?.find((vm) => vm?.error);
-
-  // Check condition type
-  const conditions = getConditions(plan);
-
-  if (!conditions || conditions?.length < 1) {
-    return 'Unknown';
-  }
-
-  if (plan?.spec?.archived && !conditions.includes('Archived')) {
-    return 'Archiving';
-  }
-
-  if (conditions.includes('Archived')) {
-    return 'Archived';
-  }
-
-  if (conditions.includes('Succeeded')) {
-    return 'Succeeded';
-  }
 
   if (conditions.includes('Failed')) {
     return 'Failed';
@@ -51,16 +58,13 @@ export const getPlanPhase = (data: PlanData): PlanPhase => {
     return 'vmError';
   }
 
+  // Check condition category
+  const isWarn = plan?.status?.conditions?.find(
+    (c) => c.category === 'Warn' && c.status === 'True',
+  );
+
   if (isWarn) {
     return 'Warning';
-  }
-
-  if (conditions.includes('Canceled')) {
-    return 'Canceled';
-  }
-
-  if (conditions.includes('Executing')) {
-    return 'Running';
   }
 
   if (conditions.includes('Ready')) {


### PR DESCRIPTION
Ref: https://github.com/kubev2v/forklift-console-plugin/issues/1314

Issue:
Critical errors take president over cancel, success and archived plans.
For example an "Archived" or "Succeeded"  plan will show "Error" instead of "Archived" or "Succeeded"  if it has an error condition

Fix:
Ignore errors and warnings for completed plans

Screenshot:
Before:
![screenshot-console-openshift-console apps bm01-libvirt-qe-pek2 lab eng pek2 redhat com-2024 09 02-14_09_03](https://github.com/user-attachments/assets/415248ba-b4e4-4f6f-99f1-c1850a0bee0d)

After:
![screenshot-localhost_9000-2024 09 02-14_08_52](https://github.com/user-attachments/assets/72237b5a-7726-41a0-a566-108b9d51430c)
