### PR TITLE
:soap: Force e2e tests to use console v4.15

### DIFF
--- a/ci/yaml/okd-console.yaml
+++ b/ci/yaml/okd-console.yaml
@@ -83,7 +83,7 @@ spec:
       serviceAccountName: console
       containers:
       - name: console
-        image: quay.io/openshift/origin-console:latest
+        image: quay.io/openshift/origin-console:4.15
         env:
         - name: BRIDGE_USER_AUTH
           value: disabled


### PR DESCRIPTION
Issue:
Our CI scripts use un authenticated console, authenticated mode is disabled in ver > 4.15

Fix:
Force e2e tests to use console v4.15