### PR TITLE
:lady_beetle: Fix Negative number for plan/migration status  VMs count

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getMigrationVmsCounts.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getMigrationVmsCounts.ts
@@ -18,13 +18,14 @@ export const getMigrationVmsCounts = (vms: V1beta1PlanStatusMigrationVms[]): Mig
   );
   const vmsCompleted = vms.filter((vm) => vm?.completed);
   const vmsError = vms.filter((vm) => vm?.error);
+  const success = vmsCompleted.length - vmsError.length - vmsCanceled.length;
 
   return {
     completed: vmsCompleted.length,
     total: vms.length,
     canceled: vmsCanceled.length,
     error: vmsError.length,
-    success: vmsCompleted.length - vmsError.length - vmsCanceled.length,
+    success: success >= 0 ? success : 0,
   };
 };
 


### PR DESCRIPTION
On both plan and migration status fields, the number of displayed migrated VMs within the status' progress bar label is sometimes negative, i.e.  the value of `X` within `"X of Y VMs migrated" `is sometimes negative.

This is reproduced when at least one VM failed to migrate.

The reason is that failed VMs are often marked with an error but they are not marked as completed yet, so the calculation of migrated = completed - error < 0.

### Before:
![Screenshot from 2024-09-05 18-12-18](https://github.com/user-attachments/assets/a67fb809-85d0-495f-aa64-d8f45f588576)

![Screenshot from 2024-09-05 17-54-25](https://github.com/user-attachments/assets/49286ea0-fd92-4a67-8754-29aeff1ea828)

![Screenshot from 2024-09-05 17-54-32](https://github.com/user-attachments/assets/1421af8b-fb2c-4897-8d33-0d2ecd19edda)


### After:
![Screenshot from 2024-09-05 18-14-25](https://github.com/user-attachments/assets/61960ff2-d048-48fc-a6fe-d70c95c6c0a3)

![Screenshot from 2024-09-05 18-14-41](https://github.com/user-attachments/assets/25d49319-a84b-4682-abe3-51192c924614)

![Screenshot from 2024-09-05 18-15-00](https://github.com/user-attachments/assets/beeea63e-2e6e-4d05-8d8c-588748700ed8)
