### PR TITLE
:lady_beetle: when migration task isn't completed but the migration is successful, mark task as successful

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
@@ -8,6 +8,7 @@ import { FlexItem, Popover, ProgressStep, ProgressStepper } from '@patternfly/re
 import { ResourcesAlmostFullIcon, ResourcesFullIcon } from '@patternfly/react-icons';
 import { Table, Tr } from '@patternfly/react-table';
 
+import { hasTaskCompleted } from '../../../utils';
 import { PlanVMsCellProps } from '../components';
 import { NameCellRenderer } from '../components/NameCellRenderer';
 import { VMData } from '../types';
@@ -222,7 +223,11 @@ const countTasks = (diskTransfer: V1beta1PlanStatusMigrationVmsPipeline) => {
   }
 
   const totalTasks = diskTransfer.tasks.length;
-  const completedTasks = diskTransfer.tasks.filter((task) => task.phase === 'Completed').length;
+
+  // search num of completed tasks (either tasks that completed successfully or ones that aren't finished but their pipeline step is).
+  const completedTasks = diskTransfer.tasks.filter((task) =>
+    hasTaskCompleted(task.phase, diskTransfer),
+  ).length;
 
   return { totalTasks, completedTasks };
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -26,6 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { TaskIcon } from '@patternfly/react-icons';
 
+import { hasTaskCompleted } from '../../../utils';
 import { PipelineTasksModal } from '../modals';
 import { VMData } from '../types';
 
@@ -352,7 +353,9 @@ const getJobPhase = (job: IoK8sApiBatchV1Job) => {
 
 const getPipelineTasks = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
   const tasks = pipeline?.tasks || [];
-  const tasksCompleted = tasks.filter((c) => c.phase === 'Completed');
+
+  // search for all completed tasks (either tasks that completed successfully or ones that aren't finished but their pipeline step is).
+  const tasksCompleted = tasks.filter((c) => hasTaskCompleted(c.phase, pipeline));
 
   return { total: tasks.length, completed: tasksCompleted.length, name: pipeline.name };
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineCompleted.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineCompleted.tsx
@@ -1,0 +1,10 @@
+import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
+
+/**
+ * Check if a given migration's pipeline step has completed successfully.
+ *
+ * @param {V1beta1PlanStatusMigrationVmsPipeline} pipeline - A given migration's pipeline step
+ * @returns {boolean} - True if the migration step has completed successfully, false otherwise.
+ */
+export const hasPipelineCompleted = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) =>
+  !pipeline?.error && pipeline?.phase === 'Completed';

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasTaskCompleted.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasTaskCompleted.tsx
@@ -1,0 +1,18 @@
+import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
+
+import { hasPipelineCompleted } from './hasPipelineCompleted';
+
+/**
+ *  Check if a given task within a pipeline has completed.
+ *
+ *  A task if marked as completed successfully if its phase is marked as completed or if
+ *  its phase is not set but its contained pipeline step has completed successfully.
+ *
+ * @param {string } taskPhase A given task's phase
+ * @param {V1beta1PlanStatusMigrationVmsPipeline} pipeline - A given migration's pipeline step which includes the task
+ * @returns {boolean} - Returns true if the task has completed.
+ */
+export const hasTaskCompleted = (
+  taskPhase: string,
+  pipeline: V1beta1PlanStatusMigrationVmsPipeline,
+) => taskPhase === 'Completed' || (taskPhase === undefined && hasPipelineCompleted(pipeline));

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/index.ts
@@ -4,8 +4,10 @@ export * from './constants';
 export * from './getInventoryApiUrl';
 export * from './getValueByJsonPath';
 export * from './hasObjectChangedInGivenFields';
+export * from './hasPipelineCompleted';
 export * from './hasPlanEditable';
 export * from './hasPlanMappingsChanged';
+export * from './hasTaskCompleted';
 export * from './mapMappingsIdsToLabels';
 export * from './patchPlanMappingsData';
 // @endindex


### PR DESCRIPTION

Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1305

In case a VM migration task is not marked as finished (i.e. task.phase is undefined), but its pipeline step is marked as completed successfully then mark the task in UI as completed successfully as well.

This will solve cases as mentioned in #1305 in which the `DiskTransferV2v` or `DiskTransfer` tasks aren't completed although the migration is successful.

This fix was done for all migration VM types (not necessarily limited for vSphere or OVA VMs).

### Before
![Screenshot from 2024-09-12 15-10-18](https://github.com/user-attachments/assets/2535007b-995b-41e3-bdfb-75004e957a15)

![Screenshot from 2024-09-12 15-12-11](https://github.com/user-attachments/assets/1c8e071e-d803-40e6-92af-ddc087c0c5f3)


### After
![Screenshot from 2024-09-12 15-13-26](https://github.com/user-attachments/assets/91c24d08-c197-4052-b820-595bcc26f00b)

![Screenshot from 2024-09-12 15-14-42](https://github.com/user-attachments/assets/9a662668-509c-4b60-a594-20e63fca2201)

Note that the Task modal popup will still show the real info and will reflect that the task was not really finished:
![Screenshot from 2024-09-12 15-15-42](https://github.com/user-attachments/assets/07931f3a-f98c-4392-9928-04d57a8b7a72)
