### PR TITLE
Avoid wrapping the migration VM status pipeline's name to the next line

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -288,7 +288,7 @@ export const MigrationVirtualMachinesRowExtended: React.FC<RowProps<VMData>> = (
         <Tbody>
           {(pipeline || []).map((p) => (
             <Tr key={p?.name}>
-              <Td>
+              <Td modifier="nowrap">
                 <ProgressStepper isCompact isVertical={true} isCenterAligned={false}>
                   <ProgressStep
                     key={p?.name}


### PR DESCRIPTION
Withing the Plans -> VMs tab -> expended VM status section -> Pipeline table -> name column:
Avoid automatic wrapping of the "`VirtualMachineCreation`" cell content into next line in specific window's width.


### Before:
[Screencast from 2024-09-12 20-13-00.webm](https://github.com/user-attachments/assets/761a20c9-35a0-4924-ab3d-2f55ab0fea14)

### After
[Screencast from 2024-09-12 20-15-33.webm](https://github.com/user-attachments/assets/a52b43c7-d821-42bd-8e8a-cb550a76cb2c)
