### PR TITLE
:lady_beetle: Changing stacking order of NamespaceDropdown pull down menu overlappng the PlanCreatePage wizard

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.style.css
@@ -79,3 +79,7 @@
 .forklift--create-plan--progress-current-step-clickable:hover {
   cursor: pointer;
 }
+
+.forklift--create-plan--wizard-appearance-order {
+  z-index: 1;
+}

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -108,6 +108,7 @@ export const PlanCreatePage: React.FC<{ namespace: string }> = ({ namespace }) =
 
       <PageSection variant="light">
         <Wizard
+          className="forklift--create-plan--wizard-appearance-order"
           navAriaLabel={`${title} steps`}
           mainAriaLabel={`${title} content`}
           steps={steps}


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/issues/1312

In create plan wizard, the `NamespaceDropdown` pull down menu is hidden when opened by the `PlanCreatePage` wizard.
Exposing the `NamespaceDropdown` menu on top of the wizard is fixed in this PR by changing the stacking order.

### Before:
[Screencast from 2024-09-12 22-28-07.webm](https://github.com/user-attachments/assets/ed79a46c-e1f9-42f0-90a3-5fe9f5713761)


### After:
[Screencast from 2024-09-12 22-28-55.webm](https://github.com/user-attachments/assets/1d9183b1-5137-418d-86bb-ac8437a34e68)
