### PR TITLE
Add source type and name when creating a network map from ocp to ocp

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -303,6 +303,8 @@ const handlers: {
         sourceNetworkLabelToId[source] === 'pod'
           ? { type: 'pod' }
           : {
+              type: sourceProvider?.spec?.type === 'openshift' ? 'multus' : undefined,
+              name: sourceProvider?.spec?.type === 'openshift' ? source : undefined,
               id: sourceNetworkLabelToId[source],
             },
       destination:


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-1201

Issue:
When creating a network map from with OCP provider as source, we need to indicate the type of the network.

Fix:
Add 'type' and 'name' to source network when source provider is openshift