### PR TITLE
:lady_beetle: Wrap password/token fields with hidden content option with InputGroup

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/EsxiCredentialsEdit.tsx
@@ -5,7 +5,15 @@ import { CertificateUpload } from 'src/modules/Providers/utils/components/Certif
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, Divider, Form, Popover, Switch, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Divider,
+  Form,
+  InputGroup,
+  Popover,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
@@ -158,23 +166,25 @@ export const EsxiCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onCh
         helperTextInvalid={state.validation.password.msg}
         validated={state.validation.password.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          aria-label="Password input"
-          onChange={(e, v) => onChangePassword(v, e)}
-          value={password}
-          validated={state.validation.password.type}
-        />
-        <Button
-          variant="control"
-          onClick={onClickTogglePassword}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            aria-label="Password input"
+            onChange={(e, v) => onChangePassword(v, e)}
+            value={password}
+            validated={state.validation.password.type}
+          />
+          <Button
+            variant="control"
+            onClick={onClickTogglePassword}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <Divider />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenshiftCredentialsEdit.tsx
@@ -5,7 +5,15 @@ import { CertificateUpload } from 'src/modules/Providers/utils/components/Certif
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, Divider, Form, Popover, Switch, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Divider,
+  Form,
+  InputGroup,
+  Popover,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
@@ -133,23 +141,25 @@ export const OpenshiftCredentialsEdit: React.FC<EditComponentProps> = ({ secret,
         helperTextInvalid={state.validation.token.msg}
         validated={state.validation.token.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          aria-label="Token input"
-          onChange={(e, v) => onChangeToken(v, e)}
-          value={token}
-          validated={state.validation.token.type}
-        />
-        <Button
-          variant="control"
-          onClick={onClickTogglePassword}
-          aria-label={state.passwordHidden ? 'Show token' : 'Hide token'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            aria-label="Token input"
+            onChange={(e, v) => onChangeToken(v, e)}
+            value={token}
+            validated={state.validation.token.type}
+          />
+          <Button
+            variant="control"
+            onClick={onClickTogglePassword}
+            aria-label={state.passwordHidden ? 'Show token' : 'Hide token'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <Divider />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
@@ -4,7 +4,7 @@ import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Pro
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, TextInput } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 
@@ -113,24 +113,26 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
         helperTextInvalid={state.validation.applicationCredentialSecret.msg}
         validated={state.validation.applicationCredentialSecret.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          id="applicationCredentialSecret"
-          name="applicationCredentialSecret"
-          value={applicationCredentialSecret}
-          onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
-          validated={state.validation.applicationCredentialSecret.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            id="applicationCredentialSecret"
+            name="applicationCredentialSecret"
+            value={applicationCredentialSecret}
+            onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
+            validated={state.validation.applicationCredentialSecret.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
@@ -4,7 +4,7 @@ import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Pro
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, TextInput } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 
@@ -109,24 +109,26 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
         helperTextInvalid={state.validation.applicationCredentialSecret.msg}
         validated={state.validation.applicationCredentialSecret.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          id="applicationCredentialSecret"
-          name="applicationCredentialSecret"
-          value={applicationCredentialSecret}
-          onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
-          validated={state.validation.applicationCredentialSecret.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            id="applicationCredentialSecret"
+            name="applicationCredentialSecret"
+            value={applicationCredentialSecret}
+            onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
+            validated={state.validation.applicationCredentialSecret.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
@@ -4,7 +4,7 @@ import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Pro
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, TextInput } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 
@@ -105,23 +105,25 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
         helperTextInvalid={state.validation.password.msg}
         validated={state.validation.password.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          aria-label="Password input"
-          value={password}
-          onChange={(e, v) => onChangeFactory('password')(v, e)}
-          validated={state.validation.password.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            aria-label="Password input"
+            value={password}
+            onChange={(e, v) => onChangeFactory('password')(v, e)}
+            validated={state.validation.password.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
@@ -4,7 +4,7 @@ import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Pro
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, TextInput } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 
@@ -82,24 +82,26 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
         helperTextInvalid={state.validation.token.msg}
         validated={state.validation.token.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          id="token"
-          name="token"
-          value={token}
-          onChange={(e, v) => onChangeFactory('token')(v, e)}
-          validated={state.validation.token.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            id="token"
+            name="token"
+            value={token}
+            onChange={(e, v) => onChangeFactory('token')(v, e)}
+            validated={state.validation.token.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
@@ -4,7 +4,7 @@ import { openstackSecretFieldValidator, safeBase64Decode } from 'src/modules/Pro
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, TextInput } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 
@@ -84,24 +84,26 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
         helperTextInvalid={state.validation.token.msg}
         validated={state.validation.token.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          id="token"
-          name="token"
-          value={token}
-          onChange={(e, v) => onChangeFactory('token')(v, e)}
-          validated={state.validation.token.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            id="token"
+            name="token"
+            value={token}
+            onChange={(e, v) => onChangeFactory('token')(v, e)}
+            validated={state.validation.token.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <FormGroupWithHelpText

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OvirtCredentialsEdit.tsx
@@ -5,7 +5,15 @@ import { CertificateUpload } from 'src/modules/Providers/utils/components/Certif
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, Divider, Form, Popover, Switch, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Divider,
+  Form,
+  InputGroup,
+  Popover,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
@@ -164,23 +172,25 @@ export const OvirtCredentialsEdit: React.FC<EditComponentProps> = ({ secret, onC
         helperTextInvalid={state.validation.password.msg}
         validated={state.validation.password.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          aria-label="Password input"
-          value={password}
-          validated={state.validation.password.type}
-          onChange={(e, v) => onChangePassword(v, e)}
-        />
-        <Button
-          variant="control"
-          onClick={onClickTogglePassword}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            aria-label="Password input"
+            value={password}
+            validated={state.validation.password.type}
+            onChange={(e, v) => onChangePassword(v, e)}
+          />
+          <Button
+            variant="control"
+            onClick={onClickTogglePassword}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <Divider />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/VCenterCredentialsEdit.tsx
@@ -5,7 +5,15 @@ import { CertificateUpload } from 'src/modules/Providers/utils/components/Certif
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import { Button, Divider, Form, Popover, Switch, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  Divider,
+  Form,
+  InputGroup,
+  Popover,
+  Switch,
+  TextInput,
+} from '@patternfly/react-core';
 import EyeIcon from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
@@ -152,23 +160,25 @@ export const VCenterCredentialsEdit: React.FC<EditComponentProps> = ({ secret, o
         helperTextInvalid={state.validation.password.msg}
         validated={state.validation.password.type}
       >
-        <TextInput
-          spellCheck="false"
-          className="pf-u-w-75"
-          isRequired
-          type={state.passwordHidden ? 'password' : 'text'}
-          aria-label="Password input"
-          onChange={(e, v) => onChangePassword(v, e)}
-          value={password}
-          validated={state.validation.password.type}
-        />
-        <Button
-          variant="control"
-          onClick={togglePasswordHidden}
-          aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
-        >
-          {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-        </Button>
+        <InputGroup>
+          <TextInput
+            spellCheck="false"
+            className="pf-u-w-75"
+            isRequired
+            type={state.passwordHidden ? 'password' : 'text'}
+            aria-label="Password input"
+            onChange={(e, v) => onChangePassword(v, e)}
+            value={password}
+            validated={state.validation.password.type}
+          />
+          <Button
+            variant="control"
+            onClick={togglePasswordHidden}
+            aria-label={state.passwordHidden ? 'Show password' : 'Hide password'}
+          >
+            {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+          </Button>
+        </InputGroup>
       </FormGroupWithHelpText>
 
       <Divider />

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/Hosts/modals/VSphereNetworkModal.tsx
@@ -11,6 +11,7 @@ import {
   Form,
   HelperText,
   HelperTextItem,
+  InputGroup,
   Modal,
   ModalVariant,
   Text,
@@ -270,19 +271,21 @@ export const VSphereNetworkModal: React.FC<VSphereNetworkModalProps> = ({
               helperTextInvalid={t('Invalid password')}
               validated={state.validation.password}
             >
-              <TextInput
-                spellCheck="false"
-                className="forklift-host-modal-input-secret"
-                isRequired
-                type={state.passwordHidden ? 'password' : 'text'}
-                aria-label="Password input"
-                value={state.password}
-                onChange={(e, v) => onChangePassword(v, e)}
-                validated={state.validation.password}
-              />
-              <Button variant="control" onClick={togglePasswordHidden}>
-                {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-              </Button>
+              <InputGroup>
+                <TextInput
+                  spellCheck="false"
+                  className="forklift-host-modal-input-secret"
+                  isRequired
+                  type={state.passwordHidden ? 'password' : 'text'}
+                  aria-label="Password input"
+                  value={state.password}
+                  onChange={(e, v) => onChangePassword(v, e)}
+                  validated={state.validation.password}
+                />
+                <Button variant="control" onClick={togglePasswordHidden}>
+                  {state.passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                </Button>
+              </InputGroup>
             </FormGroupWithHelpText>
           </>
         )}


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1572

After migrating to Patternfly 5, all  password/token fields in all forms that include the 'hidden content button' field, were split into 2 lines - i.e. the button was pushed to next line.

For fixing, need to wrap the field's entries with the `InputGroup` item.


### Few examples:
### Before
![Screenshot from 2024-10-07 12-00-56](https://github.com/user-attachments/assets/52b0ef32-f1e6-4145-b160-81f566db1704)
![Screenshot from 2024-10-07 12-03-36](https://github.com/user-attachments/assets/87f80b0e-ac26-455f-86fa-703bd66b6d04)
![Screenshot from 2024-10-07 12-03-25](https://github.com/user-attachments/assets/24f43da8-d352-4698-ba1a-0161bb3f4466)


### After
![Screenshot from 2024-10-07 12-01-30](https://github.com/user-attachments/assets/7379e908-866c-4b6e-8e94-711cff752ad9)
![Screenshot from 2024-10-07 12-01-57](https://github.com/user-attachments/assets/bebca0e2-354b-451b-8224-bcb57ac68cd6)
![Screenshot from 2024-10-07 12-02-30](https://github.com/user-attachments/assets/372810f6-c98f-4823-8240-7f94e228caaa)

