### PR TITLE
[v2.7.2] Add source type and name when creating a network map from ocp to ocp

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -303,6 +303,8 @@ const handlers: {
         sourceNetworkLabelToId[source] === 'pod'
           ? { type: 'pod' }
           : {
+              type: sourceProvider?.spec?.type === 'openshift' ? 'multus' : undefined,
+              name: sourceProvider?.spec?.type === 'openshift' ? source : undefined,
               id: sourceNetworkLabelToId[source],
             },
       destination:


### PR DESCRIPTION
Ref:
https://issues.redhat.com/browse/MTV-1201
https://issues.redhat.com/browse/MTV-1297

Backport of: https://github.com/kubev2v/forklift-console-plugin/pull/1344