### PR TITLE
Add a quesiton mark to the text msg of the Plan VMs Delete Modal

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -47,7 +47,7 @@
   "Archive Plan": "Archive Plan",
   "Archived": "Archived",
   "Archiving": "Archiving",
-  "Are you sure you want to delete this virtual machines from the migration plan.": "Are you sure you want to delete this virtual machines from the migration plan.",
+  "Are you sure you want to delete this virtual machines from the migration plan?": "Are you sure you want to delete this virtual machines from the migration plan?",
   "Assessment": "Assessment",
   "Authentication type": "Authentication type",
   "Bandwidth": "Bandwidth",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
@@ -84,7 +84,7 @@ export const PlanVMsDeleteModal: React.FC<PlanVMsDeleteModalProps> = ({ plan, se
       actions={actions}
     >
       <div className="forklift-edit-modal-body">
-        {t('Are you sure you want to delete this virtual machines from the migration plan.')}
+        {t('Are you sure you want to delete this virtual machines from the migration plan?')}
       </div>
 
       {alertMessage}


### PR DESCRIPTION
Add a missing question mark to the end of text message displayed in the Plan's delete vms popup.

### Before
![Screenshot from 2024-10-15 14-45-50](https://github.com/user-attachments/assets/70745014-bad5-4fee-91e4-d27c5dfe15a9)

### After
![Screenshot from 2024-10-15 14-41-23](https://github.com/user-attachments/assets/30dbc092-4467-4f44-9cbd-e114e624e62e)
