### PR TITLE
Fix typo in delete virtual machines from migration plan popup

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -37,7 +37,7 @@
   "All discovered storages have been mapped to the default storage.": "All discovered storages have been mapped to the default storage.",
   "All networks detected on the selected VMs require a mapping.": "All networks detected on the selected VMs require a mapping.",
   "All storages detected on the selected VMs require a mapping.": "All storages detected on the selected VMs require a mapping.",
-  "All virtual machines planed for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.": "All virtual machines planed for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.",
+  "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.": "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.",
   "Application credential ID": "Application credential ID",
   "Application credential name": "Application credential name",
   "Application credential secret": "Application credential secret",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
@@ -28,7 +28,7 @@ export const PlanVMsDeleteModal: React.FC<PlanVMsDeleteModalProps> = ({ plan, se
         <AlertMessageForModals
           title={t('Error')}
           message={t(
-            'All virtual machines planed for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
+            'All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
           )}
         />,
       );


### PR DESCRIPTION
planed => planned

### After 
![Screenshot from 2024-10-15 17-46-01](https://github.com/user-attachments/assets/c98018cd-bed4-4f6f-a998-425a0a86cb02)
