### PR TITLE
remove prefetch due to KFLUXBUGS-1508

### DIFF
--- a/.tekton/forklift-console-plugin-pull-request.yaml
+++ b/.tekton/forklift-console-plugin-pull-request.yaml
@@ -20,8 +20,9 @@ spec:
   params:
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "npm", "path": "."}'
+  # Add again when KFLUXBUGS-1508 is fixed
+  # - name: prefetch-input
+  #   value: '{"type": "npm", "path": "."}'
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/forklift-console-plugin-push.yaml
+++ b/.tekton/forklift-console-plugin-push.yaml
@@ -19,8 +19,9 @@ spec:
   params:
   - name: build-source-image
     value: "true"
-  - name: prefetch-input
-    value: '{"type": "npm", "path": "."}'
+  # Add again when KFLUXBUGS-1508 is fixed
+  # - name: prefetch-input
+  #   value: '{"type": "npm", "path": "."}'
   - name: git-url
     value: '{{source_url}}'
   - name: revision


### PR DESCRIPTION
Due to bug KFLUXBUGS-1508, the source image is never building, so by removing the prefetch task, there are less resources to add to it