### PR TITLE
Add --arch when running podman to allow running on ARM machines

### DIFF
--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -99,4 +99,5 @@ podman run \
     --publish=${CONSOLE_PORT}:${CONSOLE_PORT} \
     --name=${CONSOLE_CONTAINER_NAME} \
     --env "BRIDGE_*" \
+    --arch=amd64 \
     ${CONSOLE_IMAGE}


### PR DESCRIPTION
As suggested by @jschuler add a `--arch=amd64` flag to allow running the console pod using `podman` on an ARM machine, such as macos