### PR TITLE
For VDDK help text - replace the example with a format

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -4,7 +4,7 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
   // For a newly opened form where the field is not set yet, set the validation type to default.
   if (vddkImage === undefined)
     return {
-      msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
+      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
       type: 'default',
     };
 
@@ -18,19 +18,19 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
 
   if (trimmedVddkImage === '')
     return {
-      msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
+      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
       type: 'error',
     };
 
   if (!isValidTrimmedVddkImage) {
     return {
       type: 'error',
-      msg: 'The VDDK image is invalid. VDDK image should be a valid container image, for example: quay.io/kubev2v/vddk:latest .',
+      msg: 'The VDDK image is invalid. VDDK image should be a valid container image in the format of <registry_route_or_server_path>/vddk:<tag> .',
     };
   }
 
   return {
     type: 'success',
-    msg: 'VMware Virtual Disk Development Kit (VDDK) image, for example: quay.io/kubev2v/vddk:latest .',
+    msg: 'VMware Virtual Disk Development Kit (VDDK) image in the format of <registry_route_or_server_path>/vddk:<tag> .',
   };
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
@@ -22,7 +22,7 @@ export function vsphereProviderValidator(provider: V1beta1Provider): ValidationM
 
   if (emptyVddkInitImage === 'yes' && vddkInitImage === '') {
     return {
-      msg: 'The VDDK image is empty, it is recommended to provide an image, for example: quay.io/kubev2v/vddk:latest .',
+      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
       type: 'warning',
     };
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
@@ -26,8 +26,6 @@ export const VDDKDetailsItem: React.FC<ProviderDetailsItemProps> = ({
       valid container image path in the format of{' '}
       <strong>registry_route_or_server_path/vddk:&#8249;tag&#8250;</strong>.<br />
       <br />
-      For example: <strong>quay.io/kubev2v/example:latest</strong>.<br />
-      <br />
       It is strongly recommended to specify a VDDK init image to accelerate migrations.
     </ForkliftTrans>
   );


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1552

To avoid users from using the URL example which was provided for the Vsphere's VDDK help text field  (.....`for example: quay.io/kubev2v/vddk:latest` ) , 
replace the help text to use a format suggestion instead (...`in the format of <registry_route_or_server_path>/vddk:<tag> ..`)

This is relevant for the create, edit, tooltip fields for all validaiton statuses (error, success, default).

### Screenshots

### Before
![Screenshot from 2024-11-19 21-09-33](https://github.com/user-attachments/assets/adff20a1-2143-4a92-aeb3-ffd473589f2d)
![Screenshot from 2024-11-19 20-27-12](https://github.com/user-attachments/assets/c839a46f-7f50-4f93-a7ff-cebe941b29df)
![Screenshot from 2024-11-19 20-26-48](https://github.com/user-attachments/assets/ca51839b-bcbe-462b-9553-7ccd48d7fabf)


### After
![Screenshot from 2024-11-19 21-12-45](https://github.com/user-attachments/assets/8410a77b-5972-44f7-971c-32b1cb7085f4)
![Screenshot from 2024-11-19 21-11-09](https://github.com/user-attachments/assets/8b16a3c0-abbb-4946-a54f-9ebef7f02876)
![Screenshot from 2024-11-19 21-11-40](https://github.com/user-attachments/assets/46357a56-f22f-4723-b5ff-42c184c2b6b3)
