### PR TITLE
MTV-1698: Updating 2.6 doc references in forklift-console-plugin

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
+++ b/packages/forklift-console-plugin/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
@@ -42,7 +42,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>
@@ -64,7 +64,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>
@@ -86,7 +86,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>
@@ -108,7 +108,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>
@@ -130,7 +130,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>
@@ -152,7 +152,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#advanced-migration-options_mtv'
             }
             helpContent={
               <Text>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/editLUKSModalBody.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/editLUKSModalBody.tsx
@@ -4,7 +4,7 @@ import { ForkliftTrans } from 'src/utils';
 import { ExternalLink } from '@kubev2v/common';
 
 export const VIRT_V2V_HELP_LINK =
-  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#creating-migration-plans-ui';
+  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#creating-migration-plans-ui';
 
 export const editLUKSModalBody = (
   <>

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
@@ -4,7 +4,7 @@ import { ForkliftTrans } from 'src/utils';
 import { ExternalLink } from '@kubev2v/common';
 
 export const CREATE_VDDK_HELP_LINK =
-  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
+  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
 
 export const VDDKHelperText: React.FC = () => (
   <ForkliftTrans>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
@@ -16,7 +16,7 @@ export const TransferNetworkDetailsItem: React.FC<ProviderDetailsItemProps> = ({
   const { showModal } = useModal();
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#selecting-migration-network-for-virt-provider_mtv';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#selecting-migration-network-for-virt-provider_mtv';
   const defaultHelpContent = t(
     `You can select a default migration network for an OpenShift Virtualization provider in the
     Red Hat OpenShift web console to improve performance. The default migration network is used to

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
@@ -18,7 +18,7 @@ export const TypeDetailsItem: React.FC<ProviderDetailsItemProps> = ({
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-providers';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-providers';
   const defaultHelpContent = t(
     `Specify the type of source provider. Allowed values are ova, ovirt, vsphere,
       openshift, and openstack. This label is needed to verify the credentials are correct when the remote system is accessible and, for RHV, to retrieve the Manager CA certificate when

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/URLDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/URLDetailsItem.tsx
@@ -16,7 +16,7 @@ export const URLDetailsItem: React.FC<ProviderDetailsItemProps> = ({
   const { showModal } = useModal();
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-providers';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-providers';
   const defaultHelpContent =
     t(`URL of the providers API endpoint. The URL must be a valid endpoint for the provider type, see
       the documentation for each provider type to learn more about the URL format.`);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
@@ -19,7 +19,7 @@ export const VDDKDetailsItem: React.FC<ProviderDetailsItemProps> = ({
   const { showModal } = useModal();
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.6/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
   const defaultHelpContent = (
     <ForkliftTrans>
       Virtual Disk Development Kit (VDDK) container init image path. The path must be empty or a


### PR DESCRIPTION
### JIRA

* [MTV-1698](https://issues.redhat.com/browse/MTV-1698)

The `forklift-console-plugin` repo contains typescript links to MTV documentation. Some of these links refer to the MTV 2.6 documents.

This PR updates those references to 2.7. I have checked the links and ensured they are valid.