### PR TITLE
Allow editing plan settings only for specific plan's statuses

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
@@ -103,5 +103,19 @@ export const isPlanSucceeded = (plan: V1beta1Plan) => {
   return conditions?.includes('Succeeded');
 };
 
+export const isPlanEditable = (plan: V1beta1Plan) => {
+  const planStatus = getPlanPhase({ obj: plan });
+
+  return (
+    planStatus === 'Unknown' ||
+    planStatus === 'Canceled' ||
+    planStatus === 'Error' ||
+    planStatus === 'Failed' ||
+    planStatus === 'vmError' ||
+    planStatus === 'Warning' ||
+    planStatus === 'Ready'
+  );
+};
+
 const getConditions = (obj: V1beta1Plan) =>
   obj?.status?.conditions?.filter((c) => c.status === 'True').map((c) => c.type);

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PreserveClusterCpuModelDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PreserveClusterCpuModelDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -40,6 +41,7 @@ export const PreserveClusterCpuModelDetailsItem: React.FC<PlanDetailsItemProps> 
       crumbs={['spec', 'preserveClusterCpuModel']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(
             <EditPlanPreserveClusterCpuModel

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PreserveStaticIPsDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PreserveStaticIPsDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -40,6 +41,7 @@ export const PreserveStaticIPsDetailsItem: React.FC<PlanDetailsItemProps> = ({
       crumbs={['spec', 'preserveStaticIPs']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(
             <EditPlanPreserveStaticIPs

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/RootDiskDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/RootDiskDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -30,7 +31,11 @@ export const RootDiskDetailsItem: React.FC<PlanDetailsItemProps> = ({
       helpContent={helpContent ?? defaultHelpContent}
       moreInfoLink={VIRT_V2V_HELP_LINK}
       crumbs={['spec', 'vms', 'rootDisk']}
-      onEdit={canPatch && (() => showModal(<EditRootDisk resource={resource} />))}
+      onEdit={
+        canPatch &&
+        isPlanEditable(resource) &&
+        (() => showModal(<EditRootDisk resource={resource} />))
+      }
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/SetLUKSEncryptionPasswordsDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/SetLUKSEncryptionPasswordsDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -43,6 +44,7 @@ export const SetLUKSEncryptionPasswordsDetailsItem: React.FC<PlanDetailsItemProp
       crumbs={['spec', 'vms', 'luks']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(
             <EditLUKSEncryptionPasswords

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/TargetNamespaceDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/TargetNamespaceDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -28,6 +29,7 @@ export const TargetNamespaceDetailsItem: React.FC<PlanDetailsItemProps> = ({
       crumbs={['spec', 'targetNamespace ']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(
             <EditPlanTargetNamespace

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/TransferNetworkDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/TransferNetworkDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -37,6 +38,7 @@ export const TransferNetworkDetailsItem: React.FC<PlanDetailsItemProps> = ({
       crumbs={['spec', 'transferNetwork ']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(
             <EditPlanTransferNetwork

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/WarmDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/WarmDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isPlanEditable } from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { DetailsItem } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -38,6 +39,7 @@ export const WarmDetailsItem: React.FC<PlanDetailsItemProps> = ({
       crumbs={['spec', 'warm ']}
       onEdit={
         canPatch &&
+        isPlanEditable(resource) &&
         (() =>
           showModal(<EditPlanWarm resource={resource} destinationProvider={destinationProvider} />))
       }


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1713

Enable editing of plan details -> settings fields only for the following plan statuses:
'`Unknown`', '`Canceled`', '`Error`', '`Failed`', '`vmError`', '`Warning`', '`Ready` '
and disable the edit option for those settings fields for all other plan statuses.

### Screenshot example for an archived plan
### Before
![Screenshot from 2024-11-27 15-28-31](https://github.com/user-attachments/assets/e7671245-5bc9-4977-b1fd-281b0c38d2d5)


### After
![Screenshot from 2024-11-27 15-27-33](https://github.com/user-attachments/assets/7f09d476-8f4f-4bfa-b6d7-6f351655a9ed)
