### PR TITLE
Avoid removing VMs from an archived/archiving plans.

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -128,6 +128,7 @@
   "Delete Provider": "Delete Provider",
   "Delete StorageMap": "Delete StorageMap",
   "Delete virtual machines from migration plan": "Delete virtual machines from migration plan",
+  "Deleting virtual machines from an archived migration plan is not allowed.": "Deleting virtual machines from an archived migration plan is not allowed.",
   "Description": "Description",
   "Details": "Details",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.",

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
@@ -117,5 +117,11 @@ export const isPlanEditable = (plan: V1beta1Plan) => {
   );
 };
 
+export const isPlanArchived = (plan: V1beta1Plan) => {
+  const planStatus = getPlanPhase({ obj: plan });
+
+  return planStatus === 'Archiving' || planStatus === 'Archived';
+};
+
 const getConditions = (obj: V1beta1Plan) =>
   obj?.status?.conditions?.filter((c) => c.status === 'True').map((c) => c.type);

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
@@ -5,7 +5,7 @@ import {
   StandardPageWithSelectionProps,
 } from 'src/components/page/StandardPageWithSelection';
 import { usePlanMigration } from 'src/modules/Plans/hooks/usePlanMigration';
-import { isPlanExecuting } from 'src/modules/Plans/utils';
+import { isPlanArchived, isPlanExecuting } from 'src/modules/Plans/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { loadUserSettings, ResourceFieldFactory } from '@kubev2v/common';
@@ -244,10 +244,11 @@ export const MigrationVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => 
   }));
 
   const isExecuting = isPlanExecuting(plan);
+  const isArchived = isPlanArchived(plan);
 
-  // If plan executing allow to cancel vms, o/w remove from plan
+  // If plan executing and not archived (happens when archiving a running plan), allow to cancel vms, o/w remove from plan
   let actions: PageGlobalActions;
-  if (isExecuting) {
+  if (isExecuting && !isArchived) {
     actions = [
       ({ selectedIds }) => (
         <MigrationVMsCancelButton selectedIds={selectedIds || []} migration={lastMigration} />


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1713

Avoid removing VMs from an archived/archiving plans. If a plan's status is either archiving or archived, block the option to remove VMs for that plan.

### Screenshots
### Before
![Screenshot from 2024-11-27 21-36-04](https://github.com/user-attachments/assets/3e7edc89-6277-4b0a-b782-5f8503b27f41)


### After
![Screenshot from 2024-11-27 21-36-42](https://github.com/user-attachments/assets/2efb259a-f6e1-4c8c-9527-6af79dc4b4c7)
