### PR TITLE
Disable the cutover action for an archived plan

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
@@ -14,7 +14,14 @@ import {
   PlanDeleteModal,
   PlanStartMigrationModal,
 } from '../modals';
-import { canPlanReStart, canPlanStart, getPlanPhase, isPlanExecuting, PlanData } from '../utils';
+import {
+  canPlanReStart,
+  canPlanStart,
+  getPlanPhase,
+  isPlanArchived,
+  isPlanExecuting,
+  PlanData,
+} from '../utils';
 
 export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps) => {
   const { t } = useForkliftTranslation();
@@ -33,6 +40,7 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
   const canStart = canPlanStart(plan);
   const canReStart = canPlanReStart(plan);
   const isWarmAndExecuting = plan?.spec?.warm && isPlanExecuting(plan);
+  const isArchived = isPlanArchived(plan);
 
   const buttonStartLabel = canReStart ? t('Restart migration') : t('Start migration');
 
@@ -67,7 +75,11 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
       {buttonStartLabel}
     </DropdownItem>,
 
-    <DropdownItem key="cutover" isDisabled={!isWarmAndExecuting} onClick={onClickPlanCutover}>
+    <DropdownItem
+      key="cutover"
+      isDisabled={!isWarmAndExecuting || isArchived}
+      onClick={onClickPlanCutover}
+    >
       {t('Cutover')}
     </DropdownItem>,
 

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/getPlanPhase.ts
@@ -117,5 +117,11 @@ export const isPlanEditable = (plan: V1beta1Plan) => {
   );
 };
 
+export const isPlanArchived = (plan: V1beta1Plan) => {
+  const planStatus = getPlanPhase({ obj: plan });
+
+  return planStatus === 'Archiving' || planStatus === 'Archived';
+};
+
 const getConditions = (obj: V1beta1Plan) =>
   obj?.status?.conditions?.filter((c) => c.status === 'True').map((c) => c.type);

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/ActionsCell.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { PlanActionsDropdown } from 'src/modules/Plans/actions';
 import { PlanCutoverMigrationModal, PlanStartMigrationModal } from 'src/modules/Plans/modals';
-import { canPlanReStart, canPlanStart, isPlanExecuting } from 'src/modules/Plans/utils';
+import {
+  canPlanReStart,
+  canPlanStart,
+  isPlanArchived,
+  isPlanExecuting,
+} from 'src/modules/Plans/utils';
 import { useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -23,6 +28,7 @@ export const ActionsCell = ({ data }: CellProps) => {
   const canReStart = canPlanReStart(plan);
 
   const isWarmAndExecuting = plan?.spec?.warm && isPlanExecuting(plan);
+  const isArchived = isPlanArchived(plan);
 
   const buttonStartLabel = canReStart ? t('Restart') : t('Start');
   const buttonStartIcon = canReStart ? <ReStartIcon /> : <StartIcon />;
@@ -50,7 +56,7 @@ export const ActionsCell = ({ data }: CellProps) => {
         </FlexItem>
       )}
 
-      {isWarmAndExecuting && (
+      {isWarmAndExecuting && !isArchived && (
         <FlexItem align={{ default: 'alignRight' }}>
           <Button
             variant="secondary"


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1729

Disable the cutover action for an archived plan.

#### Screenshots
#### Before
![Screenshot from 2024-12-03 02-05-09](https://github.com/user-attachments/assets/435162e5-3bbc-4f9a-95d3-351f34d2f399)

#### after

![Screenshot from 2024-12-03 02-04-16](https://github.com/user-attachments/assets/2a4af5fd-44c1-4c1e-988d-cf159cccb918)


