### PR TITLE
Rephrase the preserve static IPs warning message

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -72,6 +72,7 @@
   "Cannot retrieve certificate": "Cannot retrieve certificate",
   "Category": "Category",
   "Certificate change detected": "Certificate change detected",
+  "choose a different mapping for your migration plan": "choose a different mapping for your migration plan",
   "Choose the root filesystem to be converted.": "Choose the root filesystem to be converted.",
   "Clear all filters": "Clear all filters",
   "Click the pencil for setting provider web UI link": "Click the pencil for setting provider web UI link",
@@ -200,7 +201,6 @@
   "First root device": "First root device",
   "Flavor": "Flavor",
   "Folder": "Folder",
-  "For fixing, update the destination network mappings to avoid using the 'Pod Networking' type.": "For fixing, update the destination network mappings to avoid using the 'Pod Networking' type.",
   "GPUs/Host Devices": "GPUs/Host Devices",
   "Hide from view": "Hide from view",
   "Hide values": "Hide values",
@@ -378,7 +378,6 @@
   "Preserve static IPs": "Preserve static IPs",
   "Preserve the CPU model and flags the VM runs with in its oVirt cluster.": "Preserve the CPU model and flags the VM runs with in its oVirt cluster.",
   "Preserve the static IPs of virtual machines migrated from vSphere.": "Preserve the static IPs of virtual machines migrated from vSphere.",
-  "Preserving static IPs of VMs might fail": "Preserving static IPs of VMs might fail",
   "Product": "Product",
   "Progress": "Progress",
   "Project": "Project",
@@ -495,7 +494,6 @@
   "The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.": "The Manager CA certificate unless it was replaced by a third-party certificate, in which case, enter the Manager Apache CA certificate.",
   "The password for the ESXi host admin": "The password for the ESXi host admin",
   "The plan is not ready": "The plan is not ready",
-  "The plan is set to preserve the static IPs of VMs mapped to a Pod network type. This is not supported and therefore VM IPs can be changed during the migration process.": "The plan is set to preserve the static IPs of VMs mapped to a Pod network type. This is not supported and therefore VM IPs can be changed during the migration process.",
   "The plan migration might not work as expected": "The plan migration might not work as expected",
   "The provider is not ready": "The provider is not ready",
   "The provider is not ready.": "The provider is not ready.",
@@ -579,5 +577,6 @@
   "You can select a migration network for a source provider to reduce risk to the source environment and to improve performance.": "You can select a migration network for a source provider to reduce risk to the source environment and to improve performance.",
   "You can select a migration network. If you do not select a migration network,\n        the default migration network is set to the providers default transfer network.": "You can select a migration network. If you do not select a migration network,\n        the default migration network is set to the providers default transfer network.",
   "You can select a migration target namespace for the migration virtual machines.": "You can select a migration target namespace for the migration virtual machines.",
-  "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy."
+  "You don't have access to this section due to cluster policy.": "You don't have access to this section due to cluster policy.",
+  "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.": "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations."
 }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
@@ -5,7 +5,7 @@ import { canPlanReStart, canPlanStart, getPlanPhase } from 'src/modules/Plans/ut
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
 import { useModal } from 'src/modules/Providers/modals';
 import { PageHeadings } from 'src/modules/Providers/utils';
-import { useForkliftTranslation } from 'src/utils';
+import { ForkliftTrans, useForkliftTranslation } from 'src/utils';
 
 import {
   NetworkMapModelGroupVersionKind,
@@ -97,13 +97,18 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
     if (preserveIpsWithPodMapCondition()) {
       alerts.push(
         <PlanWarningCondition
-          type={t('Preserving static IPs of VMs might fail')}
+          type={t('choose a different mapping for your migration plan')}
           message={t(
-            'The plan is set to preserve the static IPs of VMs mapped to a Pod network type. This is not supported and therefore VM IPs can be changed during the migration process.',
+            "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.",
           )}
-          suggestion={t(
-            "For fixing, update the destination network mappings to avoid using the 'Pod Networking' type.",
-          )}
+          suggestion={
+            <ForkliftTrans>
+              If your VMs use static IPs, click the Mappings tab of your plan, and choose a
+              different target network mapping.
+              <br />
+              If your VMs don&apos;t use static IPs, you can ignore this message.
+            </ForkliftTrans>
+          }
         />,
       );
     }

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanWarningCondition.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanWarningCondition.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import Linkify from 'react-linkify';
 import { EMPTY_MSG } from 'src/utils/constants';
@@ -8,7 +8,7 @@ import { Alert, AlertVariant, Text, TextContent, TextVariants } from '@patternfl
 const PlanWarningCondition: React.FC<{
   type: string;
   message: string;
-  suggestion: string;
+  suggestion: ReactNode;
 }> = ({ type, message, suggestion }) => {
   const { t } = useTranslation();
   return (


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1503

Based on Doc's [review](https://issues.redhat.com/browse/MTV-1503?focusedId=26232185&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26232185), rephrase the warning message for preserving static IPs while using Pod networking.

Change the `PlanWarningCondition` component to enable flexible formatting of the suggested section.

### Screenshot
![image](https://github.com/user-attachments/assets/b10d0ec7-b555-4c58-b777-20336f56f3c2)

