### PR TITLE
Exclude the 'Edit Provider Credentials' dropdown menu item for OVA provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/actions/ProviderActionsDropdownItems.tsx
@@ -24,7 +24,7 @@ export const ProviderActionsDropdownItems = ({ data }: ProviderActionsDropdownIt
     showModal(<DeleteModal resource={provider} model={ProviderModel} />);
   };
 
-  return [
+  const dropdownItems = [
     <DropdownItemLink key="EditProvider" href={providerURL}>
       {t('Edit Provider')}
     </DropdownItemLink>,
@@ -38,6 +38,11 @@ export const ProviderActionsDropdownItems = ({ data }: ProviderActionsDropdownIt
       {t('Delete Provider')}
     </DropdownItem>,
   ];
+
+  // excluding the EditCredentials options since not supported for OVA
+  const ovaDropdownItems = dropdownItems.filter((item) => item.key !== 'EditCredentials');
+
+  return provider?.spec?.type === 'ova' ? ovaDropdownItems : dropdownItems;
 };
 
 interface ProviderActionsDropdownItemsProps {


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1766

Since editing the OVA provider credentials is not supported, exclude this option from the providers drop-down menu items.

### Screenshot

![Screenshot from 2024-12-10 20-27-41](https://github.com/user-attachments/assets/31d4001f-5547-4739-a3e0-793e030ccbd8)
