### PR TITLE
[MTV-1786] Add tooltip to Create plan wizard's Target namespace field

### DIFF
--- a/packages/common/src/components/HelpIconPopover/HelpIconPopover.tsx
+++ b/packages/common/src/components/HelpIconPopover/HelpIconPopover.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Popover, PopoverProps } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
+
+interface HelpIconPopoverProps {
+  children: React.ReactNode;
+  header?: string;
+  popoverProps?: Omit<PopoverProps, 'bodyContent' | 'titleContent'>;
+}
+
+export const HelpIconPopover: React.FC<HelpIconPopoverProps> = ({
+  children,
+  header,
+  popoverProps,
+}) => (
+  <Popover position="right" bodyContent={children} headerContent={header} {...popoverProps}>
+    <button type="button" className="pf-c-form__group-label-help">
+      <HelpIcon />
+    </button>
+  </Popover>
+);

--- a/packages/common/src/components/HelpIconPopover/index.ts
+++ b/packages/common/src/components/HelpIconPopover/index.ts
@@ -1,0 +1,3 @@
+// @index(['./*', /__/g], f => `export * from '${f.path}';`)
+export * from './HelpIconPopover';
+// @endindex

--- a/packages/common/src/components/index.ts
+++ b/packages/common/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './ExternalLink';
 export * from './Filter';
 export * from './FilterGroup';
 export * from './FormGroupWithHelpText';
+export * from './HelpIconPopover';
 export * from './Icons';
 export * from './LoadingDots';
 export * from './Page';

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/components/PlansCreateForm.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode, useState } from 'react';
 import { FilterableSelect } from 'src/components';
 import SectionHeading from 'src/components/headers/SectionHeading';
-import { useForkliftTranslation } from 'src/utils/i18n';
+import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import { FormGroupWithHelpText } from '@kubev2v/common';
+import { FormGroupWithHelpText, HelpIconPopover } from '@kubev2v/common';
 import {
   NetworkMapModelGroupVersionKind,
   ProviderModelGroupVersionKind,
@@ -19,6 +19,8 @@ import {
   Form,
   FormSelect,
   FormSelectOption,
+  Stack,
+  StackItem,
   TextInput,
 } from '@patternfly/react-core';
 
@@ -275,6 +277,26 @@ export const PlansCreateForm = ({
             id="targetNamespace"
             validated={validation.targetNamespace}
             placeholder={t('Select a namespace')}
+            labelIcon={
+              <HelpIconPopover header={t('Target namespace')}>
+                <Stack hasGutter>
+                  <StackItem>
+                    <ForkliftTrans>
+                      Namespaces, also known as projects, separate resources within clusters.
+                    </ForkliftTrans>
+                  </StackItem>
+
+                  <StackItem>
+                    <ForkliftTrans>
+                      The target namespace is the namespace within your selected target provider
+                      that your virtual machines will be migrated to. This is different from the
+                      namespace that your migration plan will be created in and where your provider
+                      was created.
+                    </ForkliftTrans>
+                  </StackItem>
+                </Stack>
+              </HelpIconPopover>
+            }
           >
             <FilterableSelect
               selectOptions={availableTargetNamespaces.map((ns) => ({


### PR DESCRIPTION
https://issues.redhat.com/browse/MTV-1786

### Summary
- Added tooltip with text shared in this design JIRA:
https://issues.redhat.com/browse/HPUX-228
- Added common component for help icons with popovers. Can make a separate task to convert several repeated instances of using the same help icon popover soon if this is acceptable.

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/6f18fe45-846e-4334-96b6-99cb699bfdd7" />
