### PR TITLE
Fix the behaviour of the new project field for Kind installation

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -44,7 +44,7 @@ export const ProvidersCreatePage: React.FC<{
   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
   const [providerNames] = useK8sWatchProviderNames({ namespace });
   const defaultNamespace = process?.env?.DEFAULT_NAMESPACE || 'default';
-  const projectName = activeNamespace === '#ALL_NS#' ? 'openshift-mtv' : activeNamespace;
+  const projectName = activeNamespace === '#ALL_NS#' ? defaultNamespace : activeNamespace;
   const initialNamespace = namespace || projectName || defaultNamespace;
 
   const initialState: ProvidersCreatePageState = {

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/ProviderCreateForm.tsx
@@ -1,6 +1,9 @@
 import React, { useReducer } from 'react';
 import { Base64 } from 'js-base64';
-import { ProjectNameSelect } from 'src/modules/Plans/views/create/components/ProjectNameSelect';
+import {
+  ProjectNameSelect,
+  useProjectNameSelectOptions,
+} from 'src/modules/Plans/views/create/components/ProjectNameSelect';
 import { ModalHOC } from 'src/modules/Providers/modals';
 import { validateK8sName, ValidationMsg } from 'src/modules/Providers/utils';
 import { SelectableCard } from 'src/modules/Providers/utils/components/Gallery/SelectableCard';
@@ -8,13 +11,7 @@ import { SelectableGallery } from 'src/modules/Providers/utils/components/Galler
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
-import {
-  IoK8sApiCoreV1Secret,
-  K8sResourceCommon,
-  ProviderType,
-  V1beta1Provider,
-} from '@kubev2v/types';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { IoK8sApiCoreV1Secret, ProviderType, V1beta1Provider } from '@kubev2v/types';
 import {
   Flex,
   FlexItem,
@@ -50,14 +47,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  const [projects, projectsLoaded] = useK8sWatchResource<K8sResourceCommon[]>({
-    groupVersionKind: {
-      version: 'v1',
-      group: 'project.openshift.io',
-      kind: 'Project',
-    },
-    isList: true,
-  });
+  const projects = useProjectNameSelectOptions(projectName);
 
   const initialState = {
     validation: {
@@ -126,11 +116,7 @@ export const ProvidersCreateForm: React.FC<ProvidersCreateFormProps> = ({
         <Form isWidthLimited className="forklift-section-secret-edit">
           <ProjectNameSelect
             value={projectName}
-            options={projects.map((project) => ({
-              value: project.metadata?.name,
-              content: project.metadata?.name,
-            }))}
-            isDisabled={!projectsLoaded || !projects.length}
+            options={projects}
             onSelect={onProjectNameChange}
             popoverHelpContent={
               <ForkliftTrans>The project that your provider will be created in.</ForkliftTrans>


### PR DESCRIPTION
Reference: https://github.com/kubev2v/forklift-console-plugin/pull/1409#issuecomment-2551625234 - comment  (1).

- Enable the `ProjectNameSelect` component to run on Kind (non OCP) installation, the same as supported for the console namespaces menu.
- Fix the namespace default value for upstream (`konveyor-forklift` for u/s,  `openshift-mtv` for d/s )

### Screenshots for kind installation, current is set to `all-namespaces` 
### Before
![Screenshot from 2024-12-19 20-56-30](https://github.com/user-attachments/assets/d9d1d287-5ccc-4efa-aafa-dee367678623)


### After
![Screenshot from 2024-12-19 20-55-05](https://github.com/user-attachments/assets/050c56bd-48c7-4c6d-a8e1-a6f9c40ee6f5)


![Screenshot from 2024-12-19 20-58-35](https://github.com/user-attachments/assets/b225d5e2-65b2-4262-bf20-a2cf640a5602)



