### PR TITLE
Initilalize the validation value of the 'plan name' field to default instead of error

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -90,7 +90,8 @@ export const PlanCreatePage: React.FC<{ namespace: string }> = ({ namespace }) =
         !emptyContext &&
         !(
           !!state?.flow?.apiError ||
-          Object.values(state?.validation || []).some((validation) => validation === 'error')
+          Object.values(state?.validation || []).some((validation) => validation === 'error') ||
+          state?.validation?.planName === 'default'
         ),
       canJumpTo: filterState?.selectedVMs?.length > 0,
       nextButtonText: 'Create migration plan',

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -137,10 +137,6 @@ const handlers: {
   ) {
     // triggered from useEffect on any data change
     draft.existingResources.plans = existingPlans;
-    draft.validation.planName = validatePlanName(
-      draft.underConstruction.plan.metadata.name,
-      existingPlans,
-    );
   },
   [SET_AVAILABLE_TARGET_NAMESPACES](
     draft,


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1651

To avoid displaying an error on initialization for the 'plan name' empty field, when entering the wizard's step 2, leave the initialized validation value for this field as 'default.


### Screncast before fix
[Screencast from 2024-12-27 01-36-08.webm](https://github.com/user-attachments/assets/fe2bae86-25f1-4898-a6ee-a326a82fce55)

### Screncast after fix
[Screencast from 2024-12-27 01-44-19.webm](https://github.com/user-attachments/assets/9bea8ef1-3abb-4095-aecf-b6cfe16eb0c2)
