### PR TITLE
Reading the cacert field value as undefined in case it's empty

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/CertificateUpload/CertificateUpload.tsx
@@ -39,7 +39,7 @@ export const CertificateUpload: FC<CertificateUploadProps> = ({
       <FetchCertificateModal
         url={url}
         handleSave={(v) => onTextChange(null, v)}
-        existingCert={String(value)}
+        existingCert={value ? String(value) : undefined}
       />,
     );
   };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1653

Fix a bug in which in case of an empty/undefined cacert field value, read it as `undefined` and not as `'undefined' `(the result of (string(undefined) expr).

This fixes the verification if the cacert field is empty or not.

#### Screencast to show that this will fix bug https://issues.redhat.com/browse/MTV-1653
[Screencast from 2024-12-30 20-07-14.webm](https://github.com/user-attachments/assets/73c09c20-173d-49fb-ab07-5106dcab14e2)

