### PR TITLE
Migrate deprecated Wizard component to PF5 and fix Wizard's focus issue

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -355,6 +355,7 @@
   "Plan name": "Plan name",
   "Plans": "Plans",
   "Plans for virtualization": "Plans for virtualization",
+  "Plans wizard": "Plans wizard",
   "Please choose a NetworkAttachmentDefinition for data transfer.": "Please choose a NetworkAttachmentDefinition for data transfer.",
   "Please choose a NetworkAttachmentDefinition for default data transfer.": "Please choose a NetworkAttachmentDefinition for default data transfer.",
   "Please choose a target namespace for the migrated virtual machines.": "Please choose a target namespace for the migrated virtual machines.",

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/anyValidationErrorExists.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/anyValidationErrorExists.ts
@@ -1,0 +1,4 @@
+import { CreateVmMigrationPageState } from 'src/modules/Providers/views/migrate/types';
+
+export const anyValidationErrorExists = (state: CreateVmMigrationPageState): boolean =>
+  Object.values(state?.validation || []).some((validation) => validation === 'error');

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/index.ts
@@ -1,4 +1,5 @@
 // @index(['./*', /style/g], f => `export * from '${f.path}';`)
+export * from './anyValidationErrorExists';
 export * from './getMigrationPhase';
 export * from './getMigrationVmsCounts';
 export * from './getPlanPhase';

--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.style.css
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.style.css
@@ -80,6 +80,12 @@
   cursor: pointer;
 }
 
-.forklift--create-plan--wizard-appearance-order {
-  z-index: 1;
+.forklift--create-plan--wizard-content {
+  flex-flow: initial;
+}
+
+.forklift--create-plan--wizard-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }


### PR DESCRIPTION
References: 
https://issues.redhat.com/browse/MTV-1051
https://issues.redhat.com/browse/MTV-1863

1.  Migrate the deprecated `Wizard` component to PF5 - see https://v5-archive.patternfly.org/components/wizard/react-deprecated
2.  When moving between steps in plan's wizard, set the initial focus to the top of the step's page.
3. When clicking the `Cancel` button within the wizard, instead of always navigating to  `history.goBack()`,
the following happens now:
If the wizard is triggered by the provider - vms tab  => cancel will navigate back to the provider - vms tab
If the wizard is triggered by the plans list page  => cancel will navigate back to the plans list page
If the wizard is triggered by entering the wizard url directly => cancel will navigate back to the plans list page.

###  Screencasts
### Before
[Screencast from 2025-01-06 18-33-35.webm](https://github.com/user-attachments/assets/38ec4802-0fae-49ca-800a-44202fd3a912)

### After
[Screencast from 2025-01-06 18-38-54.webm](https://github.com/user-attachments/assets/f2344556-d3b4-46bd-ab2d-47dd9c7d2a0e)
