### PR TITLE
Fix a bug of resetting the plan name validation field when resetting the plan

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -489,6 +489,7 @@ const handlers: {
     draft.calculatedPerNamespace = newDraft.calculatedPerNamespace;
     draft.receivedAsParams = newDraft.receivedAsParams;
     draft.alerts = newDraft.alerts;
+    draft.validation = newDraft.validation;
   },
 };
 


### PR DESCRIPTION
When going back in plan's wizard from `step 2` to `step 1` and updating the Plan's VMs checked list and then going next again to `step 2`, the plan name field was not validated correctly and therefore the wizard was blocked even though the '`create migration plan`' button was enabled  - see screencast for the reproduced use case.

### Screencast before fix
[Screencast from 2025-01-06 18-44-56.webm](https://github.com/user-attachments/assets/6f6b7277-f1f5-4851-a9f6-804d387a4adf)

### Screencast after fix
[Screencast from 2025-01-06 18-48-17.webm](https://github.com/user-attachments/assets/aadd9f7e-a4cc-4097-ae9c-29ac5ff894a6)
