### PR TITLE
[MTV-1905] Canceled VMs are not displayed with status in the plans list

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
@@ -30,7 +30,6 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
   const { showModal } = useModal();
   const plan = data?.obj;
 
-  const vms = plan?.spec?.vms;
   const vmStatuses = plan?.status?.migration?.vms;
   const [lastMigration] = usePlanMigration(plan);
 
@@ -101,7 +100,7 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
       )}
 
       <Split hasGutter>
-        {vmCount?.success > 0 && (
+        {vmCount.success > 0 && (
           <SplitItem>
             <PlanStatusVmCount
               count={vmCount.success}
@@ -111,19 +110,19 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
           </SplitItem>
         )}
 
-        {phase !== PlanPhase.Running &&
-          phase !== PlanPhase.NotReady &&
-          vms?.length &&
-          !vmCount?.error &&
-          !vmCount.success && (
-            <SplitItem>
-              <PlanStatusVmCount count={vms.length} status="warning" linkPath={vmCountLinkPath} />
-            </SplitItem>
-          )}
-
-        {vmCount?.error > 0 && (
+        {vmCount.canceled > 0 && (
           <SplitItem>
-            <PlanStatusVmCount count={vmCount?.error} status="danger" linkPath={vmCountLinkPath} />
+            <PlanStatusVmCount
+              count={vmCount.canceled}
+              status="warning"
+              linkPath={vmCountLinkPath}
+            />
+          </SplitItem>
+        )}
+
+        {vmCount.error > 0 && (
+          <SplitItem>
+            <PlanStatusVmCount count={vmCount.error} status="danger" linkPath={vmCountLinkPath} />
           </SplitItem>
         )}
       </Split>


### PR DESCRIPTION
## 📝 Links
> References: https://issues.redhat.com/browse/MTV-1905

## 📝 Description
Checking for canceled VMs and using that as the source value for "warning" counts within the "Migration status" table cell.

## 🎥 Demo
**Detail view showing canceled VM**
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/ef0e8436-960d-4516-8afb-17a7c74818b8" />

**Table view**
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/a4ed6e7e-2ecd-467a-b7a8-76666c2aba94" />