### PR TITLE
[MTV-1948] Plan wizard 2nd step 'create migration' button is disabled without a reason

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -95,8 +95,7 @@ export const PlanCreatePage: React.FC<{ namespace: string }> = ({ namespace }) =
         !emptyContext &&
         !(
           !!state?.flow?.apiError ||
-          Object.values(state?.validation || []).some((validation) => validation === 'error') ||
-          state?.validation?.planName === 'default'
+          Object.values(state?.validation || []).some((validation) => validation === 'error')
         ),
       canJumpTo: isFirstStepValid,
       nextButtonText: 'Create migration plan',


### PR DESCRIPTION
## 📝 Links
> References: https://issues.redhat.com/browse/MTV-1948

## 📝 Description
Removing Plan name validation check on the 2nd step of the create migration wizard since that now lives on step 1.

## 🎥 Demo
https://github.com/user-attachments/assets/d0b55c89-1f83-47ea-ae2f-51d28da45968


