### PR TITLE
MTV-2002: Fix user access permisisons validation for the plan mappings resources

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Mappings/PlanMappingsSection.tsx
@@ -35,7 +35,7 @@ import Pencil from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 
 import { Mapping, MappingList } from '../../components';
 import {
-  canDeleteAndPatchPlanHooks,
+  canDeleteAndPatchPlanMaps,
   hasPlanMappingsChanged,
   hasSomeCompleteRunningVMs,
   mapSourceNetworksIdsToLabels,
@@ -570,7 +570,7 @@ export const PlanMappingsSection: React.FC<PlanMappingsSectionProps> = ({
     return (
       <>
         <Drawer>
-          {canDeleteAndPatchPlanHooks(plan) && (
+          {canDeleteAndPatchPlanMaps(plan) && (
             <FlexItem>
               <Button
                 variant="secondary"


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2002

## 📝 Description

The user access permisisons validation for the plan mappings resources patch/delete actions was checked against a wrong CRD entity.

This bug of invalid user access validaiton might trigger disabling/enabling the "Edit Mappings" button due to wrong user access permissions.


