### PR TITLE
[MTV-1967] Create plan wizard state is not set correctly when re-selecting a source provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/hooks/useProviderInventory.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/hooks/useProviderInventory.ts
@@ -106,6 +106,8 @@ export const useProviderInventory = <T>({
         handleError(null);
       } catch (e) {
         handleError(e);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -126,8 +128,6 @@ export const useProviderInventory = <T>({
   function handleError(e: Error): void {
     if (e?.toString() !== oldErrorRef.current?.error) {
       setError(e);
-      setLoading(false);
-
       oldErrorRef.current = { error: e?.toString() };
     }
   }
@@ -156,8 +156,6 @@ export const useProviderInventory = <T>({
 
     if (needReRender) {
       setInventory(newInventory);
-      setLoading(false);
-
       oldDataRef.current = { inventory: newInventory };
     }
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
@@ -65,6 +65,7 @@ export const useFetchEffects = (
     workArea: { targetProvider },
     flow: { editingDone },
   } = state;
+  const targetProviderName = targetProvider?.metadata?.name;
 
   const dispatchWithFallback = (
     action: PageAction<CreateVmMigration, unknown>,
@@ -81,7 +82,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatch(initState(namespace, planName, projectName, sourceProvider, selectedVms)),
-    [selectedVms],
+    [],
   );
 
   const [providers, providersLoaded, providerError] = useK8sWatchResource<V1beta1Provider[]>({
@@ -94,7 +95,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setAvailableProviders(providers), !providersLoaded, providerError),
-    [providers, providersLoaded, providerError, selectedVms],
+    [editingDone, providersLoaded, providerError?.message],
   );
 
   const [plans, plansLoaded, plansError] = useK8sWatchResource<V1beta1Plan[]>({
@@ -105,7 +106,7 @@ export const useFetchEffects = (
   });
   useEffect(
     () => !editingDone && dispatchWithFallback(setExistingPlans(plans), !plansLoaded, plansError),
-    [plans, plansLoaded, plansError, selectedVms],
+    [editingDone, plansLoaded, plansError?.message],
   );
 
   const [netMaps, netMapsLoaded, netMapsError] = useK8sWatchResource<V1beta1NetworkMap[]>({
@@ -118,7 +119,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setExistingNetMaps(netMaps), !netMapsLoaded, netMapsError),
-    [netMaps, netMapsLoaded, netMapsError, selectedVms],
+    [editingDone, netMapsLoaded, netMapsError?.message],
   );
 
   const [stMaps, stMapsLoaded, stMapsError] = useK8sWatchResource<V1beta1StorageMap[]>({
@@ -131,30 +132,30 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setExistingStorageMaps(stMaps), !stMapsLoaded, stMapsError),
-    [stMaps, stMapsLoaded, stMapsError, selectedVms],
+    [editingDone, stMapsLoaded, stMapsError?.message],
   );
 
   const [namespaces, nsLoading, nsError] = useNamespaces(targetProvider);
   useEffect(
     () =>
-      targetProvider &&
+      targetProviderName &&
       !editingDone &&
       dispatchWithFallback(setAvailableTargetNamespaces(namespaces), nsLoading, nsError),
-    [namespaces, nsLoading, nsError, targetProvider, selectedVms],
+    [editingDone, nsLoading, nsError?.message, targetProviderName],
   );
 
   const [targetNetworks, targetNetworksLoading, targetNetworksError] =
     useOpenShiftNetworks(targetProvider);
   useEffect(
     () =>
-      targetProvider &&
+      targetProviderName &&
       !editingDone &&
       dispatchWithFallback(
         setAvailableTargetNetworks(targetNetworks),
         targetNetworksLoading,
         targetNetworksError,
       ),
-    [targetNetworks, targetNetworksLoading, targetNetworksError, targetProvider, selectedVms],
+    [editingDone, targetNetworksLoading, targetNetworksError?.message, targetProviderName],
   );
 
   const [sourceStorages, sourceStoragesLoading, sourceStoragesError] =
@@ -167,21 +168,21 @@ export const useFetchEffects = (
         sourceStoragesLoading,
         sourceStoragesError,
       ),
-    [sourceStorages, sourceStoragesLoading, sourceStoragesError, selectedVms],
+    [editingDone, sourceStoragesLoading, sourceStoragesError?.message],
   );
 
   const [targetStorages, targetStoragesLoading, targetStoragesError] =
     useOpenShiftStorages(targetProvider);
   useEffect(
     () =>
-      targetProvider &&
+      targetProviderName &&
       !editingDone &&
       dispatchWithFallback(
         setAvailableTargetStorages(targetStorages),
         targetStoragesLoading,
         targetStoragesError,
       ),
-    [targetStorages, targetStoragesLoading, targetStoragesError, targetProvider, selectedVms],
+    [editingDone, targetStoragesLoading, targetProviderName],
   );
 
   const [sourceNetworks, sourceNetworksLoading, sourceNetworksError] =
@@ -194,7 +195,7 @@ export const useFetchEffects = (
         sourceNetworksLoading,
         sourceNetworksError,
       ),
-    [sourceNetworks, sourceNetworksLoading, sourceNetworksError, selectedVms],
+    [editingDone, sourceNetworksLoading, sourceNetworksError?.message],
   );
 
   const [nicProfiles, nicProfilesLoading, nicProfilesError] = useNicProfiles(sourceProvider);
@@ -202,13 +203,13 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setNicProfiles(nicProfiles), nicProfilesLoading, nicProfilesError),
-    [nicProfiles, nicProfilesLoading, nicProfilesError, selectedVms],
+    [editingDone, nicProfilesLoading, nicProfilesError?.message],
   );
 
   const [disks, disksLoading, disksError] = useDisks(sourceProvider);
   useEffect(
     () => !editingDone && dispatchWithFallback(setDisks(disks), disksLoading, disksError),
-    [disks, disksLoading, disksError, selectedVms],
+    [editingDone, disksLoading, disksError?.message],
   );
 
   return [state, dispatch, emptyContext];


### PR DESCRIPTION
## 📝 Links
> References: https://issues.redhat.com/browse/MTV-1967

## 📝 Description
When using the create migration plan wizard, selecting a provider, then de-selecting and selecting another (could be the same), source storage and network mappings were being set to empty arrays and therefore disallowing users from selecting mappings on step 2 of the wizard. 

This change addresses this, limits the initialization of state to the initial call of the `useFetchEffects` hook (which prevents the resetting of plan name validation), and also addresses other unnecessary re-rending within the `useFetchEffects` hook, which could use some refactoring still, as the amount of useEffects there leads to that hook being unreadable and one can easily get lost as to which effect they're looking at or even what this generically called hook's purpose is.

## 🎥 Demo
https://github.com/user-attachments/assets/eb7e3281-fbb5-4a8e-bb3e-d9090d365153