### PR TITLE
MTV-1727: Provide disabled reason with tooltip  on Cancel and Remove VMs buttons

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -420,6 +420,7 @@
   "Secrets": "Secrets",
   "Select a namespace": "Select a namespace",
   "Select a provider": "Select a provider",
+  "Select at least one virtual machine.": "Select at least one virtual machine.",
   "Select migration network": "Select migration network",
   "Select source provider": "Select source provider",
   "Select virtual machines": "Select virtual machines",

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
@@ -3,7 +3,7 @@ import { useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { V1beta1Migration } from '@kubev2v/types';
-import { Button, ToolbarItem } from '@patternfly/react-core';
+import { Button, ToolbarItem, Tooltip } from '@patternfly/react-core';
 
 import { MigrationVMsCancelModal } from '../modals';
 
@@ -17,11 +17,15 @@ export const MigrationVMsCancelButton: FC<{
     showModal(<MigrationVMsCancelModal migration={migration} selected={selectedIds} />);
   };
 
+  const reason = selectedIds?.length < 1 && t('Select at least one virtual machine.');
+
+  const button = (
+    <Button variant="secondary" onClick={onClick} isAriaDisabled={Boolean(reason)}>
+      {t('Cancel virtual machines')}
+    </Button>
+  );
+
   return (
-    <ToolbarItem>
-      <Button variant="secondary" onClick={onClick} isDisabled={!selectedIds?.length}>
-        {t('Cancel virtual machines')}
-      </Button>
-    </ToolbarItem>
+    <ToolbarItem>{reason ? <Tooltip content={reason}>{button}</Tooltip> : button}</ToolbarItem>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/MigrationVMsCancelButton.tsx
@@ -3,9 +3,11 @@ import { useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { V1beta1Migration } from '@kubev2v/types';
-import { Button, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { ToolbarItem } from '@patternfly/react-core';
 
 import { MigrationVMsCancelModal } from '../modals';
+
+import { VMsActionButton } from './VMsActionButton';
 
 export const MigrationVMsCancelButton: FC<{
   selectedIds: string[];
@@ -19,13 +21,11 @@ export const MigrationVMsCancelButton: FC<{
 
   const reason = selectedIds?.length < 1 && t('Select at least one virtual machine.');
 
-  const button = (
-    <Button variant="secondary" onClick={onClick} isAriaDisabled={Boolean(reason)}>
-      {t('Cancel virtual machines')}
-    </Button>
-  );
-
   return (
-    <ToolbarItem>{reason ? <Tooltip content={reason}>{button}</Tooltip> : button}</ToolbarItem>
+    <ToolbarItem>
+      <VMsActionButton onClick={onClick} disabledReason={reason}>
+        {t('Cancel virtual machines')}
+      </VMsActionButton>
+    </ToolbarItem>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
@@ -24,19 +24,17 @@ export const PlanVMsDeleteButton: FC<{
   }, [plan, selectedIds]);
 
   const reason = useMemo(() => {
-    let reason =
-      isPlanArchived(plan) &&
-      t('Deleting virtual machines from an archived migration plan is not allowed.');
-
-    reason = reason || (selectedIds?.length < 1 && t('Select at least one virtual machine.'));
-
-    reason =
-      reason ||
-      (remainingVms.length < 1 &&
-        t(
-          'All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
-        ));
-
+    if (isPlanArchived(plan)) {
+      return t('Deleting virtual machines from an archived migration plan is not allowed.');
+    }
+    if (!!selectedIds?.length) {
+      return t('Select at least one virtual machine.');
+    }
+    if (!!remainingVms.length) {
+      return t(
+        'All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
+      );
+    }
     return reason;
   }, [plan, selectedIds, remainingVms]);
 

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/PlanVMsDeleteButton.tsx
@@ -4,9 +4,11 @@ import { useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { V1beta1Plan } from '@kubev2v/types';
-import { Button, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { ToolbarItem } from '@patternfly/react-core';
 
 import { PlanVMsDeleteModal } from '../modals';
+
+import { VMsActionButton } from './VMsActionButton';
 
 export const PlanVMsDeleteButton: FC<{
   selectedIds: string[];
@@ -27,24 +29,22 @@ export const PlanVMsDeleteButton: FC<{
     if (isPlanArchived(plan)) {
       return t('Deleting virtual machines from an archived migration plan is not allowed.');
     }
-    if (!!selectedIds?.length) {
+    if (!selectedIds?.length) {
       return t('Select at least one virtual machine.');
     }
-    if (!!remainingVms.length) {
+    if (!remainingVms?.length) {
       return t(
         'All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
       );
     }
-    return reason;
+    return '';
   }, [plan, selectedIds, remainingVms]);
 
-  const button = (
-    <Button variant="secondary" onClick={onClick} isAriaDisabled={Boolean(reason)}>
-      {t('Remove virtual machines')}
-    </Button>
-  );
-
   return (
-    <ToolbarItem>{reason ? <Tooltip content={reason}>{button}</Tooltip> : button}</ToolbarItem>
+    <ToolbarItem>
+      <VMsActionButton onClick={onClick} disabledReason={reason}>
+        {t('Remove virtual machines')}
+      </VMsActionButton>
+    </ToolbarItem>
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/VMsActionButton.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/VMsActionButton.tsx
@@ -1,0 +1,21 @@
+import React, { FC, ReactNode } from 'react';
+
+import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
+
+export const VMsActionButton: FC<{
+  children: ReactNode;
+  onClick: () => void;
+  disabledReason?: string;
+}> = ({ children, onClick, disabledReason }) => {
+  const button = (
+    <Button
+      variant={ButtonVariant.secondary}
+      onClick={onClick}
+      isAriaDisabled={Boolean(disabledReason)}
+    >
+      {children}
+    </Button>
+  );
+
+  return disabledReason ? <Tooltip content={disabledReason}>{button}</Tooltip> : button;
+};

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/components/index.ts
@@ -4,4 +4,5 @@ export * from './MigrationVMsCancelButton';
 export * from './NameCellRenderer';
 export * from './PlanVMsCellProps';
 export * from './PlanVMsDeleteButton';
+export * from './VMsActionButton';
 // @endindex

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/MigrationVMsCancelModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/MigrationVMsCancelModal.tsx
@@ -5,7 +5,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { MigrationModel, V1beta1Migration } from '@kubev2v/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 
 import './PlanVMsDeleteModal.style.css';
 
@@ -53,13 +53,12 @@ export const MigrationVMsCancelModal: React.FC<MigrationVMsCancelModalProps> = (
     <Button
       key="confirm"
       onClick={handleSave}
-      variant="primary"
-      isDisabled={vms.length < 1}
+      variant={ButtonVariant.primary}
       isLoading={isLoading}
     >
       {t('Cancel migration')}
     </Button>,
-    <Button key="cancel" variant="secondary" onClick={toggleModal}>
+    <Button key="cancel" variant={ButtonVariant.secondary} onClick={toggleModal}>
       {t('Cancel')}
     </Button>,
   ];

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useCallback, useState } from 'react';
-import { isPlanArchived } from 'src/modules/Plans/utils';
 import { useToggle } from 'src/modules/Providers/hooks';
 import { AlertMessageForModals, useModal } from 'src/modules/Providers/modals';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -23,22 +22,6 @@ export const PlanVMsDeleteModal: React.FC<PlanVMsDeleteModalProps> = ({ plan, se
 
   const vms = (plan?.spec?.vms || []).filter((vm) => !selected.includes(vm.id)) || [];
 
-  React.useEffect(() => {
-    if (isPlanArchived(plan)) {
-      setAlertMessage(
-        t('Deleting virtual machines from an archived migration plan is not allowed.'),
-      );
-      return;
-    }
-    if (vms.length < 1) {
-      setAlertMessage(
-        t(
-          'All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.',
-        ),
-      );
-    }
-  }, [vms, plan]);
-
   const handleSave = useCallback(async () => {
     toggleIsLoading();
 
@@ -60,13 +43,7 @@ export const PlanVMsDeleteModal: React.FC<PlanVMsDeleteModalProps> = ({ plan, se
   }, [selected]);
 
   const actions = [
-    <Button
-      key="confirm"
-      onClick={handleSave}
-      variant="danger"
-      isDisabled={vms.length < 1 || isPlanArchived(plan)}
-      isLoading={isLoading}
-    >
+    <Button key="confirm" onClick={handleSave} variant="danger" isLoading={isLoading}>
       {t('Delete')}
     </Button>,
     <Button key="cancel" variant="secondary" onClick={toggleModal}>

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/modals/PlanVMsDeleteModal.tsx
@@ -5,7 +5,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { PlanModel, V1beta1Plan } from '@kubev2v/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 
 import './PlanVMsDeleteModal.style.css';
 
@@ -43,10 +43,10 @@ export const PlanVMsDeleteModal: React.FC<PlanVMsDeleteModalProps> = ({ plan, se
   }, [selected]);
 
   const actions = [
-    <Button key="confirm" onClick={handleSave} variant="danger" isLoading={isLoading}>
+    <Button key="confirm" onClick={handleSave} variant={ButtonVariant.danger} isLoading={isLoading}>
       {t('Delete')}
     </Button>,
-    <Button key="cancel" variant="secondary" onClick={toggleModal}>
+    <Button key="cancel" variant={ButtonVariant.secondary} onClick={toggleModal}>
       {t('Cancel')}
     </Button>,
   ];


### PR DESCRIPTION


## 📝 Links
> References: <Jira ticket urls>

https://issues.redhat.com/browse/MTV-1727

## 📝 Description

Adds a tooltip to the Cancel / Remove VMs buttons if there is a reason

## 🎥 Demo

**Archived migration plan:**

<img width="722" alt="Screenshot 2025-02-04 at 1 23 26 PM" src="https://github.com/user-attachments/assets/ab58b9b4-b682-49ce-bb8f-0839010d5afa" />

**Ready migration plan:**

https://github.com/user-attachments/assets/acfc392f-c530-40e0-967d-eaeae02dd23c

**Running migration plan:**

<img width="974" alt="Screenshot 2025-02-04 at 1 32 05 PM" src="https://github.com/user-attachments/assets/c8b796e8-964d-4734-8b3b-5c79d003ff3b" />


## 📝 CC://




> @tag as needed
