### PR TITLE
Avoid running more than one migration concurrently

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { DropdownItemLink } from 'src/components/actions/DropdownItemLink';
 import { useModal } from 'src/modules/Providers/modals';
 import { getResourceUrl } from 'src/modules/Providers/utils/helpers';
@@ -42,12 +42,22 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
   const canReStart = canPlanReStart(plan);
   const isWarmAndExecuting = plan?.spec?.warm && isPlanExecuting(plan);
   const isArchived = isPlanArchived(plan);
-
   const buttonStartLabel = canReStart ? t('Restart migration') : t('Start migration');
+
+  const [isStartItemEnabled, setIsStartItemEnabled] = useState(canStart);
+
+  useEffect(() => {
+    if (canStart) setIsStartItemEnabled(true);
+  }, [canStart]);
 
   const onClickPlanStart = () => {
     showModal(
-      <PlanStartMigrationModal resource={plan} model={PlanModel} title={buttonStartLabel} />,
+      <PlanStartMigrationModal
+        resource={plan}
+        model={PlanModel}
+        title={buttonStartLabel}
+        setButtonEnabledOnChange={setIsStartItemEnabled}
+      />,
     );
   };
 
@@ -70,7 +80,12 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
   return [
     <DropdownItemLink value={0} key="EditPlan" href={planURL} description={t('Edit Plan')} />,
 
-    <DropdownItem value={1} key="start" isDisabled={!canStart} onClick={onClickPlanStart}>
+    <DropdownItem
+      value={1}
+      key="start"
+      isDisabled={!canStart || !isStartItemEnabled}
+      onClick={onClickPlanStart}
+    >
       {buttonStartLabel}
     </DropdownItem>,
 

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { usePlanMigration } from 'src/modules/Plans/hooks';
 import { PlanStartMigrationModal } from 'src/modules/Plans/modals';
 import {
@@ -41,11 +41,12 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
 
   const vmStatuses = plan?.status?.migration?.vms;
   const [lastMigration] = usePlanMigration(plan);
+  const [isButtonEnabled, setIsButtonEnabled] = useState(true);
 
   const isWarmAndExecuting = plan.spec?.warm && isPlanExecuting(plan);
   const isWaitingForCutover = isWarmAndExecuting && !isPlanArchived(plan);
 
-  const vmPipelineTasks = lastMigration?.status.vms?.reduce(
+  const vmPipelineTasks = lastMigration?.status?.vms?.reduce(
     (acc: VmPipelineTask[], migrationVm) => {
       migrationVm.pipeline.forEach((pipelineStep) => {
         acc.push({ vmName: migrationVm.name, task: pipelineStep.name, status: pipelineStep.phase });
@@ -75,9 +76,15 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
       <Button
         variant={ButtonVariant.primary}
         icon={<StartIcon />}
+        isDisabled={!isButtonEnabled}
         onClick={() =>
           showModal(
-            <PlanStartMigrationModal resource={plan} model={PlanModel} title={t('Start')} />,
+            <PlanStartMigrationModal
+              resource={plan}
+              model={PlanModel}
+              title={t('Start')}
+              setButtonEnabledOnChange={setIsButtonEnabled}
+            />,
           )
         }
       >


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1901

## 📝 Description

Avoid running a migration (start/restart) if a migration is already running by disabling/hiding relevant buttons (in page header, actions menu and plan details status page). 
Also avoid adding the migration CR to cover cases in which rendering takes few seconds when you use the start/restart action item and then the start/restart button at once.

## 🎥 Demo

### Before

[Screencast from 2025-02-05 12-10-40.webm](https://github.com/user-attachments/assets/6411deec-0837-4ca0-8f89-63ad345d2ff5)

### After
[Screencast from 2025-02-05 12-06-55.webm](https://github.com/user-attachments/assets/6ad91391-becc-4263-bcd2-7ec570c50854)



