### PR TITLE
Replace VDDK image hint sections with rephrased warning alert sections

### DIFF
--- a/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
+++ b/packages/forklift-console-plugin/locales/en/plugin__forklift-console-plugin.json
@@ -440,7 +440,7 @@
   "Show archived": "Show archived",
   "Show the welcome card": "Show the welcome card",
   "Skip certificate validation": "Skip certificate validation",
-  "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (migration might be slow).": "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (migration might be slow).",
+  "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended).": "Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended).",
   "Snapshot polling interval (seconds)": "Snapshot polling interval (seconds)",
   "Some VMs Failed": "Some VMs Failed",
   "Something is wrong, the data was not loaded due to an error, please try to reload the page.": "Something is wrong, the data was not loaded due to an error, please try to reload the page.",

--- a/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/modals/EditProviderVDDKImage/EditProviderVDDKImage.tsx
@@ -3,7 +3,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { Modify, ProviderModel, V1beta1Provider } from '@kubev2v/types';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
-import { Checkbox, Hint, HintBody, TextInput } from '@patternfly/react-core';
+import { Alert, Checkbox, TextInput } from '@patternfly/react-core';
 
 import { VDDKHelperTextShort } from '../../utils/components/VDDKHelperText';
 import { validateVDDKImage } from '../../utils/validators';
@@ -46,21 +46,18 @@ export const EditProviderVDDKImage: React.FC<EditProviderVDDKImageProps> = (prop
   };
 
   const body = (
-    <Hint>
-      <HintBody>
-        <VDDKHelperTextShort />
-        <Checkbox
-          className="forklift-section-provider-edit-vddk-checkbox"
-          label={t(
-            'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (migration might be slow).',
-          )}
-          isChecked={isEmptyImage}
-          onChange={(e, v) => onChange(v, e)}
-          id="emptyVddkInitImage"
-          name="emptyVddkInitImage"
-        />
-      </HintBody>
-    </Hint>
+    <Alert variant="warning" isInline title={<VDDKHelperTextShort />}>
+      <Checkbox
+        className="forklift-section-provider-edit-vddk-checkbox"
+        label={t(
+          'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended).',
+        )}
+        isChecked={isEmptyImage}
+        onChange={(e, v) => onChange(v, e)}
+        id="emptyVddkInitImage"
+        name="emptyVddkInitImage"
+      />
+    </Alert>
   );
 
   return (

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
@@ -13,12 +13,14 @@ export const VDDKHelperText: React.FC = () => (
     <p>
       The Migration Toolkit for Virtualization (MTV) uses the VMware Virtual Disk Development Kit
       (VDDK) SDK to accelerate transferring virtual disks from VMware vSphere. Therefore, creating a
-      VDDK image, although optional, is highly recommended.
+      VDDK image, although optional, is highly recommended. Using MTV without VDDK is not
+      recommended and could result in significantly lower migration speeds
     </p>
     <br />
 
     <p>
-      To accelerate migrations, we recommend to create a VDDK init image. Learn more about{' '}
+      To accelerate migration and reduce the risk of a plan failing, it is strongly recommended to
+      create a VDDK init image. Learn more about{' '}
       <ExternalLink isInline href={CREATE_VDDK_HELP_LINK}>
         Creating a VDDK image
       </ExternalLink>
@@ -30,7 +32,8 @@ export const VDDKHelperText: React.FC = () => (
 export const VDDKHelperTextShort: React.FC = () => (
   <ForkliftTrans>
     <p>
-      To accelerate migrations, we recommend to create a VDDK init image. Learn more about{' '}
+      It is strongly recommended to use a VDDK image. Not using a VDDK image could result in
+      significantly lower migration speeds or a plan failing. For more information, see{' '}
       <ExternalLink isInline href={CREATE_VDDK_HELP_LINK}>
         Creating a VDDK image
       </ExternalLink>

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -4,7 +4,7 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
   // For a newly opened form where the field is not set yet, set the validation type to default.
   if (vddkImage === undefined)
     return {
-      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
+      msg: 'The VDDK image is empty. It is strongly recommended to provide an image using the following format: <registry_route_or_server_path>/vddk:<tag> .',
       type: 'default',
     };
 
@@ -18,7 +18,7 @@ export const validateVDDKImage = (vddkImage: string | number): ValidationMsg => 
 
   if (trimmedVddkImage === '')
     return {
-      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
+      msg: 'The VDDK image is empty. It is strongly recommended to provide an image using the following format: <registry_route_or_server_path>/vddk:<tag> .',
       type: 'error',
     };
 

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
@@ -22,7 +22,7 @@ export function vsphereProviderValidator(provider: V1beta1Provider): ValidationM
 
   if (emptyVddkInitImage === 'yes' && vddkInitImage === '') {
     return {
-      msg: 'The VDDK image is empty. It is recommended to provide an image in the format of <registry_route_or_server_path>/vddk:<tag> .',
+      msg: 'The VDDK image is empty. It is strongly recommended to provide an image using the following format: <registry_route_or_server_path>/vddk:<tag> .',
       type: 'warning',
     };
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -9,7 +9,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
-import { Checkbox, Form, Hint, HintBody, Popover, Radio, TextInput } from '@patternfly/react-core';
+import { Alert, Checkbox, Form, Popover, Radio, TextInput } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 export interface EsxiProviderCreateFormProps {
   provider: V1beta1Provider;
@@ -210,21 +210,18 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
           </Popover>
         }
       >
-        <Hint>
-          <HintBody>
-            <VDDKHelperTextShort />
-            <Checkbox
-              className="forklift-section-provider-edit-vddk-checkbox"
-              label={t(
-                'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (migration might be slow).',
-              )}
-              isChecked={emptyVddkInitImage === 'yes'}
-              onChange={(e, v) => onChangEmptyVddk(v, e)}
-              id="emptyVddkInitImage"
-              name="emptyVddkInitImage"
-            />
-          </HintBody>
-        </Hint>
+        <Alert variant="warning" isInline title={<VDDKHelperTextShort />}>
+          <Checkbox
+            className="forklift-section-provider-edit-vddk-checkbox"
+            label={t(
+              'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended).',
+            )}
+            isChecked={emptyVddkInitImage === 'yes'}
+            onChange={(e, v) => onChangEmptyVddk(v, e)}
+            id="emptyVddkInitImage"
+            name="emptyVddkInitImage"
+          />
+        </Alert>
         <div className="forklift-section-provider-edit-vddk-input">
           <TextInput
             spellCheck="false"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -9,7 +9,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { FormGroupWithHelpText } from '@kubev2v/common';
 import { V1beta1Provider } from '@kubev2v/types';
-import { Checkbox, Form, Hint, HintBody, Popover, Radio, TextInput } from '@patternfly/react-core';
+import { Alert, Checkbox, Form, Popover, Radio, TextInput } from '@patternfly/react-core';
 import HelpIcon from '@patternfly/react-icons/dist/esm/icons/help-icon';
 
 export interface VCenterProviderCreateFormProps {
@@ -211,21 +211,19 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
           </Popover>
         }
       >
-        <Hint>
-          <HintBody>
-            <VDDKHelperTextShort />
-            <Checkbox
-              className="forklift-section-provider-edit-vddk-checkbox"
-              label={t(
-                'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (migration might be slow).',
-              )}
-              isChecked={emptyVddkInitImage === 'yes'}
-              onChange={(e, v) => onChangEmptyVddk(v, e)}
-              id="emptyVddkInitImage"
-              name="emptyVddkInitImage"
-            />
-          </HintBody>
-        </Hint>
+        <Alert variant="warning" isInline title={<VDDKHelperTextShort />}>
+          <Checkbox
+            className="forklift-section-provider-edit-vddk-checkbox"
+            label={t(
+              'Skip VMware Virtual Disk Development Kit (VDDK) SDK acceleration (not recommended).',
+            )}
+            isChecked={emptyVddkInitImage === 'yes'}
+            onChange={(e, v) => onChangEmptyVddk(v, e)}
+            id="emptyVddkInitImage"
+            name="emptyVddkInitImage"
+          />
+        </Alert>
+
         <div className="forklift-section-provider-edit-vddk-input">
           <TextInput
             spellCheck="false"

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
@@ -26,7 +26,8 @@ export const VDDKDetailsItem: React.FC<ProviderDetailsItemProps> = ({
       valid container image path in the format of{' '}
       <strong>registry_route_or_server_path/vddk:&#8249;tag&#8250;</strong>.<br />
       <br />
-      To accelerate migrations, we recommend to specify a VDDK init image.
+      To accelerate migration and reduce the risk of a plan failing, it is strongly recommended to
+      specify a VDDK init image.
     </ForkliftTrans>
   );
 


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1783

## 📝 Description

Replace VDDK image hint sections with warning alert sections and rephrased the text to emphasize the importance of setting VDDK image value from performace reasons. 
Trying to be aligned with doc https://issues.redhat.com/browse/MTV-1782.

## 🎥 Demo

### Before
![Screenshot from 2025-02-05 21-28-07](https://github.com/user-attachments/assets/1e9f52e4-8b7b-4067-bfdb-903b9fb61025)

![Screenshot from 2025-02-05 21-28-23](https://github.com/user-attachments/assets/69131241-7047-41de-9b78-24c066567e05)
![Screenshot from 2025-02-05 21-28-49](https://github.com/user-attachments/assets/9ba67075-0c89-4b87-9d11-cc97c6f92196)
![Screenshot from 2025-02-05 21-29-06](https://github.com/user-attachments/assets/fff94810-c35f-4bbe-955c-d45314a08c93)


### After
![Screenshot from 2025-02-11 21-11-58](https://github.com/user-attachments/assets/dacbf9cf-20ec-4183-a513-5fbd67b319cb)

![Screenshot from 2025-02-11 21-12-36](https://github.com/user-attachments/assets/ddce02e3-f7fc-49fe-a96d-d00885f3d31f)

![Screenshot from 2025-02-11 21-12-59](https://github.com/user-attachments/assets/c9e97f5b-a12e-4354-80d4-7567069443c6)

![Screenshot from 2025-02-11 21-13-17](https://github.com/user-attachments/assets/22619533-b410-4d04-b517-21bd9f7d20b6)




## 📝 CC://

@RichardHoch @anarnold97 
