### PR TITLE
MTV-1791: Add id to openshift (host) storagemaps

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -317,6 +317,7 @@ const handlers: {
       if (sourceProvider?.spec?.type === 'openshift') {
         return {
           source: {
+            id: sourceStorageLabelToId[source],
             name: source.replace(/^\//g, ''),
           },
           destination: { storageClass: destination },


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-1791

## 📝 Description

When a plan is created, `id` was not added to storage maps if the source was openshift (host)

## 🎥 Demo

**Before**

https://github.com/user-attachments/assets/8751d4ec-c1f0-4e94-a881-d0a8340bcf11



**After**

https://github.com/user-attachments/assets/5bc9b13b-7b50-4d31-88c4-8fc2aaee9e9a



## 📝 CC://

> @tag as needed
