### PR TITLE
[MTV-1871] Sorting virtual machines isn't saved while refresh

### DIFF
--- a/packages/forklift-console-plugin/src/components/TableSortContext.tsx
+++ b/packages/forklift-console-plugin/src/components/TableSortContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, FC, PropsWithChildren, useContext } from 'react';
+
+import { ResourceField, SortType, useSort } from '@kubev2v/common';
+
+type TableSortContextProps = {
+  activeSort: SortType;
+  setActiveSort: (activeSort: SortType) => void;
+  compareFn: (a: unknown, b: unknown) => number;
+};
+
+const defaultTableSortContext = {
+  activeSort: { isAsc: true, resourceFieldId: undefined, label: '' },
+  setActiveSort: () => undefined,
+  compareFn: () => undefined,
+};
+
+const TableSortContext = createContext<TableSortContextProps>(defaultTableSortContext);
+
+type TableSortContextProviderProps = PropsWithChildren & {
+  fields: ResourceField[];
+};
+
+export const TableSortContextProvider: FC<TableSortContextProviderProps> = ({
+  fields,
+  children,
+}) => {
+  const [activeSort, setActiveSort, compareFn] = useSort(fields);
+
+  return (
+    <TableSortContext.Provider value={{ activeSort, setActiveSort, compareFn }}>
+      {children}
+    </TableSortContext.Provider>
+  );
+};
+
+export const useTableSortContext = () => useContext(TableSortContext);

--- a/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
+++ b/packages/forklift-console-plugin/src/components/page/StandardPage.tsx
@@ -24,7 +24,6 @@ import {
   useFields,
   usePagination,
   UserSettings,
-  useSort,
   useUrlFilters,
   ValueMatcher,
   withTr,
@@ -41,6 +40,8 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
+
+import { useTableSortContext } from '../TableSortContext';
 
 import { ManageColumnsToolbar } from './ManageColumnsToolbar';
 
@@ -299,7 +300,7 @@ export function StandardPage<T>({
   });
   const clearAllFilters = () => setSelectedFilters({});
   const [fields, setFields] = useFields(namespace, fieldsMetadata, userSettings?.fields);
-  const [activeSort, setActiveSort, compareFn] = useSort(fields);
+  const { activeSort, setActiveSort, compareFn } = useTableSortContext();
 
   const supportedMatchers = extraSupportedMatchers
     ? reduceValueFilters(extraSupportedMatchers, defaultValueMatchers)

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesList.tsx
@@ -4,6 +4,7 @@ import {
   StandardPageWithSelection,
   StandardPageWithSelectionProps,
 } from 'src/components/page/StandardPageWithSelection';
+import { TableSortContextProvider } from 'src/components/TableSortContext';
 import { usePlanMigration } from 'src/modules/Plans/hooks/usePlanMigration';
 import { isPlanArchived, isPlanExecuting } from 'src/modules/Plans/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -266,11 +267,12 @@ export const MigrationVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => 
   const canSelectWhenNotExecuting = (item: VMData) =>
     (item?.statusVM?.started === undefined || item?.statusVM?.error !== undefined) && !isExecuting;
 
+  const fieldsMetadata = fieldsMetadataFactory(t);
   const props: PageWithSelectionProps = {
+    fieldsMetadata,
     dataSource: [vmData || [], true, undefined],
     CellMapper: MigrationVirtualMachinesRow,
     ExpandedComponent: MigrationVirtualMachinesRowExtended,
-    fieldsMetadata: fieldsMetadataFactory(t),
     title: t('Virtual Machines'),
     userSettings: userSettings,
     namespace: '',
@@ -288,5 +290,9 @@ export const MigrationVirtualMachinesList: FC<{ obj: PlanData }> = ({ obj }) => 
     GlobalActionToolbarItems: actions,
   };
 
-  return <PageWithSelection {...extendedProps} />;
+  return (
+    <TableSortContextProvider fields={fieldsMetadata}>
+      <PageWithSelection {...extendedProps} />
+    </TableSortContextProvider>
+  );
 };


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-1871

## 📝 Description
- Prevent table refresh (any change to the table - included data updates, or even expanding/collapsing rows as seen in the demos below) from resetting the current active sort selection.
- Created a common context provider that can be used by other tables to achieve a similar solution if necessary. Since all tables within MTV use the same TableView and ResourceData for sorting, it could be used for any table where the same issue occurs.

## 🎥 Demo
**Before:**
https://github.com/user-attachments/assets/56c19f72-d704-407a-8725-03f5a37c8416

**After:**
https://github.com/user-attachments/assets/72880954-4c42-41fc-95f9-f260796ec047