### PR TITLE
[MTV-2052] Plan create wizard - auto calculated mapping for a plan is not displayed in 2nd step page anymore

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
@@ -24,6 +24,8 @@ export const DEFAULT_NAMESPACE = 'default';
 // action type names
 export const SET_NAME = 'SET_NAME';
 export const SET_PROJECT_NAME = 'SET_PROJECT_NAME';
+export const SET_SOURCE_PROVIDER = 'SET_SOURCE_PROVIDER';
+export const SET_SELECTED_VMS = 'SET_SELECTED_VMS';
 export const SET_DESCRIPTION = 'SET_DESCRIPTION';
 export const SET_TARGET_PROVIDER = 'SET_TARGET_PROVIDER';
 export const SET_TARGET_NAMESPACE = 'SET_TARGET_NAMESPACE';
@@ -52,6 +54,8 @@ export const INIT = 'INIT';
 export type CreateVmMigration =
   | typeof SET_NAME
   | typeof SET_PROJECT_NAME
+  | typeof SET_SOURCE_PROVIDER
+  | typeof SET_SELECTED_VMS
   | typeof SET_DESCRIPTION
   | typeof SET_TARGET_PROVIDER
   | typeof SET_TARGET_NAMESPACE
@@ -91,6 +95,15 @@ export interface PlanName {
 export interface ProjectName {
   name: string;
 }
+
+export type SourceProvider = {
+  sourceProvider: V1beta1Provider;
+};
+
+export type SelectedVms = {
+  vms: VmData[];
+  sourceProvider: V1beta1Provider;
+};
 
 export interface PlanDescription {
   description: string;
@@ -217,6 +230,26 @@ export const setProjectName = (name: string): PageAction<CreateVmMigration, Proj
   type: 'SET_PROJECT_NAME',
   payload: {
     name,
+  },
+});
+
+export const setSourceProvider = (
+  sourceProvider: V1beta1Provider,
+): PageAction<CreateVmMigration, SourceProvider> => ({
+  type: 'SET_SOURCE_PROVIDER',
+  payload: {
+    sourceProvider,
+  },
+});
+
+export const setSelectedVms = (
+  vms: VmData[],
+  sourceProvider: V1beta1Provider,
+): PageAction<CreateVmMigration, SelectedVms> => ({
+  type: 'SET_SELECTED_VMS',
+  payload: {
+    vms,
+    sourceProvider,
   },
 });
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/useFetchEffects.ts
@@ -35,6 +35,8 @@ import {
   setExistingPlans,
   setExistingStorageMaps,
   setNicProfiles,
+  setSelectedVms,
+  setSourceProvider,
 } from './reducer/actions';
 import { createInitialState } from './reducer/createInitialState';
 import { reducer } from './reducer/reducer';
@@ -85,6 +87,18 @@ export const useFetchEffects = (
     [],
   );
 
+  useEffect(() => {
+    if (!editingDone && selectedVms?.length) {
+      dispatch(setSelectedVms(selectedVms, sourceProvider));
+    }
+  }, [editingDone, selectedVms, sourceProvider]);
+
+  useEffect(() => {
+    if (!editingDone && sourceProvider) {
+      dispatch(setSourceProvider(sourceProvider));
+    }
+  }, [editingDone, sourceProvider]);
+
   const [providers, providersLoaded, providerError] = useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,
     namespaced: true,
@@ -95,7 +109,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setAvailableProviders(providers), !providersLoaded, providerError),
-    [editingDone, providersLoaded, providerError?.message],
+    [editingDone, providersLoaded, providerError?.message, selectedVms],
   );
 
   const [plans, plansLoaded, plansError] = useK8sWatchResource<V1beta1Plan[]>({
@@ -106,7 +120,7 @@ export const useFetchEffects = (
   });
   useEffect(
     () => !editingDone && dispatchWithFallback(setExistingPlans(plans), !plansLoaded, plansError),
-    [editingDone, plansLoaded, plansError?.message],
+    [editingDone, plansLoaded, plansError?.message, selectedVms],
   );
 
   const [netMaps, netMapsLoaded, netMapsError] = useK8sWatchResource<V1beta1NetworkMap[]>({
@@ -119,7 +133,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setExistingNetMaps(netMaps), !netMapsLoaded, netMapsError),
-    [editingDone, netMapsLoaded, netMapsError?.message],
+    [editingDone, netMapsLoaded, netMapsError?.message, selectedVms],
   );
 
   const [stMaps, stMapsLoaded, stMapsError] = useK8sWatchResource<V1beta1StorageMap[]>({
@@ -132,7 +146,7 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setExistingStorageMaps(stMaps), !stMapsLoaded, stMapsError),
-    [editingDone, stMapsLoaded, stMapsError?.message],
+    [editingDone, stMapsLoaded, stMapsError?.message, selectedVms],
   );
 
   const [namespaces, nsLoading, nsError] = useNamespaces(targetProvider);
@@ -141,7 +155,7 @@ export const useFetchEffects = (
       targetProviderName &&
       !editingDone &&
       dispatchWithFallback(setAvailableTargetNamespaces(namespaces), nsLoading, nsError),
-    [editingDone, nsLoading, nsError?.message, targetProviderName],
+    [editingDone, nsLoading, nsError?.message, targetProviderName, selectedVms],
   );
 
   const [targetNetworks, targetNetworksLoading, targetNetworksError] =
@@ -155,7 +169,13 @@ export const useFetchEffects = (
         targetNetworksLoading,
         targetNetworksError,
       ),
-    [editingDone, targetNetworksLoading, targetNetworksError?.message, targetProviderName],
+    [
+      editingDone,
+      targetNetworksLoading,
+      targetNetworksError?.message,
+      targetProviderName,
+      selectedVms,
+    ],
   );
 
   const [sourceStorages, sourceStoragesLoading, sourceStoragesError] =
@@ -168,7 +188,7 @@ export const useFetchEffects = (
         sourceStoragesLoading,
         sourceStoragesError,
       ),
-    [editingDone, sourceStoragesLoading, sourceStoragesError?.message],
+    [editingDone, sourceStoragesLoading, sourceStoragesError?.message, selectedVms],
   );
 
   const [targetStorages, targetStoragesLoading, targetStoragesError] =
@@ -182,7 +202,7 @@ export const useFetchEffects = (
         targetStoragesLoading,
         targetStoragesError,
       ),
-    [editingDone, targetStoragesLoading, targetProviderName],
+    [editingDone, targetStoragesLoading, targetProviderName, selectedVms],
   );
 
   const [sourceNetworks, sourceNetworksLoading, sourceNetworksError] =
@@ -195,7 +215,7 @@ export const useFetchEffects = (
         sourceNetworksLoading,
         sourceNetworksError,
       ),
-    [editingDone, sourceNetworksLoading, sourceNetworksError?.message],
+    [editingDone, sourceNetworksLoading, sourceNetworksError?.message, selectedVms],
   );
 
   const [nicProfiles, nicProfilesLoading, nicProfilesError] = useNicProfiles(sourceProvider);
@@ -203,13 +223,13 @@ export const useFetchEffects = (
     () =>
       !editingDone &&
       dispatchWithFallback(setNicProfiles(nicProfiles), nicProfilesLoading, nicProfilesError),
-    [editingDone, nicProfilesLoading, nicProfilesError?.message],
+    [editingDone, nicProfilesLoading, nicProfilesError?.message, selectedVms],
   );
 
   const [disks, disksLoading, disksError] = useDisks(sourceProvider);
   useEffect(
     () => !editingDone && dispatchWithFallback(setDisks(disks), disksLoading, disksError),
-    [editingDone, disksLoading, disksError?.message],
+    [editingDone, disksLoading, disksError?.message, selectedVms],
   );
 
   return [state, dispatch, emptyContext];


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2052

## 📝 Description
- Adding a new reducer function which makes the same calculations based on "selected VMs" as is done for the "init state" function without the resetting of all other form state.
- Also noticed that the source provider required the same attention, where this needed to be set in state using "init state" calculations whenever a new provider is selected as well.
- Added back some useEffect dependencies for selectedVms, although unknown the purpose of some, seemingly this could cause other rippling effects for say disks or target namespaces, so I've added these back.

## 🎥 Demo
https://github.com/user-attachments/assets/b40dbbd2-c17d-413a-9438-1cdf1ef21639

