### PR TITLE
MTV-2022: Remove Start/Restart migration button from plan details header

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { PlanActionsDropdown } from 'src/modules/Plans/actions';
-import { PlanStartMigrationModal } from 'src/modules/Plans/modals';
-import { canPlanReStart, canPlanStart, getPlanPhase, PlanPhase } from 'src/modules/Plans/utils';
+import { getPlanPhase, PlanPhase } from 'src/modules/Plans/utils';
 import { useGetDeleteAndEditAccessReview } from 'src/modules/Providers/hooks';
-import { useModal } from 'src/modules/Providers/modals';
 import { PageHeadings } from 'src/modules/Providers/utils';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils';
 
@@ -15,9 +13,7 @@ import {
   V1beta1Plan,
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { Button, Level, LevelItem, PageSection } from '@patternfly/react-core';
-import StartIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
-import ReStartIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
+import { Level, PageSection } from '@patternfly/react-core';
 
 import PlanCriticalCondition from './PlanCriticalCondition';
 import PlanWarningCondition from './PlanWarningCondition';
@@ -27,7 +23,6 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
   namespace,
 }) => {
   const { t } = useForkliftTranslation();
-  const { showModal } = useModal();
 
   const [plan, planLoaded, planError] = useK8sWatchResource<V1beta1Plan>({
     groupVersionKind: PlanModelGroupVersionKind,
@@ -50,12 +45,7 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
 
   const alerts = [];
 
-  const canStart = canPlanStart(plan);
-  const canReStart = canPlanReStart(plan);
   const planStatus = getPlanPhase({ obj: plan });
-
-  const buttonStartLabel = canReStart ? t('Restart migration') : t('Start migration');
-  const buttonStartIcon = canReStart ? <ReStartIcon /> : <StartIcon />;
 
   const criticalCondition =
     planLoaded &&
@@ -114,24 +104,8 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
     }
   };
 
-  const onClick = () => {
-    showModal(
-      <PlanStartMigrationModal resource={plan} model={PlanModel} title={buttonStartLabel} />,
-    );
-  };
-
   const actions = (
     <Level hasGutter>
-      {canStart && (
-        <Button variant="primary" onClick={onClick}>
-          <Level hasGutter>
-            <>
-              <LevelItem>{buttonStartIcon}</LevelItem>
-              <LevelItem>{buttonStartLabel}</LevelItem>
-            </>
-          </Level>
-        </Button>
-      )}
       <PlanActionsDropdown data={{ obj: plan, permissions }} fieldId={''} fields={[]} />
     </Level>
   );

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
@@ -64,7 +64,7 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
   if (phase === PlanPhase.Ready) {
     return (
       <Button
-        variant="secondary"
+        variant="primary"
         icon={<StartIcon />}
         onClick={() =>
           showModal(

--- a/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/list/components/PlanStatusCell.tsx
@@ -13,7 +13,16 @@ import { getResourceUrl } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { PlanModel, PlanModelRef } from '@kubev2v/types';
-import { Button, Flex, FlexItem, Label, Spinner, Split, SplitItem } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Flex,
+  FlexItem,
+  Label,
+  Spinner,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 import StartIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';
 
 import { CellProps } from './CellProps';
@@ -64,7 +73,7 @@ export const PlanStatusCell: React.FC<CellProps> = ({ data }) => {
   if (phase === PlanPhase.Ready) {
     return (
       <Button
-        variant="primary"
+        variant={ButtonVariant.primary}
         icon={<StartIcon />}
         onClick={() =>
           showModal(


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2022

## 📝 Description

Change button style to primary under the Plan details "Status" field
Remove the "Start migration"/"Restart migration" button next to the Actions dropdown

## 🎥 Demo

| Before    | After |
| -------- | ------- |
|  <img width="1254" alt="Screenshot 2025-02-11 at 11 48 06 AM" src="https://github.com/user-attachments/assets/b6f9aa1c-2d14-42db-938a-91e983a8c683" /> | <img width="1266" alt="Screenshot 2025-02-11 at 11 44 13 AM" src="https://github.com/user-attachments/assets/13ab7ae2-2436-4a2f-b91e-975700a7ae38" />    |
| <img width="1263" alt="Screenshot 2025-02-11 at 11 47 52 AM" src="https://github.com/user-attachments/assets/4f28b94b-b518-4848-aaeb-ddabc863dbe8" /> | <img width="1258" alt="Screenshot 2025-02-11 at 11 44 25 AM" src="https://github.com/user-attachments/assets/3cb1b187-facf-46a7-be9b-4d8bedfefd3f" />    |
