### PR TITLE
Change FreetextFilter to support an unsensitive-case text

### DIFF
--- a/packages/common/src/components/Filter/FreetextFilter.tsx
+++ b/packages/common/src/components/Filter/FreetextFilter.tsx
@@ -5,7 +5,7 @@ import { InputGroup, SearchInput, ToolbarFilter } from '@patternfly/react-core';
 import { FilterTypeProps } from './types';
 
 /**
- * This Filter type uses text provided by the user.
+ * This Filter type uses an unsensitive-case text provided by the user.
  * Text needs to be submitted/confirmed by clicking search button or by pressing Enter key.
  *
  * **FilterTypeProps are interpreted as follows** :<br>
@@ -32,10 +32,11 @@ export const FreetextFilter = ({
       [key: string]: string;
     },
   ) => void = () => {
-    if (!inputValue || selectedFilters.includes(inputValue)) {
+    const lowerCaseInputValue = inputValue?.toLowerCase();
+    if (!lowerCaseInputValue || selectedFilters.includes(lowerCaseInputValue)) {
       return;
     }
-    onFilterUpdate([...selectedFilters, inputValue]);
+    onFilterUpdate([...selectedFilters, lowerCaseInputValue]);
     setInputValue('');
   };
 


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1896

In all places where we use free text filter, change it to be case insensitive. This is the console standard so there is no need to support both modes (sensitive, unsensitive).

## 🎥 Demo

[Screencast from 2025-02-12 12-59-15.webm](https://github.com/user-attachments/assets/ea09389b-a28c-4732-8a9e-b2cac7216120)

