### PR TITLE
[MTV-1794] Add warning when specifying IP for a secure provider

### DIFF
--- a/packages/forklift-console-plugin/package.json
+++ b/packages/forklift-console-plugin/package.json
@@ -41,6 +41,7 @@
     "jsonpath": "^1.1.1",
     "jsrsasign": "11.1.0",
     "luxon": "^3.5.0",
+    "node-forge": "^1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-i18next": "^11.14.3",

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/common.ts
@@ -25,6 +25,7 @@ const QUERY_PARAMS = '(\\?[a-zA-Z0-9=&_]*)?';
 const URL_REGEX = new RegExp(
   `^${PROTOCOL}((${IPV4})|(${HOSTNAME}))((${PORT})(${PATH})(${QUERY_PARAMS})?)?$`,
 );
+const IPV4_REGEX = new RegExp(IPV4);
 
 // validate NFS mount NFS_SERVER:EXPORTED_DIRECTORY
 // example: 10.10.0.10:/backups
@@ -76,6 +77,10 @@ export function validateContainerImage(image: string) {
 
 export function validateURL(url: string) {
   return URL_REGEX.test(url);
+}
+
+export function validateIpv4(value: string) {
+  return IPV4_REGEX.test(value);
 }
 
 export function validateNFSMount(nfsPath: string) {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerValidator.ts
@@ -25,7 +25,7 @@ export function providerValidator(
       validationError = ovirtProviderValidator(provider);
       break;
     case 'vsphere':
-      validationError = vsphereProviderValidator(provider);
+      validationError = vsphereProviderValidator(provider, secret?.data?.cacert);
       break;
     case 'ova':
       validationError = ovaProviderValidator(provider);

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/vsphere/vsphereProviderValidator.ts
@@ -2,9 +2,13 @@ import { V1beta1Provider } from '@kubev2v/types';
 
 import { validateK8sName, validateURL, ValidationMsg } from '../../common';
 
+import { validateVCenterURL } from './validateVCenterURL';
 import { validateVDDKImage } from './validateVDDKImage';
 
-export function vsphereProviderValidator(provider: V1beta1Provider): ValidationMsg {
+export function vsphereProviderValidator(
+  provider: V1beta1Provider,
+  caCert?: string,
+): ValidationMsg {
   const name = provider?.metadata?.name;
   const url = provider?.spec?.url || '';
   const vddkInitImage = provider?.spec?.settings?.['vddkInitImage'] || '';
@@ -16,7 +20,7 @@ export function vsphereProviderValidator(provider: V1beta1Provider): ValidationM
     return { type: 'error', msg: 'invalid kubernetes resource name' };
   }
 
-  if (!validateURL(url)) {
+  if (caCert ? validateVCenterURL(url, caCert).type === 'error' : !validateURL(url)) {
     return { type: 'error', msg: 'invalid URL' };
   }
 

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EditProvider.tsx
@@ -71,7 +71,11 @@ export const EditProvider: React.FC<ProvidersCreateFormProps> = ({
         default:
           return (
             <>
-              <VCenterProviderCreateForm provider={newProvider} onChange={onNewProviderChange} />
+              <VCenterProviderCreateForm
+                provider={newProvider}
+                caCert={newSecret.data.cacert}
+                onChange={onNewProviderChange}
+              />
 
               <EditProviderSectionHeading text={t('Provider credentials')} />
               <VCenterCredentialsEdit secret={newSecret} onChange={onNewSecretChange} />


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-1794

## 📝 Description
Although "warning" messages were asked for, since with vcenter providers, having a certificate with a FQDN not matching the one offered in the URL input or the URL input not using a FQDN would lead to a failed provider connection and therefore an un-usable provider, error messages were instead used here.

Not only to identify URLs with IP addresses as asked for in the JIRA, but also to abide by the messaging outlined in the documentation for vcenter providers [here](https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.5/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_vmware), which states `If a certificate for FQDN is specified, the value of this field needs to match the FQDN in the certificate.`.

> In order to verify the certificate domain name, an already installed peer-dependency, node-forge, was leveraged here (and added as an explicit dependency).

## 🎥 Demo
https://github.com/user-attachments/assets/aac19801-ea73-4f95-a84b-113f2add074a

## 📝 CC://
@wolfeallison
