### PR TITLE
Avoid displaying double vertical scrollbars for plan's wizard

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -104,7 +104,11 @@ export const PlanCreatePage: FC<{ namespace: string }> = ({ namespace }) => {
       <PageSection variant="light">
         <Title headingLevel="h2">{'Create migration plan'}</Title>
       </PageSection>
-      <PageSection variant="light" className="forklift--create-plan--wizard-container">
+      <PageSection
+        hasOverflowScroll={true}
+        variant="light"
+        className="forklift--create-plan--wizard-container"
+      >
         <Wizard
           className="forklift--create-plan--wizard-content"
           shouldFocusContent


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2058

Fix a bug in which there are 2 vertical scrollbars displayed for the plan wizard.

Since the wizard includes vertical scrollbar needed to support jumping to step's headers while navigating between steps, then need to dismiss the wizard's container's scrollbar (i.e. page section) to avoid double scrollbars.

## 🎥 Demo
### Before
[Screencast from 2025-02-13 22-11-52.webm](https://github.com/user-attachments/assets/07eae4d9-1ffa-41ef-88db-8169923a2068)


### After
[Screencast from 2025-02-13 22-10-50.webm](https://github.com/user-attachments/assets/e62f5bd7-bbc6-4a54-918d-3f7b07bb84d9)

