### PR TITLE
[MTV-2063] Create plan wizard - a plan can't be created

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -310,12 +310,17 @@ const handlers: {
   [START_CREATE]({
     flow,
     receivedAsParams: { sourceProvider },
-    underConstruction: { plan, netMap, storageMap },
+    underConstruction: { plan, netMap, storageMap, projectName },
     calculatedOnce: { sourceNetworkLabelToId, sourceStorageLabelToId },
     calculatedPerNamespace: { networkMappings, storageMappings },
   }) {
     // triggered by the user
     flow.editingDone = true;
+
+    netMap.metadata.namespace = projectName;
+    storageMap.metadata.namespace = projectName;
+    plan.metadata.namespace = projectName;
+
     netMap.spec.map = networkMappings.map(({ source, destination }) => ({
       source:
         sourceNetworkLabelToId[source] === 'pod'
@@ -330,6 +335,7 @@ const handlers: {
           ? { type: 'pod' }
           : { name: destination, namespace: plan.spec.targetNamespace, type: 'multus' },
     }));
+
     storageMap.spec.map = storageMappings.map(({ source, destination }) => {
       if (sourceProvider?.spec?.type === 'openshift') {
         return {


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2063

## 📝 Description
Add missing namespace value based on projectName to plan/storage map/network map requests. This was previously being applied when the whole state object was being re-initialized on every VM table selection on step 1.

## 🎥 Demo
https://github.com/user-attachments/assets/11f20216-6b66-41b7-8758-6230c91f7bf1