### PR TITLE
[MTV-1788] Failed to create OSP provider with authentication type - token and username

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationCredentialNameSecretFieldsFormGroup.tsx
@@ -10,6 +10,8 @@ import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon'
 
 import { EditComponentProps } from '../../BaseCredentialsSection';
 
+import { OpenstackSecretFieldId } from './constants';
+
 export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
   secret,
   onChange,
@@ -27,17 +29,17 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
     passwordHidden: true,
     validation: {
       applicationCredentialName: openstackSecretFieldValidator(
-        'applicationCredentialName',
+        OpenstackSecretFieldId.ApplicationCredentialName,
         applicationCredentialName,
       ),
       applicationCredentialSecret: openstackSecretFieldValidator(
-        'applicationCredentialSecret',
+        OpenstackSecretFieldId.ApplicationCredentialSecret,
         applicationCredentialSecret,
       ),
-      username: openstackSecretFieldValidator('username', username),
-      regionName: openstackSecretFieldValidator('regionName', regionName),
-      projectName: openstackSecretFieldValidator('projectName', projectName),
-      domainName: openstackSecretFieldValidator('domainName', domainName),
+      username: openstackSecretFieldValidator(OpenstackSecretFieldId.Username, username),
+      regionName: openstackSecretFieldValidator(OpenstackSecretFieldId.RegionName, regionName),
+      projectName: openstackSecretFieldValidator(OpenstackSecretFieldId.ProjectName, projectName),
+      domainName: openstackSecretFieldValidator(OpenstackSecretFieldId.DomainName, domainName),
     },
   };
 
@@ -88,7 +90,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Application credential name')}
         isRequired
-        fieldId="applicationCredentialName"
+        fieldId={OpenstackSecretFieldId.ApplicationCredentialName}
         helperText={state.validation.applicationCredentialName.msg}
         helperTextInvalid={state.validation.applicationCredentialName.msg}
         validated={state.validation.applicationCredentialName.type}
@@ -97,10 +99,12 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           spellCheck="false"
           isRequired
           type="text"
-          id="applicationCredentialName"
-          name="applicationCredentialName"
+          id={OpenstackSecretFieldId.ApplicationCredentialName}
+          name={OpenstackSecretFieldId.ApplicationCredentialName}
           value={applicationCredentialName}
-          onChange={(e, v) => onChangeFactory('applicationCredentialName')(v, e)}
+          onChange={(e, v) =>
+            onChangeFactory(OpenstackSecretFieldId.ApplicationCredentialName)(v, e)
+          }
           validated={state.validation.applicationCredentialName.type}
         />
       </FormGroupWithHelpText>
@@ -108,7 +112,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Application credential secret')}
         isRequired
-        fieldId="applicationCredentialSecret"
+        fieldId={OpenstackSecretFieldId.ApplicationCredentialSecret}
         helperText={state.validation.applicationCredentialSecret.msg}
         helperTextInvalid={state.validation.applicationCredentialSecret.msg}
         validated={state.validation.applicationCredentialSecret.type}
@@ -119,10 +123,12 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
             className="pf-u-w-75"
             isRequired
             type={state.passwordHidden ? 'password' : 'text'}
-            id="applicationCredentialSecret"
-            name="applicationCredentialSecret"
+            id={OpenstackSecretFieldId.ApplicationCredentialSecret}
+            name={OpenstackSecretFieldId.ApplicationCredentialSecret}
             value={applicationCredentialSecret}
-            onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
+            onChange={(e, v) =>
+              onChangeFactory(OpenstackSecretFieldId.ApplicationCredentialSecret)(v, e)
+            }
             validated={state.validation.applicationCredentialSecret.type}
           />
           <Button
@@ -138,7 +144,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Username')}
         isRequired
-        fieldId="username"
+        fieldId={OpenstackSecretFieldId.Username}
         helperText={state.validation.username.msg}
         helperTextInvalid={state.validation.username.msg}
         validated={state.validation.username.type}
@@ -147,10 +153,10 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           spellCheck="false"
           isRequired
           type="text"
-          id="username"
-          name="username"
+          id={OpenstackSecretFieldId.Username}
+          name={OpenstackSecretFieldId.Username}
           value={username}
-          onChange={(e, v) => onChangeFactory('username')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Username)(v, e)}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -158,7 +164,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Region')}
         isRequired
-        fieldId="regionName"
+        fieldId={OpenstackSecretFieldId.RegionName}
         helperText={state.validation.regionName.msg}
         helperTextInvalid={state.validation.regionName.msg}
         validated={state.validation.regionName.type}
@@ -167,10 +173,10 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           spellCheck="false"
           isRequired
           type="text"
-          id="regionName"
-          name="regionName"
+          id={OpenstackSecretFieldId.RegionName}
+          name={OpenstackSecretFieldId.RegionName}
           value={regionName}
-          onChange={(e, v) => onChangeFactory('regionName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.RegionName)(v, e)}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -178,7 +184,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Project')}
         isRequired
-        fieldId="projectName"
+        fieldId={OpenstackSecretFieldId.ProjectName}
         helperText={state.validation.projectName.msg}
         helperTextInvalid={state.validation.projectName.msg}
         validated={state.validation.projectName.type}
@@ -187,10 +193,10 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           spellCheck="false"
           isRequired
           type="text"
-          id="projectName"
-          name="projectName"
+          id={OpenstackSecretFieldId.ProjectName}
+          name={OpenstackSecretFieldId.ProjectName}
           value={projectName}
-          onChange={(e, v) => onChangeFactory('projectName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ProjectName)(v, e)}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -198,7 +204,7 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
       <FormGroupWithHelpText
         label={t('Domain')}
         isRequired
-        fieldId="domainName"
+        fieldId={OpenstackSecretFieldId.DomainName}
         helperText={state.validation.domainName.msg}
         helperTextInvalid={state.validation.domainName.msg}
         validated={state.validation.domainName.type}
@@ -207,10 +213,10 @@ export const ApplicationCredentialNameSecretFieldsFormGroup: React.FC<EditCompon
           spellCheck="false"
           isRequired
           type="text"
-          id="domainName"
-          name="domainName"
+          id={OpenstackSecretFieldId.DomainName}
+          name={OpenstackSecretFieldId.DomainName}
           value={domainName}
-          onChange={(e, v) => onChangeFactory('domainName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.DomainName)(v, e)}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/ApplicationWithCredentialsIDFormGroup.tsx
@@ -10,6 +10,8 @@ import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon'
 
 import { EditComponentProps } from '../../BaseCredentialsSection';
 
+import { OpenstackSecretFieldId } from './constants';
+
 export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps> = ({
   secret,
   onChange,
@@ -25,15 +27,15 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
     passwordHidden: true,
     validation: {
       applicationCredentialID: openstackSecretFieldValidator(
-        'applicationCredentialID',
+        OpenstackSecretFieldId.ApplicationCredentialId,
         applicationCredentialID,
       ),
       applicationCredentialSecret: openstackSecretFieldValidator(
-        'applicationCredentialSecret',
+        OpenstackSecretFieldId.ApplicationCredentialSecret,
         applicationCredentialSecret,
       ),
-      regionName: openstackSecretFieldValidator('regionName', regionName),
-      projectName: openstackSecretFieldValidator('projectName', projectName),
+      regionName: openstackSecretFieldValidator(OpenstackSecretFieldId.RegionName, regionName),
+      projectName: openstackSecretFieldValidator(OpenstackSecretFieldId.ProjectName, projectName),
     },
   };
 
@@ -84,7 +86,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
       <FormGroupWithHelpText
         label={t('Application credential ID')}
         isRequired
-        fieldId="applicationCredentialID"
+        fieldId={OpenstackSecretFieldId.ApplicationCredentialId}
         helperText={state.validation.applicationCredentialID.msg}
         helperTextInvalid={state.validation.applicationCredentialID.msg}
         validated={state.validation.applicationCredentialID.type}
@@ -93,10 +95,10 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           spellCheck="false"
           isRequired
           type="text"
-          id="applicationCredentialID"
-          name="applicationCredentialID"
+          id={OpenstackSecretFieldId.ApplicationCredentialId}
+          name={OpenstackSecretFieldId.ApplicationCredentialId}
           value={applicationCredentialID}
-          onChange={(e, v) => onChangeFactory('applicationCredentialID')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ApplicationCredentialId)(v, e)}
           validated={state.validation.applicationCredentialID.type}
         />
       </FormGroupWithHelpText>
@@ -104,7 +106,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
       <FormGroupWithHelpText
         label={t('Application credential Secret')}
         isRequired
-        fieldId="applicationCredentialSecret"
+        fieldId={OpenstackSecretFieldId.ApplicationCredentialSecret}
         helperText={state.validation.applicationCredentialSecret.msg}
         helperTextInvalid={state.validation.applicationCredentialSecret.msg}
         validated={state.validation.applicationCredentialSecret.type}
@@ -115,10 +117,12 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
             className="pf-u-w-75"
             isRequired
             type={state.passwordHidden ? 'password' : 'text'}
-            id="applicationCredentialSecret"
-            name="applicationCredentialSecret"
+            id={OpenstackSecretFieldId.ApplicationCredentialSecret}
+            name={OpenstackSecretFieldId.ApplicationCredentialSecret}
             value={applicationCredentialSecret}
-            onChange={(e, v) => onChangeFactory('applicationCredentialSecret')(v, e)}
+            onChange={(e, v) =>
+              onChangeFactory(OpenstackSecretFieldId.ApplicationCredentialSecret)(v, e)
+            }
             validated={state.validation.applicationCredentialSecret.type}
           />
           <Button
@@ -134,7 +138,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
       <FormGroupWithHelpText
         label={t('Region')}
         isRequired
-        fieldId="regionName"
+        fieldId={OpenstackSecretFieldId.RegionName}
         helperText={state.validation.regionName.msg}
         helperTextInvalid={state.validation.regionName.msg}
         validated={state.validation.regionName.type}
@@ -143,10 +147,10 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           spellCheck="false"
           isRequired
           type="text"
-          id="regionName"
-          name="regionName"
+          id={OpenstackSecretFieldId.RegionName}
+          name={OpenstackSecretFieldId.RegionName}
           value={regionName}
-          onChange={(e, v) => onChangeFactory('regionName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.RegionName)(v, e)}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -154,7 +158,7 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
       <FormGroupWithHelpText
         label={t('Project')}
         isRequired
-        fieldId="projectName"
+        fieldId={OpenstackSecretFieldId.ProjectName}
         helperText={state.validation.projectName.msg}
         helperTextInvalid={state.validation.projectName.msg}
         validated={state.validation.projectName.type}
@@ -163,10 +167,10 @@ export const ApplicationWithCredentialsIDFormGroup: React.FC<EditComponentProps>
           spellCheck="false"
           isRequired
           type="text"
-          id="projectName"
-          name="projectName"
+          id={OpenstackSecretFieldId.ProjectName}
+          name={OpenstackSecretFieldId.ProjectName}
           value={projectName}
-          onChange={(e, v) => onChangeFactory('projectName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ProjectName)(v, e)}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/PasswordSecretFieldsFormGroup.tsx
@@ -10,6 +10,8 @@ import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon'
 
 import { EditComponentProps } from '../../BaseCredentialsSection';
 
+import { OpenstackSecretFieldId } from './constants';
+
 export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
   secret,
   onChange,
@@ -25,11 +27,11 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
   const initialState = {
     passwordHidden: true,
     validation: {
-      username: openstackSecretFieldValidator('username', username),
-      password: openstackSecretFieldValidator('password', password),
-      regionName: openstackSecretFieldValidator('regionName', regionName),
-      projectName: openstackSecretFieldValidator('projectName', projectName),
-      domainName: openstackSecretFieldValidator('domainName', domainName),
+      username: openstackSecretFieldValidator(OpenstackSecretFieldId.Username, username),
+      password: openstackSecretFieldValidator(OpenstackSecretFieldId.Password, password),
+      regionName: openstackSecretFieldValidator(OpenstackSecretFieldId.RegionName, regionName),
+      projectName: openstackSecretFieldValidator(OpenstackSecretFieldId.ProjectName, projectName),
+      domainName: openstackSecretFieldValidator(OpenstackSecretFieldId.DomainName, domainName),
     },
   };
 
@@ -80,7 +82,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       <FormGroupWithHelpText
         label={t('Username')}
         isRequired
-        fieldId="username"
+        fieldId={OpenstackSecretFieldId.Username}
         helperText={state.validation.username.msg}
         helperTextInvalid={state.validation.username.msg}
         validated={state.validation.username.type}
@@ -89,10 +91,10 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           spellCheck="false"
           isRequired
           type="text"
-          id="username"
-          name="username"
+          id={OpenstackSecretFieldId.Username}
+          name={OpenstackSecretFieldId.Username}
           value={username}
-          onChange={(e, v) => onChangeFactory('username')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Username)(v, e)}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -100,7 +102,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       <FormGroupWithHelpText
         label={t('Password')}
         isRequired
-        fieldId="password"
+        fieldId={OpenstackSecretFieldId.Password}
         helperText={state.validation.password.msg}
         helperTextInvalid={state.validation.password.msg}
         validated={state.validation.password.type}
@@ -113,7 +115,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
             type={state.passwordHidden ? 'password' : 'text'}
             aria-label="Password input"
             value={password}
-            onChange={(e, v) => onChangeFactory('password')(v, e)}
+            onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Password)(v, e)}
             validated={state.validation.password.type}
           />
           <Button
@@ -129,7 +131,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       <FormGroupWithHelpText
         label={t('Region')}
         isRequired
-        fieldId="regionName"
+        fieldId={OpenstackSecretFieldId.RegionName}
         helperText={state.validation.regionName.msg}
         helperTextInvalid={state.validation.regionName.msg}
         validated={state.validation.regionName.type}
@@ -138,10 +140,10 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           spellCheck="false"
           isRequired
           type="text"
-          id="regionName"
-          name="regionName"
+          id={OpenstackSecretFieldId.RegionName}
+          name={OpenstackSecretFieldId.RegionName}
           value={regionName}
-          onChange={(e, v) => onChangeFactory('regionName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.RegionName)(v, e)}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -149,7 +151,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       <FormGroupWithHelpText
         label={t('Project')}
         isRequired
-        fieldId="projectName"
+        fieldId={OpenstackSecretFieldId.ProjectName}
         helperText={state.validation.projectName.msg}
         helperTextInvalid={state.validation.projectName.msg}
         validated={state.validation.projectName.type}
@@ -158,10 +160,10 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           spellCheck="false"
           isRequired
           type="text"
-          id="projectName"
-          name="projectName"
+          id={OpenstackSecretFieldId.ProjectName}
+          name={OpenstackSecretFieldId.ProjectName}
           value={projectName}
-          onChange={(e, v) => onChangeFactory('projectName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ProjectName)(v, e)}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -169,7 +171,7 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
       <FormGroupWithHelpText
         label={t('Domain')}
         isRequired
-        fieldId="domainName"
+        fieldId={OpenstackSecretFieldId.DomainName}
         helperText={state.validation.domainName.msg}
         helperTextInvalid={state.validation.domainName.msg}
         validated={state.validation.domainName.type}
@@ -178,10 +180,10 @@ export const PasswordSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
           spellCheck="false"
           isRequired
           type="text"
-          id="domainName"
-          name="domainName"
+          id={OpenstackSecretFieldId.DomainName}
+          name={OpenstackSecretFieldId.DomainName}
           value={domainName}
-          onChange={(e, v) => onChangeFactory('domainName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.DomainName)(v, e)}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUserIDSecretFieldsFormGroup.tsx
@@ -10,6 +10,8 @@ import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon'
 
 import { EditComponentProps } from '../../BaseCredentialsSection';
 
+import { OpenstackSecretFieldId } from './constants';
+
 export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
   secret,
   onChange,
@@ -24,10 +26,10 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
   const initialState = {
     passwordHidden: true,
     validation: {
-      token: openstackSecretFieldValidator('token', token),
-      userID: openstackSecretFieldValidator('userID', userID),
-      projectID: openstackSecretFieldValidator('projectID', projectID),
-      regionName: openstackSecretFieldValidator('regionName', regionName),
+      token: openstackSecretFieldValidator(OpenstackSecretFieldId.Token, token),
+      userID: openstackSecretFieldValidator(OpenstackSecretFieldId.UserId, userID),
+      projectID: openstackSecretFieldValidator(OpenstackSecretFieldId.ProjectId, projectID),
+      regionName: openstackSecretFieldValidator(OpenstackSecretFieldId.RegionName, regionName),
     },
   };
 
@@ -77,7 +79,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
       <FormGroupWithHelpText
         label={t('Token')}
         isRequired
-        fieldId="token"
+        fieldId={OpenstackSecretFieldId.Token}
         helperText={state.validation.token.msg}
         helperTextInvalid={state.validation.token.msg}
         validated={state.validation.token.type}
@@ -88,10 +90,10 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
             className="pf-u-w-75"
             isRequired
             type={state.passwordHidden ? 'password' : 'text'}
-            id="token"
-            name="token"
+            id={OpenstackSecretFieldId.Token}
+            name={OpenstackSecretFieldId.Token}
             value={token}
-            onChange={(e, v) => onChangeFactory('token')(v, e)}
+            onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Token)(v, e)}
             validated={state.validation.token.type}
           />
           <Button
@@ -107,7 +109,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
       <FormGroupWithHelpText
         label={t('User ID')}
         isRequired
-        fieldId="userID"
+        fieldId={OpenstackSecretFieldId.UserId}
         helperText={state.validation.userID.msg}
         helperTextInvalid={state.validation.userID.msg}
         validated={state.validation.userID.type}
@@ -116,10 +118,10 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           spellCheck="false"
           isRequired
           type="text"
-          id="userID"
-          name="userID"
+          id={OpenstackSecretFieldId.UserId}
+          name={OpenstackSecretFieldId.UserId}
           value={userID}
-          onChange={(e, v) => onChangeFactory('userID')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.UserId)(v, e)}
           validated={state.validation.userID.type}
         />
       </FormGroupWithHelpText>
@@ -127,7 +129,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
       <FormGroupWithHelpText
         label={t('Project ID')}
         isRequired
-        fieldId="projectID"
+        fieldId={OpenstackSecretFieldId.ProjectId}
         helperText={state.validation.projectID.msg}
         helperTextInvalid={state.validation.projectID.msg}
         validated={state.validation.projectID.type}
@@ -136,10 +138,10 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           spellCheck="false"
           isRequired
           type="text"
-          id="projectID"
-          name="projectID"
+          id={OpenstackSecretFieldId.ProjectId}
+          name={OpenstackSecretFieldId.ProjectId}
           value={projectID}
-          onChange={(e, v) => onChangeFactory('projectID')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ProjectId)(v, e)}
           validated={state.validation.projectID.type}
         />
       </FormGroupWithHelpText>
@@ -147,7 +149,7 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
       <FormGroupWithHelpText
         label={t('Region')}
         isRequired
-        fieldId="regionName"
+        fieldId={OpenstackSecretFieldId.RegionName}
         helperText={state.validation.regionName.msg}
         helperTextInvalid={state.validation.regionName.msg}
         validated={state.validation.regionName.type}
@@ -156,10 +158,10 @@ export const TokenWithUserIDSecretFieldsFormGroup: React.FC<EditComponentProps> 
           spellCheck="false"
           isRequired
           type="text"
-          id="regionName"
-          name="regionName"
+          id={OpenstackSecretFieldId.RegionName}
+          name={OpenstackSecretFieldId.RegionName}
           value={regionName}
-          onChange={(e, v) => onChangeFactory('regionName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.RegionName)(v, e)}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/TokenWithUsernameSecretFieldsFormGroup.tsx
@@ -10,6 +10,8 @@ import EyeSlashIcon from '@patternfly/react-icons/dist/esm/icons/eye-slash-icon'
 
 import { EditComponentProps } from '../../BaseCredentialsSection';
 
+import { OpenstackSecretFieldId } from './constants';
+
 export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps> = ({
   secret,
   onChange,
@@ -25,11 +27,11 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
   const initialState = {
     passwordHidden: true,
     validation: {
-      token: openstackSecretFieldValidator('token', token),
-      username: openstackSecretFieldValidator('username', username),
-      regionName: openstackSecretFieldValidator('regionName', regionName),
-      projectName: openstackSecretFieldValidator('projectName', projectName),
-      domainName: openstackSecretFieldValidator('domainName', domainName),
+      token: openstackSecretFieldValidator(OpenstackSecretFieldId.Token, token),
+      username: openstackSecretFieldValidator(OpenstackSecretFieldId.Username, username),
+      regionName: openstackSecretFieldValidator(OpenstackSecretFieldId.RegionName, regionName),
+      projectName: openstackSecretFieldValidator(OpenstackSecretFieldId.ProjectName, projectName),
+      domainName: openstackSecretFieldValidator(OpenstackSecretFieldId.DomainName, domainName),
     },
   };
 
@@ -79,7 +81,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       <FormGroupWithHelpText
         label={t('Token')}
         isRequired
-        fieldId="token"
+        fieldId={OpenstackSecretFieldId.Token}
         helperText={state.validation.token.msg}
         helperTextInvalid={state.validation.token.msg}
         validated={state.validation.token.type}
@@ -90,10 +92,10 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
             className="pf-u-w-75"
             isRequired
             type={state.passwordHidden ? 'password' : 'text'}
-            id="token"
-            name="token"
+            id={OpenstackSecretFieldId.Token}
+            name={OpenstackSecretFieldId.Token}
             value={token}
-            onChange={(e, v) => onChangeFactory('token')(v, e)}
+            onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Token)(v, e)}
             validated={state.validation.token.type}
           />
           <Button
@@ -109,7 +111,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       <FormGroupWithHelpText
         label={t('Username')}
         isRequired
-        fieldId="username"
+        fieldId={OpenstackSecretFieldId.Username}
         helperText={state.validation.username.msg}
         helperTextInvalid={state.validation.username.msg}
         validated={state.validation.username.type}
@@ -118,10 +120,10 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           spellCheck="false"
           isRequired
           type="text"
-          id="username"
-          name="username"
+          id={OpenstackSecretFieldId.Username}
+          name={OpenstackSecretFieldId.Username}
           value={username}
-          onChange={(e, v) => onChangeFactory('Username')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.Username)(v, e)}
           validated={state.validation.username.type}
         />
       </FormGroupWithHelpText>
@@ -129,7 +131,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       <FormGroupWithHelpText
         label={t('Region')}
         isRequired
-        fieldId="regionName"
+        fieldId={OpenstackSecretFieldId.RegionName}
         helperText={state.validation.regionName.msg}
         helperTextInvalid={state.validation.regionName.msg}
         validated={state.validation.regionName.type}
@@ -138,10 +140,10 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           spellCheck="false"
           isRequired
           type="text"
-          id="regionName"
-          name="regionName"
+          id={OpenstackSecretFieldId.RegionName}
+          name={OpenstackSecretFieldId.RegionName}
           value={regionName}
-          onChange={(e, v) => onChangeFactory('regionName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.RegionName)(v, e)}
           validated={state.validation.regionName.type}
         />
       </FormGroupWithHelpText>
@@ -149,7 +151,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       <FormGroupWithHelpText
         label={t('Project')}
         isRequired
-        fieldId="projectName"
+        fieldId={OpenstackSecretFieldId.ProjectName}
         helperText={state.validation.projectName.msg}
         helperTextInvalid={state.validation.projectName.msg}
         validated={state.validation.projectName.type}
@@ -158,10 +160,10 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           spellCheck="false"
           isRequired
           type="text"
-          id="projectName"
-          name="projectName"
+          id={OpenstackSecretFieldId.ProjectName}
+          name={OpenstackSecretFieldId.ProjectName}
           value={projectName}
-          onChange={(e, v) => onChangeFactory('projectName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.ProjectName)(v, e)}
           validated={state.validation.projectName.type}
         />
       </FormGroupWithHelpText>
@@ -169,7 +171,7 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
       <FormGroupWithHelpText
         label={t('Domain name')}
         isRequired
-        fieldId="domainName"
+        fieldId={OpenstackSecretFieldId.DomainName}
         helperText={state.validation.domainName.msg}
         helperTextInvalid={state.validation.domainName.msg}
         validated={state.validation.domainName.type}
@@ -178,10 +180,10 @@ export const TokenWithUsernameSecretFieldsFormGroup: React.FC<EditComponentProps
           spellCheck="false"
           isRequired
           type="text"
-          id="domainName"
-          name="domainName"
+          id={OpenstackSecretFieldId.DomainName}
+          name={OpenstackSecretFieldId.DomainName}
           value={domainName}
-          onChange={(e, v) => onChangeFactory('domainName')(v, e)}
+          onChange={(e, v) => onChangeFactory(OpenstackSecretFieldId.DomainName)(v, e)}
           validated={state.validation.domainName.type}
         />
       </FormGroupWithHelpText>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/constants.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/edit/OpenstackCredentialsEditFormGroups/constants.ts
@@ -1,0 +1,13 @@
+export enum OpenstackSecretFieldId {
+  Username = 'username',
+  Password = 'password',
+  Token = 'token',
+  RegionName = 'regionName',
+  ProjectName = 'projectName',
+  DomainName = 'domainName',
+  UserId = 'userID',
+  ProjectId = 'projectID',
+  ApplicationCredentialName = 'applicationCredentialName',
+  ApplicationCredentialSecret = 'applicationCredentialSecret',
+  ApplicationCredentialId = 'applicationCredentialID',
+}


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-1788

## 📝 Description
The incorrect Field ID was being used for the "Username" field, resulting in the wrong set of fields to validate (since these are conditionally set based on the "authentication type" radio selection).

The correct Field ID being used solved the problem, but to help prevent this from happening in the future, an enum was created as a source of truth for those Field IDs used across OpenStack provider create form sections.

We could also do this for other Provider forms that are not OpenStack, but this would be out of scope for this bug, and ideally done as a tech debt follow-up if wanted.

## 🎥 Demo
**Before:**
https://github.com/user-attachments/assets/2a6caac2-826f-4600-aa0a-a85731381563

**After:**
https://github.com/user-attachments/assets/709872d7-3a2a-4933-b55b-3299d65c6514