### PR TITLE
When migration task isn't completed but  task's progress.total equals completed, mark task as successful

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRow.tsx
@@ -225,7 +225,7 @@ const countTasks = (diskTransfer: V1beta1PlanStatusMigrationVmsPipeline) => {
 
   // search num of completed tasks (either tasks that completed successfully or ones that aren't finished but their pipeline step is).
   const completedTasks = diskTransfer.tasks.filter((task) =>
-    hasTaskCompleted(task.phase, diskTransfer),
+    hasTaskCompleted(task.phase, task.progress, diskTransfer),
   ).length;
 
   return { totalTasks, completedTasks };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/VirtualMachines/Migration/MigrationVirtualMachinesRowExtended.tsx
@@ -356,7 +356,7 @@ const getPipelineTasks = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
   const tasks = pipeline?.tasks || [];
 
   // search for all completed tasks (either tasks that completed successfully or ones that aren't finished but their pipeline step is).
-  const tasksCompleted = tasks.filter((c) => hasTaskCompleted(c.phase, pipeline));
+  const tasksCompleted = tasks.filter((c) => hasTaskCompleted(c.phase, c.progress, pipeline));
 
   return { total: tasks.length, completed: tasksCompleted.length, name: pipeline.name };
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineCompleted.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineCompleted.tsx
@@ -1,5 +1,7 @@
 import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
 
+import { hasPipelineNotFailed } from './hasPipelineNotFailed';
+
 /**
  * Check if a given migration's pipeline step has completed successfully.
  *
@@ -7,4 +9,4 @@ import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
  * @returns {boolean} - True if the migration step has completed successfully, false otherwise.
  */
 export const hasPipelineCompleted = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) =>
-  !pipeline?.error && pipeline?.phase === 'Completed';
+  hasPipelineNotFailed(pipeline) && pipeline?.phase === 'Completed';

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineNotFailed.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasPipelineNotFailed.tsx
@@ -1,0 +1,10 @@
+import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
+
+/**
+ * Check if a given migration's pipeline step has not failed.
+ *
+ * @param {V1beta1PlanStatusMigrationVmsPipeline} pipeline - A given migration's pipeline step
+ * @returns {boolean} - True if the migration step has not failed, false otherwise.
+ */
+export const hasPipelineNotFailed = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) =>
+  !pipeline?.error;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasTaskCompleted.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/hasTaskCompleted.tsx
@@ -1,12 +1,20 @@
-import { V1beta1PlanStatusMigrationVmsPipeline } from '@kubev2v/types';
+import {
+  V1beta1PlanStatusMigrationVmsPipeline,
+  V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
+} from '@kubev2v/types';
 
-import { hasPipelineCompleted } from './hasPipelineCompleted';
+import { hasPipelineCompleted, hasPipelineNotFailed } from './';
 
 /**
  *  Check if a given task within a pipeline has completed.
  *
- *  A task if marked as completed successfully if its phase is marked as completed or if
- *  its phase is not set but its contained pipeline step has completed successfully.
+ *  A task if marked as completed successfully if:
+ *  1. its phase is marked as completed
+ *  or
+ *  2. its phase is not set but its contained pipeline step has completed successfully
+ *  or
+ *  3. its phase is not set and its contained pipeline step is not completed and not failed,
+ *  but its progress completed units equal its progress total units.
  *
  * @param {string } taskPhase A given task's phase
  * @param {V1beta1PlanStatusMigrationVmsPipeline} pipeline - A given migration's pipeline step which includes the task
@@ -14,5 +22,14 @@ import { hasPipelineCompleted } from './hasPipelineCompleted';
  */
 export const hasTaskCompleted = (
   taskPhase: string,
+  taskProgress: V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
   pipeline: V1beta1PlanStatusMigrationVmsPipeline,
-) => taskPhase === 'Completed' || (taskPhase === undefined && hasPipelineCompleted(pipeline));
+) =>
+  taskPhase === 'Completed' ||
+  (taskPhase === undefined && hasPipelineCompleted(pipeline)) ||
+  (taskPhase === undefined && hasPipelineOkAndTaskProgressCompleted(taskProgress, pipeline));
+
+const hasPipelineOkAndTaskProgressCompleted = (
+  taskProgress: V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
+  pipeline: V1beta1PlanStatusMigrationVmsPipeline,
+) => hasPipelineNotFailed(pipeline) && taskProgress.completed === taskProgress.total;

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/index.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/utils/index.ts
@@ -4,6 +4,7 @@ export * from './constants';
 export * from './getInventoryApiUrl';
 export * from './getValueByJsonPath';
 export * from './hasPipelineCompleted';
+export * from './hasPipelineNotFailed';
 export * from './hasPlanMappingsChanged';
 export * from './hasSomeCompleteRunningVMs';
 export * from './hasTaskCompleted';


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1718

In case a VM migration task is not marked as finished (i.e. task.phase is undefined), and its pipeline step is not marked as completed as well (but not failed) then mark the task in UI as completed successfully if taks's progress total reaches the task's progress completed.

This will solve cases in which the DiskTransferV2v or DiskTransfer tasks aren't completed although the migration is successful.

This fix was done for all migration VM types.



