### PR TITLE
Fix few create/edit provider fields validators bugs

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/validateUrlAndTokenExistence.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/validateUrlAndTokenExistence.ts
@@ -1,0 +1,23 @@
+import { ValidationMsg } from '../validators';
+
+/**
+ * Function to ensure that the input url, token fields are both set or both empty.
+ */
+export const validateUrlAndTokenExistence = (url: string, token: string): ValidationMsg => {
+  // Empty URL + token is valid as host providers
+  if (url === '' && token === '') {
+    return { type: 'default' };
+  }
+
+  // If we have url, token is required
+  if (url !== '' && token === '') {
+    return { type: 'error', msg: `Missing required fields [token]` };
+  }
+
+  // If we have token, url is required
+  if (url === '' && token !== '') {
+    return { type: 'error', msg: `Missing required fields [url]` };
+  }
+
+  return null;
+};

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftProviderValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftProviderValidator.ts
@@ -1,15 +1,24 @@
-import { V1beta1Provider } from '@kubev2v/types';
+import { IoK8sApiCoreV1Secret, V1beta1Provider } from '@kubev2v/types';
 
+import { validateUrlAndTokenExistence } from '../../../helpers/validateUrlAndTokenExistence';
 import { validateK8sName, validateURL, ValidationMsg } from '../../common';
 
-export function openshiftProviderValidator(provider: V1beta1Provider): ValidationMsg {
+export function openshiftProviderValidator(
+  provider: V1beta1Provider,
+  secret: IoK8sApiCoreV1Secret,
+): ValidationMsg {
   const name = provider?.metadata?.name;
   const url = provider?.spec?.url || '';
+  const token = secret?.data?.token || '';
 
   if (!validateK8sName(name)) {
     return { type: 'error', msg: 'Invalid kubernetes resource name' };
   }
 
+  const validation: ValidationMsg = validateUrlAndTokenExistence(url, token);
+  if (validation) return validation;
+
+  // validate fields
   if (url !== '' && !validateURL(url)) {
     return { type: 'error', msg: 'Invalid URL' };
   }

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/openshift/openshiftSecretValidator.ts
@@ -1,29 +1,21 @@
 import { Base64 } from 'js-base64';
 
-import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
+import { IoK8sApiCoreV1Secret, V1beta1Provider } from '@kubev2v/types';
 
+import { validateUrlAndTokenExistence } from '../../../helpers/validateUrlAndTokenExistence';
 import { ValidationMsg } from '../../common';
 
 import { openshiftSecretFieldValidator } from './openshiftSecretFieldValidator';
 
-export function openshiftSecretValidator(secret: IoK8sApiCoreV1Secret): ValidationMsg {
-  const url = secret?.data?.url || '';
+export function openshiftSecretValidator(
+  provider: V1beta1Provider,
+  secret: IoK8sApiCoreV1Secret,
+): ValidationMsg {
+  const url = provider?.spec?.url || '';
   const token = secret?.data?.token || '';
 
-  // Empty URL + token is valid as host providers
-  if (url === '' && token === '') {
-    return { type: 'default' };
-  }
-
-  // If we have url, token is required
-  if (url !== '' && token === '') {
-    return { type: 'error', msg: `Missing required fields [token]` };
-  }
-
-  // If we have token, url is required
-  if (url === '' && token !== '') {
-    return { type: 'error', msg: `Missing required fields [url]` };
-  }
+  const validation: ValidationMsg = validateUrlAndTokenExistence(url, token);
+  if (validation) return validation;
 
   // Validate fields
   const validateFields = ['user', 'token', 'insecureSkipVerify'];

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerAndSecretValidator.ts
@@ -13,8 +13,8 @@ export function providerAndSecretValidator(
   const subTypeString = provider?.spec?.settings?.['sdkEndpoint'] || '';
   const subType = subTypeString === 'esxi' ? 'esxi' : 'vcenter';
 
-  const secretValidation = secretValidator(type, subType, secret);
-  const providerValidation = providerValidator(provider);
+  const secretValidation = secretValidator(provider, type, subType, secret);
+  const providerValidation = providerValidator(provider, secret);
 
   // Test for validation errors
   if (providerValidation?.type === 'error') {

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/providerValidator.ts
@@ -1,4 +1,4 @@
-import { V1beta1Provider } from '@kubev2v/types';
+import { IoK8sApiCoreV1Secret, V1beta1Provider } from '@kubev2v/types';
 
 import { ValidationMsg } from '../common';
 
@@ -8,12 +8,15 @@ import { ovaProviderValidator } from './ova/ovaProviderValidator';
 import { ovirtProviderValidator } from './ovirt/ovirtProviderValidator';
 import { vsphereProviderValidator } from './vsphere/vsphereProviderValidator';
 
-export function providerValidator(provider: V1beta1Provider): ValidationMsg {
+export function providerValidator(
+  provider: V1beta1Provider,
+  secret: IoK8sApiCoreV1Secret,
+): ValidationMsg {
   let validationError: ValidationMsg;
 
   switch (provider.spec.type) {
     case 'openshift':
-      validationError = openshiftProviderValidator(provider);
+      validationError = openshiftProviderValidator(provider, secret);
       break;
     case 'openstack':
       validationError = openstackProviderValidator(provider);

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/secretValidator.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/validators/provider/secretValidator.ts
@@ -1,4 +1,4 @@
-import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
+import { IoK8sApiCoreV1Secret, V1beta1Provider } from '@kubev2v/types';
 
 import { ValidationMsg } from '../common';
 
@@ -10,6 +10,7 @@ import { esxiSecretValidator, vcenterSecretValidator } from './vsphere';
 export type SecretSubType = 'esxi' | 'vcenter';
 
 export function secretValidator(
+  provider: V1beta1Provider,
   type: string,
   subType: SecretSubType,
   secret: IoK8sApiCoreV1Secret,
@@ -18,7 +19,7 @@ export function secretValidator(
 
   switch (type) {
     case 'openshift':
-      validationError = openshiftSecretValidator(secret);
+      validationError = openshiftSecretValidator(provider, secret);
       break;
     case 'openstack':
       validationError = openstackSecretValidator(secret);

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/ProvidersCreatePage.tsx
@@ -79,12 +79,12 @@ export const ProvidersCreatePage: React.FC<{
         const value = action.payload as V1beta1Provider;
         let validationError = providerAndSecretValidator(state.newProvider, value);
 
-        if (providerNames.includes(state.newProvider?.metadata?.name)) {
-          validationError = { type: 'error', msg: 'Provider name is not unique' };
-        }
-
         if (!state.newProvider?.metadata?.name) {
           validationError = { type: 'error', msg: 'Missing provider name' };
+        }
+
+        if (providerNames.includes(state.newProvider?.metadata?.name)) {
+          validationError = { type: 'error', msg: 'Provider name is not unique' };
         }
 
         return {
@@ -97,6 +97,10 @@ export const ProvidersCreatePage: React.FC<{
       case 'SET_NEW_PROVIDER': {
         const value = action.payload as V1beta1Provider;
         let validationError = providerAndSecretValidator(value, state.newSecret);
+
+        if (!value?.metadata?.name) {
+          validationError = { type: 'error', msg: 'Missing provider name' };
+        }
 
         if (providerNames.includes(value?.metadata?.name)) {
           validationError = { type: 'error', msg: 'Provider name is not unique' };

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/CredentialsSection/components/BaseCredentialsSection.tsx
@@ -3,7 +3,7 @@ import { AlertMessageForModals } from 'src/modules/Providers/modals';
 import { ValidationMsg } from 'src/modules/Providers/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { IoK8sApiCoreV1Secret } from '@kubev2v/types';
+import { IoK8sApiCoreV1Secret, V1beta1Provider } from '@kubev2v/types';
 import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
@@ -34,7 +34,7 @@ export interface EditComponentProps {
 
 export type BaseCredentialsSectionProps = {
   secret: IoK8sApiCoreV1Secret;
-  validator: (secret: IoK8sApiCoreV1Secret) => ValidationMsg;
+  validator: (provider: V1beta1Provider, secret: IoK8sApiCoreV1Secret) => ValidationMsg;
   ListComponent: React.FC<ListComponentProps>;
   EditComponent: React.FC<EditComponentProps>;
 };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1597

Fix the following issues for the create/edit provider pages:
1. Ensure that the provider name is mandatory and validated first within the page
2. For OCP validations, ensure that the logic for the url, token fields is correct, i.e. both are set or both are emppty (for local cluster).


## 🎥 Demo

### Before (create provider button is enabled, clicking triggers nothing since it's not a valid setting)
![Screenshot from 2025-02-18 14-01-01](https://github.com/user-attachments/assets/554452b2-d034-4ad8-b253-c334c3042150)

### After

![Screenshot from 2025-02-18 14-03-22](https://github.com/user-attachments/assets/1eaae34c-d796-49ea-87c9-5c239a8557fc)


