### PR TITLE
Fix StorageMaps, NetworkMaps pages for referring to mapping's source/destination providers based on provider names

### DIFF
--- a/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -54,12 +54,16 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
   });
 
   const sourceProvider = providers.find(
-    (p) => p?.metadata?.uid === obj?.spec?.provider?.source?.uid,
+    (p) =>
+      p?.metadata?.uid === obj?.spec?.provider?.source?.uid ||
+      p?.metadata?.name === obj?.spec?.provider?.source?.name,
   );
   const [sourceNetworks] = useSourceNetworks(sourceProvider);
 
   const destinationProvider = providers.find(
-    (p) => p?.metadata?.uid === obj?.spec?.provider?.destination?.uid,
+    (p) =>
+      p?.metadata?.uid === obj?.spec?.provider?.destination?.uid ||
+      p?.metadata?.name === obj?.spec?.provider?.destination?.name,
   );
   const [destinationNetworks] = useOpenShiftNetworks(destinationProvider);
 

--- a/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -46,12 +46,16 @@ export const MapsSection: React.FC<MapsSectionProps> = ({ obj }) => {
   });
 
   const sourceProvider = providers.find(
-    (p) => p?.metadata?.uid === obj?.spec?.provider?.source?.uid,
+    (p) =>
+      p?.metadata?.uid === obj?.spec?.provider?.source?.uid ||
+      p?.metadata?.name === obj?.spec?.provider?.source?.name,
   );
   const [sourceStorages] = useSourceStorages(sourceProvider);
 
   const destinationProvider = providers.find(
-    (p) => p?.metadata?.uid === obj?.spec?.provider?.destination?.uid,
+    (p) =>
+      p?.metadata?.uid === obj?.spec?.provider?.destination?.uid ||
+      p?.metadata?.name === obj?.spec?.provider?.destination?.name,
   );
   const [destinationStorages] = useOpenShiftStorages(destinationProvider);
 


### PR DESCRIPTION

Reference: https://issues.redhat.com/browse/MTV-1421

## 📝 Description

Currently when displaying a storage mappings or metwork mappings in `StorageMaps` or `NetworkMaps` pages, the reference to the mapping's source/destination providers was done based on providers uid only and not also on providers name+namespace.

That was problematic when loading a mappings via CL yaml since the yaml required format doesn't include providers uids data. So when loading mappings via a yaml, the uids for the providers should have been set or otherwise the mappings were wrong displayed and weren't editable.

Note that mapppings displayed in the plan are supported for both name or uid.

**Examples:**
This yaml format didn't work:

```
kind: NetworkMap
...
spec:
   provider:
     source:
       name: vsphere
       namespace: konveyor-forklift
     destination:
      name: host
      namespace: konveyor-forklift
```

While this worked:

```
kind: NetworkMap
...
spec:
   provider:
     source:
       name: vsphere
       namespace: konveyor-forklift
       uid: 6cf88e38-063c-4cee-9240-cc02e023157a     <=== uid is set
     destination:
      name: host
      namespace: konveyor-forklift
      uid: 9562477b-0297-45fc-b5d4-7f61de98a002   <== uid is set

```
This PR fixes that so both yaml formats are acceptable.



## 🎥 Demo
### Before

![Screenshot from 2025-02-19 21-59-31](https://github.com/user-attachments/assets/5be1501f-a7c0-489f-94b8-b87f35264d5d)

### After
![Screenshot from 2025-02-19 22-00-14](https://github.com/user-attachments/assets/6b898005-15c5-4832-8cbe-4bb9ace7fa79)


