### PR TITLE
MTV-1609: Filter out templates from vsphere

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -31,14 +31,6 @@ export const vSphereVmFieldsMetadataFactory: ResourceFieldFactory = (t) => [
     filter: concernFilter(t),
   },
   {
-    resourceFieldId: 'isTemplate',
-    jsonPath: '$.vm.isTemplate',
-    label: t('Template'),
-    isVisible: true,
-    isIdentity: false,
-    sortable: true,
-  },
-  {
     resourceFieldId: 'host',
     jsonPath: '$.hostName',
     label: t('Host'),
@@ -92,22 +84,25 @@ export const VSphereVirtualMachinesList: React.FC<ProviderVirtualMachinesProps> 
   const { vmData } = obj;
 
   /**
-   * Processes the vmData to include folderName and hostName for each VM.
+   * Processes the vmData to filter out templates,
+   * and include folderName and hostName for each VM.
    *
    * @param {Array} vmData - The array of VM data objects.
    * @returns {Array} An array with updated VM data objects.
    */
-  const newVMData = vmData.map((data) => {
-    const vm = data.vm as VSphereVM;
-    const folder = foldersDict?.[vm.parent.id];
-    const host = hostsDict?.[vm.host];
+  const newVMData = vmData
+    .filter((data) => !(data.vm as VSphereVM).isTemplate)
+    .map((data) => {
+      const vm = data.vm as VSphereVM;
+      const folder = foldersDict?.[vm.parent.id];
+      const host = hostsDict?.[vm.host];
 
-    return {
-      ...data,
-      folderName: folder?.name,
-      hostName: host?.name,
-    };
-  });
+      return {
+        ...data,
+        folderName: folder?.name,
+        hostName: host?.name,
+      };
+    });
 
   return (
     <ProviderVirtualMachinesList

--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesRow.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesRow.tsx
@@ -35,9 +35,6 @@ const cellRenderers: Record<string, React.FC<VMCellProps>> = {
   concerns: VMConcernsCellRenderer,
   host: ({ data }) => <TableCell>{data?.hostName}</TableCell>,
   folder: ({ data }) => <TableCell>{data?.folderName}</TableCell>,
-  isTemplate: ({ data }) => (
-    <TableCell>{Boolean((data?.vm as VSphereVM)?.isTemplate).toString()}</TableCell>
-  ),
   path: ({ data }) => <TableCell>{(data?.vm as VSphereVM)?.path}</TableCell>,
   powerState: PowerStateCellRenderer,
 };


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-1609

## 📝 Description

Filter out vSphere templates as they are currently not supported for migrations.

## 🎥 Demo

**Before**

https://github.com/user-attachments/assets/0700aa0b-514c-432f-821b-0a496f25c137

**After**

https://github.com/user-attachments/assets/f0b9edbc-55f9-4b3d-97eb-afd09e8c4886


