### PR TITLE
Fix a bug for handling a plan creation failures within the plan wizard

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -367,6 +367,7 @@ const handlers: {
   [SET_API_ERROR]({ flow }, { payload: { error } }: PageAction<CreateVmMigration, PlanError>) {
     // triggered by the API callback (on failure)
     flow.apiError = error;
+    flow.editingDone = false;
   },
   [ADD_NETWORK_MAPPING](draft) {
     const { calculatedPerNamespace: cpn } = draft;
@@ -596,7 +597,7 @@ export const reducer = (
   ) {
     draft.flow.initialLoading[action.type] = true;
   }
-  return draft.flow.editingDone && !actionsAllowedAfterEditingIsDone.includes[action?.type]
+  return draft.flow.editingDone && !actionsAllowedAfterEditingIsDone.includes(action?.type)
     ? draft
     : handlers?.[action?.type]?.(draft, action) ?? draft;
 };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2112

## 📝 Description

Fix the following:
- Fix a type for handling a case of a create Plan api failures in order to display the error alert message within the plan wizard page and disable the 'create migration' button.
- Reset the edit done mode for all fields in case of a plan creation failures so that they will become enabled again.
- 
## 🎥 Demo

### Before (clicking the create triggers nothing)

![Screenshot from 2025-02-27 15-15-27](https://github.com/user-attachments/assets/f67ef6c5-d3ab-4ac5-8746-22b0fe2ff619)


### After
![Screenshot from 2025-02-27 15-16-52](https://github.com/user-attachments/assets/4d51bc14-f9aa-4dcb-ae37-411bd01f4ad2)


