### PR TITLE
Revert "MTV-1934: Disallow archiving running plan"

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/actions/PlanActionsDropdownItems.tsx
@@ -111,9 +111,7 @@ export const PlanActionsDropdownItems = ({ data }: PlanActionsDropdownItemsProps
       value={4}
       key="archive"
       isDisabled={
-        !data?.permissions?.canDelete ||
-        [PlanPhase.Archived, PlanPhase.Archiving].includes(phase) ||
-        isPlanExecuting(plan)
+        !data?.permissions?.canDelete || [PlanPhase.Archived, PlanPhase.Archiving].includes(phase)
       }
       onClick={onClickArchive}
     >


### PR DESCRIPTION
Reverts kubev2v/forklift-console-plugin#1497

Reverting since it's been confirmed that it's actually OK to archive running plans.
See discussion in https://issues.redhat.com/browse/MTV-1934

