### PR TITLE
Fix a bug to set default plan's target namespace

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/actions.ts
@@ -1,3 +1,5 @@
+import { getDefaultNamespace } from 'src/utils/namespaces';
+
 import {
   OpenShiftNamespace,
   OpenShiftNetworkAttachmentDefinition,
@@ -19,7 +21,7 @@ import { Mapping, NetworkAlerts, StorageAlerts } from '../types';
 import { InitialStateParameters } from './createInitialState';
 
 export const POD_NETWORK = 'Pod Networking';
-export const DEFAULT_NAMESPACE = 'default';
+export const DEFAULT_NAMESPACE = getDefaultNamespace();
 
 // action type names
 export const SET_NAME = 'SET_NAME';

--- a/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -193,11 +193,8 @@ const handlers: {
     }
 
     const targetNamespace =
-      // use the current namespace (inherited from source provider)
-      (isProviderLocalOpenshift(targetProvider) &&
-        !alreadyInUse(plan.metadata.namespace) &&
-        plan.metadata.namespace) ||
-      // use 'default' if exists
+      // use the selected project name
+      draft.underConstruction?.projectName ||
       (availableTargetNamespaces.find(
         (n) => n.name === DEFAULT_NAMESPACE && !alreadyInUse(DEFAULT_NAMESPACE),
       ) &&


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2144

## 📝 Description
Set the default value of plan's target namespace to be either the chosen `Project` field value or if not set then the default namespace (e.g. konveyor-forklift).


## 🎥 Demo

![Screenshot from 2025-03-04 20-35-35](https://github.com/user-attachments/assets/50727bc0-e8de-419e-8cdc-0e5fbd299326)

