### PR TITLE
MTV-2108: [UI] Cutover modal, cannot set date/time properly

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/modals/PlanCutoverMigrationModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/modals/PlanCutoverMigrationModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 
 import { usePlanMigration } from '../hooks/usePlanMigration';
+import { formatToAmPm } from '../utils/helpers/AMPMFormatter';
 
 import './PlanCutoverMigrationModal.style.css';
 
@@ -46,6 +47,7 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
   const { toggleModal } = useModal();
   const [isLoading, toggleIsLoading] = useToggle();
   const [cutoverDate, setCutoverDate] = useState<string>();
+  const [time, setTime] = useState<string>();
   const [alertMessage, setAlertMessage] = useState<ReactNode>(null);
 
   const title_ = title || t('Cutover');
@@ -57,13 +59,16 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
     const migrationCutoverDate = lastMigration?.spec?.cutover || new Date().toISOString();
 
     setCutoverDate(migrationCutoverDate);
+    setTime(formatToAmPm(new Date(migrationCutoverDate)));
   }, [lastMigration]);
 
   const onDateChange: (
     event: React.FormEvent<HTMLInputElement>,
     value: string,
     date?: Date,
-  ) => void = (_event, value) => {
+  ) => void = (_event, value, date) => {
+    if (!date) return;
+
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 
     const [year, month, day] = value.split('-').map((num: string) => parseInt(num, 10));
@@ -77,12 +82,16 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
 
   const onTimeChange: (
     event: React.FormEvent<HTMLInputElement>,
-    time: string,
+    timeInput: string,
     hour?: number,
     minute?: number,
     seconds?: number,
     isValid?: boolean,
-  ) => void = (_event, _time, hour, minute) => {
+  ) => void = (_event, timeInput, hour, minute, _seconds, isValid) => {
+    setTime(timeInput);
+
+    if (!isValid) return;
+
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 
     updatedFromDate.setHours(hour);
@@ -166,7 +175,7 @@ export const PlanCutoverMigrationModal: React.FC<PlanCutoverMigrationModalProps>
             style={{ width: '150px' }}
             onChange={onTimeChange}
             menuAppendTo={document.body}
-            time={cutoverDate ? new Date(cutoverDate) : new Date()}
+            time={time}
           />
         </InputGroup>
       </>

--- a/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/AMPMFormatter.ts
+++ b/packages/forklift-console-plugin/src/modules/Plans/utils/helpers/AMPMFormatter.ts
@@ -1,0 +1,7 @@
+export const formatToAmPm = (date: Date): string => {
+  const hours = date.getHours() % 12 || 12;
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const period = hours === 12 ? 'PM' : 'AM';
+
+  return `${hours}:${minutes} ${period}`;
+};


### PR DESCRIPTION
## 📝 Links
> References: https://issues.redhat.com/browse/MTV-2108

## 📝 Description

On every change we tried to conved to ISO string which in case of a invalid date would cause a run time error and would cause the inputs to behave unexpectedly (as we always convert the input we get and disregard it)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/2edb1780-4754-4e5b-8837-c8c15792f46f


After:

https://github.com/user-attachments/assets/620f9eef-9931-4490-8f90-1727e21fc1d5



## 📝 CC://

> @tag as needed
