### PR TITLE
Avoid displaying alert messages for archived plans

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/PlanPageHeadings.tsx
@@ -89,8 +89,8 @@ export const PlanPageHeadings: React.FC<{ name: string; namespace: string }> = (
   };
 
   const handleAlerts = () => {
-    // alerts are not relevant to display if plan was completed successfully
-    if (planStatus === PlanPhase.Succeeded) {
+    // alerts are not relevant to display if plan was completed successfully or archived
+    if (planStatus === PlanPhase.Succeeded || planStatus === PlanPhase.Archived) {
       return;
     }
 


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2186

## 📝 Description
When a plan is archived, we should avoid displaying alerts that usually include troubleshooting suggestions, since the user can't edit the plan in that state.
Only when duplicating the archived plan, those alerts will be displayed again for the duplicated plan.


## 🎥 Demo

### Before
![Screenshot from 2025-03-05 23-19-21](https://github.com/user-attachments/assets/781fb9d9-edd5-49a8-a92d-7d5d0f54ae83)

### After
![Screenshot from 2025-03-05 23-34-28](https://github.com/user-attachments/assets/825b91fa-0314-483d-a502-fd4f021f15e4)
