### PR TITLE
Disabling all hooks tab fields in case hooks editing is not allowed

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/tabs/Hooks/PlanHooks.tsx
@@ -178,6 +178,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
               label="Enable pre migration hook"
               labelOff="Do not enable a pre migration hook"
               isChecked={state.preHookSet}
+              isDisabled={!isPlanEditable(plan)}
               onChange={(e, v) => onChangePreHookSet(v, e)}
             />
           </FormGroupWithHelpText>
@@ -190,6 +191,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
                   value={state.preHook?.spec?.image}
                   type="url"
                   onChange={(e, v) => onChangePreHookImage(v, e)}
+                  isDisabled={!isPlanEditable(plan)}
                   aria-label="pre hook image"
                 />
                 <HelperText>
@@ -228,6 +230,7 @@ export const PlanHooks: React.FC<{ name: string; namespace: string }> = ({ name,
               label="Enable post migration hook"
               labelOff="Do not enable a post migration hook"
               isChecked={state.postHookSet}
+              isDisabled={!isPlanEditable(plan)}
               onChange={(e, v) => onChangePostHookSet(v, e)}
             />
           </FormGroupWithHelpText>


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1738

## 📝 Description
A follow up fix for disabling all hooks tab fields in case the plan status is either '`archived`' or '`running`'.

The only exception is that the `CodeEditor` component can't be disabled for entering the Ansible playbook content, but I think it's ok to leave it as is for now since no updating action can be done.


## 🎥 Demo
## Before
![Screenshot from 2025-03-06 17-27-02](https://github.com/user-attachments/assets/5c321b68-0590-4cae-bf6a-d058a5fc03bd)

## After

![Screenshot from 2025-03-06 17-24-48](https://github.com/user-attachments/assets/496bc51f-c964-482f-be12-b7efafc38b76)

