### PR TITLE
MTV-2216: Edit icon showing even when plan not editable

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
@@ -28,10 +28,9 @@ const NetworkNameTemplateDetailsItem: FC<PlanDetailsItemProps> = ({ resource, ca
       content={content}
       crumbs={pathArray}
       onEdit={() => {
-        if (canPatch && isPlanEditable(resource)) {
-          showModal(<NetworkNameTemplateModal resource={resource} jsonPath={pathArray} />);
-        }
+        showModal(<NetworkNameTemplateModal resource={resource} jsonPath={pathArray} />);
       }}
+      canEdit={canPatch && isPlanEditable(resource)}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
@@ -28,10 +28,9 @@ const PVCNameTemplateDetailsItem: FC<PlanDetailsItemProps> = ({ resource, canPat
       content={content}
       crumbs={pathArray}
       onEdit={() => {
-        if (canPatch && isPlanEditable(resource)) {
-          showModal(<PVCNameTemplateModal resource={plan} jsonPath={pathArray} />);
-        }
+        showModal(<PVCNameTemplateModal resource={plan} jsonPath={pathArray} />);
       }}
+      canEdit={canPatch && isPlanEditable(resource)}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/SharedDisksDetailsItem/SharedDisksDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/SharedDisksDetailsItem/SharedDisksDetailsItem.tsx
@@ -26,12 +26,11 @@ const SharedDisksDetailsItem: FC<PlanDetailsItemProps> = ({ resource, canPatch }
       content={content}
       crumbs={pathArray}
       onEdit={() => {
-        if (canPatch && isPlanEditable(resource)) {
-          showModal(
-            <MigrateSharedDisksModal resource={resource} jsonPath={pathArray} title={title} />,
-          );
-        }
+        showModal(
+          <MigrateSharedDisksModal resource={resource} jsonPath={pathArray} title={title} />,
+        );
       }}
+      canEdit={canPatch && isPlanEditable(resource)}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
@@ -28,10 +28,9 @@ const VolumeNameTemplateDetailsItem: FC<PlanDetailsItemProps> = ({ resource, can
       content={content}
       crumbs={pathArray}
       onEdit={() => {
-        if (canPatch && isPlanEditable(resource)) {
-          showModal(<VolumeNameTemplateModal resource={plan} jsonPath={pathArray} />);
-        }
+        showModal(<VolumeNameTemplateModal resource={plan} jsonPath={pathArray} />);
       }}
+      canEdit={canPatch && isPlanEditable(resource)}
     />
   );
 };

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/components/DetailsPage/DetailItem.tsx
@@ -36,6 +36,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
   crumbs,
   content,
   onEdit,
+  canEdit,
 }) => {
   const contents = ensureArray(content);
   const onEdits = ensureArray(onEdit);
@@ -56,6 +57,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
             key={'content-field-' + index}
             content={value}
             onEdit={onEdits ? (onEdits[index] as () => void) : null}
+            canEdit={canEdit}
           />
         ))}
       </DescriptionListDescription>
@@ -177,8 +179,9 @@ export const DescriptionTitle: React.FC<{ title: string }> = ({ title }) => (
 export const ContentField: React.FC<{
   content: ReactNode;
   onEdit: () => void;
-}> = ({ content, onEdit }) =>
-  onEdit ? (
+  canEdit?: boolean;
+}> = ({ content, onEdit, canEdit = true }) =>
+  canEdit && onEdit ? (
     <DescriptionListDescription>
       <Flex alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem spacer={{ default: 'spacerNone' }}>{content}</FlexItem>
@@ -204,6 +207,7 @@ export const ContentField: React.FC<{
  * @property {string[]} [crumbs] - Breadcrumbs for the details item.
  * @property {ReactNode | ReactNode[]} content - Array of content fields to be displayed for the details item.
  * @property {Function | Function[]} onEdit - Array of functions per content field to be called when the edit button is clicked or null if the field is non editable.
+ * @property {boolean} [showEditButton] - If true, show the edit button next to the content field, when missing falling back to onEdit existence.
  */
 export type DetailsItemProps = {
   title: string;
@@ -214,4 +218,5 @@ export type DetailsItemProps = {
   crumbs?: string[];
   content: ReactNode | ReactNode[];
   onEdit?: (() => void) | (() => void)[];
+  canEdit?: boolean;
 };


### PR DESCRIPTION
## 📝 Links
> References: <Jira ticket urls>

> Add more JIRA, Docs, and other PR/Issue links

## 📝 Description

onEdit prop filled 2 objectives:
1. if exist, show the pencil edit button
2. perform a edit callback.

adding another prop to fill the first objective will give us better control and separated logic when needed

## 🎥 Demo

Before:
![details-item-b4](https://github.com/user-attachments/assets/56bc3fde-7354-4462-8efa-5e28acd6e8c5)

After:
![details-item](https://github.com/user-attachments/assets/a120009a-ea2c-4b0e-86c7-4755d770c910)



## 📝 CC://

> @tag as needed
