### PR TITLE
Avoid hiding active namespace menu after plan wizard cancelation

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/create/PlanCreatePage.tsx
@@ -48,10 +48,10 @@ export const PlanCreatePage: FC<{ namespace: string }> = ({ namespace }) => {
   const plansListURL = useMemo(() => {
     return getResourceUrl({
       reference: PlanModelRef,
-      namespace: namespace,
-      namespaced: namespace !== undefined,
+      namespace: activeNamespace,
+      namespaced: true,
     });
-  }, [namespace]);
+  }, [activeNamespace]);
 
   const providerURL = useMemo(() => {
     return getResourceUrl({

--- a/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/getResourceUrl.ts
+++ b/packages/forklift-console-plugin/src/modules/Providers/utils/helpers/getResourceUrl.ts
@@ -1,3 +1,5 @@
+import { Namespace } from 'src/utils';
+
 import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 /**
@@ -13,7 +15,8 @@ export const getResourceUrl = ({
   namespace,
   name,
 }: GetResourceUrlProps): string => {
-  const ns = namespace ? `ns/${namespace}` : 'all-namespaces';
+  const ns =
+    namespace && namespace !== Namespace.AllProjects ? `ns/${namespace}` : 'all-namespaces';
   const resourcePath = namespaced ? ns : 'cluster';
   const reference_ =
     reference || `${groupVersionKind.group}~${groupVersionKind.version}~${groupVersionKind.kind}`;

--- a/packages/forklift-console-plugin/src/utils/fetch.ts
+++ b/packages/forklift-console-plugin/src/utils/fetch.ts
@@ -5,16 +5,12 @@ import {
   WatchK8sResult,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-export const useProviders = ({
-  namespace,
-  name,
-}: WatchK8sResource): WatchK8sResult<V1beta1Provider[]> =>
+export const useProviders = ({ namespace }: WatchK8sResource): WatchK8sResult<V1beta1Provider[]> =>
   useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,
-    isList: true,
     namespaced: true,
+    isList: true,
     namespace,
-    name,
   });
 
 export const useHasSourceAndTargetProviders = (


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2198


## 📝 Description
After clicking cancel on plan wizard and navigating back to plans list, fix a bug so that the active namespace menu in page header will be always displayed.


## 🎥 Demo
[Screencast from 2025-03-10 22-46-50.webm](https://github.com/user-attachments/assets/4bcd0a0a-a698-4243-8d54-bb4380d4a9e8)





