### PR TITLE
MTV-2150: storage maps has same data test id as network maps

### DIFF
--- a/packages/forklift-console-plugin/src/modules/StorageMaps/dynamic-plugin.ts
+++ b/packages/forklift-console-plugin/src/modules/StorageMaps/dynamic-plugin.ts
@@ -26,8 +26,8 @@ export const extensions: EncodedExtension[] = [
       name: '%plugin__forklift-console-plugin~StorageMaps for virtualization%',
       model: StorageMapModelGroupVersionKind,
       dataAttributes: {
-        'data-quickstart-id': 'qs-nav-network-mappings',
-        'data-testid': 'network-mappings-nav-item',
+        'data-quickstart-id': 'qs-nav-storage-mappings',
+        'data-testid': 'storage-mappings-nav-item',
       },
     },
   } as EncodedExtension<ResourceNSNavItem>,


### PR DESCRIPTION
## 📝 Links
> References: https://issues.redhat.com/browse/MTV-2150

## 📝 Description

StorageMaps navigation item had same test id as NetworkMaps navigation item

## 🎥 Demo

> Please add a video or an image of the behavior/changes

## 📝 CC://

> @tag as needed
