### PR TITLE
MTV-2259: Fix plan's "PVC name template" details item value

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
@@ -15,7 +15,7 @@ const PVCNameTemplateDetailsItem: FC<PlanDetailsItemProps> = ({ resource, canPat
 
   const plan = resource as EnhancedPlan;
 
-  const content = plan?.spec?.volumeNameTemplate
+  const content = plan?.spec?.pvcNameTemplate
     ? t('Use custom PVC name template')
     : t('Use default PVC name template');
 


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2259

## 📝 Description
Fix the plan's "PVC name template" details item label value to be set based on plan's PVC name template and not other plan's property.

## 🎥 Demo
[Screencast from 2025-03-18 21-08-34.webm](https://github.com/user-attachments/assets/1d4a6abb-bd6c-420c-82ac-a25bc7d2b7aa)

