### PR TITLE
MTV-2265: Present template naming fields only for vsphere provider

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/views/details/components/SettingsSection/SettingsSection.tsx
@@ -46,6 +46,7 @@ export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, p
     namespace: obj?.spec?.provider?.destination?.namespace,
   });
 
+  const isVsphere = sourceProvider?.spec?.type === 'vsphere';
   return (
     <>
       <DescriptionList
@@ -73,27 +74,27 @@ export const SettingsSectionInternal: React.FC<SettingsSectionProps> = ({ obj, p
           <PreserveClusterCpuModelDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
 
-        {['vsphere'].includes(sourceProvider?.spec?.type) && (
+        {isVsphere && (
           <PreserveStaticIPsDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
 
-        {['vsphere'].includes(sourceProvider?.spec?.type) && (
+        {isVsphere && (
           <SetLUKSEncryptionPasswordsDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
 
-        {['vsphere'].includes(sourceProvider?.spec?.type) && (
-          <RootDiskDetailsItem resource={obj} canPatch={permissions.canPatch} />
+        {isVsphere && <RootDiskDetailsItem resource={obj} canPatch={permissions.canPatch} />}
+
+        {isVsphere && <SharedDisksDetailsItem resource={obj} canPatch={permissions.canPatch} />}
+
+        {isVsphere && <PVCNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />}
+
+        {isVsphere && (
+          <VolumeNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
 
-        {['vsphere'].includes(sourceProvider?.spec?.type) && (
-          <SharedDisksDetailsItem resource={obj} canPatch={permissions.canPatch} />
+        {isVsphere && (
+          <NetworkNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />
         )}
-
-        <PVCNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />
-
-        <VolumeNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />
-
-        <NetworkNameTemplateDetailsItem resource={obj} canPatch={permissions.canPatch} />
       </DescriptionList>
     </>
   );


### PR DESCRIPTION
## 📝 Links
> References: https://redhat-internal.slack.com/archives/C07HDAK66QG/p1742384437713739?thread_ts=1742378635.575279&cid=C07HDAK66QG

## 📝 Description

Changing to template settings to be shown only for vsphere provider plans

## 🎥 Demo

> Please add a video or an image of the behavior/changes

## 📝 CC://

> @tag as needed
