### PR TITLE
MTV-2266: Avoid displaying the "Host cluster" label for non ocp providers

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isProviderLocalOpenshift } from 'src/utils';
 import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -31,7 +32,7 @@ export const TypeDetailsItem: React.FC<ProviderDetailsItemProps> = ({
       content={
         <>
           {type}{' '}
-          {!provider?.spec?.url && (
+          {isProviderLocalOpenshift(provider) && (
             <Label isCompact color={'grey'} className="forklift-table__flex-cell-label">
               {t('Host cluster')}
             </Label>

--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProviderLinkCell.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/components/ProviderLinkCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TableLinkCell } from 'src/modules/Providers/utils';
+import { isProviderLocalOpenshift } from 'src/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelGroupVersionKind } from '@kubev2v/types';
@@ -16,8 +17,7 @@ export const ProviderLinkCell: React.FC<CellProps> = ({ data }) => {
 
   const { provider } = data;
   const { name, namespace } = provider?.metadata || {};
-  const localCluster =
-    provider?.spec?.type === 'openshift' && (!provider?.spec?.url || provider?.spec?.url === '');
+  const localCluster = isProviderLocalOpenshift(provider);
 
   return (
     <TableLinkCell


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2266

## 📝 Description
Display the "host cluster" label only for ocp providers and not for other providers types.


## 🎥 Demo
### Before
![image](https://github.com/user-attachments/assets/428a824a-58f6-4215-9307-324f9e0182d8)

### After
![Screenshot from 2025-03-19 16-03-41](https://github.com/user-attachments/assets/62bb5ace-dcff-4f96-985f-a659a12e1ecb)

