### PR TITLE
Reset the vSphere VDDK init image field validation and value if 'skip vddk' is checked

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/EsxiProviderCreateForm.tsx
@@ -57,10 +57,7 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
       const trimmedValue = value?.trim();
 
       if (id == 'emptyVddkInitImage') {
-        const vddValidationState = validateVDDKImage(provider?.spec?.settings?.vddkInitImage);
-        const initVddkValidationState = validateVDDKImage(undefined);
-        const validationState =
-          trimmedValue === 'yes' ? initVddkValidationState : vddValidationState;
+        const validationState = validateVDDKImage(undefined);
 
         dispatch({
           type: 'SET_FIELD_VALIDATED',
@@ -74,6 +71,13 @@ export const EsxiProviderCreateForm: React.FC<EsxiProviderCreateFormProps> = ({
             annotations: {
               ...(provider?.metadata?.annotations as object),
               'forklift.konveyor.io/empty-vddk-init-image': trimmedValue || undefined,
+            },
+          },
+          spec: {
+            ...provider?.spec,
+            settings: {
+              ...provider?.spec?.settings,
+              vddkInitImage: '',
             },
           },
         });

--- a/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/create/components/VCenterProviderCreateForm.tsx
@@ -71,10 +71,7 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
       const trimmedValue = value?.trim();
 
       if (id == 'emptyVddkInitImage') {
-        const vddValidationState = validateVDDKImage(provider?.spec?.settings?.vddkInitImage);
-        const initVddkValidationState = validateVDDKImage(undefined);
-        const validationState =
-          trimmedValue === 'yes' ? initVddkValidationState : vddValidationState;
+        const validationState = validateVDDKImage(undefined);
 
         dispatch({
           type: 'SET_FIELD_VALIDATED',
@@ -88,6 +85,13 @@ export const VCenterProviderCreateForm: React.FC<VCenterProviderCreateFormProps>
             annotations: {
               ...(provider?.metadata?.annotations as object),
               'forklift.konveyor.io/empty-vddk-init-image': trimmedValue || undefined,
+            },
+          },
+          spec: {
+            ...provider?.spec,
+            settings: {
+              ...provider?.spec?.settings,
+              vddkInitImage: '',
             },
           },
         });


### PR DESCRIPTION

Reference: https://issues.redhat.com/browse/MTV-2268

## 📝 Description
Once the skip vddk field is checked for vSphere providers, reset the vddk field's validation so that the validation won't block the user from creating the provider.


## 🎥 Demo
### Before
[Screencast from 2025-03-20 21-14-31.webm](https://github.com/user-attachments/assets/ee0f2796-be0a-4242-93b2-36fc28c5dc7a)


### After

[Screencast from 2025-03-20 21-15-41.webm](https://github.com/user-attachments/assets/ffb39b86-e57c-4333-8572-4230726ad63d)


