### PR TITLE
MTV-1901: Avoid double clicking the start migration button within the modal

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Plans/modals/PlanStartMigrationModal.tsx
+++ b/packages/forklift-console-plugin/src/modules/Plans/modals/PlanStartMigrationModal.tsx
@@ -44,6 +44,7 @@ export const PlanStartMigrationModal: React.FC<PlanStartMigrationModalProps> = (
   const history = useHistory();
   const [alertMessage, setAlertMessage] = useState<ReactNode>(null);
   const [lastMigration] = usePlanMigration(resource);
+  const [startButtonEnabled, setStartButtonEnabled] = useState(true);
 
   const isRunningMigrationExist =
     lastMigration !== undefined && lastMigration?.status?.completed === undefined;
@@ -54,6 +55,7 @@ export const PlanStartMigrationModal: React.FC<PlanStartMigrationModalProps> = (
   const onStart = useCallback(async () => {
     toggleIsLoading();
     setButtonEnabledOnChange(false);
+    setStartButtonEnabled(false);
 
     try {
       if (isRunningMigrationExist) {
@@ -106,7 +108,7 @@ export const PlanStartMigrationModal: React.FC<PlanStartMigrationModalProps> = (
   };
 
   const actions = [
-    <Button key="confirm" onClick={onStart} isLoading={isLoading}>
+    <Button key="confirm" onClick={onStart} isLoading={isLoading} isDisabled={!startButtonEnabled}>
       {t('Start')}
     </Button>,
     <Button key="cancel" variant="secondary" onClick={onClickToggleModal}>


### PR DESCRIPTION

Reference: https://issues.redhat.com/browse/MTV-1901

## 📝 Description
Avoid running more than one migration concurrently by double clicking the start migration modal.

For reproducing this use case:
1. Click on the plan's "Start" button (from either plans list or plan details).
2. Once the `PlanStartMigrationModal` is displayed, double click quickly on the "Start" button of this modal before the modal is toggled and closed.



## 🎥 Demo
### Before
[Screencast from 2025-03-20 21-56-19.webm](https://github.com/user-attachments/assets/13384e1f-ac35-46cf-9a87-9848824aa147)


### After
[Screencast from 2025-03-20 21-55-03.webm](https://github.com/user-attachments/assets/3ed60228-38c2-4cd7-be22-affd6d5239e0)

