### PR TITLE
MTV-2053: Update links in forklift-console-plugin

### DIFF
--- a/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
+++ b/src/modules/Overview/views/overview/tabs/Details/cards/SettingsCard.tsx
@@ -38,7 +38,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               obj?.spec?.controller_max_vm_inflight || <span className="text-muted">{'20'}</span>
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#max-concurrent-vms_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#max-concurrent-vms_mtv'
             }
             helpContent={
               <ForkliftTrans>
@@ -65,7 +65,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
             }
             helpContent={
               <Text>
@@ -89,7 +89,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
             }
             helpContent={
               <Text>
@@ -113,7 +113,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
             }
             helpContent={
               <Text>
@@ -135,7 +135,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               obj?.spec?.controller_precopy_interval || <span className="text-muted">{'60'}</span>
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
             }
             helpContent={
               <Text>
@@ -159,7 +159,7 @@ const SettingsCard_: FC<SettingsCardProps> = ({ obj }) => {
               )
             }
             moreInfoLink={
-              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
+              'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#mtv-settings_mtv'
             }
             helpContent={
               <Text>

--- a/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/editLUKSModalBody.tsx
+++ b/src/modules/Plans/views/details/components/SettingsSection/modals/EditLUKSEncryptionPasswords/editLUKSModalBody.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from 'src/components/common/ExternalLink/ExternalLink';
 import { ForkliftTrans } from 'src/utils/i18n';
 
 export const VIRT_V2V_HELP_LINK =
-  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-vms-web-console_mtv#creating-migration-plans-ui';
+  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-migration-plan-2-8_cnv';
 
 export const editLUKSModalBody = (
   <>

--- a/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
+++ b/src/modules/Providers/utils/components/VDDKHelperText/VDDKHelperText.tsx
@@ -3,7 +3,7 @@ import { ExternalLink } from 'src/components/common/ExternalLink/ExternalLink';
 import { ForkliftTrans } from 'src/utils/i18n';
 
 const CREATE_VDDK_HELP_LINK =
-  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
+  'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
 
 export const VDDKHelperText: FC = () => (
   <ForkliftTrans>

--- a/src/modules/Providers/views/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
+++ b/src/modules/Providers/views/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
@@ -16,7 +16,7 @@ export const TransferNetworkDetailsItem: FC<ProviderDetailsItemProps> = ({
   const { showModal } = useModal();
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#selecting-migration-network-for-virt-provider_mtv';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-virt_cnv#selecting-migration-network-for-virt-provider_dest_cnv';
   const defaultHelpContent = t(
     `You can select a default migration network for an OpenShift Virtualization provider in the
     Red Hat OpenShift web console to improve performance. The default migration network is used to

--- a/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
+++ b/src/modules/Providers/views/details/components/DetailsSection/components/TypeDetailsItem.tsx
@@ -18,7 +18,7 @@ export const TypeDetailsItem: FC<ProviderDetailsItemProps> = ({
   const type = PROVIDERS[provider?.spec?.type] || provider?.spec?.type;
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-providers';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-virt_cnv#adding-source-provider_cnv';
   const defaultHelpContent = t(
     `Specify the type of source provider. Allowed values are ova, ovirt, vsphere,
       openshift, and openstack. This label is needed to verify the credentials are correct when the remote system is accessible and, for RHV, to retrieve the Manager CA certificate when

--- a/src/modules/Providers/views/details/components/DetailsSection/components/URLDetailsItem.tsx
+++ b/src/modules/Providers/views/details/components/DetailsSection/components/URLDetailsItem.tsx
@@ -26,7 +26,7 @@ export const URLDetailsItem: FC<ProviderDetailsItemProps> = ({
   });
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-providers';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-virt_cnv#adding-source-provider_cnv';
   const defaultHelpContent =
     t(`URL of the providers API endpoint. The URL must be a valid endpoint for the provider type, see
       the documentation for each provider type to learn more about the URL format.`);

--- a/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
+++ b/src/modules/Providers/views/details/components/DetailsSection/components/VDDKDetailsItem.tsx
@@ -19,7 +19,7 @@ export const VDDKDetailsItem: FC<ProviderDetailsItemProps> = ({
   const { showModal } = useModal();
 
   const defaultMoreInfoLink =
-    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
+    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#creating-vddk-image_mtv';
   const defaultHelpContent = (
     <ForkliftTrans>
       Virtual Disk Development Kit (VDDK) container init image path. The path must be empty or a


### PR DESCRIPTION
### JIRA

* [MTV-2053](https://issues.redhat.com/browse/MTV-2053)

Updating doc links from 2.7. to 2.8

Due to changes in the docs, where we now have specific documentation instead of generic, I have pointing to OpenShift Virt. So
```
    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.7/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#selecting-migration-network-for-virt-provider_mtv';
```
Is replaced with:
```    
    'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.8/html/installing_and_using_the_migration_toolkit_for_virtualization/migrating-virt_cnv#selecting-migration-network-for-virt-provider_dest_cnv';
```

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Links

<!---
> References: <Jira ticket urls>

> Add more JIRA, Docs, and other PR/Issue links
-->

## 📝 Description

<!---
> Add a brief description
-->

## 🎥 Demo

<!---
> Please add a video or an image of the behavior/changes
-->

## 📝 CC://

<!---
> @tag as needed
-->
