### PR TITLE
[MTV-1969] Fixing some leftover issues after rebase/fixing of lint issues

### DIFF
--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -313,9 +313,13 @@ const StandardPageInner = <T,>({
   };
   const [fields, setFields] = useFields(namespace, fieldsMetadata, userSettings?.fields);
 
-  const supportedMatchers = extraSupportedMatchers
-    ? reduceValueFilters(extraSupportedMatchers, defaultValueMatchers)
-    : defaultValueMatchers;
+  const supportedMatchers = useMemo(
+    () =>
+      extraSupportedMatchers
+        ? reduceValueFilters(extraSupportedMatchers, defaultValueMatchers)
+        : defaultValueMatchers,
+    [extraSupportedMatchers],
+  );
   const supportedFilters = extraSupportedFilters
     ? { ...defaultSupportedFilters, ...extraSupportedFilters }
     : defaultSupportedFilters;

--- a/src/modules/Providers/views/migrate/reducer/createInitialState.ts
+++ b/src/modules/Providers/views/migrate/reducer/createInitialState.ts
@@ -7,8 +7,8 @@ import {
 import { networkMapTemplate } from '../../create/templates/networkMapTemplate';
 import { planTemplate } from '../../create/templates/planTemplate';
 import { storageMapTemplate } from '../../create/templates/storageMapTemplate';
-import { toId } from '../../details/tabs/VirtualMachines/components/ProviderVirtualMachinesList';
 import type { VmData } from '../../details/tabs/VirtualMachines/components/VMCellProps';
+import { getVmId } from '../../details/tabs/VirtualMachines/utils/helpers/vmProps';
 import {
   type CreateVmMigrationPageState,
   MULTIPLE_NICS_ON_THE_SAME_NETWORK,
@@ -137,7 +137,7 @@ export const createInitialState = ({
           },
           targetNamespace: namespace,
           vms: selectedVms.map((data) => ({
-            id: toId(data),
+            id: getVmId(data),
             name: data.name,
             namespace: data.namespace,
           })),

--- a/src/modules/Providers/views/migrate/reducer/reducer.ts
+++ b/src/modules/Providers/views/migrate/reducer/reducer.ts
@@ -4,7 +4,7 @@ import { isProviderLocalOpenshift } from 'src/utils/resources';
 
 import type { ProviderType } from '@kubev2v/types';
 
-import { toId } from '../../details/tabs/VirtualMachines/components/ProviderVirtualMachinesList';
+import { getVmId } from '../../details/tabs/VirtualMachines/utils/helpers/vmProps';
 import {
   type CreateVmMigrationPageState,
   type Mapping,
@@ -447,7 +447,7 @@ const handlers: Record<
     const hasVmNicWithEmptyProfile = hasNicWithEmptyProfile(sourceProvider, vms);
 
     draft.underConstruction.plan.spec.vms = vms.map((data) => ({
-      id: toId(data),
+      id: getVmId(data),
       name: data.name,
       namespace: data.namespace,
     }));


### PR DESCRIPTION
## 📝 Links
Relates to [MTV-1969](https://issues.redhat.com/browse/MTV-1969)

## 📝 Description
Because this change touched the StandardPage file, I had tried to fix some lint issues there after rebasing. This led to a new dependency to a useEffect in this file which was causing infinite re-renders. Memoizing the supportedMatchers fixes this issue.

Also while I was here, I fixed a couple import warnings, where `getVmId` should have been used instead of `toId` in the other 2 touched files.