### PR TITLE
[MTV-2460] Create plan wizard: Additional setup - Hooks step

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -78,6 +78,7 @@
   "All networks detected on the selected VMs require a mapping.": "All networks detected on the selected VMs require a mapping.",
   "All storages detected on the selected VMs require a mapping.": "All storages detected on the selected VMs require a mapping.",
   "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.": "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.",
+  "Ansible playbook": "Ansible playbook",
   "Application credential ID": "Application credential ID",
   "Application credential name": "Application credential name",
   "Application credential secret": "Application credential secret",
@@ -275,8 +276,10 @@
   "Hide from view": "Hide from view",
   "Hide values": "Hide values",
   "Hide variables": "Hide variables",
+  "Hook runner image": "Hook runner image",
   "Hooks": "Hooks",
   "Hooks (optional)": "Hooks (optional)",
+  "Hooks are contained in Ansible playbooks that can be run before or after the migration.": "Hooks are contained in Ansible playbooks that can be run before or after the migration.",
   "Host": "Host",
   "Host cluster": "Host cluster",
   "Hosts": "Hosts",
@@ -285,6 +288,7 @@
   "If true, the provider's CA certificate won't be validated.": "If true, the provider's CA certificate won't be validated.",
   "If true, the provider's TLS certificate won't be validated.": "If true, the provider's TLS certificate won't be validated.",
   "If virtual machines are using shared disks, the shared disks will migrate only once by default.": "If virtual machines are using shared disks, the shared disks will migrate only once by default.",
+  "If you specify a playbook, the image must be hook-runner.": "If you specify a playbook, the image must be hook-runner.",
   "If your VMs use static IPs, click the Mappings tab of your plan, and choose a different target network mapping.<1></1>If your VMs do not use static IPs, you can ignore this message.": "If your VMs use static IPs, click the Mappings tab of your plan, and choose a different target network mapping.<1></1>If your VMs do not use static IPs, you can ignore this message.",
   "If your VMs use static IPs, click the Mappings tab of your plan, and choose a different target network mapping.<1></1>If your VMs don't use static IPs, you can ignore this message.": "If your VMs use static IPs, click the Mappings tab of your plan, and choose a different target network mapping.<1></1>If your VMs don't use static IPs, you can ignore this message.",
   "Image": "Image",
@@ -764,5 +768,6 @@
   "You can select a migration network. If you do not select a migration network,\n        the default migration network is set to the providers default transfer network.": "You can select a migration network. If you do not select a migration network,\n        the default migration network is set to the providers default transfer network.",
   "You can select a migration network. If you do not select a migration network, the default migration network is set to the providers default transfer network.": "You can select a migration network. If you do not select a migration network, the default migration network is set to the providers default transfer network.",
   "You can select a migration target namespace for the migration virtual machines.": "You can select a migration target namespace for the migration virtual machines.",
+  "You can use a custom hook-runner image or specify a custom image, for example quay.io/konveyor/hook-runner.": "You can use a custom hook-runner image or specify a custom image, for example quay.io/konveyor/hook-runner.",
   "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.": "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations."
 }

--- a/src/plans/create/CreatePlanWizard.tsx
+++ b/src/plans/create/CreatePlanWizard.tsx
@@ -1,12 +1,13 @@
 import { type FC, useState } from 'react';
 import { FormProvider, useWatch } from 'react-hook-form';
 
-import { Form, Title, Wizard, WizardStep, type WizardStepType } from '@patternfly/react-core';
+import { Wizard, WizardStep, type WizardStepType } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import { GeneralFormFieldId } from './steps/general-information/constants';
 import GeneralInformationStep from './steps/general-information/GeneralInformationStep';
+import HooksStep from './steps/hooks/HooksStep';
 import MigrationTypeStep from './steps/migration-type/MigrationTypeStep';
 import NetworkMapStep from './steps/network-map/NetworkMapStep';
 import OtherSettingsStep from './steps/other-settings/OtherSettingsStep';
@@ -96,9 +97,7 @@ const CreatePlanWizard: FC = () => {
               <OtherSettingsStep />
             </WizardStep>,
             <WizardStep key={PlanWizardStepId.Hooks} {...getStepProps(PlanWizardStepId.Hooks)}>
-              <Form>
-                <Title headingLevel="h2">{t('Hooks')}</Title>
-              </Form>
+              <HooksStep />
             </WizardStep>,
           ]}
         />

--- a/src/plans/create/steps/general-information/GeneralInformationStep.tsx
+++ b/src/plans/create/steps/general-information/GeneralInformationStep.tsx
@@ -35,7 +35,7 @@ const GeneralInformationStep: FC = () => {
   return (
     <WizardStepContainer title={planStepNames[PlanWizardStepId.General]}>
       <Form>
-        <FormSection title={t('Plan information')} titleElement="h3">
+        <FormSection title={t('Plan information')}>
           <p>{t('Name your plan and choose the project you would like it to be created in.')}</p>
 
           <FormGroupWithErrorText
@@ -59,7 +59,7 @@ const GeneralInformationStep: FC = () => {
           <PlanProjectField />
         </FormSection>
 
-        <FormSection title={t('Source and target providers')} titleElement="h3">
+        <FormSection title={t('Source and target providers')}>
           <p>
             {t(
               'Select the provider you would like to migrate your virtual machines from (source provider) and the provider you want to migrate your virtual machines to (target provider).',

--- a/src/plans/create/steps/hooks/AnsiblePlaybookField.tsx
+++ b/src/plans/create/steps/hooks/AnsiblePlaybookField.tsx
@@ -1,0 +1,50 @@
+import type { FC } from 'react';
+import { Controller } from 'react-hook-form';
+
+import { CodeEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { FormGroup, FormHelperText } from '@patternfly/react-core';
+import { useForkliftTranslation } from '@utils/i18n';
+
+import { useCreatePlanFormContext } from '../../hooks';
+
+import { type HooksFormFieldId, MigrationHookFieldId } from './constants';
+import { getHooksFormFieldLabels, getHooksSubFieldId } from './utils';
+
+type AnsiblePlaybookFieldProps = {
+  fieldId: HooksFormFieldId;
+};
+
+const AnsiblePlaybookField: FC<AnsiblePlaybookFieldProps> = ({ fieldId }) => {
+  const { t } = useForkliftTranslation();
+  const { control } = useCreatePlanFormContext();
+  const subFieldId = getHooksSubFieldId(fieldId, MigrationHookFieldId.AnsiblePlaybook);
+
+  return (
+    <FormGroup
+      fieldId={subFieldId}
+      label={getHooksFormFieldLabels(fieldId)[MigrationHookFieldId.AnsiblePlaybook]}
+    >
+      <Controller
+        name={subFieldId}
+        control={control}
+        render={({ field }) => (
+          <CodeEditor
+            language="yaml"
+            value={field.value}
+            onChange={(value) => {
+              field.onChange(value);
+            }}
+            minHeight="400px"
+            showMiniMap={false}
+          />
+        )}
+      />
+
+      <FormHelperText>
+        {t('If you specify a playbook, the image must be hook-runner.')}
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default AnsiblePlaybookField;

--- a/src/plans/create/steps/hooks/EnableHookCheckbox.tsx
+++ b/src/plans/create/steps/hooks/EnableHookCheckbox.tsx
@@ -1,0 +1,44 @@
+import type { FC } from 'react';
+import { Controller } from 'react-hook-form';
+
+import { Checkbox } from '@patternfly/react-core';
+
+import { useCreatePlanFormContext } from '../../hooks';
+
+import { type HooksFormFieldId, MigrationHookFieldId } from './constants';
+import { getHooksFormFieldLabels, getHooksSubFieldId } from './utils';
+
+type EnableHookCheckboxProps = {
+  fieldId: HooksFormFieldId;
+};
+
+const EnableHookCheckbox: FC<EnableHookCheckboxProps> = ({ fieldId }) => {
+  const { control, unregister } = useCreatePlanFormContext();
+  const subFieldId = getHooksSubFieldId(fieldId, MigrationHookFieldId.EnableHook);
+
+  return (
+    <Controller
+      name={subFieldId}
+      control={control}
+      render={({ field }) => (
+        <Checkbox
+          id={subFieldId}
+          label={getHooksFormFieldLabels(fieldId)[MigrationHookFieldId.EnableHook]}
+          isChecked={field.value}
+          onChange={(_, value) => {
+            field.onChange(value);
+
+            if (!value) {
+              unregister([
+                getHooksSubFieldId(fieldId, MigrationHookFieldId.HookRunnerImage),
+                getHooksSubFieldId(fieldId, MigrationHookFieldId.AnsiblePlaybook),
+              ]);
+            }
+          }}
+        />
+      )}
+    />
+  );
+};
+
+export default EnableHookCheckbox;

--- a/src/plans/create/steps/hooks/HookRunnerImageField.tsx
+++ b/src/plans/create/steps/hooks/HookRunnerImageField.tsx
@@ -1,0 +1,41 @@
+import type { FC } from 'react';
+import { Controller } from 'react-hook-form';
+
+import { FormGroup, FormHelperText, TextInput } from '@patternfly/react-core';
+import { useForkliftTranslation } from '@utils/i18n';
+
+import { useCreatePlanFormContext } from '../../hooks';
+
+import { type HooksFormFieldId, MigrationHookFieldId } from './constants';
+import { getHooksFormFieldLabels, getHooksSubFieldId } from './utils';
+
+type HookRunnerImageFieldProps = {
+  fieldId: HooksFormFieldId;
+};
+
+const HookRunnerImageField: FC<HookRunnerImageFieldProps> = ({ fieldId }) => {
+  const { t } = useForkliftTranslation();
+  const { control } = useCreatePlanFormContext();
+  const subFieldId = getHooksSubFieldId(fieldId, MigrationHookFieldId.HookRunnerImage);
+
+  return (
+    <FormGroup
+      fieldId={subFieldId}
+      label={getHooksFormFieldLabels(fieldId)[MigrationHookFieldId.HookRunnerImage]}
+    >
+      <Controller
+        name={subFieldId}
+        control={control}
+        render={({ field }) => <TextInput {...field} />}
+      />
+
+      <FormHelperText>
+        {t(
+          'You can use a custom hook-runner image or specify a custom image, for example quay.io/konveyor/hook-runner.',
+        )}
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default HookRunnerImageField;

--- a/src/plans/create/steps/hooks/HooksStep.tsx
+++ b/src/plans/create/steps/hooks/HooksStep.tsx
@@ -1,0 +1,58 @@
+import type { FC } from 'react';
+import { useWatch } from 'react-hook-form';
+
+import WizardStepContainer from '@components/common/WizardStepContainer';
+import { Form, FormSection } from '@patternfly/react-core';
+import { useForkliftTranslation } from '@utils/i18n';
+
+import { planStepNames, PlanWizardStepId } from '../../constants';
+import { useCreatePlanFormContext } from '../../hooks';
+
+import AnsiblePlaybookField from './AnsiblePlaybookField';
+import { HooksFormFieldId } from './constants';
+import EnableHookCheckbox from './EnableHookCheckbox';
+import HookRunnerImageField from './HookRunnerImageField';
+
+const HooksStep: FC = () => {
+  const { t } = useForkliftTranslation();
+  const { control } = useCreatePlanFormContext();
+  const [preMigrationHook, postMigrationHook] = useWatch({
+    control,
+    name: [HooksFormFieldId.PreMigration, HooksFormFieldId.PostMigration],
+  });
+
+  return (
+    <WizardStepContainer
+      title={planStepNames[PlanWizardStepId.Hooks]}
+      description={t(
+        'Hooks are contained in Ansible playbooks that can be run before or after the migration.',
+      )}
+    >
+      <Form className="pf-v5-u-mt-md">
+        <FormSection title={t('Pre migration hook')}>
+          <EnableHookCheckbox fieldId={HooksFormFieldId.PreMigration} />
+
+          {preMigrationHook?.enableHook && (
+            <>
+              <HookRunnerImageField fieldId={HooksFormFieldId.PreMigration} />
+              <AnsiblePlaybookField fieldId={HooksFormFieldId.PreMigration} />
+            </>
+          )}
+        </FormSection>
+
+        <FormSection title={t('Post migration hook')}>
+          <EnableHookCheckbox fieldId={HooksFormFieldId.PostMigration} />
+
+          {postMigrationHook?.enableHook && (
+            <>
+              <HookRunnerImageField fieldId={HooksFormFieldId.PostMigration} />
+              <AnsiblePlaybookField fieldId={HooksFormFieldId.PostMigration} />
+            </>
+          )}
+        </FormSection>
+      </Form>
+    </WizardStepContainer>
+  );
+};
+
+export default HooksStep;

--- a/src/plans/create/steps/hooks/constants.ts
+++ b/src/plans/create/steps/hooks/constants.ts
@@ -1,0 +1,16 @@
+export enum HooksFormFieldId {
+  PreMigration = 'preMigrationHook',
+  PostMigration = 'postMigrationHook',
+}
+
+export enum MigrationHookFieldId {
+  EnableHook = 'enableHook',
+  HookRunnerImage = 'runnerImage',
+  AnsiblePlaybook = 'ansiblePlaybook',
+}
+
+export type MigrationHook = {
+  [MigrationHookFieldId.EnableHook]: boolean;
+  [MigrationHookFieldId.HookRunnerImage]: string;
+  [MigrationHookFieldId.AnsiblePlaybook]: string;
+};

--- a/src/plans/create/steps/hooks/utils.ts
+++ b/src/plans/create/steps/hooks/utils.ts
@@ -1,0 +1,20 @@
+import { t } from '@utils/i18n';
+
+import { HooksFormFieldId, MigrationHookFieldId } from './constants';
+
+type HooksSubFieldId = `${HooksFormFieldId}.${MigrationHookFieldId}`;
+
+export const getHooksSubFieldId = (
+  fieldId: HooksFormFieldId,
+  subFieldId: MigrationHookFieldId,
+): HooksSubFieldId => `${fieldId}.${subFieldId}`;
+
+export const getHooksFormFieldLabels = (
+  fieldId: HooksFormFieldId,
+): Partial<Record<MigrationHookFieldId, ReturnType<typeof t>>> => ({
+  [MigrationHookFieldId.AnsiblePlaybook]: t('Ansible playbook'),
+  [MigrationHookFieldId.EnableHook]: t(
+    `Enable ${fieldId === HooksFormFieldId.PreMigration ? 'pre' : 'post'} migration hook`,
+  ),
+  [MigrationHookFieldId.HookRunnerImage]: t('Hook runner image'),
+});

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -10,6 +10,7 @@ import type {
 } from '@kubev2v/types';
 
 import type { GeneralFormFieldId } from './steps/general-information/constants';
+import type { HooksFormFieldId, MigrationHook } from './steps/hooks/constants';
 import type { MigrationTypeFieldId, MigrationTypeValue } from './steps/migration-type/constants';
 import type { NetworkMapFieldId, NetworkMapping } from './steps/network-map/constants';
 import type { DiskPassPhrase, OtherSettingsFormFieldId } from './steps/other-settings/constants';
@@ -52,4 +53,6 @@ export type CreatePlanFormData = FieldValues & {
   [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: DiskPassPhrase[];
   [OtherSettingsFormFieldId.PreserveStaticIps]: boolean;
   [OtherSettingsFormFieldId.SharedDisks]: boolean;
+  [HooksFormFieldId.PreMigration]: MigrationHook;
+  [HooksFormFieldId.PostMigration]: MigrationHook;
 };


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2460

## 📝 Description
Added hooks step to the wizard which consists of 2 checkboxes which either enable or disable pre/post migration hooks. You can select both or none as the step is optional. After selecting enable, 2 fields show for each hook, an ansible playbook code editor and a runtime image text input. Both of these inputs are based on what the user currently sees in the plan details page.

## 🎥 Demo
https://github.com/user-attachments/assets/b7a106d6-5dd4-4404-a231-d8ad98992568

## 📝 CC://
@mmenestr 