### PR TITLE
MTV-2348: Change the FreetextFilter matcher to be case insensitive (release-2.8.3)

### DIFF
--- a/packages/common/src/components/FilterGroup/matchers.ts
+++ b/packages/common/src/components/FilterGroup/matchers.ts
@@ -87,7 +87,8 @@ export const createMatcher =
  */
 export const freetextMatcher = {
   filterType: 'freetext',
-  matchValue: (value: string) => (filter: string) => value?.includes(filter?.trim()),
+  matchValue: (value: string) => (filter: string) =>
+    value?.toLowerCase()?.includes(filter?.toLowerCase()?.trim()),
 };
 
 /**


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2348

(Backported from https://github.com/kubev2v/forklift-console-plugin/pull/1594)

Change the filters matcher of FreetextFilter within the StandardPage to be case-insensitive.
