### PR TITLE
MTV-2670: Removing k8s objects icon badges in plans table

### DIFF
--- a/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
+++ b/src/modules/Providers/utils/components/TableCell/TableLinkCell.tsx
@@ -13,6 +13,7 @@ import { TableLabelCell, type TableLabelCellProps } from './TableLabelCell';
 export const TableLinkCell: FC<TableLinkCellProps> = ({
   groupVersionKind,
   hasLabel = false,
+  hideIcon,
   label,
   labelColor = 'grey',
   name,
@@ -20,7 +21,12 @@ export const TableLinkCell: FC<TableLinkCellProps> = ({
 }) => {
   return (
     <TableLabelCell hasLabel={hasLabel} label={label} labelColor={labelColor} isWrap={true}>
-      <ResourceLink groupVersionKind={groupVersionKind} name={name} namespace={namespace} />
+      <ResourceLink
+        groupVersionKind={groupVersionKind}
+        name={name}
+        namespace={namespace}
+        hideIcon={hideIcon}
+      />
     </TableLabelCell>
   );
 };
@@ -29,4 +35,5 @@ type TableLinkCellProps = {
   groupVersionKind: K8sGroupVersionKind;
   name: string | undefined;
   namespace: string | undefined;
+  hideIcon?: boolean;
 } & TableLabelCellProps;

--- a/src/plans/list/components/PlanRow/hooks/usePlanListRowFields.tsx
+++ b/src/plans/list/components/PlanRow/hooks/usePlanListRowFields.tsx
@@ -44,6 +44,7 @@ export const usePlanListRowFields = (plan: V1beta1Plan) => {
         groupVersionKind={ProviderModelGroupVersionKind}
         name={destinationProviderName}
         namespace={destinationProviderNamespace}
+        hideIcon={true}
       />
     ),
     [PlanTableResourceId.MigrationStarted]: (
@@ -55,6 +56,7 @@ export const usePlanListRowFields = (plan: V1beta1Plan) => {
         groupVersionKind={PlanModelGroupVersionKind}
         name={planName}
         namespace={planNamespace}
+        hideIcon={true}
       />
     ),
     [PlanTableResourceId.Namespace]: (
@@ -62,6 +64,7 @@ export const usePlanListRowFields = (plan: V1beta1Plan) => {
         groupVersionKind={{ kind: 'Project', version: 'v1' }}
         name={planNamespace}
         namespace={planNamespace}
+        hideIcon={true}
       />
     ),
     [PlanTableResourceId.Phase]: <PlanStatus plan={plan} />,


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2670
Based on:  https://issues.redhat.com/browse/HPUX-453

Remove the k8s icon badges next to all table cells in plan list table.


## 🎥 Demo
## Before
![Screenshot from 2025-06-04 20-33-03](https://github.com/user-attachments/assets/6c7b0b82-232b-4556-9db6-50e46aa939ac)


## After
![Screenshot from 2025-06-04 20-32-40](https://github.com/user-attachments/assets/6c7709b7-938c-4652-b278-ebbde05ef151)

## 📝 CC://
  @heyethankim 
