### PR TITLE
MTV-2676: pod network created with 'multus' type instead of 'pod'

### DIFF
--- a/src/plans/create/utils/createNetworkMap.ts
+++ b/src/plans/create/utils/createNetworkMap.ts
@@ -1,4 +1,5 @@
 import { getObjectRef } from 'src/modules/Providers/views/migrate/reducer/helpers';
+import { PodNetworkLabel } from 'src/plans/details/tabs/Mappings/utils/constants';
 import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import {
@@ -41,11 +42,11 @@ export const createNetworkMap = async ({
     },
     spec: {
       map: mappings?.reduce((acc: V1beta1NetworkMapSpecMap[], { sourceNetwork, targetNetwork }) => {
-        if (sourceNetwork.name && targetNetwork.name) {
+        if (sourceNetwork.name) {
           acc.push({
             // Handle pod network type or multus network type for the destination
             destination:
-              targetNetwork.name === ''
+              targetNetwork.name === PodNetworkLabel.Source || targetNetwork.name === ''
                 ? { type: 'pod' }
                 : {
                     name: targetNetwork.name.includes('/')

--- a/src/plans/details/tabs/Mappings/utils/constants.ts
+++ b/src/plans/details/tabs/Mappings/utils/constants.ts
@@ -1,6 +1,6 @@
 export const STANDARD = 'standard';
 
-export enum PodNetworkLabel {
-  Source = 'Pod Network',
-  Target = 'Pod',
-}
+export const PodNetworkLabel = {
+  Source: 'Pod network',
+  Target: 'Pod',
+} as const;


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2676

## 📝 Description
When creating a new plan with new net map, when entering pod network, the net map gets type of `multus` which causing the net map to be not ready

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/f79d2b62-68c3-41cd-bc75-50d397770c07

After:

https://github.com/user-attachments/assets/5a7a6fcf-858d-44ad-95ac-93ec3ab62189

## 📝 CC://

<!---
> @tag as needed
-->
