### PR TITLE
MTV-2706: Create plan with hook miss base64 encoding

### DIFF
--- a/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
+++ b/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
@@ -1,7 +1,8 @@
 import type { FC } from 'react';
 import { Controller } from 'react-hook-form';
+import { Base64 } from 'js-base64';
 
-import { CodeEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { CodeEditor, Language } from '@patternfly/react-code-editor';
 import { FormGroup, FormHelperText } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -29,13 +30,13 @@ const AnsiblePlaybookField: FC<AnsiblePlaybookFieldProps> = ({ fieldId }) => {
         control={control}
         render={({ field }) => (
           <CodeEditor
-            language="yaml"
-            value={field.value}
+            language={Language.yaml}
+            code={Base64.decode(field.value ?? '')}
             onChange={(value) => {
-              field.onChange(value);
+              field.onChange(Base64.encode(String(value)));
             }}
-            minHeight="400px"
-            showMiniMap={false}
+            height="20rem"
+            isMinimapVisible={false}
           />
         )}
       />


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2706

## 📝 Description

Replacing code editor from console SDK to PF as the console component is not displayed well with PF6.
Also adding encoding/decoding to yaml hooks on plan creation
## 🎥 Demo

Before:

https://github.com/user-attachments/assets/0b2d65a2-4982-4cbc-bce4-2b5838b5462b

After:

https://github.com/user-attachments/assets/2e21d5bf-9750-48ce-9f20-36d6480e66d1


## 📝 CC://

<!---
> @tag as needed
-->
