### PR TITLE
Include revision label in containerfile

### DIFF
--- a/.tekton/forklift-console-plugin-dev-preview-pull-request.yaml
+++ b/.tekton/forklift-console-plugin-dev-preview-pull-request.yaml
@@ -37,6 +37,9 @@ spec:
     value: '[{"type": "yarn", "path": "."}, {"type": "npm", "path": ".konflux"}]'
   - name: build-args-file
     value: build/release.conf
+  - name: build-args
+    value:
+      - "REVISION={{revision}}"
   taskRunSpecs:
   - pipelineTaskName: build-container
     computeResources:

--- a/.tekton/forklift-console-plugin-dev-preview-push.yaml
+++ b/.tekton/forklift-console-plugin-dev-preview-push.yaml
@@ -34,6 +34,9 @@ spec:
     value: '[{"type": "yarn", "path": "."}, {"type": "npm", "path": ".konflux"}]'
   - name: build-args-file
     value: build/release.conf
+  - name: build-args
+    value:
+      - "REVISION={{revision}}"
   taskRunSpecs:
   - pipelineTaskName: build-container
     computeResources:

--- a/build/Containerfile-downstream
+++ b/build/Containerfile-downstream
@@ -46,6 +46,7 @@ CMD nginx -g "daemon off;"
 
 ARG VERSION
 ARG REGISTRY
+ARG REVISION
 
 LABEL \
         com.redhat.component="mtv-console-plugin-container" \
@@ -57,4 +58,5 @@ LABEL \
         io.openshift.tags="migration,mtv,forklift" \
         summary="Migration Toolkit for Virtualization - User Console Plugin Interface" \
         maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
-        description="Migration Toolkit for Virtualization - User Console Plugin Interface"
+        description="Migration Toolkit for Virtualization - User Console Plugin Interface" \
+        revision="$REVISION"


### PR DESCRIPTION
Issue: If we want to know from which commit the image was built, we need to include revision as a label.
