### PR TITLE
[release-2.8]: Fix create provider crash

### DIFF
--- a/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
+++ b/packages/forklift-console-plugin/src/modules/Providers/views/list/ProvidersListPage.tsx
@@ -206,7 +206,11 @@ const ProvidersListPage: React.FC<{
   return (
     <StandardPage<ProviderData>
       data-testid="providers-list"
-      addButton={permissions.canCreate && <ProvidersAddButton dataTestId="add-provider-button" />}
+      addButton={
+        permissions.canCreate && (
+          <ProvidersAddButton namespace={namespace} dataTestId="add-provider-button" />
+        )
+      }
       dataSource={[data || [], providersLoaded, providersLoadError]}
       RowMapper={ProviderRow}
       fieldsMetadata={fieldsMetadataFactory(t)}


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2807

## 📝 Description

Missing namespace prop to the create provider button caused to navigate to /k8s/cluster URL which is not accessible to users that are not cluster-readers
## 🎥 Demo

Before:

https://github.com/user-attachments/assets/8c039fb0-21cc-4e37-9454-c5e39b01987c

After:

https://github.com/user-attachments/assets/8472f80e-aa14-4c20-b24b-106d9a413a4f



