### PR TITLE
MTV-2689: UI Search for VMs in UI only displays results on first page

### DIFF
--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -186,6 +186,12 @@ const StandardPageInner = <T,>({
     }
   }, [sortedData, metaMatcher]);
 
+  useEffect(() => {
+    if (Object.values(selectedFilters).some((filter) => !isEmpty(filter))) {
+      setPage(1); // When filters are applied, reset to page 1 to show correct results
+    }
+  }, [selectedFilters]);
+
   const showPagination = useMemo(
     () => pagination === 'on' || (typeof pagination === 'number' && sortedData.length > pagination),
     [pagination, sortedData.length],


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2689

## 📝 Description

Resetting the pagination to first page when filters applied to show the filter results
## 🎥 Demo

Before:

https://github.com/user-attachments/assets/29329a98-00d7-407d-9c81-e122725d332b


https://github.com/user-attachments/assets/c65b5c52-d48f-4080-bc46-848e37cf3cbb

After:

https://github.com/user-attachments/assets/328335b5-5e53-44b0-b84c-3542e1a89255



## 📝 CC://

<!---
> @tag as needed
-->
