### PR TITLE
[MTV-2786, MTV-2790, MTV-2788] Create plan - validate names across al…

### DIFF
--- a/src/modules/NetworkMaps/components/NetworkMapsAddButton.tsx
+++ b/src/modules/NetworkMaps/components/NetworkMapsAddButton.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { getResourceUrl } from 'src/modules/Providers/utils/helpers/getResourceUrl';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -11,7 +11,7 @@ const NetworkMapsAddButton: FC<{ namespace: string; dataTestId?: string }> = ({
   namespace,
 }) => {
   const { t } = useForkliftTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   const NetworkMapsListURL = getResourceUrl({
     namespace,
@@ -20,7 +20,7 @@ const NetworkMapsAddButton: FC<{ namespace: string; dataTestId?: string }> = ({
   });
 
   const onClick = () => {
-    history.push(`${NetworkMapsListURL}/~new`);
+    navigate(`${NetworkMapsListURL}/~new`);
   };
 
   return (

--- a/src/plans/create/CreatePlanWizardContextProvider.tsx
+++ b/src/plans/create/CreatePlanWizardContextProvider.tsx
@@ -6,6 +6,7 @@ import { useSourceStorages } from 'src/modules/Providers/hooks/useStorages';
 import useTargetStorages from '@utils/hooks/useTargetStorages';
 
 import { useCreatePlanFormContext } from './hooks/useCreatePlanFormContext';
+import { useOvirtNicProfiles } from './hooks/useOvirtNicProfiles';
 import { GeneralFormFieldId } from './steps/general-information/constants';
 import { CreatePlanWizardContext } from './constants';
 
@@ -24,12 +25,14 @@ const CreatePlanWizardContextProvider: React.FC<PropsWithChildren> = ({ children
   // Fetch network and storage data based on selected providers.
   const sourceNetworksResult = useSourceNetworks(sourceProvider);
   const targetNetworksResult = useOpenShiftNetworks(targetProvider);
+  const oVirtNicProfilesResult = useOvirtNicProfiles(sourceProvider);
   const sourceStoragesResult = useSourceStorages(sourceProvider);
   const targetStoragesResult = useTargetStorages(targetProvider, targetProject);
 
   const value = useMemo(
     () => ({
       network: {
+        oVirtNicProfiles: oVirtNicProfilesResult,
         sources: sourceNetworksResult,
         targets: targetNetworksResult,
       },
@@ -38,7 +41,13 @@ const CreatePlanWizardContextProvider: React.FC<PropsWithChildren> = ({ children
         targets: targetStoragesResult,
       },
     }),
-    [sourceNetworksResult, sourceStoragesResult, targetNetworksResult, targetStoragesResult],
+    [
+      sourceNetworksResult,
+      targetNetworksResult,
+      oVirtNicProfilesResult,
+      sourceStoragesResult,
+      targetStoragesResult,
+    ],
   );
 
   return (

--- a/src/plans/create/CreatePlanWizardFooter.tsx
+++ b/src/plans/create/CreatePlanWizardFooter.tsx
@@ -1,5 +1,5 @@
 import type { FC, MouseEvent } from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { type Location, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { getResourceUrl } from 'src/modules/Providers/utils/helpers/getResourceUrl';
 
 import { PlanModelRef } from '@kubev2v/types';
@@ -15,6 +15,7 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import { useCreatePlanFormContext } from './hooks/useCreatePlanFormContext';
 import { PlanWizardStepId } from './constants';
+import type { CreatePlanFormData } from './types';
 
 type CreatePlanWizardFooterProps = Partial<Pick<WizardFooterProps, 'nextButtonText' | 'onNext'>> & {
   hasError?: boolean;
@@ -26,6 +27,7 @@ const CreatePlanWizardFooter: FC<CreatePlanWizardFooterProps> = ({
   onNext: onSubmit,
 }) => {
   const navigate = useNavigate();
+  const location: Location<CreatePlanFormData> = useLocation();
   const { t } = useForkliftTranslation();
   const [activeNamespace] = useActiveNamespace();
   const {
@@ -62,12 +64,19 @@ const CreatePlanWizardFooter: FC<CreatePlanWizardFooterProps> = ({
   };
 
   const onCancel = () => {
-    const plansListURL = getResourceUrl({
+    // If we have a sourceProvider in the location state, go back to the previous page (provider details)
+    if (location.state?.sourceProvider) {
+      navigate(-1);
+      return;
+    }
+
+    // Otherwise, navigate to the plans list page
+    const plansListUrl = getResourceUrl({
       namespace: activeNamespace,
       reference: PlanModelRef,
     });
 
-    navigate(plansListURL);
+    navigate(plansListUrl);
   };
 
   return (

--- a/src/plans/create/hooks/useOvirtNicProfiles.ts
+++ b/src/plans/create/hooks/useOvirtNicProfiles.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import useProviderInventory from 'src/modules/Providers/hooks/useProviderInventory';
+
+import type { OVirtNicProfile, V1beta1Provider } from '@kubev2v/types';
+
+export const useOvirtNicProfiles = (
+  provider: V1beta1Provider | undefined,
+): [OVirtNicProfile[], boolean, Error | null] => {
+  const isOVirt = provider?.spec?.type === 'ovirt';
+  const {
+    error,
+    inventory: nicProfiles,
+    loading,
+  } = useProviderInventory<OVirtNicProfile[]>({
+    disabled: !provider || !isOVirt,
+    provider,
+    subPath: '/nicprofiles?detail=1',
+  });
+
+  const typedNicProfiles: OVirtNicProfile[] = useMemo(
+    () => (Array.isArray(nicProfiles) ? nicProfiles : []),
+    [nicProfiles],
+  );
+
+  return [typedNicProfiles, loading, error];
+};

--- a/src/plans/create/steps/general-information/PlanNameField.tsx
+++ b/src/plans/create/steps/general-information/PlanNameField.tsx
@@ -3,7 +3,7 @@ import { Controller } from 'react-hook-form';
 
 import FormGroupWithErrorText from '@components/common/FormGroupWithErrorText';
 import { PlanModelGroupVersionKind, type V1beta1Plan } from '@kubev2v/types';
-import { useActiveNamespace, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { TextInput } from '@patternfly/react-core';
 import { getInputValidated } from '@utils/form';
 
@@ -17,13 +17,9 @@ const PlanNameField: FC = () => {
     control,
     formState: { errors },
   } = useCreatePlanFormContext();
-  const [activeNamespace] = useActiveNamespace();
-
   const [plans] = useK8sWatchResource<V1beta1Plan[]>({
     groupVersionKind: PlanModelGroupVersionKind,
     isList: true,
-    namespace: activeNamespace,
-    namespaced: true,
   });
 
   return (

--- a/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
+++ b/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
@@ -20,26 +20,23 @@ const NewNetworkMapFields: FC = () => {
   const { t } = useForkliftTranslation();
   const { control, getFieldState, setValue } = useCreatePlanFormContext();
   const { network } = useCreatePlanWizardContext();
-  const [targetProject, sourceProvider, vms, networkMap] = useWatch({
+  const [targetProject, vms, networkMap] = useWatch({
     control,
-    name: [
-      GeneralFormFieldId.TargetProject,
-      GeneralFormFieldId.SourceProvider,
-      VmFormFieldId.Vms,
-      NetworkMapFieldId.NetworkMap,
-    ],
+    name: [GeneralFormFieldId.TargetProject, VmFormFieldId.Vms, NetworkMapFieldId.NetworkMap],
   });
 
   const [availableSourceNetworks, sourceNetworksLoading, sourceNetworksError] = network.sources;
   const [availableTargetNetworks, targetNetworksLoading, targetNetworksError] = network.targets;
+  const [oVirtNicProfiles, oVirtNicProfilesLoading, oVirtNicProfilesError] =
+    network.oVirtNicProfiles;
   const isNetMapEmpty = isEmpty(networkMap);
-  const isLoading = sourceNetworksLoading || targetNetworksLoading;
+  const isLoading = sourceNetworksLoading || targetNetworksLoading || oVirtNicProfilesLoading;
   const { error } = getFieldState(NetworkMapFieldId.NetworkMap);
 
   const { other: otherSourceNetworks, used: usedSourceNetworks } = getSourceNetworkValues(
-    sourceProvider,
     availableSourceNetworks,
     Object.values(vms),
+    oVirtNicProfiles,
   );
 
   const targetNetworkMap = useMemo(
@@ -83,7 +80,7 @@ const NewNetworkMapFields: FC = () => {
         usedSourceNetworks={usedSourceNetworks}
         otherSourceNetworks={otherSourceNetworks}
         isLoading={isLoading}
-        loadError={sourceNetworksError ?? targetNetworksError}
+        loadError={sourceNetworksError ?? targetNetworksError ?? oVirtNicProfilesError}
       />
 
       <FormGroupWithHelpText

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -12,6 +12,7 @@ import type {
   OvaNetwork,
   OvaVM,
   OVirtNetwork,
+  OVirtNicProfile,
   OVirtVM,
   V1beta1Hook,
   V1beta1NetworkMap,
@@ -109,6 +110,7 @@ export type CreatePlanWizardContextProps = {
   network: {
     sources: ResourceQueryResult<InventoryNetwork[]>;
     targets: ResourceQueryResult<OpenShiftNetworkAttachmentDefinition[]>;
+    oVirtNicProfiles: ResourceQueryResult<OVirtNicProfile[]>;
   };
   storage: {
     sources: ResourceQueryResult<InventoryStorage[]>;

--- a/src/plans/list/components/PlansAddButton.tsx
+++ b/src/plans/list/components/PlansAddButton.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react';
-import { useHistory } from 'react-router';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { getResourceUrl } from 'src/modules/Providers/utils/helpers/getResourceUrl';
 import { useHasSufficientProviders } from 'src/utils/fetch';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -15,7 +15,7 @@ type PlansAddButtonProps = {
 
 const PlansAddButton: FC<PlansAddButtonProps> = ({ canCreate, dataTestId, namespace }) => {
   const { t } = useForkliftTranslation();
-  const history = useHistory();
+  const navigate = useNavigate();
   const hasSufficientProviders = useHasSufficientProviders(namespace);
 
   const onClick = () => {
@@ -24,7 +24,7 @@ const PlansAddButton: FC<PlansAddButtonProps> = ({ canCreate, dataTestId, namesp
       reference: PlanModelRef,
     });
 
-    history.push(`${planResourceUrl}/~new`);
+    navigate(`${planResourceUrl}/~new`);
   };
 
   const button = (

--- a/src/storageMaps/types.ts
+++ b/src/storageMaps/types.ts
@@ -1,3 +1,5 @@
+import type { OVirtVM } from '@kubev2v/types';
+
 export type TargetStorage = {
   id: string;
   name: string;
@@ -9,3 +11,10 @@ export enum StorageClassAnnotation {
 }
 
 export type StorageMappingValue = { id?: string; name: string };
+
+export type OVirtVMWithDisks = OVirtVM & {
+  disks?: {
+    id: string;
+    storageDomain?: string;
+  }[];
+};


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2790
https://issues.redhat.com/browse/MTV-2786
https://issues.redhat.com/browse/MTV-2788

## 📝 Description
- Updated mapping helper functions for the wizard so that nicProfiles are fetched and used to better determine default source network and storage values.

- Updated the fetch of plans to not be namespace scoped so that all plan names are factored into the plan name validation function.

- Updated route logic for the wizard so that when coming from the Providers details page, when cancelling the wizard, you go back to that page and not the plans list page.

## 🎥 Demo
#### Route fix
https://github.com/user-attachments/assets/8d634eab-6d0f-4e66-85a9-61994e2db264

#### Plan name validation across all namespaces
https://github.com/user-attachments/assets/7c4cde04-04fa-498e-877f-19b00c5dc15c

#### Default storage and network maps for rhv provider
**BEFORE**

https://github.com/user-attachments/assets/bd9f98ed-94ae-45ec-b0da-43c8dc8bc8a6



**AFTER**

https://github.com/user-attachments/assets/d8686b95-d195-409f-8a0e-6e675555de2c



## 📝 CC://
@mmenestr 
