### PR TITLE
MTV-2789: Edit plan source mapping doesnt always apply

### DIFF
--- a/src/plans/details/tabs/Mappings/PlanMappingsPage.tsx
+++ b/src/plans/details/tabs/Mappings/PlanMappingsPage.tsx
@@ -20,22 +20,20 @@ const PlanMappingsPage: FC<PlanPageProps> = ({ name, namespace }) => {
 
   const {
     loadingResources,
-    networkMaps,
     planNetworkMap,
     planStorageMap,
     resourcesError,
     sourceNetworks,
     sourceStorages,
-    storageMaps,
     targetNetworks,
     targetStorages,
   } = useMappingResources(plan);
 
   const message = getMappingPageMessage({
     loadingResources,
-    networkMapsEmpty: isEmpty(networkMaps),
+    networkMapsEmpty: isEmpty(planNetworkMap),
     resourcesError,
-    storageMapsEmpty: isEmpty(storageMaps),
+    storageMapsEmpty: isEmpty(planStorageMap),
   });
 
   if (message) {
@@ -61,8 +59,8 @@ const PlanMappingsPage: FC<PlanPageProps> = ({ name, namespace }) => {
       />
       <PlanMappingsSection
         plan={plan}
-        planNetworkMaps={planNetworkMap!}
-        planStorageMaps={planStorageMap!}
+        planNetworkMap={planNetworkMap!}
+        planStorageMap={planStorageMap!}
         setAlertMessage={setAlert}
         sourceNetworks={sourceNetworks}
         sourceStorages={sourceStorages}

--- a/src/plans/details/tabs/Mappings/components/PlanMappingsSection.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanMappingsSection.tsx
@@ -21,8 +21,8 @@ import PlanMappingsViewMode from './PlanMappingsViewMode';
 
 type PlanMappingsSectionProps = {
   plan: V1beta1Plan;
-  planNetworkMaps: V1beta1NetworkMap;
-  planStorageMaps: V1beta1StorageMap;
+  planNetworkMap: V1beta1NetworkMap;
+  planStorageMap: V1beta1StorageMap;
   setAlertMessage: (message: string) => void;
   sourceNetworks: InventoryNetwork[];
   sourceStorages: InventoryStorage[];
@@ -32,8 +32,8 @@ type PlanMappingsSectionProps = {
 
 const PlanMappingsSection: FC<PlanMappingsSectionProps> = ({
   plan,
-  planNetworkMaps,
-  planStorageMaps,
+  planNetworkMap,
+  planStorageMap,
   setAlertMessage,
   sourceNetworks,
   sourceStorages,
@@ -56,8 +56,8 @@ const PlanMappingsSection: FC<PlanMappingsSectionProps> = ({
     updatedNetwork,
     updatedStorage,
   } = usePlanMappingsHandlers({
-    planNetworkMaps,
-    planStorageMaps,
+    planNetworkMap,
+    planStorageMap,
     sourceNetworks,
     sourceStorages,
     targetNetworks,
@@ -69,8 +69,8 @@ const PlanMappingsSection: FC<PlanMappingsSectionProps> = ({
     setIsLoading(true);
     try {
       await patchPlanMappingsData({
-        planNetworkMaps,
-        planStorageMaps,
+        planNetworkMap,
+        planStorageMap,
         updatedNetwork,
         updatedStorage,
       });

--- a/src/plans/details/tabs/Mappings/hooks/useMappingResources.ts
+++ b/src/plans/details/tabs/Mappings/hooks/useMappingResources.ts
@@ -33,8 +33,6 @@ import {
 type MappingResources = {
   loadingResources: boolean;
   resourcesError: Error | undefined;
-  networkMaps: V1beta1NetworkMap[];
-  storageMaps: V1beta1StorageMap[];
   planNetworkMap: V1beta1NetworkMap | null;
   planStorageMap: V1beta1StorageMap | null;
   sourceNetworks: InventoryNetwork[];
@@ -113,7 +111,6 @@ export const useMappingResources = (plan: V1beta1Plan): MappingResources => {
       targetNetworksLoading ||
       sourceStoragesLoading ||
       targetStoragesLoading,
-    networkMaps: networkMaps ?? [],
     planNetworkMap: planNetworkMaps ?? null,
     planStorageMap: planStorageMaps ?? null,
     resourcesError:
@@ -126,7 +123,6 @@ export const useMappingResources = (plan: V1beta1Plan): MappingResources => {
       targetStoragesError,
     sourceNetworks: sourceNetworks ?? [],
     sourceStorages: sourceStorages ?? [],
-    storageMaps: storageMaps ?? [],
     targetNetworks: targetNetworks ?? [],
     targetStorages: targetStorages ?? [],
   };

--- a/src/plans/details/tabs/Mappings/hooks/usePlanMappingsHandlers.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanMappingsHandlers.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import type { InventoryNetwork } from 'src/modules/Providers/hooks/useNetworks';
 import type { InventoryStorage } from 'src/modules/Providers/hooks/useStorages';
+import { POD } from 'src/plans/details/components/PlanPageHeader/utils/constants';
 import { StorageClassAnnotation } from 'src/storageMaps/types';
 
 import type {
@@ -11,6 +12,7 @@ import type {
 } from '@kubev2v/types';
 import { CONDITION_STATUS } from '@utils/constants';
 
+import { PodNetworkLabel } from '../utils/constants';
 import {
   mapSourceNetworksIdsToLabels,
   mapSourceStoragesIdsToLabels,
@@ -39,8 +41,8 @@ type PlanMappingsHandlers = {
 } & UsePlanMappingsStateResult;
 
 type PlanMappingsHandlersParams = {
-  planNetworkMaps: V1beta1NetworkMap;
-  planStorageMaps: V1beta1StorageMap;
+  planNetworkMap: V1beta1NetworkMap;
+  planStorageMap: V1beta1StorageMap;
   sourceNetworks: InventoryNetwork[];
   sourceStorages: InventoryStorage[];
   targetNetworks: OpenShiftNetworkAttachmentDefinition[];
@@ -50,14 +52,14 @@ type PlanMappingsHandlersParams = {
 type UsePlanMappingsHandlers = (params: PlanMappingsHandlersParams) => PlanMappingsHandlers;
 
 export const usePlanMappingsHandlers: UsePlanMappingsHandlers = ({
-  planNetworkMaps,
-  planStorageMaps,
+  planNetworkMap,
+  planStorageMap,
   sourceNetworks,
   sourceStorages,
   targetNetworks,
   targetStorages,
 }) => {
-  const mappingsState = usePlanMappingsState(planNetworkMaps, planStorageMaps);
+  const mappingsState = usePlanMappingsState(planNetworkMap, planStorageMap);
   const { setUpdatedNetwork, setUpdatedStorage, updatedNetwork, updatedStorage } = mappingsState;
 
   const [canAddNetwork, setCanAddNetwork] = useState(true);
@@ -124,7 +126,8 @@ export const usePlanMappingsHandlers: UsePlanMappingsHandlers = ({
           mapSourceNetworksIdsToLabels(sourceNetworks)[item.source.id ?? item.source.type!] ===
             current.source &&
           (item.destination.name === current.destination ||
-            `${item.destination.namespace}/${item.destination.name}` === current.destination),
+            `${item.destination.namespace}/${item.destination.name}` === current.destination ||
+            (current.destination === PodNetworkLabel.Source && item.destination.type === POD)),
         newMap,
       );
       setUpdatedNetwork(newState);

--- a/src/plans/details/tabs/Mappings/utils/mapMappingsIdsToLabels.ts
+++ b/src/plans/details/tabs/Mappings/utils/mapMappingsIdsToLabels.ts
@@ -63,7 +63,6 @@ export const mapSourceNetworksIdsToLabels = (
     })
     .filter(Boolean);
 
-  tuples.push([POD, PodNetworkLabel.Source]);
   const labelToId = resolveCollisions(tuples);
   return labelToId;
 };
@@ -111,7 +110,7 @@ export const mapTargetNetworksIdsToLabels = (
     )
     .map((net) => [net.uid, `${net.namespace}/${net.name}`]);
 
-  tuples.push([POD, PodNetworkLabel.Target]);
+  tuples.push([POD, PodNetworkLabel.Source]);
   const labelToId = resolveCollisions(tuples);
   return labelToId;
 };

--- a/src/plans/details/tabs/Mappings/utils/planMappingsHandlers.ts
+++ b/src/plans/details/tabs/Mappings/utils/planMappingsHandlers.ts
@@ -24,7 +24,7 @@ export const createReplacedNetworkMap = (
 
   const targetEntry: V1beta1NetworkMapSpecMapDestination = target
     ? { name: target.name, namespace: target.namespace, type: MULTUS }
-    : { name: POD, namespace: '', type: POD };
+    : { type: POD };
 
   return { destination: { ...targetEntry }, source: sourceEntry };
 };

--- a/src/plans/details/tabs/Mappings/utils/utils.ts
+++ b/src/plans/details/tabs/Mappings/utils/utils.ts
@@ -72,15 +72,15 @@ const updateNetworkMapSpecMapDestination = (
 };
 
 type UpdatePlanMappingsDataParams = {
-  planNetworkMaps: V1beta1NetworkMap;
-  planStorageMaps: V1beta1StorageMap;
+  planNetworkMap: V1beta1NetworkMap;
+  planStorageMap: V1beta1StorageMap;
   updatedNetwork: V1beta1NetworkMapSpecMap[];
   updatedStorage: V1beta1StorageMapSpecMap[];
 };
 
 export const patchPlanMappingsData = async ({
-  planNetworkMaps,
-  planStorageMaps,
+  planNetworkMap,
+  planStorageMap,
   updatedNetwork,
   updatedStorage,
 }: UpdatePlanMappingsDataParams) => {
@@ -93,7 +93,7 @@ export const patchPlanMappingsData = async ({
       },
     ],
     model: NetworkMapModel,
-    resource: planNetworkMaps,
+    resource: planNetworkMap,
   });
 
   await k8sPatch({
@@ -105,6 +105,6 @@ export const patchPlanMappingsData = async ({
       },
     ],
     model: StorageMapModel,
-    resource: planStorageMaps,
+    resource: planStorageMap,
   });
 };


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2789

## 📝 Description

Source network wasn't changing, target called Pod instead of Pod network, when refreshing browser the tab would crash and Pod network was listed as an option source network even though it doesn't exist

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/a6542e56-1d1b-449f-8d61-3f6c3af78734

After:

https://github.com/user-attachments/assets/68e77d61-7906-4356-8c3b-a03a57e2a81b

## 📝 CC://

<!---
> @tag as needed
-->
