### PR TITLE
MTV-2791: Ensure the hook steps are updated correctly

### DIFF
--- a/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
+++ b/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
@@ -50,7 +50,7 @@ const HooksCodeEditor: FC<HooksCodeEditorProps> = ({ planEditable, type }) => {
                 })}
                 isChecked={value}
                 isDisabled={!planEditable}
-                onChange={(e, checked) => {
+                onChange={(_e, checked) => {
                   onChange(checked);
                 }}
               />


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2791

Fix a bug to ensure that the plan's k8s entity is updated correctly for both VMs hooks steps.
Without this fix, the `createUpdateOrDeleteHook` func is updating a not up-to date plan.

## 🎥 Demo

### Before
[Screencast from 2025-07-01 20-15-19.webm](https://github.com/user-attachments/assets/af8c4d20-5f31-4d89-a2e4-f17a0320ba6b)



### After
[Screencast from 2025-07-01 20-13-05.webm](https://github.com/user-attachments/assets/aa6bd0e7-5728-432b-96fa-8cb0fae3da89)


