### PR TITLE
[release-2.9] MTV-2851: addional settings fixes

### DIFF
--- a/src/components/FieldBuilderTable/FieldBuilderTable.style.scss
+++ b/src/components/FieldBuilderTable/FieldBuilderTable.style.scss
@@ -9,7 +9,6 @@
     .pf-v5-c-form__group-label {
       padding-top: 0;
       padding-bottom: 0;
-      color: var(--pf-v5-global--palette--white);
     }
 
     .pf-v5-c-table__th:first-of-type {

--- a/src/plans/create/utils/getDefaultFormValues.ts
+++ b/src/plans/create/utils/getDefaultFormValues.ts
@@ -24,6 +24,6 @@ export const getDefaultFormValues = (
     },
     [NetworkMapFieldId.NetworkMapType]: NetworkMapType.Existing,
     [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: [defaultDiskPassPhrase],
-    [OtherSettingsFormFieldId.SharedDisks]: false,
+    [OtherSettingsFormFieldId.SharedDisks]: true,
   };
 };


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2847
https://issues.redhat.com/browse/MTV-2851

manual backport of: https://github.com/kubev2v/forklift-console-plugin/pull/1691

## 📝 Description

setting default to true instead of false for shared disks, and removing white color CSS that made the header invisible.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/5106bc3c-67f2-4ba5-9a32-fdc3bd626639

After:

https://github.com/user-attachments/assets/a1e2a2e5-2dcd-4799-ac0c-739615d1076e



## 📝 CC://

<!---
> @tag as needed
-->
