### PR TITLE
[MTV-2860] Under StorageMaps, the source storage displays storage ID rather than it's name

### DIFF
--- a/src/storageMaps/create/fields/InventorySourceStorageField.tsx
+++ b/src/storageMaps/create/fields/InventorySourceStorageField.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import type { InventoryStorage } from 'src/modules/Providers/hooks/useStorages';
+import { getMapResourceLabel } from 'src/plans/create/steps/utils';
 import type { StorageMappingValue } from 'src/storageMaps/types';
 
 import FormGroupWithErrorText from '@components/common/FormGroupWithErrorText';
@@ -51,18 +52,26 @@ const InventorySourceStorageField: FC<InventorySourceStorageFieldProps> = ({
                   {t('Select a source provider to list available source storages')}
                 </SelectOption>
               ) : (
-                sourceStorages.map((storage) => (
-                  <SelectOption
-                    key={storage.name}
-                    value={storage}
-                    isDisabled={storageMappings?.some(
-                      (mapping: StorageMapping) =>
-                        mapping[StorageMapFieldId.SourceStorage].name === storage.name,
-                    )}
-                  >
-                    {storage.name}
-                  </SelectOption>
-                ))
+                sourceStorages.map((storage) => {
+                  const storageLabel = getMapResourceLabel(storage);
+                  const storageValue: StorageMappingValue = {
+                    id: storage.id,
+                    name: storageLabel,
+                  };
+
+                  return (
+                    <SelectOption
+                      key={storage.id}
+                      value={storageValue}
+                      isDisabled={storageMappings?.some(
+                        (mapping: StorageMapping) =>
+                          mapping[StorageMapFieldId.SourceStorage].name === storageLabel,
+                      )}
+                    >
+                      {storageLabel}
+                    </SelectOption>
+                  );
+                })
               )}
             </SelectList>
           </Select>


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2860

## 📝 Description
Needed to use helper to get the map label for just the storage map source storage dropdown. The other source storage dropdowns associated with the migration plan pages were doing this already.

## 🎥 Demo
#### Before

https://github.com/user-attachments/assets/c6e3b1da-59da-4f37-9bf5-82d1f8ce9dc1



#### After

https://github.com/user-attachments/assets/1570687b-80b8-441d-b980-78374429f1d4

