### PR TITLE
MTV-2887: Rephrase the "shared Disks" field name in plan wizard

### DIFF
--- a/src/plans/create/steps/other-settings/SharedDisksField.tsx
+++ b/src/plans/create/steps/other-settings/SharedDisksField.tsx
@@ -12,7 +12,7 @@ import { otherFormFieldLabels, OtherSettingsFormFieldId } from './constants';
 const SharedDisksField: FC = () => {
   const { t } = useForkliftTranslation();
   const { control } = useCreatePlanFormContext();
-  const fieldId = OtherSettingsFormFieldId.SharedDisks;
+  const fieldId = OtherSettingsFormFieldId.MigrateSharedDisks;
   const label = otherFormFieldLabels[fieldId];
 
   return (

--- a/src/plans/create/steps/other-settings/constants.ts
+++ b/src/plans/create/steps/other-settings/constants.ts
@@ -5,14 +5,14 @@ export enum OtherSettingsFormFieldId {
   TransferNetwork = 'transferNetwork',
   PreserveStaticIps = 'preserveStaticIps',
   RootDevice = 'rootDevice',
-  SharedDisks = 'sharedDisks',
+  MigrateSharedDisks = 'migrateSharedDisks',
 }
 
 export const otherFormFieldLabels: Record<OtherSettingsFormFieldId, ReturnType<typeof t>> = {
   [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: t('Disk decryption passphrases'),
+  [OtherSettingsFormFieldId.MigrateSharedDisks]: t('Migrate shared disks'),
   [OtherSettingsFormFieldId.PreserveStaticIps]: t('Preserve static IPs'),
   [OtherSettingsFormFieldId.RootDevice]: t('Root device'),
-  [OtherSettingsFormFieldId.SharedDisks]: t('Shared disks'),
   [OtherSettingsFormFieldId.TransferNetwork]: t('Transfer network'),
 };
 

--- a/src/plans/create/steps/review/OtherSettingsReviewSection.tsx
+++ b/src/plans/create/steps/review/OtherSettingsReviewSection.tsx
@@ -37,7 +37,7 @@ const OtherSettingsReviewSection: FC = () => {
       OtherSettingsFormFieldId.TransferNetwork,
       OtherSettingsFormFieldId.PreserveStaticIps,
       OtherSettingsFormFieldId.RootDevice,
-      OtherSettingsFormFieldId.SharedDisks,
+      OtherSettingsFormFieldId.MigrateSharedDisks,
     ],
   });
   const isVsphere = sourceProvider?.spec?.type === PROVIDER_TYPES.vsphere;
@@ -104,7 +104,7 @@ const OtherSettingsReviewSection: FC = () => {
 
             <DescriptionListGroup>
               <DescriptionListTerm>
-                {otherFormFieldLabels[OtherSettingsFormFieldId.SharedDisks]}
+                {otherFormFieldLabels[OtherSettingsFormFieldId.MigrateSharedDisks]}
               </DescriptionListTerm>
 
               <DescriptionListDescription>

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -71,7 +71,7 @@ export type CreatePlanFormData = FieldValues & {
   [MigrationTypeFieldId.MigrationType]: MigrationTypeValue;
   [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: DiskPassPhrase[];
   [OtherSettingsFormFieldId.PreserveStaticIps]: boolean;
-  [OtherSettingsFormFieldId.SharedDisks]: boolean;
+  [OtherSettingsFormFieldId.MigrateSharedDisks]: boolean;
   [HooksFormFieldId.PreMigration]: MigrationHook;
   [HooksFormFieldId.PostMigration]: MigrationHook;
   [OtherSettingsFormFieldId.RootDevice]: string;
@@ -98,7 +98,7 @@ export type CreatePlanParams = {
   preserveStaticIps?: boolean;
   rootDevice?: string;
   transferNetwork?: V1beta1PlanSpecTransferNetwork;
-  sharedDisks?: boolean;
+  migrateSharedDisks?: boolean;
   luks?: V1beta1PlanSpecVmsLuks;
   preHook?: V1beta1Hook;
   postHook?: V1beta1Hook;

--- a/src/plans/create/utils/createPlan.ts
+++ b/src/plans/create/utils/createPlan.ts
@@ -15,6 +15,7 @@ import { buildPlanSpecVms } from './buildPlanSpecVms';
  */
 export const createPlan = async ({
   luks,
+  migrateSharedDisks,
   migrationType,
   networkMap,
   planName,
@@ -23,7 +24,6 @@ export const createPlan = async ({
   preHook,
   preserveStaticIps,
   rootDevice,
-  sharedDisks,
   sourceProvider,
   storageMap,
   targetProject,
@@ -43,7 +43,7 @@ export const createPlan = async ({
         network: getObjectRef(networkMap),
         storage: getObjectRef(storageMap),
       },
-      migrateSharedDisks: sharedDisks,
+      migrateSharedDisks,
       provider: {
         destination: getObjectRef(targetProvider),
         source: getObjectRef(sourceProvider),

--- a/src/plans/create/utils/getDefaultFormValues.ts
+++ b/src/plans/create/utils/getDefaultFormValues.ts
@@ -24,6 +24,6 @@ export const getDefaultFormValues = (
     },
     [NetworkMapFieldId.NetworkMapType]: NetworkMapType.Existing,
     [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: [defaultDiskPassPhrase],
-    [OtherSettingsFormFieldId.SharedDisks]: true,
+    [OtherSettingsFormFieldId.MigrateSharedDisks]: true,
   };
 };

--- a/src/plans/create/utils/submitMigrationPlan.ts
+++ b/src/plans/create/utils/submitMigrationPlan.ts
@@ -23,6 +23,7 @@ export const submitMigrationPlan = async (formData: CreatePlanFormData): Promise
     diskDecryptionPassPhrases,
     existingNetworkMap,
     existingStorageMap,
+    migrateSharedDisks,
     migrationType,
     networkMap: newNetworkMap,
     networkMapName,
@@ -32,7 +33,6 @@ export const submitMigrationPlan = async (formData: CreatePlanFormData): Promise
     preMigrationHook,
     preserveStaticIps,
     rootDevice,
-    sharedDisks,
     sourceProvider,
     storageMap: newStorageMap,
     storageMapName,
@@ -96,6 +96,7 @@ export const submitMigrationPlan = async (formData: CreatePlanFormData): Promise
   // Create the migration plan
   const createdPlanRef = await createPlan({
     luks: createdSecret ? { name: createdSecret.metadata?.name } : undefined,
+    migrateSharedDisks,
     migrationType,
     networkMap: planNetworkMap,
     planName,
@@ -104,7 +105,6 @@ export const submitMigrationPlan = async (formData: CreatePlanFormData): Promise
     preHook: createdHooks.preHook,
     preserveStaticIps,
     rootDevice,
-    sharedDisks,
     sourceProvider,
     storageMap: planStorageMap,
     targetProject,


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2887

Rename the field label name of plan creation wizard -> other settings step -> "shared Disks" field name to "Migrate shared disks"


## 🎥 Demo
### After
<img width="1160" height="660" alt="Screenshot from 2025-07-13 22-14-38" src="https://github.com/user-attachments/assets/6f7ea0ab-f091-441a-b856-f4880e750702" />
