### PR TITLE
MTV-2580: Change the interval for fetching provider inventory data to default of 20 secs

### DIFF
--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/hooks/useInventoryVms.tsx
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/hooks/useInventoryVms.tsx
@@ -25,7 +25,6 @@ export const useInventoryVms = (
   const validProvider = providerLoaded && !providerLoadError ? provider : undefined;
 
   const inventoryOptions: UseProviderInventoryParams = {
-    interval: 180000,
     provider: validProvider,
     subPath: 'vms?detail=4',
   };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2580

Change the polling interval for fetching the provider inventory data from 3 mins to default value of 20 seconds max.
That means that within a 20 seconds interval, the provider -> virtual machines list tab with updated data will be fetched and rendered instead of waiting up to 3 mins.
