### PR TITLE
[MTV-2928] UI Losing position when searching VM

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -142,6 +142,14 @@ export const createEslintConfig = (ideMode = false) =>
         'import/no-named-as-default-member': 'off',
         'import/no-unresolved': 'off',
         'import/order': 'off',
+        'max-lines': [
+          'error',
+          {
+            max: 300,
+            skipBlankLines: true,
+            skipComments: true,
+          },
+        ],
         'max-lines-per-function': ['error', 150],
         'max-statements': 'off',
         'new-cap': [

--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+/* eslint-disable max-lines-per-function */
 import { type FC, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -178,22 +180,10 @@ const StandardPageInner = <T,>({
   );
 
   useEffect(() => {
-    if (!filteredData) {
-      setFinalFilteredData([]);
-      return;
-    }
-    if (!postFilterData) {
-      setFinalFilteredData(filteredData);
-      return;
-    }
-    setFinalFilteredData(postFilterData(filteredData, selectedFilters, fields));
-  }, [filteredData, postFilterData, selectedFilters, fields]);
-
-  useEffect(() => {
-    if (flatData) {
+    if (flatData && loaded && !error) {
       setSortedData([...flatData].sort(compareFn));
     }
-  }, [flatData, compareFn, loaded]);
+  }, [flatData, compareFn, loaded, error]);
 
   const metaMatcher = useMemo(
     () => createMetaMatcher(selectedFilters, fields, supportedMatchers),
@@ -201,10 +191,28 @@ const StandardPageInner = <T,>({
   );
 
   useEffect(() => {
-    if (sortedData) {
+    if (sortedData && loaded && !error) {
       setFilteredData(sortedData.filter(metaMatcher));
     }
-  }, [sortedData, metaMatcher]);
+  }, [sortedData, metaMatcher, loaded, error]);
+
+  useEffect(() => {
+    if (!loaded || error) {
+      return;
+    }
+
+    if (!filteredData || filteredData.length === 0) {
+      setFinalFilteredData([]);
+      return;
+    }
+
+    if (!postFilterData) {
+      setFinalFilteredData(filteredData);
+      return;
+    }
+
+    setFinalFilteredData(postFilterData(filteredData, selectedFilters, fields));
+  }, [filteredData, postFilterData, selectedFilters, fields, loaded, error]);
 
   useEffect(() => {
     if (Object.values(selectedFilters).some((filter) => !isEmpty(filter))) {


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-2928

## 📝 Description
Updates the StandardPage components to create more stable references for the "enhanced" version that deals with selection of checkboxes so that the StandardPage component is not re-rendered on click of those checkboxes.

Updated the lint rules to exclude imports and blank lines from the line count restriction. Also, just disabling the rules for "StandardPage" for now since every time we need to debug this file it is all highlighted red and difficult to work with otherwise. The whole component needs replacing, so I see no harm in just leaving the lint disabled there while we're still working with it.

## 🎥 Demo
**Before:**

https://github.com/user-attachments/assets/a3923dc3-f5eb-433d-8502-7cc2d04b3c4a

**After:**

https://github.com/user-attachments/assets/f0609798-9185-4153-9326-df934a10530d