### PR TITLE
MTV-2952: Fix the filter used by the "Confirm selections with critical issues" modal

### DIFF
--- a/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/OVirtVirtualMachinesList.tsx
@@ -11,6 +11,7 @@ import { ovirtHostFilter } from './utils/filters/OvirtHostFilter';
 import { getConcernsResourceField } from './utils/helpers/getConcernsResourceField';
 import { getVmPowerState } from './utils/helpers/getVmPowerState';
 import { getVmTableResourceFields } from './utils/helpers/getVmTableResourceFields';
+import { CustomFilterType } from './constants';
 import { OVirtVirtualMachinesCells } from './OVirtVirtualMachinesRow';
 
 const oVirtVmFieldsMetadataFactory = [
@@ -45,7 +46,7 @@ const oVirtVmFieldsMetadataFactory = [
     isVisible: true,
     jsonPath: '$.vm.host',
     label: t('Host'),
-    resourceFieldId: 'host',
+    resourceFieldId: CustomFilterType.Host,
     sortable: true,
   },
   {

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList.tsx
@@ -10,6 +10,7 @@ import type { VmData } from './components/VMCellProps';
 import { getOpenShiftFeatureMap } from './utils/helpers/getOpenShiftFeatureMap';
 import { getVmPowerState } from './utils/helpers/getVmPowerState';
 import { toVmFeatureEnum } from './utils/helpers/toVmFeatureEnum';
+import { CustomFilterType } from './constants';
 import { OpenShiftVirtualMachinesCells } from './OpenShiftVirtualMachinesRow';
 
 const openShiftVmFieldsMetadataFactory = [
@@ -53,14 +54,14 @@ const openShiftVmFieldsMetadataFactory = [
   {
     filter: {
       placeholderLabel: t('Filter by features'),
-      type: 'features',
+      type: CustomFilterType.Features,
       values: enumToTuple(toVmFeatureEnum()),
     },
     isIdentity: false,
     isVisible: true,
     jsonPath: (data: VmData) => getOpenShiftFeatureMap(data?.vm),
     label: t('Features'),
-    resourceFieldId: 'features',
+    resourceFieldId: CustomFilterType.Features,
     sortable: true,
   },
   {

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/VSphereVirtualMachinesList.tsx
@@ -13,6 +13,7 @@ import { getConcernsResourceField } from './utils/helpers/getConcernsResourceFie
 import { getVmPowerState } from './utils/helpers/getVmPowerState';
 import { getVmTableResourceFields } from './utils/helpers/getVmTableResourceFields';
 import { useVSphereInventoryVms } from './utils/hooks/useVSphereInventoryVms';
+import { CustomFilterType } from './constants';
 import { VSphereVirtualMachinesCells } from './VSphereVirtualMachinesRow';
 
 const vSphereVmFieldsMetadataFactory = [
@@ -35,7 +36,7 @@ const vSphereVmFieldsMetadataFactory = [
     isVisible: true,
     jsonPath: '$.hostName',
     label: t('Host'),
-    resourceFieldId: 'host',
+    resourceFieldId: CustomFilterType.Host,
     sortable: true,
   },
   {

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
@@ -1,6 +1,8 @@
 import type { EnumValue } from '@components/common/utils/types';
 import { t } from '@utils/i18n';
 
+import { CustomFilterType } from '../../constants';
+
 const labelToFilterItem = (label: string): EnumValue =>
   label !== '' ? { id: label, label } : { id: label, label: 'Undefined' };
 
@@ -18,6 +20,6 @@ export const ovirtHostFilter = () => {
     }),
     placeholderLabel: t('Host'),
     primary: true,
-    type: 'host',
+    type: CustomFilterType.Host,
   };
 };

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/VsphereHostFilter.ts
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/VsphereHostFilter.ts
@@ -1,6 +1,8 @@
 import type { EnumValue } from '@components/common/utils/types';
 import { t } from '@utils/i18n';
 
+import { CustomFilterType } from '../../constants';
+
 const labelToFilterItem = (label: string): EnumValue =>
   label !== '' ? { id: label, label } : { id: label, label: 'Undefined' };
 
@@ -18,6 +20,6 @@ export const vsphereHostFilter = () => {
     }),
     placeholderLabel: t('Host'),
     primary: true,
-    type: 'host',
+    type: CustomFilterType.Host,
   };
 };

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/concernFilter.ts
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/concernFilter.ts
@@ -3,6 +3,8 @@ import { enumToTuple } from 'src/components/common/FilterGroup/helpers';
 import type { EnumValue } from '@components/common/utils/types';
 import { t } from '@utils/i18n';
 
+import { CustomFilterType } from '../../constants';
+
 export const concernFilter = () => ({
   dynamicFilter: (items: { vm: { concerns: { label: string }[] } }[]) => ({
     values: [
@@ -28,5 +30,5 @@ export const concernFilter = () => ({
   ],
   placeholderLabel: t('Concerns'),
   primary: true,
-  type: 'concerns',
+  type: CustomFilterType.Concerns,
 });

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/helpers/getConcernsResourceField.tsx
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/helpers/getConcernsResourceField.tsx
@@ -1,6 +1,7 @@
 import { t } from '@utils/i18n';
 
 import ConcernsColumnPopover from '../../components/ConcernsColumnPopover';
+import { CustomFilterType } from '../../constants';
 import { concernFilter } from '../filters/concernFilter';
 
 export const getConcernsResourceField = () => ({
@@ -12,6 +13,6 @@ export const getConcernsResourceField = () => ({
   isVisible: true,
   jsonPath: '$.vm.concerns',
   label: t('Concerns'),
-  resourceFieldId: 'concerns',
+  resourceFieldId: CustomFilterType.Concerns,
   sortable: true,
 });

--- a/src/plans/create/steps/virtual-machines/constants.ts
+++ b/src/plans/create/steps/virtual-machines/constants.ts
@@ -1,3 +1,5 @@
+import { CustomFilterType } from 'src/modules/Providers/views/details/tabs/VirtualMachines/constants';
+
 import type { ResourceField } from '@components/common/utils/types';
 import { t } from '@utils/i18n';
 
@@ -11,7 +13,7 @@ export const criticalConcernTableField: ResourceField = {
   filter: criticalConcernFilter(),
   jsonPath: '$.vm.concerns',
   label: t('Critical concerns'),
-  resourceFieldId: 'concerns',
+  resourceFieldId: CustomFilterType.CriticalConcerns,
 };
 
 export const defaultVms = {};


### PR DESCRIPTION

Reference: https://issues.redhat.com/browse/MTV-2952

The "Confirm selections with critical issues" modal uses a dedicated "Filter by critical concerns" filter with an invalid already exists id used for the vms tab "Concerns" filter. That caused a wrong filter algorithm that ended up with an empty list once both filters were activated.

Fixing the filter's id solved the problem.

## 🎥 Demo
### Before

[Screencast from 2025-07-17 11-58-21.webm](https://github.com/user-attachments/assets/6bc88116-90fa-4c39-bc34-023c4d6c23c4)

### After

[Screencast from 2025-07-17 11-56-01.webm](https://github.com/user-attachments/assets/b372942f-770d-4865-a642-3e171466bc3e)
