### PR TITLE
MTV-2709: Show errors in migration plan VMs table

### DIFF
--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationProgressTable/MigrationProgressTable.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationProgressTable/MigrationProgressTable.tsx
@@ -8,7 +8,15 @@ import { ConsoleTimestamp } from '@components/ConsoleTimestamp/ConsoleTimestamp'
 import { useDrawer } from '@components/DrawerContext/useDrawer';
 import HelpText from '@components/HelpText';
 import type { V1beta1Plan, V1beta1PlanStatusMigrationVms } from '@kubev2v/types';
-import { Button, ButtonVariant, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core';
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { taskStatuses } from '@utils/constants';
 import { VirtualMachineModelGroupVersionKind } from '@utils/crds/common/models';
@@ -128,6 +136,17 @@ const MigrationProgressTable: FC<MigrationProgressTableProps> = ({
                       </Button>
                     </StackItem>
                   </Stack>
+                )}
+                {pipe?.error?.reasons && !isEmpty(pipe?.error?.reasons) && (
+                  <div className="pf-v5-u-mt-sm">
+                    <Alert variant="danger" title={t('Error details')} isInline isPlain>
+                      <ul>
+                        {pipe.error.reasons.map((reason: string, idx: number) => (
+                          <li key={idx}>{reason}</li>
+                        ))}
+                      </ul>
+                    </Alert>
+                  </div>
                 )}
               </Td>
               <Td>


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2709

## 📝 Description

The linked issue talks about not having information about a specific error once a pipeline step has failed, but it is a general issue that we don't display errors in the VMs table. This is addressed in the PR.

## 🎥 Demo

<img width="1270" height="698" alt="Screenshot 2025-07-18 at 9 27 16 AM" src="https://github.com/user-attachments/assets/75f6f42d-5bb1-4d78-88d7-a97f77c8365d" />



## 📝 CC://

<!---
> @tag as needed
-->
