### PR TITLE
MTV-2977: Allow displaying only non critical messages as plan alerts

### DIFF
--- a/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import type { V1beta1Plan } from '@kubev2v/types';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { isEmpty } from '@utils/helpers';
 
 import { PlanStatuses } from '../../../PlanStatus/utils/types';
 import usePlanAlerts from '../../hooks/usePlanAlerts';
@@ -28,20 +29,22 @@ const PlanAlerts: FC<Props> = ({ plan }) => {
 
   const alertsNotRelevant = status === PlanStatuses.Completed || status === PlanStatuses.Archived;
 
-  if (alertsNotRelevant || !criticalCondition || !networkMapsLoaded || networkMapsError) {
+  if (alertsNotRelevant || !networkMapsLoaded || networkMapsError) {
     return null;
   }
 
   return (
     <PageSection variant={PageSectionVariants.light} className="plan-header-alerts">
-      <PlanCriticalCondition
-        plan={plan}
-        condition={criticalCondition}
-        storageMaps={storageMaps}
-        networkMaps={networkMaps}
-        sourceStorages={sourceStorages}
-        sourceNetworks={sourceNetworks}
-      />
+      {!isEmpty(criticalCondition) && (
+        <PlanCriticalCondition
+          plan={plan}
+          condition={criticalCondition}
+          storageMaps={storageMaps}
+          networkMaps={networkMaps}
+          sourceStorages={sourceStorages}
+          sourceNetworks={sourceNetworks}
+        />
+      )}
       <PlanPreserveIPWarning
         plan={plan}
         networkMaps={networkMaps}

--- a/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
@@ -33,7 +33,7 @@ import TroubleshootMessage from './TroubleshootMessage';
 
 type PlanCriticalConditionProps = PropsWithChildren & {
   plan: V1beta1Plan;
-  condition: V1beta1PlanStatusConditions;
+  condition: V1beta1PlanStatusConditions | undefined;
   storageMaps: V1beta1StorageMap[];
   networkMaps: V1beta1NetworkMap[];
   sourceStorages: InventoryStorage[];
@@ -50,7 +50,7 @@ const PlanCriticalCondition: FC<PlanCriticalConditionProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const type = condition.type as PlanConditionType;
+  const type = condition?.type as PlanConditionType;
 
   const planStorageMapName = getPlanStorageMapName(plan);
   const planNetworkMapName = getPlanNetworkMapName(plan);
@@ -95,8 +95,8 @@ const PlanCriticalCondition: FC<PlanCriticalConditionProps> = ({
       <Stack hasGutter>
         <TextContent className="forklift-providers-list-header__alert">
           <Text component={TextVariants.p}>
-            <Linkify>{condition.message ?? EMPTY_MSG}</Linkify>
-            {condition.message?.endsWith('.') ? ' ' : '. '}
+            <Linkify>{condition?.message ?? EMPTY_MSG}</Linkify>
+            {condition?.message?.endsWith('.') ? ' ' : '. '}
             <TroubleshootMessage planURL={getPlanURL(plan)} type={type} />
           </Text>
         </TextContent>


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2977

If a  plan includes only warnings that won't bock the migration with no critical conditions, we should still allow displaying it as warning alerts for a plan. 
As an example, plan status is '`Ready for migration`' and there is a warning alert of  `PlanPreserveIPWarning`.


## 🎥 Demo
<img width="1327" height="495" alt="Screenshot from 2025-07-21 14-30-55" src="https://github.com/user-attachments/assets/555ec2f5-47de-4ede-a2b3-1074c519ba6b" />
