### PR TITLE
MTV-2978: fix redundant slash added to inventory api calls

### DIFF
--- a/src/modules/Providers/hooks/useNetworks.ts
+++ b/src/modules/Providers/hooks/useNetworks.ts
@@ -44,7 +44,7 @@ export const useSourceNetworks = (
   } = useProviderInventory<InventoryNetwork[]>({
     disabled: !provider,
     provider,
-    subPath: providerType === 'openshift' ? '/networkattachmentdefinitions' : '/networks',
+    subPath: providerType === 'openshift' ? 'networkattachmentdefinitions' : 'networks',
   });
 
   const typedNetworks = useMemo(() => {
@@ -73,7 +73,7 @@ export const useOpenShiftNetworks = (
   } = useProviderInventory<OpenShiftNetworkAttachmentDefinition[]>({
     disabled: !provider || !isOpenShift,
     provider,
-    subPath: '/networkattachmentdefinitions',
+    subPath: 'networkattachmentdefinitions',
   });
 
   const typedNetworks: OpenShiftNetworkAttachmentDefinition[] = useMemo(

--- a/src/modules/Providers/hooks/useStorages.ts
+++ b/src/modules/Providers/hooks/useStorages.ts
@@ -26,11 +26,11 @@ const glanceStorage: InventoryStorage = {
 };
 
 const subPath: Record<ProviderType, string> = {
-  openshift: '/storageclasses?detail=1',
-  openstack: '/volumetypes',
-  ova: '/storages?detail=1',
-  ovirt: '/storagedomains',
-  vsphere: '/datastores',
+  openshift: 'storageclasses?detail=1',
+  openstack: 'volumetypes',
+  ova: 'storages?detail=1',
+  ovirt: 'storagedomains',
+  vsphere: 'datastores',
 };
 
 export type InventoryStorage =
@@ -80,7 +80,7 @@ export const useOpenShiftStorages = (
   } = useProviderInventory<OpenShiftStorageClass[]>({
     disabled: !provider || providerType !== 'openshift',
     provider,
-    subPath: '/storageclasses?detail=1',
+    subPath: 'storageclasses?detail=1',
   });
 
   const typedStorages = useMemo(

--- a/src/plans/create/hooks/useOvirtNicProfiles.ts
+++ b/src/plans/create/hooks/useOvirtNicProfiles.ts
@@ -14,7 +14,7 @@ export const useOvirtNicProfiles = (
   } = useProviderInventory<OVirtNicProfile[]>({
     disabled: !provider || !isOVirt,
     provider,
-    subPath: '/nicprofiles?detail=1',
+    subPath: 'nicprofiles?detail=1',
   });
 
   const typedNicProfiles: OVirtNicProfile[] = useMemo(


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2978

Remove extra slash added as a prefix for part of the inventory api calls.



## 🎥 Demo

<img width="1919" height="853" alt="Screenshot from 2025-07-22 21-15-19" src="https://github.com/user-attachments/assets/452f379b-dd65-4575-b9c7-d0d908c05431" />
