### PR TITLE
MTV-2893: Fix missing OVA resources tab values

### DIFF
--- a/src/plans/details/tabs/Resources/utils/utils.ts
+++ b/src/plans/details/tabs/Resources/utils/utils.ts
@@ -92,8 +92,8 @@ const getOVAPlanResources = (planInventory: EnhancedOvaVM[]): PlanResourcesTable
   const totalResources = planInventory.reduce(
     (accumulator, currentVM) => {
       return {
-        cpuCount: accumulator.cpuCount + currentVM.CpuCount,
-        memoryMB: accumulator.memoryMB + currentVM.MemoryMB,
+        cpuCount: accumulator.cpuCount + currentVM.cpuCount,
+        memoryMB: accumulator.memoryMB + currentVM.memoryMB,
       };
     },
     { cpuCount: 0, memoryMB: 0 },
@@ -102,8 +102,8 @@ const getOVAPlanResources = (planInventory: EnhancedOvaVM[]): PlanResourcesTable
   const totalResourcesRunning = planInventoryRunning.reduce(
     (accumulator, currentVM) => {
       return {
-        cpuCount: accumulator.cpuCount + currentVM.CpuCount,
-        memoryMB: accumulator.memoryMB + currentVM.MemoryMB,
+        cpuCount: accumulator.cpuCount + currentVM.cpuCount,
+        memoryMB: accumulator.memoryMB + currentVM.memoryMB,
       };
     },
     { cpuCount: 0, memoryMB: 0 },


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2893

Fix the missing resources values calculations of total CPU count and total memory count for OVA plans - Resources tab.


## 🎥 Demo
### Before
<img width="1416" height="515" alt="Screenshot from 2025-07-23 19-10-31" src="https://github.com/user-attachments/assets/618a392d-14d6-4a07-9e68-7c833abb4e5a" />


### After
<img width="1416" height="515" alt="Screenshot from 2025-07-23 19-09-57" src="https://github.com/user-attachments/assets/193b0b36-c9e9-4bb9-8974-1f140b626dbd" />
