### PR TITLE
MTV-2918: Code editor component incompatible with OCP 4.17

### DIFF
--- a/cspell.wordlist.txt
+++ b/cspell.wordlist.txt
@@ -97,3 +97,5 @@ operatorhub
 powerflex
 apiextensions
 customresourcedefinitions
+clusterversion
+clusterversions

--- a/src/components/VersionedCodeEditor/VersionedCodeEditor.tsx
+++ b/src/components/VersionedCodeEditor/VersionedCodeEditor.tsx
@@ -1,0 +1,63 @@
+import type { FC } from 'react';
+import { Base64 } from 'js-base64';
+import Loading from 'src/overview/components/Loading';
+
+import { CodeEditor as SDKCodeEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { CodeEditor as PFCodeEditor, Language as PFLanguage } from '@patternfly/react-code-editor';
+import useOpenshiftClusterVersion from '@utils/hooks/useOpenshiftClusterVersion/useOpenshiftClusterVersion';
+
+import { OCP_VERSION_4_18 } from './utils/constants';
+import { isVersionGte } from './utils/utils';
+
+type VersionedCodeEditorProps = {
+  value: string | undefined;
+  onChange: (encodedValue: string) => void;
+  minHeight?: string;
+};
+
+// VersionedCodeEditor component that uses the appropriate CodeEditor based on OCP version
+// https://issues.redhat.com/browse/MTV-2918
+const VersionedCodeEditor: FC<VersionedCodeEditorProps> = ({
+  minHeight = '20rem',
+  onChange,
+  value,
+}) => {
+  const [ocpVersion, loaded] = useOpenshiftClusterVersion();
+
+  const decodedValue = Base64.decode(value ?? '');
+
+  if (!loaded) {
+    return <Loading />;
+  }
+
+  // Checking it's OCP version 4.18 or greater to decide which CodeEditor to use
+  // on OCP 4.17 PF code editor is not used, And
+  // on OCP 4.19 SDK code editor is having a bug where it doesn't show the code
+  if (isVersionGte(ocpVersion, OCP_VERSION_4_18)) {
+    return (
+      <PFCodeEditor
+        language={PFLanguage.yaml}
+        code={decodedValue}
+        onChange={(val) => {
+          onChange(Base64.encode(String(val)));
+        }}
+        height={minHeight}
+        isMinimapVisible={false}
+      />
+    );
+  }
+
+  return (
+    <SDKCodeEditor
+      language="yaml"
+      value={decodedValue}
+      onChange={(val) => {
+        onChange(Base64.encode(String(val)));
+      }}
+      minHeight={minHeight}
+      showMiniMap={false}
+    />
+  );
+};
+
+export default VersionedCodeEditor;

--- a/src/components/VersionedCodeEditor/utils/constants.ts
+++ b/src/components/VersionedCodeEditor/utils/constants.ts
@@ -1,0 +1,1 @@
+export const OCP_VERSION_4_18 = '4.18';

--- a/src/components/VersionedCodeEditor/utils/utils.ts
+++ b/src/components/VersionedCodeEditor/utils/utils.ts
@@ -1,0 +1,8 @@
+const parseOcpVersion = (version?: string): number[] =>
+  version?.split('.').map((versionSection) => parseInt(versionSection, 10)) ?? [];
+
+export const isVersionGte = (actual: string | undefined, target: string): boolean => {
+  const [aMajor = 0, aMinor = 0] = parseOcpVersion(actual);
+  const [tMajor = 0, tMinor = 0] = parseOcpVersion(target);
+  return aMajor > tMajor || (aMajor === tMajor && aMinor >= tMinor);
+};

--- a/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
+++ b/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { Controller } from 'react-hook-form';
 import { Base64 } from 'js-base64';
 
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import VersionedCodeEditor from '@components/VersionedCodeEditor/VersionedCodeEditor';
 import { FormGroup, FormHelperText } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -29,14 +29,11 @@ const AnsiblePlaybookField: FC<AnsiblePlaybookFieldProps> = ({ fieldId }) => {
         name={subFieldId}
         control={control}
         render={({ field }) => (
-          <CodeEditor
-            language={Language.yaml}
-            code={Base64.decode(field.value ?? '')}
+          <VersionedCodeEditor
+            value={Base64.decode(field.value ?? '')}
             onChange={(value) => {
               field.onChange(Base64.encode(String(value)));
             }}
-            height="20rem"
-            isMinimapVisible={false}
           />
         )}
       />

--- a/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
+++ b/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
@@ -4,7 +4,7 @@ import { Base64 } from 'js-base64';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import SectionHeading from '@components/headers/SectionHeading';
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import VersionedCodeEditor from '@components/VersionedCodeEditor/VersionedCodeEditor';
 import { Form, HelperText, HelperTextItem, Switch, TextInput } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -93,14 +93,11 @@ const HooksCodeEditor: FC<HooksCodeEditorProps> = ({ planEditable, type }) => {
                     : HOOK_FORM_FIELD_NAMES.postHookPlaybook
                 }
                 render={({ field: { onChange, value } }) => (
-                  <CodeEditor
-                    language={Language.yaml}
-                    code={Base64.decode(value)}
+                  <VersionedCodeEditor
+                    value={Base64.decode(value)}
                     onChange={(code) => {
                       onChange(Base64.encode(code));
                     }}
-                    height="20rem"
-                    isMinimapVisible={false}
                   />
                 )}
               />

--- a/src/utils/hooks/useOpenshiftClusterVersion/useOpenshiftClusterVersion.ts
+++ b/src/utils/hooks/useOpenshiftClusterVersion/useOpenshiftClusterVersion.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+
+import {
+  getGroupVersionKindForModel,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+import { type ClusterVersion, ClusterVersionModel } from './utils/constants';
+
+const useOpenshiftClusterVersion = (): [string | undefined, boolean, unknown] => {
+  const [clusterVersionResources, clusterVersionLoaded, clusterVersionError] = useK8sWatchResource<
+    ClusterVersion[]
+  >({
+    groupVersionKind: getGroupVersionKindForModel(ClusterVersionModel),
+    isList: true,
+  });
+
+  const clusterVersion = useMemo(() => {
+    return clusterVersionResources?.find((versionCR) => versionCR?.status?.desired?.version)?.status
+      ?.desired?.version;
+  }, [clusterVersionResources]);
+
+  return [clusterVersion, clusterVersionLoaded, clusterVersionError];
+};
+
+export default useOpenshiftClusterVersion;

--- a/src/utils/hooks/useOpenshiftClusterVersion/utils/constants.ts
+++ b/src/utils/hooks/useOpenshiftClusterVersion/utils/constants.ts
@@ -1,0 +1,24 @@
+import type { K8sModel, K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
+
+export type ClusterVersion = K8sResourceKind & {
+  status: {
+    desired: {
+      version: string;
+    };
+  };
+};
+
+export const ClusterVersionModel: K8sModel = {
+  abbr: 'CV',
+  apiGroup: 'config.openshift.io',
+  apiVersion: 'v1',
+  crd: true,
+  id: 'clusterversion',
+  kind: 'ClusterVersion',
+  label: 'ClusterVersion',
+  labelKey: 'ClusterVersion',
+  labelPlural: 'ClusterVersions',
+  labelPluralKey: 'ClusterVersions',
+  namespaced: false,
+  plural: 'clusterversions',
+};


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-2918

## 📝 Description

CodeEditor from SDK was buggy when using OCP 4.19+ so we used CodeEditor from PF, which is crashing for OCP 4.17 and below. creating a HOC component to decide which one to use based on ClusterVersion resource. tested against MTV 2.9.0 on OCP 4.17/4.18/4.19

## 🎥 Demo

Before:


https://github.com/user-attachments/assets/358f0ee8-7b50-4fd0-a4a9-f2143d646427

After:

https://github.com/user-attachments/assets/cf6aec91-adf8-44b9-8305-d63e51330131



## 📝 CC://

<!---
> @tag as needed
-->
