### PR TITLE
MTV-3040: Add an info alert for the OCP provider url and token optionality

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -345,6 +345,7 @@
   "Hosts": "Hosts",
   "HPE Primera/3PAR": "HPE Primera/3PAR",
   "I trust the authenticity of this certificate": "I trust the authenticity of this certificate",
+  "if both 'URL' and 'Service account bearer token' fields are left empty, the local OpenShift cluster is used.": "if both 'URL' and 'Service account bearer token' fields are left empty, the local OpenShift cluster is used.",
   "If true, the provider's CA certificate won't be validated.": "If true, the provider's CA certificate won't be validated.",
   "If true, the provider's TLS certificate won't be validated.": "If true, the provider's TLS certificate won't be validated.",
   "If you specify a playbook, the image must be hook-runner.": "If you specify a playbook, the image must be hook-runner.",

--- a/src/providers/details/tabs/Credentials/components/OpenshiftCredentialsEdit.tsx
+++ b/src/providers/details/tabs/Credentials/components/OpenshiftCredentialsEdit.tsx
@@ -4,9 +4,17 @@ import { FormGroupWithHelpText } from 'src/components/common/FormGroupWithHelpTe
 import type { CredentialsEditModeByTypeProps } from 'src/providers/details/tabs/Credentials/components/utils/types';
 import { SecretFieldsId } from 'src/providers/utils/constants';
 import type { ValidationMsg } from 'src/providers/utils/types';
-import { useForkliftTranslation } from 'src/utils/i18n';
+import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import { Button, Divider, Form, InputGroup, TextInput } from '@patternfly/react-core';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  Divider,
+  Form,
+  InputGroup,
+  TextInput,
+} from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 
 import { getDecodedValue } from './utils/getDecodedValue';
@@ -104,6 +112,17 @@ const OpenshiftCredentialsEdit: FC<CredentialsEditModeByTypeProps> = ({
           </Button>
         </InputGroup>
       </FormGroupWithHelpText>
+
+      <Alert
+        variant={AlertVariant.info}
+        isInline
+        title={
+          <ForkliftTrans>
+            if both 'URL' and 'Service account bearer token' fields are left empty, the local
+            OpenShift cluster is used.
+          </ForkliftTrans>
+        }
+      ></Alert>
 
       <Divider />
 


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-3040

As a follow up for https://github.com/kubev2v/forklift-console-plugin/pull/1730, add a help text info alert to reflect that for ocp provider, if both URL and Service account bearer token are left blank, the local OpenShift cluster is used.

## 🎥 Demo

<img width="690" height="734" alt="Screenshot from 2025-07-28 15-07-48" src="https://github.com/user-attachments/assets/15261e1d-ed35-491e-98e7-366a8114530d" />
