### PR TITLE
MTV-2971: display the 'clear all filters' button for WwitchFilter component

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -795,6 +795,7 @@
   "Total: {{length}}": "Total: {{length}}",
   "Transfer network": "Transfer network",
   "Transfer Network": "Transfer Network",
+  "true": "true",
   "True": "True",
   "Type": "Type",
   "Unable to retrieve data": "Unable to retrieve data",

--- a/src/components/common/Filter/SwitchFilter.tsx
+++ b/src/components/common/Filter/SwitchFilter.tsx
@@ -1,7 +1,8 @@
 import type { FormEvent } from 'react';
 
-import { Switch, ToolbarItem } from '@patternfly/react-core';
+import { Switch, ToolbarFilter } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
+import { useForkliftTranslation } from '@utils/i18n';
 
 import type { FilterTypeProps } from './types';
 
@@ -23,19 +24,27 @@ export const SwitchFilter = ({
   placeholderLabel,
   selectedFilters,
 }: FilterTypeProps) => {
+  const { t } = useForkliftTranslation();
+
   const onChange: (checked: boolean, event: FormEvent<HTMLInputElement>) => void = (checked) => {
     onFilterUpdate(checked ? [Boolean(checked).toString()] : []);
   };
 
+  const isChecked = (): boolean => !isEmpty(selectedFilters) && selectedFilters?.[0] === 'true';
+
   return (
-    <ToolbarItem className="forklift-switch-filter">
+    <ToolbarFilter
+      chips={isChecked() ? [t('true')] : undefined}
+      categoryName={placeholderLabel!}
+      deleteChip={() => onFilterUpdate([])}
+    >
       <Switch
         label={placeholderLabel}
-        isChecked={!isEmpty(selectedFilters) && selectedFilters?.[0] === 'true'}
+        isChecked={isChecked()}
         onChange={(e, value) => {
           onChange(value, e);
         }}
       />
-    </ToolbarItem>
+    </ToolbarFilter>
   );
 };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2971

When a filter from type of `SwitchFilter` is applied. the 'clear all filters' button is not displayed, even though clicking on this button (once displayed for other filters) does reset the switch filter to default value.

An example for that is the plans list -> 'Show archived' persistent filter.

Solving it by adding a chip for the `SwitchFilter` which will enable adding the reset button to the toolbar. 
Once clicking on the reset button, all filters including the 'show archived' are now reset to default.



## 🎥 Demo

### Before

[Screencast from 2025-07-30 00-47-29.webm](https://github.com/user-attachments/assets/9a4baf8b-74a1-4da5-8df3-033d7e26ae29)





### After

[Screencast from 2025-07-30 00-44-57.webm](https://github.com/user-attachments/assets/e2c8b907-dd9d-4bd5-ac3b-c4b5e0e1e515)
