### PR TITLE
[MTV-3082] Fix label-less button and don't show alert when no message is returned from the API

### DIFF
--- a/src/components/ModalForm/ModalForm.tsx
+++ b/src/components/ModalForm/ModalForm.tsx
@@ -11,7 +11,6 @@ import {
   Modal,
   ModalVariant,
 } from '@patternfly/react-core';
-import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
 type ModalFormProps = {
@@ -76,11 +75,13 @@ const ModalForm: FC<ModalFormProps> = ({
         >
           {confirmLabel ?? t('Save')}
         </Button>,
-        !isEmpty(additionalAction) && (
-          <Button key="secondary" {...additionalAction}>
-            {additionalAction?.children}
-          </Button>
-        ),
+        ...(additionalAction
+          ? [
+              <Button key="secondary" {...additionalAction}>
+                {additionalAction?.children}
+              </Button>,
+            ]
+          : []),
         <Button key="cancel" variant={ButtonVariant.secondary} onClick={toggleModal}>
           {cancelLabel ?? t('Cancel')}
         </Button>,

--- a/src/components/common/SmartLinkify.tsx
+++ b/src/components/common/SmartLinkify.tsx
@@ -1,0 +1,21 @@
+import type { FC, PropsWithChildren } from 'react';
+import Linkify from 'react-linkify';
+
+const SmartLinkify: FC<PropsWithChildren> = ({ children }) => {
+  const linkifyDecorator = (decoratedHref: string, decoratedText: string, key: number) => {
+    // Only linkify if the original text actually contains http/https protocol
+    if (decoratedText.includes('http://') || decoratedText.includes('https://')) {
+      return (
+        <a href={decoratedHref} key={key} target="_blank" rel="noopener noreferrer">
+          {decoratedText}
+        </a>
+      );
+    }
+
+    return decoratedText;
+  };
+
+  return <Linkify componentDecorator={linkifyDecorator}>{children}</Linkify>;
+};
+
+export default SmartLinkify;

--- a/src/modules/NetworkMaps/components/NetworkMapCriticalConditions.tsx
+++ b/src/modules/NetworkMaps/components/NetworkMapCriticalConditions.tsx
@@ -1,17 +1,18 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import Linkify from 'react-linkify';
+import SmartLinkify from 'src/components/common/SmartLinkify';
 import { EMPTY_MSG } from 'src/utils/constants';
 
 import { Alert, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const NetworkMapCriticalConditions: FC<{ type: string; message: string }> = ({ message, type }) => {
   const { t } = useTranslation();
+
   return (
     <Alert title={type} variant="danger">
       <TextContent className="forklift-providers-list-header__alert">
         <Text component={TextVariants.p}>
-          <Linkify>{message || EMPTY_MSG}</Linkify>
+          <SmartLinkify>{message || EMPTY_MSG}</SmartLinkify>
           <br />
           {t('To troubleshoot, check the Forklift controller pod logs.')}
         </Text>

--- a/src/modules/Providers/views/list/components/ProviderCriticalCondition.tsx
+++ b/src/modules/Providers/views/list/components/ProviderCriticalCondition.tsx
@@ -1,17 +1,18 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import Linkify from 'react-linkify';
+import SmartLinkify from 'src/components/common/SmartLinkify';
 import { EMPTY_MSG } from 'src/utils/constants';
 
 import { Alert, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const ProviderCriticalCondition: FC<{ type: string; message: string }> = ({ message, type }) => {
   const { t } = useTranslation();
+
   return (
     <Alert title={`${t('The provider is not ready')} - ${type}`} variant="danger">
       <TextContent className="forklift-providers-list-header__alert">
         <Text component={TextVariants.p}>
-          <Linkify>{message || EMPTY_MSG}</Linkify>
+          <SmartLinkify>{message || EMPTY_MSG}</SmartLinkify>
           {'. '}
           {t('To troubleshoot, check the Forklift controller pod logs.')}
         </Text>

--- a/src/modules/Providers/views/list/components/StatusCell.tsx
+++ b/src/modules/Providers/views/list/components/StatusCell.tsx
@@ -1,13 +1,21 @@
 import type { FC } from 'react';
-import Linkify from 'react-linkify';
 import { Link } from 'react-router-dom-v5-compat';
 import { getResourceFieldValue } from 'src/components/common/FilterGroup/matchers';
+import SmartLinkify from 'src/components/common/SmartLinkify';
 import { TableIconCell } from 'src/modules/Providers/utils/components/TableCell/TableIconCell';
 import { getResourceUrl } from 'src/modules/Providers/utils/helpers/getResourceUrl';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModelRef } from '@kubev2v/types';
-import { Button, Popover, Spinner, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Popover,
+  Spinner,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { t } from '@utils/i18n';
 
@@ -93,10 +101,14 @@ const ErrorStatusCell: FC<CellProps> = ({ data, fields }) => {
   return (
     <Popover
       headerContent={phaseLabel}
-      bodyContent={bodyContent && <Linkify>{bodyContent}</Linkify>}
+      bodyContent={bodyContent && <SmartLinkify>{bodyContent}</SmartLinkify>}
       footerContent={footerContent}
     >
-      <Button variant="link" isInline data-testid="popover-status-button-providers-list">
+      <Button
+        variant={ButtonVariant.link}
+        isInline
+        data-testid="popover-status-button-providers-list"
+      >
         <TableIconCell icon={statusIcons[phase]}>{phaseLabel}</TableIconCell>
       </Button>
     </Popover>

--- a/src/modules/StorageMaps/components/StorageMapCriticalConditions.tsx
+++ b/src/modules/StorageMaps/components/StorageMapCriticalConditions.tsx
@@ -1,17 +1,18 @@
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import Linkify from 'react-linkify';
+import SmartLinkify from 'src/components/common/SmartLinkify';
 import { EMPTY_MSG } from 'src/utils/constants';
 
 import { Alert, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const StorageMapCriticalConditions: FC<{ type: string; message: string }> = ({ message, type }) => {
   const { t } = useTranslation();
+
   return (
     <Alert title={type} variant="danger">
       <TextContent className="forklift-providers-list-header__alert">
         <Text component={TextVariants.p}>
-          <Linkify>{message || EMPTY_MSG}</Linkify>
+          <SmartLinkify>{message || EMPTY_MSG}</SmartLinkify>
           <br />
           {t('To troubleshoot, check the Forklift controller pod logs.')}
         </Text>

--- a/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
@@ -2,7 +2,6 @@ import type { FC } from 'react';
 
 import type { V1beta1Plan } from '@kubev2v/types';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { isEmpty } from '@utils/helpers';
 
 import { PlanStatuses } from '../../../PlanStatus/utils/types';
 import usePlanAlerts from '../../hooks/usePlanAlerts';
@@ -21,6 +20,8 @@ const PlanAlerts: FC<Props> = ({ plan }) => {
     networkMaps,
     networkMapsError,
     networkMapsLoaded,
+    showCriticalCondition,
+    showPreserveIPWarning,
     sourceNetworks,
     sourceStorages,
     status,
@@ -33,9 +34,13 @@ const PlanAlerts: FC<Props> = ({ plan }) => {
     return null;
   }
 
+  if (!showCriticalCondition && !showPreserveIPWarning) {
+    return null;
+  }
+
   return (
     <PageSection variant={PageSectionVariants.light} className="plan-header-alerts">
-      {!isEmpty(criticalCondition) && (
+      {showCriticalCondition && (
         <PlanCriticalCondition
           plan={plan}
           condition={criticalCondition}
@@ -45,12 +50,7 @@ const PlanAlerts: FC<Props> = ({ plan }) => {
           sourceNetworks={sourceNetworks}
         />
       )}
-      <PlanPreserveIPWarning
-        plan={plan}
-        networkMaps={networkMaps}
-        loaded={networkMapsLoaded}
-        error={networkMapsError}
-      />
+      {showPreserveIPWarning && <PlanPreserveIPWarning />}
     </PageSection>
   );
 };

--- a/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
@@ -1,6 +1,6 @@
 import { type FC, type PropsWithChildren, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import Linkify from 'react-linkify';
+import SmartLinkify from 'src/components/common/SmartLinkify';
 import type { InventoryNetwork } from 'src/modules/Providers/hooks/useNetworks';
 import type { InventoryStorage } from 'src/modules/Providers/hooks/useStorages';
 import { EMPTY_MSG } from 'src/utils/constants';
@@ -95,7 +95,7 @@ const PlanCriticalCondition: FC<PlanCriticalConditionProps> = ({
       <Stack hasGutter>
         <TextContent className="forklift-providers-list-header__alert">
           <Text component={TextVariants.p}>
-            <Linkify>{condition?.message ?? EMPTY_MSG}</Linkify>
+            <SmartLinkify>{condition?.message ?? EMPTY_MSG}</SmartLinkify>
             {condition?.message?.endsWith('.') ? ' ' : '. '}
             <TroubleshootMessage planURL={getPlanURL(plan)} type={type} />
           </Text>

--- a/src/plans/details/components/PlanPageHeader/components/PlanPreserveIPWarning.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanPreserveIPWarning.tsx
@@ -1,38 +1,11 @@
-import { type FC, useMemo } from 'react';
+import type { FC } from 'react';
 import Linkify from 'react-linkify';
-import { POD } from 'src/plans/details/utils/constants';
 
-import type { V1beta1NetworkMap, V1beta1Plan } from '@kubev2v/types';
 import { Alert, AlertVariant, Text, TextContent, TextVariants } from '@patternfly/react-core';
-import { getName } from '@utils/crds/common/selectors';
-import { getPlanNetworkMapName, getPlanPreserveIP } from '@utils/crds/plans/selectors';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
 
-type PlanPreserveIPWarningProps = {
-  plan: V1beta1Plan;
-  networkMaps: V1beta1NetworkMap[];
-  loaded: boolean;
-  error: Error | null;
-};
-
-const PlanPreserveIPWarning: FC<PlanPreserveIPWarningProps> = ({
-  error,
-  loaded,
-  networkMaps,
-  plan,
-}) => {
+const PlanPreserveIPWarning: FC = () => {
   const { t } = useForkliftTranslation();
-
-  const shouldWarn = useMemo(() => {
-    if (!loaded || error) return false;
-    const isPreserveStaticIPs = getPlanPreserveIP(plan);
-    const networkMap = networkMaps.find((net) => getName(net) === getPlanNetworkMapName(plan));
-    const isMapToPod =
-      networkMap?.spec?.map.some((entry) => entry.destination.type === POD) ?? false;
-    return Boolean(isPreserveStaticIPs && isMapToPod);
-  }, [error, loaded, networkMaps, plan]);
-
-  if (!shouldWarn) return null;
 
   return (
     <Alert

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 export const isEmpty = (value: object | unknown[] | string | undefined | null): boolean => {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return true;
   }
 


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3082

## 📝 Description
- Fixing condition for a secondary button displayed conditonally in ModalForm
- Added condition for alerts on the details page, where without a message, the alert was still being shown with just a "-" character.
- Corrected Linkify usage, where it was creating links to text returned from the API that it shouldn't - see screenshots for an example.

## 🎥 Demo
**Before:**
<img width="603" height="462" alt="image" src="https://github.com/user-attachments/assets/886ca895-470f-4a02-8680-b7b3a7c8ac38" />
<img width="1448" height="603" alt="image" src="https://github.com/user-attachments/assets/06e79990-eccc-43ea-b8c1-fa3e03cb2a52" />
<img width="978" height="342" alt="image" src="https://github.com/user-attachments/assets/fa1d13d5-c9d1-4384-a098-ec1312eaa89a" />


**After:**
<img width="677" height="471" alt="image" src="https://github.com/user-attachments/assets/d02c47d2-a2a0-46a6-987e-ea98c738fe20" />
<img width="1724" height="951" alt="image" src="https://github.com/user-attachments/assets/9bb13fa2-011d-4f06-9c23-c142d15ad2fa" />
<img width="978" height="342" alt="image" src="https://github.com/user-attachments/assets/bbafff96-f642-45c0-a572-8357e42d518f" />


## 📝 CC://
@mmenestr 
