### PR TITLE
MTV-2943: Change plan status 'cant start' from variant warning to danger

### DIFF
--- a/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanCriticalCondition.tsx
@@ -87,11 +87,7 @@ const PlanCriticalCondition: FC<PlanCriticalConditionProps> = ({
     type === PlanConditionType.VMStorageNotMapped || type === PlanConditionType.VMNetworksNotMapped;
 
   return (
-    <Alert
-      title={t('The plan is not ready')}
-      variant={AlertVariant.warning}
-      isExpandable={showList}
-    >
+    <Alert title={t('The plan is not ready')} variant={AlertVariant.danger} isExpandable={showList}>
       <Stack hasGutter>
         <TextContent className="forklift-providers-list-header__alert">
           <Text component={TextVariants.p}>

--- a/src/plans/details/components/PlanStatus/utils/statusIconMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/statusIconMapper.tsx
@@ -4,7 +4,6 @@ import { Icon } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
-  ExclamationTriangleIcon,
   MinusCircleIcon,
   PauseCircleIcon,
 } from '@patternfly/react-icons';
@@ -19,8 +18,8 @@ export const migrationStatusIconMap: Record<MigrationVirtualMachineStatus, React
     </Icon>
   ),
   [MigrationVirtualMachineStatus.CantStart]: (
-    <Icon status="warning">
-      <ExclamationTriangleIcon />
+    <Icon status="danger">
+      <ExclamationCircleIcon />
     </Icon>
   ),
   [MigrationVirtualMachineStatus.Failed]: (


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-2943

Till the design for 2.10 will be final for the plan vms status icons, meanwhile let's change the status variant level from warning which is not correct to error/danger.


## 🎥 Demo
<img width="1509" height="536" alt="Screenshot from 2025-08-07 22-49-03" src="https://github.com/user-attachments/assets/a4367c25-68de-43e9-a71c-bfeb95493ac7" />

<img width="1509" height="536" alt="Screenshot from 2025-08-07 22-49-58" src="https://github.com/user-attachments/assets/ccde4d56-e4fa-4cbe-a18f-ed38acff977d" />
