### PR TITLE
[MTV-3133] Initial setup for segment

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -297,6 +297,15 @@ export const createEslintConfig = (ideMode = false) =>
         'no-restricted-syntax': 'off',
       },
     },
+    // Telemetry file specific rules
+    {
+      files: ['**/utils/analytics/**/*.ts'],
+      rules: {
+        '@cspell/spellchecker': 'off',
+        'no-console': 'off',
+        'no-underscore-dangle': 'off',
+      },
+    },
     // Testing directory specific rules
     {
       files: ['testing/**/*.{js,ts,jsx,tsx}', '**/__{tests,mocks}__/**/*.{js,ts,jsx,tsx}'],
@@ -305,8 +314,11 @@ export const createEslintConfig = (ideMode = false) =>
         '@typescript-eslint/class-methods-use-this': 'off',
         '@typescript-eslint/consistent-type-definitions': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-magic-numbers': 'off',
         '@typescript-eslint/no-namespace': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
         'max-lines-per-function': 'off',
         'perfectionist/sort-objects': 'off',
         'react-refresh/only-export-components': 'off',

--- a/src/utils/analytics/__tests__/sendAnalyticsEvent.test.ts
+++ b/src/utils/analytics/__tests__/sendAnalyticsEvent.test.ts
@@ -1,0 +1,244 @@
+import { initializeAnalytics } from '../initializeAnalytics';
+import { sendAnalyticsEvent } from '../sendAnalyticsEvent';
+import type { AnalyticsConfig } from '../types';
+
+jest.mock('../initializeAnalytics');
+
+const mockInitializeAnalytics = initializeAnalytics as jest.MockedFunction<
+  typeof initializeAnalytics
+>;
+
+describe('sendAnalyticsEvent', () => {
+  const mockAnalyticsConfig: AnalyticsConfig = {
+    clusterId: 'test-cluster-id',
+    segmentKey: 'test-segment-key',
+  };
+
+  const mockTrack = jest.fn();
+  const originalConsoleLog = console.log;
+  const originalConsoleWarn = console.warn;
+  const mockConsoleLog = jest.fn();
+  const mockConsoleWarn = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (window as any).analytics;
+    delete process.env.NODE_ENV;
+    delete process.env.VERSION;
+
+    console.log = mockConsoleLog;
+    console.warn = mockConsoleWarn;
+
+    Object.defineProperty(navigator, 'userAgent', {
+      writable: true,
+      value: 'test-user-agent',
+    });
+  });
+
+  afterEach(() => {
+    delete (window as any).analytics;
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+  });
+
+  it('initializes analytics with segment key', () => {
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockInitializeAnalytics).toHaveBeenCalledWith('test-segment-key');
+  });
+
+  it('sends analytics event with properties and config data', () => {
+    (window as any).analytics = { track: mockTrack };
+    process.env.VERSION = '1.2.3';
+
+    const properties = { planId: 'test-plan', action: 'create' };
+    const expectedTimestamp = Date.now();
+
+    jest.spyOn(Date, 'now').mockReturnValue(expectedTimestamp);
+
+    sendAnalyticsEvent('plan_created', properties, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'plan_created',
+      {
+        clusterId: 'test-cluster-id',
+        plugin: 'forklift-console-plugin',
+        timestamp: expectedTimestamp,
+        userAgent: 'test-user-agent',
+        version: '1.2.3',
+        planId: 'test-plan',
+        action: 'create',
+      },
+      {
+        context: {
+          ip: '0.0.0.0',
+        },
+      },
+    );
+  });
+
+  it('uses "unknown" version when VERSION env is not set', () => {
+    (window as any).analytics = { track: mockTrack };
+    delete process.env.VERSION;
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'test_event',
+      expect.objectContaining({
+        version: 'unknown',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('does not call analytics.track when analytics is not available', () => {
+    delete (window as any).analytics;
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockTrack).not.toHaveBeenCalled();
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+    expect(mockConsoleWarn).not.toHaveBeenCalled();
+  });
+
+  it('returns early when analytics is null', () => {
+    (window as any).analytics = null;
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockInitializeAnalytics).toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('logs debug information in development mode', () => {
+    process.env.NODE_ENV = 'development';
+    (window as any).analytics = { track: mockTrack };
+
+    const properties = { planId: 'test-plan' };
+
+    sendAnalyticsEvent('test_event', properties, mockAnalyticsConfig);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith('[Forklift Analytics] Tracking event: test_event', {
+      clusterId: 'test-cluster-id',
+      eventData: expect.objectContaining({
+        clusterId: 'test-cluster-id',
+        plugin: 'forklift-console-plugin',
+        planId: 'test-plan',
+      }),
+    });
+  });
+
+  it('does not log debug information in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it('does not log debug information when NODE_ENV is undefined', () => {
+    delete process.env.NODE_ENV;
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockConsoleLog).not.toHaveBeenCalled();
+  });
+
+  it('handles errors during analytics.track call', () => {
+    const error = new Error('Analytics error');
+    mockTrack.mockImplementation(() => {
+      throw error;
+    });
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockConsoleWarn).toHaveBeenCalledWith(
+      '[Forklift Analytics] Failed to track test_event:',
+      error,
+    );
+  });
+
+  it('spreads custom properties into event data', () => {
+    (window as any).analytics = { track: mockTrack };
+
+    const customProperties = {
+      planName: 'migration-plan-1',
+      sourceProvider: 'vmware',
+      targetProvider: 'openshift',
+    };
+
+    sendAnalyticsEvent('migration_started', customProperties, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'migration_started',
+      expect.objectContaining(customProperties),
+      expect.any(Object),
+    );
+  });
+
+  it('preserves all required context properties', () => {
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        clusterId: 'test-cluster-id',
+        plugin: 'forklift-console-plugin',
+        timestamp: expect.any(Number),
+        userAgent: expect.any(String),
+        version: expect.any(String),
+      }),
+      {
+        context: {
+          ip: '0.0.0.0',
+        },
+      },
+    );
+  });
+
+  it('handles empty properties object', () => {
+    (window as any).analytics = { track: mockTrack };
+
+    sendAnalyticsEvent('test_event', {}, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'test_event',
+      expect.objectContaining({
+        clusterId: 'test-cluster-id',
+        plugin: 'forklift-console-plugin',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('merges properties without overriding built-in properties', () => {
+    (window as any).analytics = { track: mockTrack };
+
+    // Try to override built-in properties
+    const maliciousProperties = {
+      clusterId: 'malicious-cluster',
+      plugin: 'malicious-plugin',
+      timestamp: 123456789,
+    };
+
+    sendAnalyticsEvent('test_event', maliciousProperties, mockAnalyticsConfig);
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      'test_event',
+      expect.objectContaining({
+        clusterId: 'test-cluster-id',
+        plugin: 'forklift-console-plugin',
+        timestamp: expect.any(Number),
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/utils/analytics/__tests__/sendAnalyticsEvent.test.ts
+++ b/src/utils/analytics/__tests__/sendAnalyticsEvent.test.ts
@@ -150,6 +150,7 @@ describe('sendAnalyticsEvent', () => {
   });
 
   it('handles errors during analytics.track call', () => {
+    process.env.NODE_ENV = 'development';
     const error = new Error('Analytics error');
     mockTrack.mockImplementation(() => {
       throw error;

--- a/src/utils/analytics/constants.ts
+++ b/src/utils/analytics/constants.ts
@@ -1,0 +1,55 @@
+export const ConfigMapModel = {
+  abbr: 'CM',
+  apiGroup: '',
+  apiVersion: 'v1',
+  kind: 'ConfigMap',
+  label: 'ConfigMap',
+  labelPlural: 'ConfigMaps',
+  plural: 'configmaps',
+};
+
+export const ConsoleConfigMap = {
+  Name: 'console-config',
+  Namespace: 'openshift-console',
+} as const;
+
+export enum TelemetryConfigField {
+  ClusterId = 'CLUSTER_ID',
+  SegmentPublicApiKey = 'SEGMENT_PUBLIC_API_KEY',
+  DevSegmentApiKey = 'DEV_SEGMENT_API_KEY',
+}
+
+export const SEGMENT_SNIPPET_VERSION = '5.2.0';
+
+export const SEGMENT_METHODS = [
+  'trackSubmit',
+  'trackClick',
+  'trackLink',
+  'trackForm',
+  'pageview',
+  'identify',
+  'reset',
+  'group',
+  'track',
+  'ready',
+  'alias',
+  'debug',
+  'page',
+  'screen',
+  'once',
+  'off',
+  'on',
+  'addSourceMiddleware',
+  'addIntegrationMiddleware',
+  'setAnonymousId',
+  'addDestinationMiddleware',
+  'register',
+] as const;
+
+// Add new events here following the pattern:
+// EVENT_NAME: 'event_name_in_snake_case'
+export const TELEMETRY_EVENTS = {
+  PLAN_CREATE_COMPLETED: 'plan_create_completed',
+  PLAN_CREATE_FAILED: 'plan_create_failed',
+  PLAN_CREATE_STARTED: 'plan_create_started',
+} as const;

--- a/src/utils/analytics/constants.ts
+++ b/src/utils/analytics/constants.ts
@@ -9,6 +9,7 @@ export const ConfigMapModel = {
 };
 
 export const ConsoleConfigMap = {
+  ConfigKey: 'console-config.yaml',
   Name: 'console-config',
   Namespace: 'openshift-console',
 } as const;

--- a/src/utils/analytics/hooks/__tests__/useAnalyticsConfig.test.ts
+++ b/src/utils/analytics/hooks/__tests__/useAnalyticsConfig.test.ts
@@ -1,6 +1,7 @@
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { ConsoleConfigMap } from '../../constants';
 import { useAnalyticsConfig } from '../useAnalyticsConfig';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
@@ -41,7 +42,7 @@ describe('useAnalyticsConfig', () => {
     `;
 
     (mockUseK8sWatchResource as any).mockReturnValue([
-      { data: { 'console-config.yaml': yamlContent } },
+      { data: { [ConsoleConfigMap.ConfigKey]: yamlContent } },
       true,
     ]);
 
@@ -63,7 +64,7 @@ describe('useAnalyticsConfig', () => {
     `;
 
     (mockUseK8sWatchResource as any).mockReturnValue([
-      { data: { 'console-config.yaml': yamlContent } },
+      { data: { [ConsoleConfigMap.ConfigKey]: yamlContent } },
       true,
     ]);
 
@@ -79,7 +80,7 @@ describe('useAnalyticsConfig', () => {
     const yamlContent = 'some: other-config';
 
     (mockUseK8sWatchResource as any).mockReturnValue([
-      { data: { 'console-config.yaml': yamlContent } },
+      { data: { [ConsoleConfigMap.ConfigKey]: yamlContent } },
       true,
     ]);
 
@@ -98,7 +99,7 @@ describe('useAnalyticsConfig', () => {
     `;
 
     (mockUseK8sWatchResource as any).mockReturnValue([
-      { data: { 'console-config.yaml': yamlContent } },
+      { data: { [ConsoleConfigMap.ConfigKey]: yamlContent } },
       true,
     ]);
 

--- a/src/utils/analytics/hooks/__tests__/useAnalyticsConfig.test.ts
+++ b/src/utils/analytics/hooks/__tests__/useAnalyticsConfig.test.ts
@@ -1,0 +1,112 @@
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useAnalyticsConfig } from '../useAnalyticsConfig';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  getGroupVersionKindForModel: jest.fn(() => ({ group: '', version: 'v1', kind: 'ConfigMap' })),
+  useK8sWatchResource: jest.fn(),
+}));
+
+const mockUseK8sWatchResource = useK8sWatchResource as jest.MockedFunction<
+  typeof useK8sWatchResource
+>;
+
+describe('useAnalyticsConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NODE_ENV;
+  });
+
+  it('returns empty config when not loaded', () => {
+    (mockUseK8sWatchResource as any).mockReturnValue([undefined, false]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({ clusterId: '', segmentKey: '' });
+  });
+
+  it('returns empty config when yaml content is missing', () => {
+    (mockUseK8sWatchResource as any).mockReturnValue([{ data: {} }, true]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({ clusterId: '', segmentKey: '' });
+  });
+
+  it('extracts production segment key and cluster ID from yaml', () => {
+    const yamlContent = `
+      SEGMENT_PUBLIC_API_KEY: prod-segment-key
+      CLUSTER_ID: test-cluster-123
+    `;
+
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      { data: { 'console-config.yaml': yamlContent } },
+      true,
+    ]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({
+      clusterId: 'test-cluster-123',
+      segmentKey: 'prod-segment-key',
+    });
+  });
+
+  it('extracts development segment key when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development';
+
+    const yamlContent = `
+      DEV_SEGMENT_API_KEY: dev-segment-key
+      SEGMENT_PUBLIC_API_KEY: prod-segment-key
+      CLUSTER_ID: test-cluster-123
+    `;
+
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      { data: { 'console-config.yaml': yamlContent } },
+      true,
+    ]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({
+      clusterId: 'test-cluster-123',
+      segmentKey: 'dev-segment-key',
+    });
+  });
+
+  it('handles missing values gracefully', () => {
+    const yamlContent = 'some: other-config';
+
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      { data: { 'console-config.yaml': yamlContent } },
+      true,
+    ]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({
+      clusterId: '',
+      segmentKey: '',
+    });
+  });
+
+  it('trims whitespace from extracted values', () => {
+    const yamlContent = `
+      SEGMENT_PUBLIC_API_KEY:   prod-segment-key
+      CLUSTER_ID:   test-cluster-123
+    `;
+
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      { data: { 'console-config.yaml': yamlContent } },
+      true,
+    ]);
+
+    const { result } = renderHook(() => useAnalyticsConfig());
+
+    expect(result.current).toEqual({
+      clusterId: 'test-cluster-123',
+      segmentKey: 'prod-segment-key',
+    });
+  });
+});

--- a/src/utils/analytics/hooks/__tests__/useForkliftAnalytics.test.ts
+++ b/src/utils/analytics/hooks/__tests__/useForkliftAnalytics.test.ts
@@ -1,6 +1,7 @@
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { renderHook } from '@testing-library/react-hooks';
 
+import { ConsoleConfigMap } from '../../constants';
 import { initializeAnalytics } from '../../initializeAnalytics';
 import { sendAnalyticsEvent } from '../../sendAnalyticsEvent';
 import { useForkliftAnalytics } from '../useForkliftAnalytics';
@@ -29,7 +30,7 @@ describe('useForkliftAnalytics', () => {
     (mockUseK8sWatchResource as any).mockReturnValue([
       {
         data: {
-          'console-config.yaml': `
+          [ConsoleConfigMap.ConfigKey]: `
             SEGMENT_PUBLIC_API_KEY: test-segment-key
             CLUSTER_ID: test-cluster-id
           `,
@@ -59,7 +60,7 @@ describe('useForkliftAnalytics', () => {
 
   it('does not initialize when segment key is missing', () => {
     (mockUseK8sWatchResource as any).mockReturnValue([
-      { data: { 'console-config.yaml': 'CLUSTER_ID: test-cluster' } },
+      { data: { [ConsoleConfigMap.ConfigKey]: 'CLUSTER_ID: test-cluster' } },
       true,
     ]);
 
@@ -136,7 +137,7 @@ describe('useForkliftAnalytics', () => {
 
     it('does not send event when segment key is missing', () => {
       (mockUseK8sWatchResource as any).mockReturnValue([
-        { data: { 'console-config.yaml': 'CLUSTER_ID: test-cluster' } },
+        { data: { [ConsoleConfigMap.ConfigKey]: 'CLUSTER_ID: test-cluster' } },
         true,
       ]);
 
@@ -149,7 +150,7 @@ describe('useForkliftAnalytics', () => {
 
     it('does not send event when cluster ID is missing', () => {
       (mockUseK8sWatchResource as any).mockReturnValue([
-        { data: { 'console-config.yaml': 'SEGMENT_PUBLIC_API_KEY: test-key' } },
+        { data: { [ConsoleConfigMap.ConfigKey]: 'SEGMENT_PUBLIC_API_KEY: test-key' } },
         true,
       ]);
 

--- a/src/utils/analytics/hooks/__tests__/useForkliftAnalytics.test.ts
+++ b/src/utils/analytics/hooks/__tests__/useForkliftAnalytics.test.ts
@@ -1,0 +1,214 @@
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { initializeAnalytics } from '../../initializeAnalytics';
+import { sendAnalyticsEvent } from '../../sendAnalyticsEvent';
+import { useForkliftAnalytics } from '../useForkliftAnalytics';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  getGroupVersionKindForModel: jest.fn(() => ({ group: '', version: 'v1', kind: 'ConfigMap' })),
+  useK8sWatchResource: jest.fn(),
+}));
+
+jest.mock('../../initializeAnalytics');
+jest.mock('../../sendAnalyticsEvent');
+
+const mockUseK8sWatchResource = useK8sWatchResource as jest.MockedFunction<
+  typeof useK8sWatchResource
+>;
+const mockInitializeAnalytics = initializeAnalytics as jest.MockedFunction<
+  typeof initializeAnalytics
+>;
+const mockSendAnalyticsEvent = sendAnalyticsEvent as jest.MockedFunction<typeof sendAnalyticsEvent>;
+
+describe('useForkliftAnalytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete (window as any).analytics;
+    delete (window as any).SERVER_FLAGS;
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      {
+        data: {
+          'console-config.yaml': `
+            SEGMENT_PUBLIC_API_KEY: test-segment-key
+            CLUSTER_ID: test-cluster-id
+          `,
+        },
+      },
+      true,
+    ]);
+  });
+
+  afterEach(() => {
+    delete (window as any).analytics;
+    delete (window as any).SERVER_FLAGS;
+  });
+
+  it('initializes analytics with segment key', () => {
+    renderHook(() => useForkliftAnalytics());
+
+    expect(mockInitializeAnalytics).toHaveBeenCalledWith('test-segment-key');
+  });
+
+  it('prevents duplicate initialization', () => {
+    const { rerender } = renderHook(() => useForkliftAnalytics());
+    rerender();
+
+    expect(mockInitializeAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not initialize when segment key is missing', () => {
+    (mockUseK8sWatchResource as any).mockReturnValue([
+      { data: { 'console-config.yaml': 'CLUSTER_ID: test-cluster' } },
+      true,
+    ]);
+
+    renderHook(() => useForkliftAnalytics());
+
+    expect(mockInitializeAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('skips initialization when analytics already exists', () => {
+    (window as any).analytics = { track: jest.fn() };
+
+    renderHook(() => useForkliftAnalytics());
+
+    expect(mockInitializeAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('does not initialize when telemetry is disabled', () => {
+    (window as any).SERVER_FLAGS = {
+      telemetry: { TELEMETRY_DISABLED: 'true' },
+    };
+
+    renderHook(() => useForkliftAnalytics());
+
+    expect(mockInitializeAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('initializes when telemetry disabled flag is not true', () => {
+    (window as any).SERVER_FLAGS = {
+      telemetry: { TELEMETRY_DISABLED: 'false' },
+    };
+
+    renderHook(() => useForkliftAnalytics());
+
+    expect(mockInitializeAnalytics).toHaveBeenCalledWith('test-segment-key');
+  });
+
+  it('returns trackEvent function', () => {
+    const { result } = renderHook(() => useForkliftAnalytics());
+
+    expect(typeof result.current.trackEvent).toBe('function');
+  });
+
+  describe('trackEvent', () => {
+    beforeEach(() => {
+      (window as any).analytics = { track: jest.fn() };
+    });
+
+    it('sends analytics event with properties', () => {
+      const { result } = renderHook(() => useForkliftAnalytics());
+      const properties = { planId: 'test-plan' };
+
+      result.current.trackEvent('test_event', properties);
+
+      expect(mockSendAnalyticsEvent).toHaveBeenCalledWith('test_event', properties, {
+        clusterId: 'test-cluster-id',
+        segmentKey: 'test-segment-key',
+      });
+    });
+
+    it('sends analytics event with empty properties by default', () => {
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).toHaveBeenCalledWith(
+        'test_event',
+        {},
+        {
+          clusterId: 'test-cluster-id',
+          segmentKey: 'test-segment-key',
+        },
+      );
+    });
+
+    it('does not send event when segment key is missing', () => {
+      (mockUseK8sWatchResource as any).mockReturnValue([
+        { data: { 'console-config.yaml': 'CLUSTER_ID: test-cluster' } },
+        true,
+      ]);
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not send event when cluster ID is missing', () => {
+      (mockUseK8sWatchResource as any).mockReturnValue([
+        { data: { 'console-config.yaml': 'SEGMENT_PUBLIC_API_KEY: test-key' } },
+        true,
+      ]);
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not send event when analytics is not available', () => {
+      delete (window as any).analytics;
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not send event when analytics.track is not available', () => {
+      (window as any).analytics = {};
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not send event when telemetry is disabled', () => {
+      (window as any).SERVER_FLAGS = {
+        telemetry: { TELEMETRY_DISABLED: 'true' },
+      };
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).not.toHaveBeenCalled();
+    });
+
+    it('sends event when telemetry disabled flag is not true', () => {
+      (window as any).SERVER_FLAGS = {
+        telemetry: { TELEMETRY_DISABLED: 'false' },
+      };
+
+      const { result } = renderHook(() => useForkliftAnalytics());
+
+      result.current.trackEvent('test_event');
+
+      expect(mockSendAnalyticsEvent).toHaveBeenCalledWith(
+        'test_event',
+        {},
+        {
+          clusterId: 'test-cluster-id',
+          segmentKey: 'test-segment-key',
+        },
+      );
+    });
+  });
+});

--- a/src/utils/analytics/hooks/useAnalyticsConfig.ts
+++ b/src/utils/analytics/hooks/useAnalyticsConfig.ts
@@ -19,7 +19,7 @@ export const useAnalyticsConfig = (): AnalyticsConfig => {
   });
 
   return useMemo(() => {
-    const yamlContent = configMap?.data?.['console-config.yaml'];
+    const yamlContent = configMap?.data?.[ConsoleConfigMap.ConfigKey];
 
     if (!loaded || !yamlContent) {
       return { clusterId: '', segmentKey: '' };

--- a/src/utils/analytics/hooks/useAnalyticsConfig.ts
+++ b/src/utils/analytics/hooks/useAnalyticsConfig.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+import {
+  getGroupVersionKindForModel,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+import { ConfigMapModel, ConsoleConfigMap, TelemetryConfigField } from '../constants';
+import type { AnalyticsConfig, ConsoleConfigMap as ConsoleConfigMapType } from '../types';
+
+/**
+ * Hook to get analytics configuration from console-config ConfigMap
+ */
+export const useAnalyticsConfig = (): AnalyticsConfig => {
+  const [configMap, loaded] = useK8sWatchResource<ConsoleConfigMapType>({
+    groupVersionKind: getGroupVersionKindForModel(ConfigMapModel),
+    name: ConsoleConfigMap.Name,
+    namespace: ConsoleConfigMap.Namespace,
+  });
+
+  return useMemo(() => {
+    const yamlContent = configMap?.data?.['console-config.yaml'];
+
+    if (!loaded || !yamlContent) {
+      return { clusterId: '', segmentKey: '' };
+    }
+
+    const segmentKeyName =
+      process.env.NODE_ENV === 'development'
+        ? TelemetryConfigField.DevSegmentApiKey
+        : TelemetryConfigField.SegmentPublicApiKey;
+
+    const segmentKey =
+      new RegExp(`${segmentKeyName}:\\s*(?<key>.+)`, 'u').exec(yamlContent)?.groups?.key?.trim() ??
+      '';
+
+    const clusterId =
+      new RegExp(`${TelemetryConfigField.ClusterId}:\\s*(?<id>.+)`, 'u')
+        .exec(yamlContent)
+        ?.groups?.id?.trim() ?? '';
+
+    return { clusterId, segmentKey };
+  }, [configMap, loaded]);
+};

--- a/src/utils/analytics/hooks/useForkliftAnalytics.ts
+++ b/src/utils/analytics/hooks/useForkliftAnalytics.ts
@@ -26,11 +26,7 @@ export const useForkliftAnalytics = () => {
   }, [segmentKey, isTelemetryDisabled]);
 
   const trackEvent = (eventType: string, properties: Record<string, unknown> = {}) => {
-    if (!segmentKey || !clusterId || isTelemetryDisabled) {
-      return;
-    }
-
-    if (!window.analytics?.track) {
+    if (!segmentKey || !clusterId || isTelemetryDisabled || !window.analytics?.track) {
       return;
     }
 

--- a/src/utils/analytics/hooks/useForkliftAnalytics.ts
+++ b/src/utils/analytics/hooks/useForkliftAnalytics.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+import { initializeAnalytics } from '../initializeAnalytics';
+import { sendAnalyticsEvent } from '../sendAnalyticsEvent';
+
+import { useAnalyticsConfig } from './useAnalyticsConfig';
+
+/**
+ * React hook for forklift telemetry with ConfigMap configuration
+ */
+export const useForkliftAnalytics = () => {
+  const { clusterId, segmentKey } = useAnalyticsConfig();
+  const initializationAttempted = useRef(false);
+  const isTelemetryDisabled = window.SERVER_FLAGS?.telemetry?.TELEMETRY_DISABLED === 'true';
+
+  useEffect(() => {
+    if (
+      segmentKey &&
+      !initializationAttempted.current &&
+      !window.analytics?.track &&
+      !isTelemetryDisabled
+    ) {
+      initializationAttempted.current = true;
+      initializeAnalytics(segmentKey);
+    }
+  }, [segmentKey, isTelemetryDisabled]);
+
+  const trackEvent = (eventType: string, properties: Record<string, unknown> = {}) => {
+    if (!segmentKey || !clusterId || isTelemetryDisabled) {
+      return;
+    }
+
+    if (!window.analytics?.track) {
+      return;
+    }
+
+    sendAnalyticsEvent(eventType, properties, { clusterId, segmentKey });
+  };
+
+  return { trackEvent };
+};

--- a/src/utils/analytics/initializeAnalytics.ts
+++ b/src/utils/analytics/initializeAnalytics.ts
@@ -1,0 +1,87 @@
+import { SEGMENT_METHODS, SEGMENT_SNIPPET_VERSION } from './constants';
+
+/**
+ * Initialize Segment analytics using official snippet v5.2.0
+ */
+export const initializeAnalytics = (segmentKey: string) => {
+  if (window.analytics && typeof window.analytics.track === 'function') {
+    return;
+  }
+
+  const analyticsKey = 'analytics';
+  window[analyticsKey] ??= [] as unknown as SegmentAnalytics;
+  const analytics = window[analyticsKey];
+
+  if (!analytics.initialize) {
+    if (analytics.invoked) {
+      if (window.console?.error) {
+        window.console.error('Segment snippet included twice.');
+      }
+    } else {
+      analytics.invoked = true;
+      analytics.methods = [...SEGMENT_METHODS];
+
+      analytics.factory = function factory(method: string) {
+        return function analyticsMethodWrapper(...args: unknown[]) {
+          if (window.analytics?.initialized) {
+            const analyticsMethod = window.analytics[method as keyof SegmentAnalytics];
+
+            if (typeof analyticsMethod === 'function') {
+              return (analyticsMethod as (...args: unknown[]) => SegmentAnalytics).call(
+                window.analytics,
+                ...args,
+              );
+            }
+
+            return window.analytics;
+          }
+
+          const argsArray = Array.prototype.slice.call(args);
+
+          if (['track', 'screen', 'alias', 'group', 'page', 'identify'].includes(method)) {
+            const canonical = document.querySelector("link[rel='canonical']");
+
+            argsArray.push({
+              __t: 'bpc',
+              canonical: canonical?.getAttribute('href') ?? undefined,
+              pathname: location.pathname,
+              referrer: document.referrer,
+              search: location.search,
+              title: document.title,
+              url: location.href,
+            });
+          }
+          argsArray.unshift(method);
+          analytics.push(argsArray);
+
+          return analytics;
+        };
+      };
+
+      for (const key of analytics.methods) {
+        analytics[key] = analytics.factory(key);
+      }
+
+      analytics.load = function load(key: string, options?: Record<string, unknown>) {
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.async = true;
+        script.setAttribute('data-global-segment-analytics-key', analyticsKey);
+        // Use configurable Segment JS URL for CSP compliance
+        const jsUrl =
+          window.SERVER_FLAGS?.telemetry?.SEGMENT_JS_URL ||
+          `https://cdn.segment.com/analytics.js/v1/${encodeURIComponent(key)}/analytics.min.js`;
+        script.src = jsUrl;
+
+        const first = document.getElementsByTagName('script')[0];
+        first?.parentNode?.insertBefore(script, first);
+        analytics._loadOptions = options;
+      };
+
+      analytics._writeKey = segmentKey;
+      analytics.SNIPPET_VERSION = SEGMENT_SNIPPET_VERSION;
+      analytics.load(segmentKey);
+      analytics.page();
+    }
+  }
+};

--- a/src/utils/analytics/sendAnalyticsEvent.ts
+++ b/src/utils/analytics/sendAnalyticsEvent.ts
@@ -40,6 +40,8 @@ export const sendAnalyticsEvent = (
       },
     });
   } catch (error) {
-    console.warn(`[Forklift Analytics] Failed to track ${eventType}:`, error);
+    if (process.env.NODE_ENV === 'development') {
+      console.warn(`[Forklift Analytics] Failed to track ${eventType}:`, error);
+    }
   }
 };

--- a/src/utils/analytics/sendAnalyticsEvent.ts
+++ b/src/utils/analytics/sendAnalyticsEvent.ts
@@ -1,0 +1,45 @@
+import { initializeAnalytics } from './initializeAnalytics';
+import type { AnalyticsConfig } from './types';
+
+/**
+ * Sends analytics event to Segment with cluster configuration
+ */
+export const sendAnalyticsEvent = (
+  eventType: string,
+  properties: Record<string, unknown>,
+  config: AnalyticsConfig,
+) => {
+  initializeAnalytics(config.segmentKey);
+
+  const eventData = {
+    ...properties,
+    clusterId: config.clusterId,
+    plugin: 'forklift-console-plugin',
+    timestamp: Date.now(),
+    userAgent: navigator.userAgent,
+    version: process.env.VERSION ?? 'unknown',
+  };
+
+  const { analytics } = window;
+
+  if (!analytics) {
+    return;
+  }
+
+  try {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`[Forklift Analytics] Tracking event: ${eventType}`, {
+        clusterId: config.clusterId,
+        eventData,
+      });
+    }
+
+    analytics.track(eventType, eventData, {
+      context: {
+        ip: '0.0.0.0',
+      },
+    });
+  } catch (error) {
+    console.warn(`[Forklift Analytics] Failed to track ${eventType}:`, error);
+  }
+};

--- a/src/utils/analytics/types.ts
+++ b/src/utils/analytics/types.ts
@@ -1,0 +1,16 @@
+export type AnalyticsConfig = {
+  clusterId: string;
+  segmentKey: string;
+};
+
+export type ConsoleConfigMap = {
+  apiVersion: string;
+  data?: {
+    'console-config.yaml'?: string;
+  };
+  kind: string;
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+};

--- a/src/utils/analytics/types.ts
+++ b/src/utils/analytics/types.ts
@@ -5,9 +5,7 @@ export type AnalyticsConfig = {
 
 export type ConsoleConfigMap = {
   apiVersion: string;
-  data?: {
-    'console-config.yaml'?: string;
-  };
+  data?: Record<string, string>;
   kind: string;
   metadata: {
     name: string;

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -62,12 +62,35 @@ interface Window {
     hubConsoleURL: string;
     k8sMode: string;
     capabilities: Record<string, string>[];
+    clusterID?: string;
   };
+  analytics?: SegmentAnalytics;
 }
+
+// Based on Segment Analytics.js 2.0 snippet v5.2.0
+// Reference: https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/
+type SegmentAnalytics = {
+  [key: string]: unknown;
+  initialized?: boolean;
+  track: (
+    event: string,
+    properties?: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ) => void;
+  factory: (method: string) => (...args: unknown[]) => SegmentAnalytics;
+  invoked?: boolean;
+  load: (key: string, options?: Record<string, unknown>) => void;
+  methods?: string[];
+  page: () => void;
+  push: (args: unknown[]) => number;
+  SNIPPET_VERSION?: string;
+  _loadOptions?: Record<string, unknown>;
+  _writeKey?: string;
+};
 
 declare module 'eslint-plugin-import' {
   const flatConfigs: {
-    recommended: any;
+    recommended: unknown;
   };
   export { flatConfigs };
 }


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3133

## 📝 Description
- Added initialization for segment, helpers, and hooks for usage inside of react components.
    - Use kubevirt-plugin as a reference, but we are using the latest segment snippet version here instead, and tried to improve some of the organization/typings, and simplified some areas where able.
- All clusters should have a `SEGMENT_PUBLIC_API_KEY` already, but since openshift console tracking is rate limited, to reliably test and track in a development environment, we are using `DEV_SEGMENT_API_KEY`, which needs to be added to your cluster's `telemetry-config` ConfigMap (If you'd like to try this in your own cluster and `DEV_SEGMENT_API_KEY` doesn't exist, I can send this value via slack).
- Added 3 track events to start with. These will change as a part of a more formal implementation of specific track events outlined [here](https://docs.google.com/spreadsheets/d/1KieG-LV3BUFtayWiNecVdRGaheeTWELpLZp4ExlC4xA/edit?pli=1&gid=719557856#gid=719557856), which will be addressed in this [sub-task](https://issues.redhat.com/browse/MTV-3134).
- Added unit tests for new analytics hooks

## 🎥 Demo
How tracking events are logged in the console:
<img width="689" height="83" alt="image" src="https://github.com/user-attachments/assets/bf3cf8ad-c8d8-49fa-a2a2-e43cb0b65e2e" />

Amplitude chart demonstrating that these initial test events are propagated and discoverable:
https://app.amplitude.com/analytics/redhat/chart/v0lzs0fh

(If you do not have access to Amplitude, here is a screenshot)
<img width="1384" height="853" alt="image" src="https://github.com/user-attachments/assets/3756c26b-9a85-4e3e-a68e-cfdc9516ec01" />

## 📝 CC://
@mmenestr 