### PR TITLE
MTV-1430: Support creating a plan via CLI while vm id or vm name are set

### DIFF
--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
@@ -21,6 +21,7 @@ import {
   getPlanVirtualMachines,
 } from '@utils/crds/plans/selectors';
 
+import { getPlanVirtualMachineIdByName } from '../../utils/getPlanVirtualMachineIdByName';
 import { getPlanVirtualMachinesDict } from '../../utils/utils';
 import type { MigrationStatusVirtualMachinePageData } from '../utils/types';
 import { groupByVmId } from '../utils/utils';
@@ -84,17 +85,20 @@ export const useMigrationResources = (plan: V1beta1Plan): MigrationResources => 
   const vmDict = getPlanVirtualMachinesDict(plan);
 
   const migrationListData = useMemo(() => {
-    return virtualMachines.map((specVM) => ({
-      dvs: dvsDict[specVM.id!],
-      isWarm: getPlanIsWarm(plan),
-      jobs: jobsDict[specVM.id!],
-      plan,
-      pods: podsDict[specVM.id!],
-      pvcs: pvcsDict[specVM.id!],
-      specVM,
-      statusVM: vmDict[specVM.id!],
-      targetNamespace: getPlanTargetNamespace(plan),
-    })) as MigrationStatusVirtualMachinePageData[];
+    return virtualMachines.map((specVM) => {
+      const id = specVM?.id ?? getPlanVirtualMachineIdByName(plan, specVM?.name);
+      return {
+        dvs: dvsDict[id!],
+        isWarm: getPlanIsWarm(plan),
+        jobs: jobsDict[id!],
+        plan,
+        pods: podsDict[id!],
+        pvcs: pvcsDict[id!],
+        specVM,
+        statusVM: vmDict[id!],
+        targetNamespace: getPlanTargetNamespace(plan),
+      };
+    }) as MigrationStatusVirtualMachinePageData[];
   }, [virtualMachines, dvsDict, jobsDict, podsDict, pvcsDict, vmDict, plan]);
 
   return {

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/fields.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/fields.tsx
@@ -33,11 +33,11 @@ export const getMigrationStatusVirtualMachinesRowFields = (
     [MigrationStatusVirtualMachinesTableResourceId.Name]: vmCreated ? (
       <TableLinkCell
         groupVersionKind={VirtualMachineModelGroupVersionKind}
-        name={specVM?.name}
+        name={specVM?.name ?? statusVM?.name}
         namespace={targetNamespace}
       />
     ) : (
-      <>{specVM?.name}</>
+      <>{specVM?.name ?? statusVM?.name}</>
     ),
     [MigrationStatusVirtualMachinesTableResourceId.Status]: (
       <MigrationStatusLabel statusVM={statusVM} />

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesListData.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesListData.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { VmData } from 'src/modules/Providers/views/details/tabs/VirtualMachines/components/VMCellProps';
 import { useInventoryVms } from 'src/modules/Providers/views/details/tabs/VirtualMachines/utils/hooks/useInventoryVms';
 import usePlanSourceProvider from 'src/plans/details/hooks/usePlanSourceProvider';
@@ -20,8 +20,16 @@ export const useSpecVirtualMachinesListData = (
   const [vmInventoryData, loading, error] = useInventoryVms({ provider: sourceProvider });
 
   const virtualMachines = useMemo(() => getPlanVirtualMachines(plan), [plan]);
+
   const vmDict = useMemo(() => getPlanVirtualMachinesDict(plan), [plan]);
   const conditionsDict = useMemo(() => getPlanConditionsDict(plan), [plan]);
+
+  const getInventoryVmIdByName = useCallback(
+    (vmName: string | undefined) => {
+      return vmInventoryData.find((vmData) => vmData?.vm?.name === vmName)?.vm?.id;
+    },
+    [vmInventoryData],
+  );
 
   const inventoryVmMap = useMemo(() => {
     const map = new Map<string, VmData>();
@@ -41,7 +49,7 @@ export const useSpecVirtualMachinesListData = (
     let vmIndex = 0;
 
     for (const specVM of virtualMachines) {
-      const id = specVM?.id;
+      const id = specVM?.id ?? getInventoryVmIdByName(specVM?.name);
       if (id) {
         out.push({
           conditions: conditionsDict[id],
@@ -57,7 +65,16 @@ export const useSpecVirtualMachinesListData = (
     }
 
     return out;
-  }, [virtualMachines, plan, vmDict, conditionsDict, inventoryVmMap, loading, error]);
+  }, [
+    loading,
+    error,
+    virtualMachines,
+    getInventoryVmIdByName,
+    conditionsDict,
+    inventoryVmMap,
+    plan,
+    vmDict,
+  ]);
 
   return [specVirtualMachinesListData, loading, error];
 };

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/fields.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/fields.tsx
@@ -23,7 +23,9 @@ export const getSpecVirtualMachinesRowFields = (fieldsData: SpecVirtualMachinePa
     [PlanSpecVirtualMachinesTableResourceId.Concerns]: (
       <VMConcernsCellRenderer data={inventoryVmData} fieldId="" fields={[]} />
     ),
-    [PlanSpecVirtualMachinesTableResourceId.Name]: <>{fieldsData?.specVM?.name}</>,
+    [PlanSpecVirtualMachinesTableResourceId.Name]: (
+      <>{fieldsData?.specVM?.name ?? inventoryVmData?.vm?.name}</>
+    ),
     [PlanSpecVirtualMachinesTableResourceId.VMTargetName]: <>{vm?.targetName ?? EMPTY_MSG}</>,
   };
 };

--- a/src/plans/details/tabs/VirtualMachines/components/utils/getPlanVirtualMachineIdByName.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/utils/getPlanVirtualMachineIdByName.ts
@@ -1,0 +1,8 @@
+import type { V1beta1Plan } from '@kubev2v/types';
+import { getPlanVirtualMachinesMigrationStatus } from '@utils/crds/plans/selectors';
+
+export const getPlanVirtualMachineIdByName = (plan: V1beta1Plan, vmName: string | undefined) => {
+  const migrationVirtualMachines = getPlanVirtualMachinesMigrationStatus(plan);
+
+  return migrationVirtualMachines.find((migrationVm) => migrationVm?.name === vmName)?.id;
+};


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-1430

Based on a bug mentioned in MTV-1430 and on regressions added later, the plan was not created successfully when done via yaml without setting both vm id and vm name per each vm:
E.g.
```
vms:
    - id: vm-3252 name: Auto-esx8.0-debian12.5-contains-repos
```

After this fix, a plan is created succesfully even when only vm name or vm id are set per vm. Both examples are supported:
```
vms:
    - id: vm-3252

vms:
    - name: Auto-esx8.0-debian12.5-contains-repos

```

