### PR TITLE
[MTV-3185] plan create wizard - for a RHV source provider storage map picklist will no populate properly

### DIFF
--- a/src/plans/create/hooks/useOvirtDisksForVMs.ts
+++ b/src/plans/create/hooks/useOvirtDisksForVMs.ts
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import useProviderInventory from 'src/modules/Providers/hooks/useProviderInventory';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
+
+import type { OVirtDisk, OVirtVM, ProviderVirtualMachine, V1beta1Provider } from '@kubev2v/types';
+import { isEmpty } from '@utils/helpers';
+
+/**
+ * Fetches oVirt disk data and adds storage domain info to VMs
+ */
+export const useOvirtDisksForVMs = (
+  provider: V1beta1Provider | undefined,
+  vms: ProviderVirtualMachine[],
+) => {
+  const isOvirtProvider = provider?.spec?.type === PROVIDER_TYPES.ovirt;
+
+  const {
+    error: disksError,
+    inventory: disks,
+    loading: disksLoading,
+  } = useProviderInventory<OVirtDisk[]>({
+    disabled: !isOvirtProvider,
+    provider,
+    subPath: 'disks?detail=10',
+  });
+
+  const vmsWithDisks = useMemo(() => {
+    if (!isOvirtProvider || disksLoading || isEmpty(vms) || isEmpty(disks)) {
+      return vms;
+    }
+
+    const diskMap = new Map<string, OVirtDisk>();
+    disks?.forEach((disk) => {
+      diskMap.set(disk.id, disk);
+    });
+
+    return vms.map((vm) => {
+      const ovirtVm = vm as OVirtVM;
+      const vmDisks =
+        ovirtVm.diskAttachments
+          ?.map((attachment) => {
+            const disk = diskMap.get(attachment.disk);
+            return disk ? { id: disk.id, storageDomain: disk.storageDomain } : null;
+          })
+          .filter(Boolean) ?? [];
+
+      return { ...vm, disks: vmDisks };
+    });
+  }, [isOvirtProvider, disksLoading, vms, disks]);
+
+  return { error: disksError, loading: disksLoading, vmsWithDisks };
+};

--- a/src/plans/create/steps/storage-map/NewStorageMapFields.tsx
+++ b/src/plans/create/steps/storage-map/NewStorageMapFields.tsx
@@ -5,6 +5,7 @@ import { getSourceStorageValues } from 'src/storageMaps/utils/getSourceStorageVa
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
+import type { ProviderVirtualMachine } from '@kubev2v/types';
 import { Alert, AlertVariant, Stack, StackItem, TextInput } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -13,7 +14,6 @@ import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
 import { useCreatePlanWizardContext } from '../../hooks/useCreatePlanWizardContext';
 import { useInitializeMappings } from '../../hooks/useInitializeMappings';
 import { GeneralFormFieldId } from '../general-information/constants';
-import { VmFormFieldId } from '../virtual-machines/constants';
 
 import { CreatePlanStorageMapFieldId, createPlanStorageMapFieldLabels } from './constants';
 import CreatePlanStorageMapFieldTable from './CreatePlanStorageMapFieldTable';
@@ -21,25 +21,23 @@ import CreatePlanStorageMapFieldTable from './CreatePlanStorageMapFieldTable';
 const NewStorageMapFields: FC = () => {
   const { t } = useForkliftTranslation();
   const { control, getFieldState } = useCreatePlanFormContext();
-  const { storage } = useCreatePlanWizardContext();
+  const { storage, vmsWithDisks: vmsWithDisksResult } = useCreatePlanWizardContext();
   const { error } = getFieldState(CreatePlanStorageMapFieldId.StorageMap);
-  const [sourceProvider, vms, storageMap] = useWatch({
+  const [sourceProvider, storageMap] = useWatch({
     control,
-    name: [
-      GeneralFormFieldId.SourceProvider,
-      VmFormFieldId.Vms,
-      CreatePlanStorageMapFieldId.StorageMap,
-    ],
+    name: [GeneralFormFieldId.SourceProvider, CreatePlanStorageMapFieldId.StorageMap],
   });
 
   const [availableSourceStorages, sourceStoragesLoading, sourceStoragesError] = storage.sources;
   const [availableTargetStorages, _targetStoragesLoading, targetStoragesError] = storage.targets;
-  const isLoading = sourceStoragesLoading;
+  const [vmsWithDisks, vmsWithDisksLoading] = vmsWithDisksResult;
+
+  const isLoading = sourceStoragesLoading || vmsWithDisksLoading;
 
   const { other: otherSourceStorages, used: usedSourceStorages } = getSourceStorageValues(
     sourceProvider,
     availableSourceStorages,
-    Object.values(vms),
+    vmsWithDisks as ProviderVirtualMachine[],
   );
   const defaultTargetStorageName = availableTargetStorages?.[0]?.name;
 
@@ -60,7 +58,7 @@ const NewStorageMapFields: FC = () => {
     <Stack hasGutter className="pf-v5-u-ml-lg">
       {error?.root && <Alert variant={AlertVariant.danger} isInline title={error.root.message} />}
 
-      {isEmpty(usedSourceStorages) && !sourceStoragesLoading && (
+      {isEmpty(usedSourceStorages) && !isLoading && (
         <Alert
           variant={AlertVariant.warning}
           isInline
@@ -72,7 +70,7 @@ const NewStorageMapFields: FC = () => {
         targetStorages={availableTargetStorages}
         usedSourceStorages={usedSourceStorages}
         otherSourceStorages={otherSourceStorages}
-        isLoading={sourceStoragesLoading}
+        isLoading={isLoading}
         loadError={sourceStoragesError ?? targetStoragesError}
       />
 

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -120,4 +120,5 @@ export type CreatePlanWizardContextProps = {
     sources: ResourceQueryResult<InventoryStorage[]>;
     targets: ResourceQueryResult<TargetStorage[]>;
   };
+  vmsWithDisks: ResourceQueryResult<ProviderVirtualMachine[]>;
 };


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3185

## 📝 Description
API regression: oVirt /vms endpoint no longer returns disk storage domain mappings, requiring separate /disks API call to restore storage selection functionality.

## 🎥 Demo
https://github.com/user-attachments/assets/ac3ee179-43a0-415f-b0ba-73de8a8a6f9e