### PR TITLE
MTV-3194: Clarify migration history section

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -103,6 +103,7 @@
   "All": "All",
   "All changes saved": "All changes saved",
   "All networks detected on the selected VMs require a mapping.": "All networks detected on the selected VMs require a mapping.",
+  "All past migration runs for this plan. This includes both successful and failed attempts, but detailed logs and other data are not available after the migration pods are deleted. If you retry an incomplete migration, only the failed VMs will migrate again.": "All past migration runs for this plan. This includes both successful and failed attempts, but detailed logs and other data are not available after the migration pods are deleted. If you retry an incomplete migration, only the failed VMs will migrate again.",
   "All storages detected on the selected VMs require a mapping.": "All storages detected on the selected VMs require a mapping.",
   "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.": "All virtual machines planned for migration are selected for deletion, deleting all virtual machines from a migration plan is not allowed.",
   "All VMs were migrated": "All VMs were migrated",

--- a/src/components/ExpandableSectionHeading/ExpandableSectionHeading.tsx
+++ b/src/components/ExpandableSectionHeading/ExpandableSectionHeading.tsx
@@ -2,44 +2,59 @@ import type { FC, ReactNode } from 'react';
 import useToggle from 'src/modules/Providers/hooks/useToggle';
 
 import SectionHeading from '@components/headers/SectionHeading';
-import { Button, ButtonVariant, Flex } from '@patternfly/react-core';
-import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
+import { Button, ButtonVariant, Flex, FlexItem, Icon, Tooltip } from '@patternfly/react-core';
+import { AngleDownIcon, AngleRightIcon, HelpIcon } from '@patternfly/react-icons';
 
 import './ExpandableSectionHeading.scss';
 
 type ExpandableSectionHeadingProps = {
   section: ReactNode;
   sectionTitle: ReactNode;
+  sectionHelpTip?: ReactNode;
   initialExpanded?: boolean;
 };
 
 const ExpandableSectionHeading: FC<ExpandableSectionHeadingProps> = ({
   initialExpanded = false,
   section,
+  sectionHelpTip,
   sectionTitle,
 }) => {
   const [showSection, setShowSection] = useToggle(initialExpanded);
   return (
     <>
-      <Button
-        className="expandable-section-heading"
-        isInline
-        variant={ButtonVariant.plain}
-        onClick={setShowSection}
-      >
-        <SectionHeading
-          text={
-            <Flex
-              className="expandable-section-heading__title"
-              alignItems={{ default: 'alignItemsCenter' }}
-              gap={{ default: 'gapSm' }}
-            >
-              {showSection ? <AngleDownIcon /> : <AngleRightIcon />}
-              <>{sectionTitle}</>
-            </Flex>
-          }
-        />
-      </Button>
+      <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+        <FlexItem>
+          <Button
+            className="expandable-section-heading"
+            isInline
+            variant={ButtonVariant.plain}
+            onClick={setShowSection}
+          >
+            <SectionHeading
+              text={
+                <Flex
+                  className="expandable-section-heading__title"
+                  alignItems={{ default: 'alignItemsCenter' }}
+                  gap={{ default: 'gapSm' }}
+                >
+                  <FlexItem>{showSection ? <AngleDownIcon /> : <AngleRightIcon />}</FlexItem>
+                  <FlexItem>{sectionTitle}</FlexItem>
+                </Flex>
+              }
+            />
+          </Button>
+        </FlexItem>
+        {sectionHelpTip ? (
+          <FlexItem>
+            <Tooltip content={sectionHelpTip}>
+              <Icon size="md">
+                <HelpIcon />
+              </Icon>
+            </Tooltip>
+          </FlexItem>
+        ) : null}
+      </Flex>
       {showSection && section}
     </>
   );

--- a/src/components/HelpText.tsx
+++ b/src/components/HelpText.tsx
@@ -1,14 +1,10 @@
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 
-import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, type HelperTextProps } from '@patternfly/react-core';
 
-type HelpTextProps = {
-  children: ReactNode;
-};
-
-const HelpText: FC<HelpTextProps> = ({ children }) => {
+const HelpText: FC<HelperTextProps> = ({ children, ...props }) => {
   return (
-    <HelperText>
+    <HelperText {...props}>
       <HelperTextItem>{children}</HelperTextItem>
     </HelperText>
   );

--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -14,8 +14,6 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import TableBulkSelect from '@components/TableBulkSelect';
 import {
-  Button,
-  ButtonVariant,
   Flex,
   FlexItem,
   Icon,
@@ -348,25 +346,23 @@ const StandardPageInner = <T,>({
         <PageSection variant="light" className="forklift-page__main-title">
           <Level>
             <LevelItem>
-              <Title headingLevel="h1">
-                <Flex
-                  alignItems={{ default: 'alignItemsCenter' }}
-                  spaceItems={{ default: 'spaceItemsSm' }}
-                >
-                  <FlexItem>{title}</FlexItem>
-                  {titleHelpContent && (
-                    <FlexItem>
-                      <Tooltip content={titleHelpContent}>
-                        <Button variant={ButtonVariant.plain} className="pf-v5-u-p-0">
-                          <Icon size="md">
-                            <HelpIcon />
-                          </Icon>
-                        </Button>
-                      </Tooltip>
-                    </FlexItem>
-                  )}
-                </Flex>
-              </Title>
+              <Flex
+                alignItems={{ default: 'alignItemsCenter' }}
+                spaceItems={{ default: 'spaceItemsSm' }}
+              >
+                <FlexItem>
+                  <Title headingLevel="h1">{title}</Title>
+                </FlexItem>
+                {titleHelpContent && (
+                  <FlexItem>
+                    <Tooltip content={titleHelpContent}>
+                      <Icon size="md">
+                        <HelpIcon />
+                      </Icon>
+                    </Tooltip>
+                  </FlexItem>
+                )}
+              </Flex>
             </LevelItem>
             {addButton && <LevelItem>{addButton}</LevelItem>}
           </Level>

--- a/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
+++ b/src/modules/NetworkMaps/views/details/components/MapsSection/MapsSection.tsx
@@ -177,7 +177,7 @@ export const MapsSection: FC<MapsSectionProps> = ({ obj }) => {
         onUpdate={onUpdate}
         onCancel={onCancel}
       />
-      <DescriptionListDescription className="forklift-page-mapping-list">
+      <DescriptionListDescription className="forklift-page-mapping-list pf-v5-u-mt-md">
         <MappingList
           addMapping={onAdd}
           replaceMapping={onReplace}

--- a/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/src/modules/NetworkMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -104,6 +104,7 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({ obj }) => {
       </Flex>
 
       <DescriptionList
+        className="pf-v5-u-mt-md"
         columnModifier={{
           default: '1Col',
         }}

--- a/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
+++ b/src/modules/StorageMaps/views/details/components/ProvidersSection/ProvidersSection.tsx
@@ -99,6 +99,7 @@ export const ProvidersSection: FC<ProvidersSectionProps> = ({ obj }) => {
       </Flex>
 
       <DescriptionList
+        className="pf-v5-u-mt-md"
         columnModifier={{
           default: '1Col',
         }}

--- a/src/plans/details/tabs/Details/PlanDetailsPage.tsx
+++ b/src/plans/details/tabs/Details/PlanDetailsPage.tsx
@@ -46,6 +46,9 @@ const PlanDetailsPage: FC<PlanPageProps> = ({ name, namespace }) => {
         <ExpandableSectionHeading
           section={<MigrationsSection plan={plan} />}
           sectionTitle={t('Migration history')}
+          sectionHelpTip={t(
+            `All past migration runs for this plan. This includes both successful and failed attempts, but detailed logs and other data are not available after the migration pods are deleted. If you retry an incomplete migration, only the failed VMs will migrate again.`,
+          )}
         />
       </PageSection>
       <Divider />

--- a/src/plans/details/tabs/Details/components/MigrationsSection/components/MigrationsTable.tsx
+++ b/src/plans/details/tabs/Details/components/MigrationsSection/components/MigrationsTable.tsx
@@ -31,7 +31,11 @@ const MigrationsTable: FC<MigrationTableProps> = ({ migrations, plan }) => {
   const { t } = useForkliftTranslation();
 
   if (isEmpty(migrations)) {
-    return <HelpText>{t('The plan has not been executed for migration.')}</HelpText>;
+    return (
+      <HelpText className="pf-v5-u-mt-md">
+        {t('The plan has not been executed for migration.')}
+      </HelpText>
+    );
   }
 
   const planStatus = getPlanStatus(plan);


### PR DESCRIPTION
## 📝 Links
[MTV-3194](https://issues.redhat.com/browse/MTV-3194)

## 📝 Description
Adds a help tooltip for the `Migration history` section for the Migration plans. 
Updated page help tooltips to not be part of a button so that they won't have the hand pointer when hovering (there is no click actions so it is confusing to show that cursor).
Updated same spacing issues.

## 🎥 Demo

### Migration history tip
<img width="674" height="568" alt="image" src="https://github.com/user-attachments/assets/1f7dff7c-b8f2-4903-b945-8efeb66c8260" />

### Standard page tip
<img width="685" height="313" alt="image" src="https://github.com/user-attachments/assets/1417e2e4-ce37-4fa3-9e63-bb0c8575945e" />

### Storage maps spacing

### Before
<img width="840" height="471" alt="image" src="https://github.com/user-attachments/assets/b9fb9bff-99c5-4d43-a581-308e8c156cf0" />

### After
<img width="867" height="489" alt="image" src="https://github.com/user-attachments/assets/6bd12921-eff8-4566-8da9-f97676757965" />

### Network maps spacing

### Before
<img width="993" height="387" alt="image" src="https://github.com/user-attachments/assets/0da675b6-3eb7-4a68-8e77-7321e9dbccbc" />

### After
<img width="998" height="414" alt="image" src="https://github.com/user-attachments/assets/0425da84-c834-421b-8317-388295909d00" />

### Migration history empty text

### Before
<img width="477" height="113" alt="image" src="https://github.com/user-attachments/assets/2ab89b00-a7c9-4731-a9e4-a92ee4b86516" />

### After
<img width="470" height="115" alt="image" src="https://github.com/user-attachments/assets/3191dd34-a573-4c83-baf8-41aa99af0df3" />

## 📝 CC://

@mmenestr
