### PR TITLE
MTV-3084: Set The forward slash (/) as a valid character for plan labels/node selector labels

### DIFF
--- a/src/components/LabelsModal/utils/isLabelValid.ts
+++ b/src/components/LabelsModal/utils/isLabelValid.ts
@@ -1,5 +1,5 @@
 export const isLabelValid = (label: string) => {
-  const LABEL_REGEX = /^[a-zA-Z0-9-_.]+=[a-zA-Z0-9-_.]+$/u;
+  const LABEL_REGEX = /^[a-zA-Z0-9-_./]+=[a-zA-Z0-9-_./]+$/u;
   const LABEL_NO_WHITESPACE_REGEX = /^[^\s]+$/u;
   return LABEL_REGEX.test(label) && LABEL_NO_WHITESPACE_REGEX.test(label);
 };


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-3084

Set The forward slash (/) as a valid character for plan labels/node selectors labels


## 🎥 Demo

<img width="731" height="340" alt="Screenshot from 2025-08-28 23-18-28" src="https://github.com/user-attachments/assets/037f18a9-65f5-4c69-b7c4-9998a9350631" />
