### PR TITLE
Fix version container tag

### DIFF
--- a/build/Containerfile-downstream
+++ b/build/Containerfile-downstream
@@ -9,8 +9,8 @@ FROM registry.redhat.io/rhel9/nodejs-22:9.6-1747320144 AS build
 #      --build-arg VERSION=1.2.3 .
 
 # Need this as ARG from konflux does not propagate
-ARG VERSION
-ENV VERSION=${VERSION}
+ARG RVERSION
+ENV VERSION=${RVERSION}
 
 # Copy app source
 COPY . /opt/app-root/src/app
@@ -44,13 +44,13 @@ COPY --from=build /opt/app-root/src/app/dist /opt/app-root/src
 # Run the server
 CMD nginx -g "daemon off;"
 
-ARG VERSION
+ARG RVERSION
 ARG REGISTRY
 ARG REVISION
 
 LABEL \
         com.redhat.component="mtv-console-plugin-container" \
-        version="$VERSION" \
+        version="$RVERSION" \
         name="${REGISTRY}/mtv-console-plugin-rhel9" \
         license="Apache License 2.0" \
         io.k8s.display-name="Migration Toolkit for Virtualization" \

--- a/build/release.conf
+++ b/build/release.conf
@@ -1,5 +1,5 @@
 # Global version specifying version for every component and for bundle, format "x.y.z"
-VERSION=2.10.0
+RVERSION=2.10.0
 
 # Release version, format "vX.Y"
 RELEASE=v2.10


### PR DESCRIPTION
VERSION arg is getting overwritten by VERSION env thus tagged images have tags "0-x" as a result.

Fix this by separating these by name.
