### PR TITLE
MTV-3290: display migration type section within plan's wizard overview page when relevant

### DIFF
--- a/src/plans/create/CreatePlanWizardInner.tsx
+++ b/src/plans/create/CreatePlanWizardInner.tsx
@@ -154,6 +154,7 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
         {...getStepProps(PlanWizardStepId.ReviewAndCreate)}
       >
         <ReviewStep
+          isLiveMigrationEnabled={isLiveMigrationEnabled}
           error={createPlanError}
           onBackToReviewClick={() => {
             setCreatePlanError(undefined);

--- a/src/plans/create/steps/review/MigrationTypeReviewSection.tsx
+++ b/src/plans/create/steps/review/MigrationTypeReviewSection.tsx
@@ -13,13 +13,27 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import { planStepNames, PlanWizardStepId } from '../../constants';
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
+import { hasLiveMigrationProviderType } from '../../utils/hasLiveMigrationProviderType';
+import { hasWarmMigrationProviderType } from '../../utils/hasWarmMigrationProviderType';
+import { GeneralFormFieldId } from '../general-information/constants';
 import { MigrationTypeFieldId, migrationTypeLabels } from '../migration-type/constants';
 
-const MigrationTypeReviewSection: FC = () => {
+const MigrationTypeReviewSection: FC<{ isLiveMigrationEnabled: boolean }> = ({
+  isLiveMigrationEnabled,
+}) => {
   const { t } = useForkliftTranslation();
   const { goToStepById } = useWizardContext();
   const { control } = useCreatePlanFormContext();
-  const migrationType = useWatch({ control, name: MigrationTypeFieldId.MigrationType });
+  const [migrationType, sourceProvider] = useWatch({
+    control,
+    name: [MigrationTypeFieldId.MigrationType, GeneralFormFieldId.SourceProvider],
+  });
+
+  const planSupportMigrationTypes =
+    hasWarmMigrationProviderType(sourceProvider) ||
+    (hasLiveMigrationProviderType(sourceProvider) && isLiveMigrationEnabled);
+
+  if (!planSupportMigrationTypes) return null;
 
   return (
     <ExpandableReviewSection

--- a/src/plans/create/steps/review/ReviewStep.tsx
+++ b/src/plans/create/steps/review/ReviewStep.tsx
@@ -19,9 +19,14 @@ import VirtualMachinesReviewSection from './VirtualMachinesReviewSection';
 type ReviewStepProps = {
   error: Error | undefined;
   onBackToReviewClick: () => void;
+  isLiveMigrationEnabled: boolean;
 };
 
-const ReviewStep: FC<ReviewStepProps> = ({ error, onBackToReviewClick }) => {
+const ReviewStep: FC<ReviewStepProps> = ({
+  error,
+  isLiveMigrationEnabled,
+  onBackToReviewClick,
+}) => {
   const { t } = useForkliftTranslation();
   const {
     formState: { isSubmitting },
@@ -55,7 +60,7 @@ const ReviewStep: FC<ReviewStepProps> = ({ error, onBackToReviewClick }) => {
       <VirtualMachinesReviewSection />
       <NetworkMapReviewSection />
       <StorageMapReviewSection />
-      <MigrationTypeReviewSection />
+      <MigrationTypeReviewSection isLiveMigrationEnabled={isLiveMigrationEnabled} />
       <OtherSettingsReviewSection />
       <HooksReviewSection />
     </WizardStepContainer>


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/MTV-3290

When creating a plan and reaching the review step page, the "migration type" section should be displayed only when warm or live migration are supported. If not supported, it should be hidden.


## 🎥 Demo
### Before
[Screencast from 2025-09-04 20-19-01.webm](https://github.com/user-attachments/assets/e2f87ce1-b93f-4215-b37d-78e17b9ddf33)


### After
[Screencast from 2025-09-04 20-17-36.webm](https://github.com/user-attachments/assets/9f9c1700-da6e-4bca-b1b7-b56d8ab3afb6)

