### PR TITLE
[MTV-3248] [UI] Migration with Pre-hook phase fails with Job has reached the specified backoff limit

### DIFF
--- a/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
+++ b/src/plans/details/tabs/Hooks/components/HooksCodeEditor.tsx
@@ -118,10 +118,8 @@ const HooksCodeEditor: FC<HooksCodeEditorProps> = ({ planEditable, type }) => {
                 render={({ field: { onChange, value } }) => (
                   <VersionedCodeEditor
                     isDarkTheme={isDarkTheme}
-                    value={value || ''}
-                    onChange={(code) => {
-                      onChange(code);
-                    }}
+                    value={value ?? ''}
+                    onChange={onChange}
                     isReadOnly={!planEditable}
                   />
                 )}


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3248

## 📝 Description
VersionedCodeEditor is already encoding once on initial load of the playbook fields, and we were doing that again with the HooksCodeEditor, leading to encoding an encoded string, which we were saving to the backend, and the backend was only decoding once.