### PR TITLE
[MTV-3309] [UI] Can't create migration plan, failed to create storage map

### DIFF
--- a/src/plans/create/steps/storage-map/NewStorageMapFields.tsx
+++ b/src/plans/create/steps/storage-map/NewStorageMapFields.tsx
@@ -19,7 +19,7 @@ import CreatePlanStorageMapFieldTable from './CreatePlanStorageMapFieldTable';
 
 const NewStorageMapFields: FC = () => {
   const { t } = useForkliftTranslation();
-  const { control, getFieldState } = useCreatePlanFormContext();
+  const { control, getFieldState, setValue } = useCreatePlanFormContext();
   const { storage, vmsWithDisks: vmsWithDisksResult } = useCreatePlanWizardContext();
   const { error } = getFieldState(CreatePlanStorageMapFieldId.StorageMap);
   const [sourceProvider, storageMap] = useWatch({
@@ -39,6 +39,8 @@ const NewStorageMapFields: FC = () => {
     vmsWithDisks as ProviderVirtualMachine[],
   );
   const defaultTargetStorageName = availableTargetStorages?.[0]?.name;
+
+  const isStorageMapEmpty = isEmpty(storageMap);
 
   // When the storage mappings are empty, default to source storage values used by VMs,
   // otherwise set empty inputs for the field array to force an empty field table row.


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3309

## 📝 Description
Add missing isStorageMapEmpty. Seems this was removed from a previous backfill to the release-2.9 branch.

## 🎥 Demo
https://github.com/user-attachments/assets/ee8b348e-1f5a-45cf-b476-6b5d3d8cf87e

