### PR TITLE
MTV-3432: Remove preserve static IP alert validation and rely on backend validation

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -1150,7 +1150,7 @@
   "You must select a source and target storage": "You must select a source and target storage",
   "You need to ensure a clean state.": "You need to ensure a clean state.",
   "You need to stage the migration over a period of time.": "You need to stage the migration over a period of time.",
-  "Your migration plan preserves the static IPs of VMs and uses Default Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Default Networking migrations.": "Your migration plan preserves the static IPs of VMs and uses Default Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Default Networking migrations.",
+  "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.": "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.",
   "Your selected network mappings will automatically save as a network map when your plan is created.": "Your selected network mappings will automatically save as a network map when your plan is created.",
   "Your selected storage mappings will automatically save as a storage map when your plan is created.": "Your selected storage mappings will automatically save as a storage map when your plan is created.",
   "Your VMs can be migrated in 2 different ways:": "Your VMs can be migrated in 2 different ways:"

--- a/src/plans/details/components/PlanPageHeader/components/PlanPreserveIPWarning.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanPreserveIPWarning.tsx
@@ -18,7 +18,7 @@ const PlanPreserveIPWarning: FC = () => {
         <Text component={TextVariants.p}>
           <Linkify>
             {t(
-              "Your migration plan preserves the static IPs of VMs and uses Default Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Default Networking migrations.",
+              "Your migration plan preserves the static IPs of VMs and uses Pod Networking target network mapping. This combination isn't supported, because VM IPs aren't preserved in Pod Networking migrations.",
             )}
           </Linkify>
         </Text>

--- a/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { useSourceNetworks } from 'src/modules/Providers/hooks/useNetworks';
 import usePlanProviders from 'src/modules/Providers/hooks/usePlanSourceProvider';
 import { useSourceStorages } from 'src/modules/Providers/hooks/useStorages';
-import { POD } from 'src/plans/details/utils/constants';
 
 import {
   NetworkMapModelGroupVersionKind,
@@ -13,8 +12,7 @@ import {
 } from '@kubev2v/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { CATEGORY_TYPES } from '@utils/constants';
-import { getName, getNamespace } from '@utils/crds/common/selectors';
-import { getPlanNetworkMapName, getPlanPreserveIP } from '@utils/crds/plans/selectors';
+import { getNamespace } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
 
 import { getPlanStatus } from '../../PlanStatus/utils/utils';
@@ -48,17 +46,12 @@ const usePlanAlerts = (plan: V1beta1Plan) => {
   );
 
   const showPreserveIPWarning = useMemo(() => {
-    if (!networkMapsLoaded || networkMapsError) {
-      return false;
-    }
+    const preserveStaticIpWarning = plan?.status?.conditions?.find(
+      (condition) => condition?.type === 'NetMapPreservingIPsOnPodNetwork',
+    );
 
-    const isPreserveStaticIPs = getPlanPreserveIP(plan);
-    const networkMap = networkMaps.find((net) => getName(net) === getPlanNetworkMapName(plan));
-    const isMapToPod =
-      networkMap?.spec?.map.some((entry) => entry.destination.type === POD) ?? false;
-
-    return Boolean(isPreserveStaticIPs && isMapToPod);
-  }, [networkMapsError, networkMapsLoaded, networkMaps, plan]);
+    return !isEmpty(preserveStaticIpWarning);
+  }, [plan]);
 
   const showCriticalCondition = !isEmpty(criticalCondition);
 


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-3432

Backend PR: https://github.com/kubev2v/forklift/pull/2858

## 📝 Description

Moving the preserve static IP validation to the backend and relying on the plan status

## 🎥 Demo

<!---
> Please add a video or an image of the behavior/changes
-->

## 📝 CC://

<!---
> @tag as needed
-->
