### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-console-plugin-2-9

### DIFF
--- a/build/Containerfile-downstream
+++ b/build/Containerfile-downstream
@@ -59,4 +59,5 @@ LABEL \
         summary="Migration Toolkit for Virtualization - User Console Plugin Interface" \
         maintainer="Migration Toolkit for Virtualization Team <migtoolkit-virt@redhat.com>" \
         description="Migration Toolkit for Virtualization - User Console Plugin Interface" \
+        cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
         revision="$REVISION"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
