### PR TITLE
MTV-3416: migration hook double encoded

### DIFF
--- a/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
+++ b/src/plans/create/steps/migration-hooks/AnsiblePlaybookField.tsx
@@ -1,6 +1,5 @@
 import type { FC } from 'react';
 import { Controller } from 'react-hook-form';
-import { Base64 } from 'js-base64';
 
 import VersionedCodeEditor from '@components/VersionedCodeEditor/VersionedCodeEditor';
 import { FormGroup, FormHelperText } from '@patternfly/react-core';
@@ -33,10 +32,8 @@ const AnsiblePlaybookField: FC<AnsiblePlaybookFieldProps> = ({ fieldId }) => {
         render={({ field }) => (
           <VersionedCodeEditor
             isDarkTheme={isDarkTheme}
-            value={Base64.decode(field.value ?? '')}
-            onChange={(value) => {
-              field.onChange(Base64.encode(String(value)));
-            }}
+            value={field.value ?? ''}
+            onChange={field.onChange}
           />
         )}
       />


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-3416

## 📝 Description

remove double base 64 encoding 

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/84abdd7f-89d0-4458-a37f-8597c02a9149

After:

https://github.com/user-attachments/assets/ed3cd5c9-c8b6-45f7-b173-090bf9b40cf7

## 📝 CC://

<!---
> @tag as needed
-->
