### PR TITLE
[MTV-3480] Improve lint run time & fix some lint issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp/
 yarn-error.log
 openapitools.json
 tsconfig.tsbuildinfo
+.eslintcache
 
 ci/yaml/openapi.yaml
 

--- a/eslint-rules-disabled.ts
+++ b/eslint-rules-disabled.ts
@@ -22,8 +22,6 @@ const disabledRules: CustomExtends = {
     'max-lines': 'off',
     'max-lines-per-function': 'off',
     'no-console': 'off',
-    'no-negated-condition': 'off',
-    'no-underscore-dangle': 'off',
     'react-hooks/exhaustive-deps': 'off',
     'react-refresh/only-export-components': 'off',
     'require-atomic-updates': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,3 @@
-/* eslint-disable max-lines */
-/* eslint-disable max-lines-per-function */
-/* eslint-disable @cspell/spellchecker */
-
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -40,6 +36,7 @@ export const createEslintConfig = (ideMode = false) =>
         'yarn.lock',
         'package-lock.json',
         '**/generated/**',
+        'eslint.config.ts',
       ],
     },
     eslint.configs.all,
@@ -100,7 +97,7 @@ export const createEslintConfig = (ideMode = false) =>
         '@typescript-eslint/naming-convention': 'off',
         '@typescript-eslint/no-deprecated': 'off',
         '@typescript-eslint/no-dynamic-delete': 'off',
-        // '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true }],
         '@typescript-eslint/no-magic-numbers': 'off',
         '@typescript-eslint/no-misused-promises': [
@@ -124,14 +121,6 @@ export const createEslintConfig = (ideMode = false) =>
             enforceForJSX: true,
           },
         ],
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          {
-            argsIgnorePattern: '^_',
-            caughtErrorsIgnorePattern: '^_',
-            varsIgnorePattern: '^_',
-          },
-        ],
         '@typescript-eslint/prefer-readonly-parameter-types': 'off',
         '@typescript-eslint/strict-boolean-expressions': 'off',
         '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
@@ -140,8 +129,6 @@ export const createEslintConfig = (ideMode = false) =>
         'capitalized-comments': 'off',
         complexity: 'off',
         'id-length': ['error', { exceptions: ['t', 'e', 'x', 'y', 'a', 'b', '_', 'i'] }],
-        'import/named': 'error',
-        'import/no-duplicates': ['error', { 'prefer-inline': true }],
         'import/no-named-as-default-member': 'off',
         'import/no-unresolved': 'off',
         'import/order': 'off',
@@ -219,7 +206,6 @@ export const createEslintConfig = (ideMode = false) =>
         ],
         'no-ternary': 'off',
         'no-undefined': 'off',
-        'no-unused-vars': 'off',
         'no-warning-comments': 'off',
         'one-var': 'off',
         'perfectionist/sort-classes': [
@@ -279,6 +265,15 @@ export const createEslintConfig = (ideMode = false) =>
         'sort-imports': 'off',
         'sort-keys': 'off',
         'sort-vars': ['error'],
+
+        // Rules redundant with TypeScript compiler + IDE
+        '@typescript-eslint/no-redeclare': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        'import/default': 'off',
+        'import/named': 'off',
+        'import/namespace': 'off',
+        'import/no-duplicates': 'off',
+        'no-unused-vars': 'off',
       },
       settings: {
         react: {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:analyze": "ANALYZE_BUNDLE=true NODE_ENV=production webpack",
     "start": "NODE_ENV=development webpack serve --progress",
     "i18n": "i18next \"./src/**/*.{js,jsx,ts,tsx}\" ./plugin-extensions.ts [-oc] -c ./i18next-parser.config.ts",
-    "lint": "eslint . && stylelint \"src/**/*.css\" --allow-empty-input",
+    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' plugin-extensions.ts plugin-metadata.ts environment-defaults.ts --cache --cache-location .eslintcache && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "lint:ia": "rm -rf node_modules/.cache/eslint-interactive && npx eslint-interactive .",
     "test:i18n": "bash ./ci/test-i18n.sh",

--- a/src/components/common/Page/usePagination.tsx
+++ b/src/components/common/Page/usePagination.tsx
@@ -38,7 +38,7 @@ export const usePagination = ({
         savePerPage(perPageArg);
       }
     },
-    [setPerPage, savePerPage, clearSavedPerPage],
+    [clearSavedPerPage, savePerPage],
   );
 
   return {

--- a/src/modules/NetworkMaps/actions/NetworkMapActionsDropdown.tsx
+++ b/src/modules/NetworkMaps/actions/NetworkMapActionsDropdown.tsx
@@ -18,26 +18,25 @@ import { NetworkMapActionsDropdownItems } from './NetworkMapActionsDropdownItems
 
 import './NetworkMapActionsDropdown.style.css';
 
-const NetworkMapActionsKebabDropdown_: FC<NetworkMapActionsDropdownProps> = ({ data, isKebab }) => {
+const NetworkMapActionsKebabDropdown: FC<NetworkMapActionsDropdownProps> = ({ data, isKebab }) => {
   const { t } = useForkliftTranslation();
 
   const [isOpen, setIsOpen] = useState(false);
 
   const onToggleClick = () => {
-    setIsOpen((isOpen) => !isOpen);
+    setIsOpen((value) => !value);
   };
 
   const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
     setIsOpen(false);
   };
 
-  // Returning the Dropdown component from PatternFly library
   return (
     <Dropdown
       className={isKebab ? undefined : 'forklift-dropdown pf-c-menu-toggle'}
       isOpen={isOpen}
-      onOpenChange={(isOpen: boolean) => {
-        setIsOpen(isOpen);
+      onOpenChange={(value: boolean) => {
+        setIsOpen(value);
       }}
       onSelect={onSelect}
       toggle={(toggleRef: Ref<MenuToggleElement>) => (
@@ -67,7 +66,7 @@ export const NetworkMapActionsDropdown: FC<NetworkMapActionsDropdownProps> = (pr
     <Flex flex={{ default: 'flex_3' }} flexWrap={{ default: 'nowrap' }}>
       <FlexItem grow={{ default: 'grow' }} />
       <FlexItem align={{ default: 'alignRight' }}>
-        <NetworkMapActionsKebabDropdown_ {...props} />
+        <NetworkMapActionsKebabDropdown {...props} />
       </FlexItem>
     </Flex>
   </ModalHOC>

--- a/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/src/modules/NetworkMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -6,6 +6,22 @@ import { ProviderModelGroupVersionKind, type V1beta1Provider } from '@kubev2v/ty
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormSelect, FormSelectOption } from '@patternfly/react-core';
 
+type FindProviderFunction = (args: {
+  providers: V1beta1Provider[];
+  name: string;
+}) => V1beta1Provider | undefined;
+
+const findProvider: FindProviderFunction = ({ name, providers }) =>
+  providers.find((provider) => provider.metadata?.name === name);
+
+const ProviderOption = (provider: V1beta1Provider, index: number) => (
+  <FormSelectOption
+    key={provider?.metadata?.name ?? index}
+    value={provider?.metadata?.name}
+    label={provider?.metadata?.name ?? ''}
+  />
+);
+
 export const ProvidersEdit: FC<ProvidersEditProps> = ({
   helpContent,
   invalidLabel,
@@ -17,9 +33,9 @@ export const ProvidersEdit: FC<ProvidersEditProps> = ({
   selectedProviderName,
   setMode,
 }) => {
-  const targetProvider = fineProvider({ name: selectedProviderName, providers });
+  const targetProvider = findProvider({ name: selectedProviderName, providers });
 
-  const validated = targetProvider !== undefined ? 'success' : 'error';
+  const validated = targetProvider ? 'success' : 'error';
   const hasProviders = providers?.length > 0;
 
   if (mode === 'edit') {
@@ -65,7 +81,7 @@ export const ProvidersEdit: FC<ProvidersEditProps> = ({
           name={selectedProviderName}
           namespace={targetProvider?.metadata?.namespace}
           groupVersionKind={ProviderModelGroupVersionKind}
-          linkTo={targetProvider !== undefined}
+          linkTo={Boolean(targetProvider)}
         />
       }
       onEdit={
@@ -81,14 +97,6 @@ export const ProvidersEdit: FC<ProvidersEditProps> = ({
   );
 };
 
-const ProviderOption = (provider, index) => (
-  <FormSelectOption
-    key={provider?.metadata?.name || index}
-    value={provider?.metadata?.name}
-    label={provider?.metadata?.name}
-  />
-);
-
 type ProvidersEditProps = {
   providers: V1beta1Provider[];
   selectedProviderName: string;
@@ -100,11 +108,3 @@ type ProvidersEditProps = {
   mode: 'edit' | 'view';
   setMode: (mode: 'edit' | 'view') => void;
 };
-
-type FindProviderFunction = (args: {
-  providers: V1beta1Provider[];
-  name: string;
-}) => V1beta1Provider;
-
-const fineProvider: FindProviderFunction = ({ name, providers }) =>
-  providers.find((provider) => provider.metadata.name === name);

--- a/src/modules/Providers/utils/components/TableCell/TableCell.tsx
+++ b/src/modules/Providers/utils/components/TableCell/TableCell.tsx
@@ -18,7 +18,7 @@ export const TableCell: FC<TableCellProps> = ({ children, isWrap = false }) => {
       <Flex
         spaceItems={{ default: 'spaceItemsXs' }}
         display={{ default: 'inlineFlex' }}
-        flexWrap={!isWrap ? { default: 'nowrap' } : {}}
+        flexWrap={isWrap ? {} : { default: 'nowrap' }}
       >
         {Children.map(arrayChildren, (child) => (
           <FlexItem>{child}</FlexItem>

--- a/src/modules/Providers/utils/helpers/getResourceUrl.ts
+++ b/src/modules/Providers/utils/helpers/getResourceUrl.ts
@@ -2,6 +2,14 @@ import { Namespace } from 'src/utils/constants';
 
 import type { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
+type GetResourceUrlProps = {
+  reference?: string;
+  groupVersionKind?: K8sGroupVersionKind;
+  namespaced?: boolean;
+  namespace?: string;
+  name?: string;
+};
+
 /**
  * Provides resource url.
  *
@@ -18,17 +26,14 @@ export const getResourceUrl = ({
   const ns =
     namespace && namespace !== Namespace.AllProjects ? `ns/${namespace}` : 'all-namespaces';
   const resourcePath = namespaced ? ns : 'cluster';
-  const reference_ =
-    reference || `${groupVersionKind.group}~${groupVersionKind.version}~${groupVersionKind.kind}`;
-  const name_ = name ? `/${encodeURIComponent(name)}` : '';
+  if (!reference && !groupVersionKind) {
+    return '';
+  }
 
-  return `/k8s/${resourcePath}/${reference_}${name_}`;
-};
+  const resourceReference =
+    reference ??
+    `${groupVersionKind?.group}~${groupVersionKind?.version}~${groupVersionKind?.kind}`;
+  const nameSegment = name ? `/${encodeURIComponent(name)}` : '';
 
-type GetResourceUrlProps = {
-  reference?: string;
-  groupVersionKind?: K8sGroupVersionKind;
-  namespaced?: boolean;
-  namespace?: string;
-  name?: string;
+  return `/k8s/${resourcePath}/${resourceReference}${nameSegment}`;
 };

--- a/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
+++ b/src/modules/Providers/views/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
@@ -4,7 +4,7 @@ import { t } from '@utils/i18n';
 import { CustomFilterType } from '../../constants';
 
 const labelToFilterItem = (label: string): EnumValue =>
-  label !== '' ? { id: label, label } : { id: label, label: 'Undefined' };
+  label ? { id: label, label } : { id: label, label: 'Undefined' };
 
 /**
  * This component enables filtering the oVirt virtual machines

--- a/src/modules/StorageMaps/actions/StorageMapActionsDropdown.tsx
+++ b/src/modules/StorageMaps/actions/StorageMapActionsDropdown.tsx
@@ -18,20 +18,18 @@ import { StorageMapActionsDropdownItems } from './StorageMapActionsDropdownItems
 
 import './StorageMapActionsDropdown.style.css';
 
-const StorageMapActionsKebabDropdown_: FC<StorageMapActionsDropdownProps> = ({ data, isKebab }) => {
+const StorageMapActionsKebabDropdown: FC<StorageMapActionsDropdownProps> = ({ data, isKebab }) => {
   const { t } = useForkliftTranslation();
-
   const [isOpen, setIsOpen] = useState(false);
 
   const onToggleClick = () => {
-    setIsOpen((isOpen) => !isOpen);
+    setIsOpen((value) => !value);
   };
 
   const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
     setIsOpen(false);
   };
 
-  // Returning the Dropdown component from PatternFly library
   return (
     <Dropdown
       className={isKebab ? undefined : 'forklift-dropdown pf-c-menu-toggle'}
@@ -65,7 +63,7 @@ export const StorageMapActionsDropdown: FC<StorageMapActionsDropdownProps> = (pr
     <Flex flex={{ default: 'flex_3' }} flexWrap={{ default: 'nowrap' }}>
       <FlexItem grow={{ default: 'grow' }} />
       <FlexItem align={{ default: 'alignRight' }}>
-        <StorageMapActionsKebabDropdown_ {...props} />
+        <StorageMapActionsKebabDropdown {...props} />
       </FlexItem>
     </Flex>
   </ModalHOC>

--- a/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
+++ b/src/modules/StorageMaps/views/details/components/ProvidersSection/components/ProvidersEdit.tsx
@@ -6,6 +6,14 @@ import { ProviderModelGroupVersionKind, type V1beta1Provider } from '@kubev2v/ty
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormSelect, FormSelectOption } from '@patternfly/react-core';
 
+type FindProviderFunction = (args: {
+  providers: V1beta1Provider[];
+  name: string;
+}) => V1beta1Provider | undefined;
+
+const findProvider: FindProviderFunction = ({ name, providers }) =>
+  providers.find((provider) => provider.metadata?.name === name);
+
 export const ProvidersEdit: FC<ProvidersEditProps> = ({
   helpContent,
   invalidLabel,
@@ -17,17 +25,17 @@ export const ProvidersEdit: FC<ProvidersEditProps> = ({
   selectedProviderName,
   setMode,
 }) => {
-  const ProviderOption = (provider, index) => (
+  const ProviderOption = (provider: V1beta1Provider, index: number) => (
     <FormSelectOption
       key={provider?.metadata?.name ?? index}
       value={provider?.metadata?.name}
-      label={provider?.metadata?.name}
+      label={provider?.metadata?.name ?? ''}
     />
   );
 
-  const targetProvider = fineProvider({ name: selectedProviderName, providers });
+  const targetProvider = findProvider({ name: selectedProviderName, providers });
 
-  const validated = targetProvider !== undefined ? 'success' : 'error';
+  const validated = targetProvider ? 'success' : 'error';
   const hasProviders = providers?.length > 0;
 
   if (mode === 'edit') {
@@ -73,7 +81,7 @@ export const ProvidersEdit: FC<ProvidersEditProps> = ({
           name={selectedProviderName}
           namespace={targetProvider?.metadata?.namespace}
           groupVersionKind={ProviderModelGroupVersionKind}
-          linkTo={targetProvider !== undefined}
+          linkTo={Boolean(targetProvider)}
         />
       }
       onEdit={
@@ -100,11 +108,3 @@ type ProvidersEditProps = {
   mode: 'edit' | 'view';
   setMode: (mode: 'edit' | 'view') => void;
 };
-
-type FindProviderFunction = (args: {
-  providers: V1beta1Provider[];
-  name: string;
-}) => V1beta1Provider;
-
-const fineProvider: FindProviderFunction = ({ name, providers }) =>
-  providers.find((provider) => provider.metadata.name === name);

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "dist", "locales", "docs", "ci"]
+  "include": ["src/**/*", "*.ts"],
+  "exclude": ["node_modules", "dist", "locales", "docs", "ci", "testing"]
 }


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3480

## 📝 Description
- Improved run time of the yarn lint command we use. This will speed local development and CI builds. Below are the statistics of this improvement.
- While I was working on improving the speed of tests, I worked on ridding of a couple rules from our disabled rules list:
    - `no-negated-condition`
    - `no-underscore-dangle`
    
**Before improvements:**
- Time: 1 minute 40 seconds (100.15s)
- Total wall clock time: 1:40.25

**After improvements:**
- Time: 22 seconds (21.96s) first run
- Time: 2 seconds (2.05s) subsequent runs (with cache)