### PR TITLE
[MTV-3312] Plan creation navigation breaks on mappings validation error

### DIFF
--- a/src/plans/create/steps/virtual-machines/VirtualMachinesStepFooter.tsx
+++ b/src/plans/create/steps/virtual-machines/VirtualMachinesStepFooter.tsx
@@ -12,8 +12,10 @@ import {
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
+import { PlanWizardStepId } from '../../constants';
 import CreatePlanWizardFooter from '../../CreatePlanWizardFooter';
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
+import { useStepValidation } from '../../hooks/useStepValidation';
 import type { ProviderVirtualMachine } from '../../types';
 import { GeneralFormFieldId } from '../general-information/constants';
 
@@ -27,6 +29,7 @@ const VirtualMachinesStepFooter: FC = () => {
   const [pendingVmIds, setPendingVmIds] = useState<string[]>();
   const { goToNextStep } = useWizardContext();
   const { control, setValue, trigger } = useCreatePlanFormContext();
+  const { validateStep } = useStepValidation();
   const [sourceProvider, selectedVms] = useWatch({
     control,
     name: [GeneralFormFieldId.SourceProvider, VmFormFieldId.Vms],
@@ -50,7 +53,7 @@ const VirtualMachinesStepFooter: FC = () => {
 
   // Validate form and handle next step or show warning modal
   const handleNextStep = useCallback(async () => {
-    const isValid = await trigger(undefined, { shouldFocus: true });
+    const isValid = await validateStep(PlanWizardStepId.VirtualMachines);
 
     if (isValid) {
       // Skip modal if no critical issues found
@@ -62,7 +65,7 @@ const VirtualMachinesStepFooter: FC = () => {
       // Show warning modal for VMs with critical issues
       setIsModalOpen(true);
     }
-  }, [trigger, vmsWithCriticalIssues, goToNextStep]);
+  }, [validateStep, vmsWithCriticalIssues, goToNextStep]);
 
   const closeModal = useCallback(() => {
     setIsModalOpen(false);

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -84,6 +84,12 @@ export type CreatePlanFormData = FieldValues & {
 
 export type MappingValue = { id?: string; name: string };
 
+export type MappingFieldIds = {
+  sourceField: string;
+  targetField: string;
+  mapField: string;
+};
+
 export type CategorizedSourceMappings = {
   used: MappingValue[];
   other: MappingValue[];

--- a/src/plans/create/utils/fillUnmappedSources.ts
+++ b/src/plans/create/utils/fillUnmappedSources.ts
@@ -1,0 +1,48 @@
+import type { MappingFieldIds, MappingValue } from '../types';
+
+type FillMappingsOptions<T> = {
+  existingMappings: T[];
+  unmappedSources: MappingValue[];
+  targetValue: MappingValue;
+  fieldIds: MappingFieldIds;
+};
+
+/**
+ * Fills empty mapping rows with unmapped sources, then creates new mappings for remaining sources
+ */
+export const fillUnmappedSources = <T extends Record<string, unknown>>({
+  existingMappings,
+  fieldIds,
+  targetValue,
+  unmappedSources,
+}: FillMappingsOptions<T>): T[] => {
+  // Fill empty rows with unmapped sources
+  let sourceIndex = 0;
+  const updatedMappings = existingMappings.map((mapping) => {
+    const sourceField = mapping[fieldIds.sourceField] as MappingValue | undefined;
+    const isEmptyRow = !sourceField?.name?.trim();
+
+    if (isEmptyRow && sourceIndex < unmappedSources.length) {
+      const filledMapping = {
+        ...mapping,
+        [fieldIds.sourceField]: unmappedSources[sourceIndex],
+      } as T;
+      sourceIndex += 1;
+      return filledMapping;
+    }
+
+    return mapping;
+  });
+
+  // Create new mappings for any remaining sources
+  const remainingSources = unmappedSources.slice(sourceIndex);
+  const newMappings = remainingSources.map(
+    (source): T =>
+      ({
+        [fieldIds.sourceField]: source,
+        [fieldIds.targetField]: targetValue,
+      }) as T,
+  );
+
+  return [...updatedMappings, ...newMappings];
+};


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3312

## 📝 Description
- Updated validation between the VM and network/storage map steps. Before we were triggering validation on all steps when clicking "Next" from the VM step, now it only validates the VM selections.
- When fixing this issue, another couple were addressed, in that the filling of default source maps was not populating empty rows when navigating back to the network/storage map steps (with new map creation radio selected), and the validation was not being re-triggered after the auto-population took place.

## 🎥 Demo

https://github.com/user-attachments/assets/a104b133-759f-4f82-8fe4-c9a0232146b4

