### PR TITLE
[MTV-3489] [UI] Make default: Preserve static IPs

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -173,7 +173,7 @@
   "Browse or search for the virtual machines you want to include in this migration plan from the selected source provider.": "Browse or search for the virtual machines you want to include in this migration plan from the selected source provider.",
   "Building image": "Building image",
   "Building image...": "Building image...",
-  "By default, vNICs change during migration causing VMs to lose their static IPs. Enable to preserve static IP configurations.": "By default, vNICs change during migration causing VMs to lose their static IPs. Enable to preserve static IP configurations.",
+  "By default, vNICs change during migration and static IPs linked to interface names are lost. Enable to preserve static IP configurations.": "By default, vNICs change during migration and static IPs linked to interface names are lost. Enable to preserve static IP configurations.",
   "CA certificate": "CA certificate",
   "Can not update plan hooks when the plan is not editable.": "Can not update plan hooks when the plan is not editable.",
   "Cancel": "Cancel",

--- a/src/plans/create/steps/other-settings/PreserveStaticIpsField.tsx
+++ b/src/plans/create/steps/other-settings/PreserveStaticIpsField.tsx
@@ -34,7 +34,7 @@ const PreserveStaticIpsField: FC = () => {
       labelIcon={
         <HelpIconPopover header={label}>
           {t(
-            'By default, vNICs change during migration causing VMs to lose their static IPs. Enable to preserve static IP configurations.',
+            'By default, vNICs change during migration and static IPs linked to interface names are lost. Enable to preserve static IP configurations.',
           )}
         </HelpIconPopover>
       }
@@ -48,7 +48,7 @@ const PreserveStaticIpsField: FC = () => {
         <Controller
           name={OtherSettingsFormFieldId.PreserveStaticIps}
           control={control}
-          defaultValue={false}
+          defaultValue={true}
           render={({ field }) => (
             <Checkbox
               id={OtherSettingsFormFieldId.PreserveStaticIps}

--- a/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
+++ b/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
@@ -34,7 +34,7 @@ const TestWrapper = ({
       [OtherSettingsFormFieldId.NBDEClevis]: nbdeClevis,
       [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: diskPassPhrases,
       [OtherSettingsFormFieldId.TransferNetwork]: null,
-      [OtherSettingsFormFieldId.PreserveStaticIps]: false,
+      [OtherSettingsFormFieldId.PreserveStaticIps]: true,
       [OtherSettingsFormFieldId.RootDevice]: '',
       [OtherSettingsFormFieldId.MigrateSharedDisks]: false,
       [OtherSettingsFormFieldId.TargetPowerState]: { label: 'Running' },


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3489

## 📝 Description
Just updating the create plan wizard to default the preserve static IPs value to true (Enabled) by default (For those providers that actually have this option). The verbiage for the help text was also slightly corrected.

## 🎥 Demo

https://github.com/user-attachments/assets/58a3860c-2cab-46fa-9235-93601a584301


## 📝 CC://
@mnecas
