### PR TITLE
[MTV-2651] Update the Migration history chart displayed dates/times

### DIFF
--- a/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryCard.tsx
+++ b/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryCard.tsx
@@ -48,6 +48,7 @@ const VmMigrationsHistoryCard: FC<MigrationsCardProps> = () => {
       <CardBody className="forklift-overview__status-migration-chart">
         <LoadingSuspend obj={obj} loaded={loaded} loadError={loadError}>
           <VmMigrationsHistoryChart
+            selectedRange={selectedRange}
             vmMigrationsDataPoints={{
               failed,
               running,

--- a/src/overview/tabs/Overview/hooks/useVmMigrationsDataPoints.ts
+++ b/src/overview/tabs/Overview/hooks/useVmMigrationsDataPoints.ts
@@ -13,12 +13,13 @@ import { getName } from '@utils/crds/common/selectors';
 import { TimeRangeOptions, TimeRangeOptionsDictionary } from '../utils/timeRangeOptions';
 import type { MigrationDataPoint } from '../utils/types';
 
-const toHourLabel = (date: DateTime | null) => (date ? date.toLocal().toFormat('HH:mm') : '');
+const toHourLabel = (date: DateTime | null) =>
+  date ? date.toLocal().toFormat('LLL dd HH:mm') : '';
 const toDayLabel = (date: DateTime | null) => (date ? date.toLocal().toFormat('LLL dd') : '');
 
 const createTimeBuckets = (selectedTimeRange: TimeRangeOptions, singleBucket = false) => {
   const { bucket, span, unit } = TimeRangeOptionsDictionary[selectedTimeRange];
-  const now = DateTime.now().toUTC();
+  const now = DateTime.now().endOf(unit).toUTC();
   const start = now.minus(span).startOf(unit);
   let end = now;
 
@@ -42,7 +43,7 @@ const createTimeBuckets = (selectedTimeRange: TimeRangeOptions, singleBucket = f
     intervals.push(Interval.fromDateTimes(cursor, next));
     cursor = next;
   }
-  return intervals.slice(-12);
+  return intervals;
 };
 
 const createBuckets = (intervals: Interval[], migrations: V1beta1Migration[]) => {

--- a/src/overview/tabs/Overview/utils/timeRangeOptions.ts
+++ b/src/overview/tabs/Overview/utils/timeRangeOptions.ts
@@ -27,10 +27,6 @@ export const valueToLabel = {
   [TimeRangeOptions.Last31Days]: t('Last 31 days'),
 };
 
-const BUCKET_SM_HOURS = 2;
-const BUCKET_MD_DAYS = 1;
-const BUCKET_LARGE_DAYS = 4;
-
 export const TimeRangeOptionsDictionary: {
   Last10Days: TimeRangeOptionsProperties;
   Last31Days: TimeRangeOptionsProperties;
@@ -38,27 +34,27 @@ export const TimeRangeOptionsDictionary: {
   All: TimeRangeOptionsProperties;
 } = {
   All: {
-    bucket: { day: BUCKET_LARGE_DAYS },
+    bucket: { day: 1 },
     filter: () => true,
-    span: { days: 365 * 10 },
+    span: { days: 365 * 10 - 1 },
     unit: 'day',
   },
   Last10Days: {
-    bucket: { day: BUCKET_MD_DAYS },
+    bucket: { day: 1 },
     filter: isLast10Days,
-    span: { days: 10 },
+    span: { days: 9 },
     unit: 'day',
   },
   Last24H: {
-    bucket: { hour: BUCKET_SM_HOURS },
+    bucket: { hour: 1 },
     filter: isLast24H,
-    span: { hours: 24 },
+    span: { hours: 23 },
     unit: 'hour',
   },
   Last31Days: {
-    bucket: { day: BUCKET_LARGE_DAYS },
+    bucket: { day: 1 },
     filter: isLast31Days,
-    span: { days: 31 },
+    span: { days: 30 },
     unit: 'day',
   },
 };

--- a/src/overview/tabs/Overview/utils/types.ts
+++ b/src/overview/tabs/Overview/utils/types.ts
@@ -14,4 +14,5 @@ export type MigrationDataPoint = {
   dateLabel: string;
   value: number;
   interval: Interval<true> | Interval<false>;
+  migrations: string[];
 };


### PR DESCRIPTION
## 📝 Links

Fixes [MTV-2651](https://issues.redhat.com/browse/MTV-2651)

## 📝 Description

Updates the migration history chart to use single unit buckets (a data point for every day / hour). This allows us to show the correct number of days/hours as selected by the user.

## 🎥 Demo

![Kapture 2025-09-24 at 13 37 47](https://github.com/user-attachments/assets/477d9a9e-7d0c-439f-b793-da4cbcff7654)

## 📝 CC://

@heyethankim 