### PR TITLE
[MTV-3187] Don't allow removal of required network mappings

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -160,6 +160,7 @@
   "Area chart with VM migration history": "Area chart with VM migration history",
   "Assessment": "Assessment",
   "At least one network mapping is required.": "At least one network mapping is required.",
+  "At least one network mapping must be provided.": "At least one network mapping must be provided.",
   "At least one row must have both source and target storages": "At least one row must have both source and target storages",
   "At least one source and one target provider in the {{name}} project must be available.": "At least one source and one target provider in the {{name}} project must be available.",
   "At least one source and one target provider must be available.": "At least one source and one target provider must be available.",

--- a/src/components/FieldBuilderTable/FieldBuilderTable.tsx
+++ b/src/components/FieldBuilderTable/FieldBuilderTable.tsx
@@ -8,6 +8,7 @@ import {
   FormGroup,
   type FormGroupProps,
   Icon,
+  Tooltip,
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, type ThProps, Tr } from '@patternfly/react-table';
@@ -56,6 +57,23 @@ const FieldBuilderTable: FC<FieldBuilderTableProps<FormData>> = ({
         <Tbody>
           {fieldRows.reduce<ReactNode[]>((acc, fieldRow, rowIndex) => {
             // Main row containing field inputs and remove button
+            const removeButtonTip = removeButton.tooltip(rowIndex);
+            const button = (
+              <Button
+                icon={
+                  <Icon size="md">
+                    <MinusCircleIcon />
+                  </Icon>
+                }
+                isInline
+                variant={ButtonVariant.plain}
+                isDisabled={removeButton.isDisabled(rowIndex)}
+                onClick={() => {
+                  removeButton.onClick(rowIndex);
+                }}
+              />
+            );
+
             acc.push(
               <Tr key={fieldRow.id}>
                 {fieldRow.inputs.map((fieldInput) => (
@@ -64,19 +82,13 @@ const FieldBuilderTable: FC<FieldBuilderTableProps<FormData>> = ({
 
                 {/* Remove button cell */}
                 <Td isActionCell>
-                  <Button
-                    icon={
-                      <Icon size="md">
-                        <MinusCircleIcon />
-                      </Icon>
-                    }
-                    isInline
-                    variant={ButtonVariant.plain}
-                    isDisabled={removeButton.isDisabled}
-                    onClick={() => {
-                      removeButton.onClick(rowIndex);
-                    }}
-                  />
+                  {removeButtonTip ? (
+                    <Tooltip content={removeButtonTip}>
+                      <span>{button}</span>
+                    </Tooltip>
+                  ) : (
+                    button
+                  )}
                 </Td>
               </Tr>,
             );

--- a/src/components/FieldBuilderTable/types.ts
+++ b/src/components/FieldBuilderTable/types.ts
@@ -9,7 +9,8 @@ export type AddButtonType = {
 
 export type RemoveButtonType = {
   onClick: (fieldIndex: number) => void;
-  isDisabled?: boolean;
+  isDisabled: (fieldIndex: number) => boolean;
+  tooltip: (fieldIndex: number) => string | undefined;
 };
 
 export type FieldRow<FormData extends FieldValues> = FieldArrayWithId<

--- a/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
@@ -88,11 +88,33 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
         },
       }}
       removeButton={{
-        isDisabled: netMappingFields.length <= 1,
+        isDisabled: (index) => {
+          if (netMappingFields.length <= 1) {
+            return true;
+          }
+          return Boolean(
+            usedSourceNetworks.find(
+              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            ),
+          );
+        },
         onClick: (index) => {
           if (netMappingFields.length > 1) {
             remove(index);
           }
+        },
+        tooltip: (index) => {
+          if (netMappingFields.length <= 1) {
+            return t('At least one network mapping must be provided.');
+          }
+          if (
+            usedSourceNetworks.find(
+              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            )
+          ) {
+            return t('All networks detected on the selected VMs require a mapping.');
+          }
+          return undefined;
         },
       }}
     />


### PR DESCRIPTION
## 📝 Links

Fixes [MTV-3187](https://issues.redhat.com/browse/MTV-3187)

## 📝 Description

Prevents user removal of required network mappings when creating a migration plan.
Disables the remove button and adds an explanatory tooltip.

## 🎥 Demo

![Kapture 2025-09-25 at 15 36 27](https://github.com/user-attachments/assets/8402b4ab-5840-4b8b-87ec-5f95508936cc)

## 📝 CC://

/cc @heyethankim 
