### PR TITLE
MTV-3177: NADs not showing on Mappings tab edit mode

### DIFF
--- a/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
+++ b/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
@@ -10,7 +10,6 @@ import { useForkliftTranslation } from '@utils/i18n';
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
 import { useCreatePlanWizardContext } from '../../hooks/useCreatePlanWizardContext';
 import { useInitializeMappings } from '../../hooks/useInitializeMappings';
-import { GeneralFormFieldId } from '../general-information/constants';
 import { VmFormFieldId } from '../virtual-machines/constants';
 
 import {
@@ -20,15 +19,15 @@ import {
   type NetworkMapping,
 } from './constants';
 import NetworkMapFieldTable from './NetworkMapFieldTable';
-import { filterTargetNetworksByProject, getSourceNetworkValues } from './utils';
+import { getSourceNetworkValues, getTargetNetworksMappingValue } from './utils';
 
 const NewNetworkMapFields: FC = () => {
   const { t } = useForkliftTranslation();
   const { control, getFieldState } = useCreatePlanFormContext();
   const { network } = useCreatePlanWizardContext();
-  const [targetProject, vms, networkMap] = useWatch({
+  const [vms, networkMap] = useWatch({
     control,
-    name: [GeneralFormFieldId.TargetProject, VmFormFieldId.Vms, NetworkMapFieldId.NetworkMap],
+    name: [VmFormFieldId.Vms, NetworkMapFieldId.NetworkMap],
   });
 
   const [availableSourceNetworks, sourceNetworksLoading, sourceNetworksError] = network.sources;
@@ -45,8 +44,8 @@ const NewNetworkMapFields: FC = () => {
   );
 
   const targetNetworkMap = useMemo(
-    () => filterTargetNetworksByProject(availableTargetNetworks, targetProject),
-    [availableTargetNetworks, targetProject],
+    () => getTargetNetworksMappingValue(availableTargetNetworks),
+    [availableTargetNetworks],
   );
 
   useInitializeMappings<NetworkMapping>({

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -7,7 +7,6 @@ import type {
   OVirtVM,
   ProviderVirtualMachine,
 } from '@kubev2v/types';
-import { Namespace } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
 
@@ -154,28 +153,19 @@ export const validateNetworkMap = (validateNetworkMapParams: ValidateNetworkMapP
   return undefined;
 };
 
-/**
- * Filters target networks by project/namespace and transforms to mapping object
- */
-export const filterTargetNetworksByProject = (
+export const getTargetNetworksMappingValue = (
   availableTargetNetworks: OpenShiftNetworkAttachmentDefinition[],
-  targetProject: string,
 ) => {
-  if (isEmpty(availableTargetNetworks) || !targetProject) {
+  if (isEmpty(availableTargetNetworks)) {
     return { podNetwork: defaultNetMapping[NetworkMapFieldId.TargetNetwork] };
   }
 
   return availableTargetNetworks.reduce(
     (networkMap: Record<string, MappingValue>, network) => {
-      const isValidNamespace =
-        network.namespace === targetProject || network.namespace === Namespace.Default;
-
-      if (isValidNamespace) {
-        networkMap[network.uid] = {
-          id: network.id,
-          name: `${network.namespace}/${network.name}`,
-        };
-      }
+      networkMap[network.uid] = {
+        id: network.id,
+        name: `${network.namespace}/${network.name}`,
+      };
 
       return networkMap;
     },

--- a/src/plans/details/tabs/Mappings/components/PlanMappingsActionsBar/PlanMappingsActionsBar.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanMappingsActionsBar/PlanMappingsActionsBar.tsx
@@ -43,7 +43,9 @@ const PlanMappingsActionsBar: FC<PlanMappingsActionsBarProps> = ({
         <FlexItem>
           <Button
             variant={ButtonVariant.secondary}
-            onClick={reset}
+            onClick={() => {
+              reset();
+            }}
             data-testid="cancel-mappings-button"
           >
             {t('Cancel')}

--- a/src/plans/details/tabs/Mappings/utils/getLabeledAndAvailableMappings.ts
+++ b/src/plans/details/tabs/Mappings/utils/getLabeledAndAvailableMappings.ts
@@ -38,11 +38,11 @@ export const getLabeledAndAvailableMappings = ({
   updatedNetwork,
   updatedStorage,
 }: GetMappingsParams) => {
+  const labeledTargetNetworkMap = mapTargetNetworksIdsToLabels(targetNetworks);
   const labeledNetworkMappings: Mapping[] = updatedNetwork.map((obj) => ({
     destination:
-      mapTargetNetworksIdsToLabels(targetNetworks, plan)[obj.destination.type] ??
-      obj.destination?.name ??
-      t('Not available'),
+      labeledTargetNetworkMap[obj.destination?.type] ??
+      `${obj.destination?.namespace}/${obj.destination?.name}`,
     source: mapSourceNetworksIdsToLabels(sourceNetworks)[obj.source.id ?? obj.source.type!],
   }));
 
@@ -64,9 +64,9 @@ export const getLabeledAndAvailableMappings = ({
     ),
   ).sort((netA, netB) => universalComparator(netA, netB, 'en'));
 
-  const availableNetworkTargets = Object.values(
-    mapTargetNetworksIdsToLabels(targetNetworks, plan),
-  ).sort((netA, netB) => universalComparator(netA, netB, 'en'));
+  const availableNetworkTargets = Object.values(labeledTargetNetworkMap).sort((netA, netB) =>
+    universalComparator(netA, netB, 'en'),
+  );
 
   const availableStorageSources = Object.values(
     mapSourceStoragesIdsToLabels(

--- a/src/plans/details/tabs/Mappings/utils/mapMappingsIdsToLabels.ts
+++ b/src/plans/details/tabs/Mappings/utils/mapMappingsIdsToLabels.ts
@@ -8,7 +8,6 @@ import type {
   OpenShiftStorageClass,
   V1beta1Plan,
 } from '@kubev2v/types';
-import { Namespace } from '@utils/constants';
 import { getPlanTargetNamespace } from '@utils/crds/plans/selectors';
 
 import { DefaultNetworkLabel, IgnoreNetwork, STANDARD } from './constants';
@@ -101,14 +100,11 @@ export const mapSourceStoragesIdsToLabels = (
 
 export const mapTargetNetworksIdsToLabels = (
   targets: OpenShiftNetworkAttachmentDefinition[],
-  plan: V1beta1Plan,
 ): Record<string, string> => {
-  const tuples: [string, string][] = targets
-    .filter(
-      ({ namespace }) =>
-        namespace === getPlanTargetNamespace(plan) || namespace === Namespace.Default,
-    )
-    .map((net) => [net.uid, `${net.namespace}/${net.name}`]);
+  const tuples: [string, string][] = targets.map((net) => [
+    net.uid,
+    `${net.namespace}/${net.name}`,
+  ]);
 
   tuples.push([POD, DefaultNetworkLabel.Source], [IgnoreNetwork.Type, IgnoreNetwork.Label]);
   const labelToId = resolveCollisions(tuples);

--- a/src/plans/details/tabs/Mappings/utils/planMappingsHandlers.ts
+++ b/src/plans/details/tabs/Mappings/utils/planMappingsHandlers.ts
@@ -55,7 +55,7 @@ export const createOnAddNetworkMapping = (
     newState.push(createReplacedNetworkMap(unused));
   }
 
-  return { canAddMore: Boolean(unused), newState };
+  return { canAddMore: newState.length < sources.length, newState };
 };
 
 export const createOnAddStorageMapping = (
@@ -72,7 +72,7 @@ export const createOnAddStorageMapping = (
     newState.push(createReplacedStorageMap(unused, target));
   }
 
-  return { canAddMore: Boolean(unused), newState };
+  return { canAddMore: newState.length < sources.length, newState };
 };
 
 export const createOnDeleteMapping = <


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-3177

## 📝 Description

This PR fixes:
- Filtering nads from namespaces that are not the plan target namespace.
- Add mapping button is can be clicked even though there's no more mapping to do, button get disabled after we click on add mapping and nothing happens.
- when adding mappings to plan on mappings tab and clicking cancel the UI looks like it was added and needs a refresh to see the actual state.

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/9a981e29-a77b-4796-b188-8b771e9bb410

After:

https://github.com/user-attachments/assets/c4bcbac4-8411-49f3-a0d1-b711c9e8e0c4


## 📝 CC://

<!---
> @tag as needed
-->
