### PR TITLE
[MTV-3187] Add fallback to auto-populate when re-adding mappings

### DIFF
--- a/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
@@ -81,8 +81,16 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
           Boolean(loadError),
         label: t('Add mapping'),
         onClick: () => {
+          const missingNetwork = usedSourceNetworks.find(
+            (sourceNetwork) =>
+              !netMappingFields.find(
+                (netMapping) => netMapping.sourceNetwork.id === sourceNetwork.id,
+              ),
+          );
+
           append({
-            [NetworkMapFieldId.SourceNetwork]: defaultNetMapping[NetworkMapFieldId.SourceNetwork],
+            [NetworkMapFieldId.SourceNetwork]:
+              missingNetwork ?? defaultNetMapping[NetworkMapFieldId.SourceNetwork],
             [NetworkMapFieldId.TargetNetwork]: defaultNetMapping[NetworkMapFieldId.TargetNetwork],
           });
         },
@@ -99,7 +107,12 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
           );
         },
         onClick: (index) => {
-          if (netMappingFields.length > 1) {
+          if (
+            netMappingFields.length > 1 &&
+            !usedSourceNetworks.find(
+              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            )
+          ) {
             remove(index);
           }
         },


### PR DESCRIPTION
## 📝 Links

Continues [MTV-3187](https://issues.redhat.com/browse/MTV-3187)

## 📝 Description

Adds a check when to prevent removing a used source network when adding network mappings to a migration plan.
Adds code to auto-populate an added network mapping if for some reason a required source network is missing.
