### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for forklift-console-plugin-dev-preview

### DIFF
--- a/build/Containerfile-downstream
+++ b/build/Containerfile-downstream
@@ -50,6 +50,7 @@ ARG REVISION
 
 LABEL \
         com.redhat.component="mtv-console-plugin-container" \
+        cpe="cpe:/a:redhat:migration_toolkit_virtualization:2.9::el9" \
         version="$RVERSION" \
         name="${REGISTRY}/mtv-console-plugin-rhel9" \
         license="Apache License 2.0" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
