### PR TITLE
[MTV-3311] [UI] mandatory storage incorrectly identified when editing mappings

### DIFF
--- a/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.tsx
@@ -15,6 +15,7 @@ import { CATEGORY_TYPES } from '@utils/constants';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
 
+import { usePlanMappingData } from '../../../hooks/usePlanMappingData';
 import { getPlanStatus } from '../../PlanStatus/utils/utils';
 
 const usePlanAlerts = (plan: V1beta1Plan) => {
@@ -38,8 +39,17 @@ const usePlanAlerts = (plan: V1beta1Plan) => {
   });
 
   const [sourceProvider] = usePlanProviders(plan, namespace!);
-  const [sourceStorages] = useSourceStorages(sourceProvider);
-  const [sourceNetworks] = useSourceNetworks(sourceProvider);
+  const [providerStorages] = useSourceStorages(sourceProvider);
+  const [providerNetworks] = useSourceNetworks(sourceProvider);
+
+  const { sourceNetworks, sourceStorages } = usePlanMappingData({
+    networkMaps,
+    plan,
+    providerNetworks,
+    providerStorages,
+    sourceProvider,
+    storageMaps,
+  });
 
   const criticalCondition = plan?.status?.conditions?.find(
     (condition) => condition?.category === CATEGORY_TYPES.CRITICAL,

--- a/src/plans/details/hooks/usePlanMappingData.ts
+++ b/src/plans/details/hooks/usePlanMappingData.ts
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import type { InventoryNetwork } from 'src/modules/Providers/hooks/useNetworks';
+import type { InventoryStorage } from 'src/modules/Providers/hooks/useStorages';
+
+import type {
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1Provider,
+  V1beta1StorageMap,
+} from '@kubev2v/types';
+import { getName } from '@utils/crds/common/selectors';
+import { getPlanNetworkMapName, getPlanStorageMapName } from '@utils/crds/plans/selectors';
+import { isEmpty } from '@utils/helpers';
+
+type UsePlanMappingDataOptions = {
+  plan: V1beta1Plan;
+  networkMaps: V1beta1NetworkMap[];
+  storageMaps: V1beta1StorageMap[];
+  providerStorages: InventoryStorage[];
+  providerNetworks: InventoryNetwork[];
+  sourceProvider?: V1beta1Provider;
+};
+
+/**
+ * Returns source storage/network data with fallback to map references
+ * when provider inventory is unavailable.
+ */
+export const usePlanMappingData = ({
+  networkMaps,
+  plan,
+  providerNetworks,
+  providerStorages,
+  sourceProvider,
+  storageMaps,
+}: UsePlanMappingDataOptions) => {
+  const planNetworkMap = useMemo(
+    () => networkMaps.find((map) => getName(map) === getPlanNetworkMapName(plan)),
+    [networkMaps, plan],
+  );
+
+  const planStorageMap = useMemo(
+    () => storageMaps.find((map) => getName(map) === getPlanStorageMapName(plan)),
+    [storageMaps, plan],
+  );
+
+  const sourceStorages = useMemo(() => {
+    if (!isEmpty(providerStorages)) return providerStorages;
+
+    return (planStorageMap?.status?.references ?? []).map((ref) => ({
+      id: ref.id ?? '',
+      name: ref.name ?? '',
+      providerType: sourceProvider?.spec?.type,
+    })) as InventoryStorage[];
+  }, [providerStorages, planStorageMap, sourceProvider]);
+
+  const sourceNetworks = useMemo(() => {
+    if (!isEmpty(providerNetworks)) return providerNetworks;
+
+    return (planNetworkMap?.status?.references ?? []).map((ref) => ({
+      id: ref.id ?? '',
+      name: ref.name ?? '',
+      providerType: sourceProvider?.spec?.type,
+    })) as InventoryNetwork[];
+  }, [providerNetworks, planNetworkMap, sourceProvider]);
+
+  return {
+    planNetworkMap,
+    planStorageMap,
+    sourceNetworks,
+    sourceStorages,
+  };
+};


### PR DESCRIPTION
## 📝 Links
https://issues.redhat.com/browse/MTV-3311

## 📝 Description
Created a fallback data hook that uses map status references when provider inventory is unavailable due to connectivity issues. This ensures plan mapping UIs remain functional even when the source provider is disconnected, resolving empty dropdowns.

**NOTE:** Ideally we fix this by replacing this plan details page with react-hook-form and FieldBuilder, but that would be overkill to fix this problem, so I consider this a temporary fix till that tech debt is addressed. Also, the editing of plan details pages like this is being redesigned to be edited in modals soon, so there's that too.

## 🎥 Demo
#### Before
<img width="1440" height="713" alt="image" src="https://github.com/user-attachments/assets/841ee8e6-2494-49e9-b267-79a34cb5a31a" />

#### After
<img width="1440" height="713" alt="image" src="https://github.com/user-attachments/assets/cf39acd5-4d05-4285-860c-b4631ebe08b4" />
