### PR TITLE
Resolves: MTV-3987 | Add E2E tests for plan wizard-details consistency

### DIFF
--- a/src/plans/create/utils/getDefaultFormValues.ts
+++ b/src/plans/create/utils/getDefaultFormValues.ts
@@ -46,6 +46,7 @@ export const getDefaultFormValues = (
     [NetworkMapFieldId.NetworkMapType]: NetworkMapType.Existing,
     [OtherSettingsFormFieldId.DiskDecryptionPassPhrases]: [defaultDiskPassPhrase],
     [OtherSettingsFormFieldId.MigrateSharedDisks]: true,
+    [OtherSettingsFormFieldId.PreserveStaticIps]: true,
     [OtherSettingsFormFieldId.TargetPowerState]: defaultTargetPowerStateOption,
     [StorageMapFieldId.StorageMap]: [defaultStorageMapping],
     [VmFormFieldId.Vms]: defaultVms,

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -151,12 +151,12 @@ export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
 
   const conditions = getConditions(plan);
 
-  if (isEmpty(conditions)) {
-    return PlanStatuses.Unknown;
-  }
-
   if (plan?.spec?.archived || conditions.includes(PlanStatuses.Archived)) {
     return PlanStatuses.Archived;
+  }
+
+  if (isEmpty(conditions)) {
+    return PlanStatuses.Unknown;
   }
 
   if (conditions.includes(CATEGORY_TYPES.SUCCEEDED)) {

--- a/testing/playwright/e2e/downstream/plans/plan-add-virtual-machines.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-add-virtual-machines.spec.ts
@@ -13,7 +13,7 @@ test.describe('Plan Details - Add Virtual Machines', { tag: '@downstream' }, () 
     createCustomPlan,
     resourceManager,
   }) => {
-    test.setTimeout(120_000);
+    test.setTimeout(180_000);
     const testPlan = await createCustomPlan({
       virtualMachines: [{ folder: 'vm' }],
       criticalIssuesAction: 'confirm',

--- a/testing/playwright/e2e/downstream/plans/plan-additional-settings.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-additional-settings.spec.ts
@@ -259,7 +259,7 @@ test.describe('Plan additional settings', { tag: '@downstream' }, () => {
 test.describe('Plan additional settings - PR #2292', { tag: '@downstream' }, () => {
   requireVersion(test, V2_12_0);
 
-  test('should edit preserve static IPs from details page', async ({
+  test('should edit preserve static IPs and shared disks from details page', async ({
     page,
     testProvider,
     resourceManager,
@@ -276,84 +276,47 @@ test.describe('Plan additional settings - PR #2292', { tag: '@downstream' }, () 
       await wizard.fillAndSubmit(testData);
     });
 
-    const planDetailsPage = new PlanDetailsPage(page);
+    const { detailsTab } = new PlanDetailsPage(page);
+    await detailsTab.navigateToDetailsTab();
 
-    await test.step('Verify initial state on details page (default is enabled for vSphere)', async () => {
-      await planDetailsPage.detailsTab.navigateToDetailsTab();
-      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
+    await test.step('Verify preserve static IPs default is enabled (vSphere)', async () => {
+      await detailsTab.verifyPreserveStaticIPs(true);
     });
 
-    await test.step('Open edit modal and disable preserve static IPs', async () => {
-      await planDetailsPage.detailsTab.clickEditPreserveStaticIPs();
-      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).toBeChecked();
-      await planDetailsPage.detailsTab.preserveStaticIPsCheckbox.uncheck();
-      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).not.toBeChecked();
-      await planDetailsPage.detailsTab.savePreserveStaticIPs();
-    });
-
-    await test.step('Verify preserve static IPs is now disabled', async () => {
-      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(false);
+    await test.step('Disable preserve static IPs', async () => {
+      await detailsTab.clickEditPreserveStaticIPs();
+      await expect(detailsTab.preserveStaticIPsCheckbox).toBeChecked();
+      await detailsTab.preserveStaticIPsCheckbox.uncheck();
+      await expect(detailsTab.preserveStaticIPsCheckbox).not.toBeChecked();
+      await detailsTab.savePreserveStaticIPs();
+      await detailsTab.verifyPreserveStaticIPs(false);
     });
 
     await test.step('Re-enable preserve static IPs', async () => {
-      await planDetailsPage.detailsTab.clickEditPreserveStaticIPs();
-      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).not.toBeChecked();
-      await planDetailsPage.detailsTab.preserveStaticIPsCheckbox.check();
-      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).toBeChecked();
-      await planDetailsPage.detailsTab.savePreserveStaticIPs();
+      await detailsTab.clickEditPreserveStaticIPs();
+      await detailsTab.preserveStaticIPsCheckbox.check();
+      await expect(detailsTab.preserveStaticIPsCheckbox).toBeChecked();
+      await detailsTab.savePreserveStaticIPs();
+      await detailsTab.verifyPreserveStaticIPs(true);
     });
 
-    await test.step('Verify preserve static IPs is now enabled again', async () => {
-      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
-    });
-  });
-
-  test('should edit shared disks from details page', async ({
-    page,
-    testProvider,
-    resourceManager,
-  }) => {
-    const testData: PlanTestData = createPlanTestData({
-      sourceProvider: testProvider?.metadata?.name ?? '',
-    });
-    resourceManager.addPlan(testData.planName, testData.planProject);
-
-    await test.step('Create plan via wizard', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
-      await wizard.navigate();
-      await wizard.waitForWizardLoad();
-      await wizard.fillAndSubmit(testData);
-    });
-
-    const planDetailsPage = new PlanDetailsPage(page);
-
-    await test.step('Navigate to details tab', async () => {
-      await planDetailsPage.detailsTab.navigateToDetailsTab();
-    });
-
-    await test.step('Open edit modal and enable shared disks migration', async () => {
-      await planDetailsPage.detailsTab.clickEditMigrateSharedDisks();
-      await planDetailsPage.detailsTab.migrateSharedDisksCheckbox.check();
-      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).toBeChecked();
-      await expect(planDetailsPage.detailsTab.sharedDisksInfoAlert).toBeVisible();
-      await planDetailsPage.detailsTab.saveMigrateSharedDisks();
-    });
-
-    await test.step('Verify shared disks migration is enabled', async () => {
-      await planDetailsPage.detailsTab.verifySharedDisks(true);
+    await test.step('Enable shared disks migration', async () => {
+      await detailsTab.clickEditMigrateSharedDisks();
+      await detailsTab.migrateSharedDisksCheckbox.check();
+      await expect(detailsTab.migrateSharedDisksCheckbox).toBeChecked();
+      await expect(detailsTab.sharedDisksInfoAlert).toBeVisible();
+      await detailsTab.saveMigrateSharedDisks();
+      await detailsTab.verifySharedDisks(true);
     });
 
     await test.step('Disable shared disks migration', async () => {
-      await planDetailsPage.detailsTab.clickEditMigrateSharedDisks();
-      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).toBeChecked();
-      await planDetailsPage.detailsTab.migrateSharedDisksCheckbox.uncheck();
-      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).not.toBeChecked();
-      await expect(planDetailsPage.detailsTab.sharedDisksInfoAlert).not.toBeVisible();
-      await planDetailsPage.detailsTab.saveMigrateSharedDisks();
-    });
-
-    await test.step('Verify shared disks migration is disabled', async () => {
-      await planDetailsPage.detailsTab.verifySharedDisks(false);
+      await detailsTab.clickEditMigrateSharedDisks();
+      await expect(detailsTab.migrateSharedDisksCheckbox).toBeChecked();
+      await detailsTab.migrateSharedDisksCheckbox.uncheck();
+      await expect(detailsTab.migrateSharedDisksCheckbox).not.toBeChecked();
+      await expect(detailsTab.sharedDisksInfoAlert).not.toBeVisible();
+      await detailsTab.saveMigrateSharedDisks();
+      await detailsTab.verifySharedDisks(false);
     });
   });
 
@@ -376,36 +339,30 @@ test.describe('Plan additional settings - PR #2292', { tag: '@downstream' }, () 
     });
     resourceManager.addPlan(testData.planName, testData.planProject);
 
-    await test.step('Navigate to Migration Type step in wizard', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
-      await wizard.navigate();
-      await wizard.waitForWizardLoad();
-      await wizard.navigateToMigrationTypeStep(testData);
-      await wizard.migrationType.verifyStepVisible();
-    });
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await wizard.navigate();
+    await wizard.waitForWizardLoad();
+    await wizard.navigateToMigrationTypeStep(testData);
 
-    await test.step('Verify cold migration is selected by default with no warning', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await test.step('Verify cold migration is default with no VDDK warning', async () => {
+      await wizard.migrationType.verifyStepVisible();
       await expect(wizard.migrationType.coldMigrationRadio).toBeChecked();
       await expect(wizard.migrationType.vddkWarningAlert).not.toBeVisible();
     });
 
     await test.step('Select warm migration and verify VDDK warning appears', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
       await wizard.migrationType.selectMigrationType(MigrationType.WARM);
       await expect(wizard.migrationType.warmMigrationRadio).toBeChecked();
       await expect(wizard.migrationType.vddkWarningAlert).toBeVisible();
     });
 
-    await test.step('Switch back to cold migration and verify warning disappears', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await test.step('Switch back to cold and verify warning disappears', async () => {
       await wizard.migrationType.selectMigrationType(MigrationType.COLD);
       await expect(wizard.migrationType.coldMigrationRadio).toBeChecked();
       await expect(wizard.migrationType.vddkWarningAlert).not.toBeVisible();
     });
 
     await test.step('Create the plan', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
       await wizard.clickNext();
       await wizard.clickSkipToReview();
       await wizard.review.verifyReviewStep(testData);
@@ -413,41 +370,34 @@ test.describe('Plan additional settings - PR #2292', { tag: '@downstream' }, () 
       await wizard.waitForPlanCreation();
     });
 
-    const planDetailsPage = new PlanDetailsPage(page);
+    const { detailsTab } = new PlanDetailsPage(page);
 
-    await test.step('Navigate to Details tab on plan details page', async () => {
-      await planDetailsPage.detailsTab.navigateToDetailsTab();
-      await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.COLD);
+    await test.step('Verify cold migration on details page', async () => {
+      await detailsTab.navigateToDetailsTab();
+      await detailsTab.verifyMigrationType(MigrationType.COLD);
     });
 
-    await test.step('Edit migration type to warm and verify VDDK warning appears', async () => {
-      await planDetailsPage.detailsTab.clickEditMigrationType();
-      await expect(planDetailsPage.detailsTab.editMigrationTypeModal).toBeVisible();
-      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
-      await planDetailsPage.detailsTab.selectMigrationType(MigrationType.WARM);
-      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
-      await expect(planDetailsPage.detailsTab.vddkWarningAlert).toBeVisible();
+    await test.step('Edit to warm and verify VDDK warning in modal', async () => {
+      await detailsTab.clickEditMigrationType();
+      await expect(detailsTab.editMigrationTypeModal).toBeVisible();
+      await expect(detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
+      await detailsTab.selectMigrationType(MigrationType.WARM);
+      await expect(detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
+      await expect(detailsTab.vddkWarningAlert).toBeVisible();
     });
 
-    await test.step('Switch back to cold migration and verify warning disappears', async () => {
-      await planDetailsPage.detailsTab.selectMigrationType(MigrationType.COLD);
-      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
-      await expect(planDetailsPage.detailsTab.vddkWarningAlert).not.toBeVisible();
+    await test.step('Switch to cold and verify warning clears', async () => {
+      await detailsTab.selectMigrationType(MigrationType.COLD);
+      await expect(detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
+      await expect(detailsTab.vddkWarningAlert).not.toBeVisible();
     });
 
-    await test.step('Switch to warm migration again and verify warning reappears', async () => {
-      await planDetailsPage.detailsTab.selectMigrationType(MigrationType.WARM);
-      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
-      await expect(planDetailsPage.detailsTab.vddkWarningAlert).toBeVisible();
-    });
-
-    await test.step('Save the migration type change', async () => {
-      await planDetailsPage.detailsTab.saveMigrationTypeButton.click();
-      await expect(planDetailsPage.detailsTab.editMigrationTypeModal).not.toBeVisible();
-    });
-
-    await test.step('Verify migration type is now warm', async () => {
-      await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.WARM);
+    await test.step('Save warm migration and verify', async () => {
+      await detailsTab.selectMigrationType(MigrationType.WARM);
+      await expect(detailsTab.vddkWarningAlert).toBeVisible();
+      await detailsTab.saveMigrationTypeButton.click();
+      await expect(detailsTab.editMigrationTypeModal).not.toBeVisible();
+      await detailsTab.verifyMigrationType(MigrationType.WARM);
     });
   });
 });

--- a/testing/playwright/e2e/downstream/plans/plan-additional-settings.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-additional-settings.spec.ts
@@ -5,7 +5,7 @@ import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/Cre
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
 import { MigrationType } from '../../../types/enums';
 import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_11_0, V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe('Plan additional settings', { tag: '@downstream' }, () => {
@@ -254,6 +254,108 @@ test.describe('Plan additional settings', { tag: '@downstream' }, () => {
     await planDetailsPage.detailsTab.saveDiskDecryptionButton.click();
     await expect(planDetailsPage.detailsTab.editDiskDecryptionModal).not.toBeVisible();
   });
+});
+
+test.describe('Plan additional settings - PR #2292', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_12_0);
+
+  test('should edit preserve static IPs from details page', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    await test.step('Create plan via wizard', async () => {
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.fillAndSubmit(testData);
+    });
+
+    const planDetailsPage = new PlanDetailsPage(page);
+
+    await test.step('Verify initial state on details page (default is enabled for vSphere)', async () => {
+      await planDetailsPage.detailsTab.navigateToDetailsTab();
+      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
+    });
+
+    await test.step('Open edit modal and disable preserve static IPs', async () => {
+      await planDetailsPage.detailsTab.clickEditPreserveStaticIPs();
+      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).toBeChecked();
+      await planDetailsPage.detailsTab.preserveStaticIPsCheckbox.uncheck();
+      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).not.toBeChecked();
+      await planDetailsPage.detailsTab.savePreserveStaticIPs();
+    });
+
+    await test.step('Verify preserve static IPs is now disabled', async () => {
+      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(false);
+    });
+
+    await test.step('Re-enable preserve static IPs', async () => {
+      await planDetailsPage.detailsTab.clickEditPreserveStaticIPs();
+      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).not.toBeChecked();
+      await planDetailsPage.detailsTab.preserveStaticIPsCheckbox.check();
+      await expect(planDetailsPage.detailsTab.preserveStaticIPsCheckbox).toBeChecked();
+      await planDetailsPage.detailsTab.savePreserveStaticIPs();
+    });
+
+    await test.step('Verify preserve static IPs is now enabled again', async () => {
+      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
+    });
+  });
+
+  test('should edit shared disks from details page', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    await test.step('Create plan via wizard', async () => {
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.fillAndSubmit(testData);
+    });
+
+    const planDetailsPage = new PlanDetailsPage(page);
+
+    await test.step('Navigate to details tab', async () => {
+      await planDetailsPage.detailsTab.navigateToDetailsTab();
+    });
+
+    await test.step('Open edit modal and enable shared disks migration', async () => {
+      await planDetailsPage.detailsTab.clickEditMigrateSharedDisks();
+      await planDetailsPage.detailsTab.migrateSharedDisksCheckbox.check();
+      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).toBeChecked();
+      await expect(planDetailsPage.detailsTab.sharedDisksInfoAlert).toBeVisible();
+      await planDetailsPage.detailsTab.saveMigrateSharedDisks();
+    });
+
+    await test.step('Verify shared disks migration is enabled', async () => {
+      await planDetailsPage.detailsTab.verifySharedDisks(true);
+    });
+
+    await test.step('Disable shared disks migration', async () => {
+      await planDetailsPage.detailsTab.clickEditMigrateSharedDisks();
+      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).toBeChecked();
+      await planDetailsPage.detailsTab.migrateSharedDisksCheckbox.uncheck();
+      await expect(planDetailsPage.detailsTab.migrateSharedDisksCheckbox).not.toBeChecked();
+      await expect(planDetailsPage.detailsTab.sharedDisksInfoAlert).not.toBeVisible();
+      await planDetailsPage.detailsTab.saveMigrateSharedDisks();
+    });
+
+    await test.step('Verify shared disks migration is disabled', async () => {
+      await planDetailsPage.detailsTab.verifySharedDisks(false);
+    });
+  });
 
   test('should show validation error when selecting warm migration with provider without VDDK', async ({
     page,
@@ -327,13 +429,13 @@ test.describe('Plan additional settings', { tag: '@downstream' }, () => {
       await expect(planDetailsPage.detailsTab.vddkWarningAlert).toBeVisible();
     });
 
-    await test.step('Toggle back to cold migration and verify warning disappears', async () => {
+    await test.step('Switch back to cold migration and verify warning disappears', async () => {
       await planDetailsPage.detailsTab.selectMigrationType(MigrationType.COLD);
       await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
       await expect(planDetailsPage.detailsTab.vddkWarningAlert).not.toBeVisible();
     });
 
-    await test.step('Toggle to warm migration again and verify warning reappears', async () => {
+    await test.step('Switch to warm migration again and verify warning reappears', async () => {
       await planDetailsPage.detailsTab.selectMigrationType(MigrationType.WARM);
       await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
       await expect(planDetailsPage.detailsTab.vddkWarningAlert).toBeVisible();

--- a/testing/playwright/e2e/downstream/plans/plan-migration-type-provider-gating.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-migration-type-provider-gating.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+
+import { sharedProviderCustomPlanFixtures as test } from '../../../fixtures/resourceFixtures';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { V2_12_0 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+test.describe('Plan Details - Migration Type Provider Gating', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_12_0);
+
+  test('should only show Cold and Warm options for vSphere provider', async ({
+    page,
+    createCustomPlan,
+    testProvider: _testProvider,
+  }) => {
+    await createCustomPlan();
+
+    const planDetailsPage = new PlanDetailsPage(page);
+    await planDetailsPage.detailsTab.navigateToDetailsTab();
+
+    await test.step('Open edit migration type modal', async () => {
+      await planDetailsPage.detailsTab.clickEditMigrationType();
+      await expect(planDetailsPage.detailsTab.editMigrationTypeModal).toBeVisible();
+    });
+
+    await test.step('Verify Cold and Warm radios are visible', async () => {
+      await expect(planDetailsPage.detailsTab.coldMigrationRadio).toBeVisible();
+      await expect(planDetailsPage.detailsTab.warmMigrationRadio).toBeVisible();
+    });
+
+    await test.step('Verify Live migration radio is NOT visible for vSphere', async () => {
+      await expect(planDetailsPage.detailsTab.liveMigrationRadio).not.toBeVisible();
+    });
+  });
+});

--- a/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
@@ -1,18 +1,19 @@
+import { expect } from '@playwright/test';
+
 import { sharedProviderCustomPlanFixtures as test } from '../../../fixtures/resourceFixtures';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
 import { MigrationType } from '../../../types/enums';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
-  requireVersion(test, V2_11_0);
+  requireVersion(test, V2_12_0);
 
   test('should edit migration type', async ({
     page,
     createCustomPlan,
     testProvider: _testProvider,
   }) => {
-    // Create a plan with warm migration type (already navigates to plan details page)
     await createCustomPlan({ migrationType: MigrationType.WARM });
 
     const planDetailsPage = new PlanDetailsPage(page);
@@ -22,9 +23,17 @@ test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
       await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.WARM);
     });
 
-    await test.step('Edit migration type from warm to cold', async () => {
+    await test.step('Open edit modal and verify radio buttons', async () => {
       await planDetailsPage.detailsTab.clickEditMigrationType();
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeVisible();
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeVisible();
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).not.toBeChecked();
+    });
+
+    await test.step('Select cold migration and save', async () => {
       await planDetailsPage.detailsTab.selectMigrationType(MigrationType.COLD);
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
       await planDetailsPage.detailsTab.saveMigrationType();
     });
 
@@ -32,9 +41,11 @@ test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
       await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.COLD);
     });
 
-    await test.step('Edit migration type from cold back to warm', async () => {
+    await test.step('Edit back to warm migration', async () => {
       await planDetailsPage.detailsTab.clickEditMigrationType();
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeChecked();
       await planDetailsPage.detailsTab.selectMigrationType(MigrationType.WARM);
+      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
       await planDetailsPage.detailsTab.saveMigrationType();
     });
 

--- a/testing/playwright/e2e/downstream/plans/plan-wizard-details-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-wizard-details-consistency.spec.ts
@@ -1,0 +1,139 @@
+import { expect } from '@playwright/test';
+
+import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
+import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { MigrationType } from '../../../types/enums';
+import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
+import { V2_12_0 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+test.describe('Plan Wizard-Details Consistency', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_12_0);
+
+  test('should verify warm migration type in review step matches details page', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+      migrationType: MigrationType.WARM,
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await wizard.navigate();
+    await wizard.waitForWizardLoad();
+
+    await test.step('Navigate to Migration Type step and select Warm', async () => {
+      await wizard.navigateToMigrationTypeStep(testData);
+      await wizard.migrationType.verifyStepVisible();
+      await wizard.migrationType.selectMigrationType(MigrationType.WARM);
+      await expect(wizard.migrationType.warmMigrationRadio).toBeChecked();
+    });
+
+    await test.step('Skip to Review and verify migration type value', async () => {
+      await wizard.clickSkipToReview();
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifyMigrationTypeValue('Warm migration');
+    });
+
+    await test.step('Create the plan', async () => {
+      await wizard.clickNext();
+      await wizard.waitForPlanCreation();
+    });
+
+    await test.step('Verify migration type on details page matches review', async () => {
+      const planDetailsPage = new PlanDetailsPage(page);
+      await planDetailsPage.detailsTab.navigateToDetailsTab();
+      await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.WARM);
+    });
+  });
+
+  test('should verify preserve static IPs default in review step matches details page', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await wizard.navigate();
+    await wizard.waitForWizardLoad();
+
+    await test.step('Navigate through wizard to review step', async () => {
+      await wizard.generalInformation.fillAndComplete(testData);
+      await wizard.clickNext();
+      await wizard.virtualMachines.fillAndComplete(testData.virtualMachines);
+      await wizard.clickNext();
+      await wizard.networkMap.fillAndComplete(testData.networkMap);
+      await wizard.clickNext();
+      await wizard.storageMap.fillAndComplete(testData.storageMap);
+      await wizard.clickNext();
+      await wizard.clickSkipToReview();
+    });
+
+    await test.step('Verify preserve static IPs is Enabled in review (vSphere default)', async () => {
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifyPreserveStaticIPs(true);
+    });
+
+    await test.step('Create the plan', async () => {
+      await wizard.clickNext();
+      await wizard.waitForPlanCreation();
+    });
+
+    await test.step('Verify preserve static IPs on details page matches review', async () => {
+      const planDetailsPage = new PlanDetailsPage(page);
+      await planDetailsPage.detailsTab.navigateToDetailsTab();
+      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
+    });
+  });
+
+  test('should verify shared disks default in review step matches details page', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await wizard.navigate();
+    await wizard.waitForWizardLoad();
+
+    await test.step('Navigate through wizard to review step', async () => {
+      await wizard.generalInformation.fillAndComplete(testData);
+      await wizard.clickNext();
+      await wizard.virtualMachines.fillAndComplete(testData.virtualMachines);
+      await wizard.clickNext();
+      await wizard.networkMap.fillAndComplete(testData.networkMap);
+      await wizard.clickNext();
+      await wizard.storageMap.fillAndComplete(testData.storageMap);
+      await wizard.clickNext();
+      await wizard.clickSkipToReview();
+    });
+
+    await test.step('Verify shared disks is Enabled in review (default)', async () => {
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifySharedDisks(true);
+    });
+
+    await test.step('Create the plan', async () => {
+      await wizard.clickNext();
+      await wizard.waitForPlanCreation();
+    });
+
+    await test.step('Verify shared disks on details page matches review', async () => {
+      const planDetailsPage = new PlanDetailsPage(page);
+      await planDetailsPage.detailsTab.navigateToDetailsTab();
+      await planDetailsPage.detailsTab.verifySharedDisks(true);
+    });
+  });
+});

--- a/testing/playwright/e2e/downstream/plans/plan-wizard-details-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-wizard-details-consistency.spec.ts
@@ -39,19 +39,16 @@ test.describe('Plan Wizard-Details Consistency', { tag: '@downstream' }, () => {
       await wizard.review.verifyMigrationTypeValue('Warm migration');
     });
 
-    await test.step('Create the plan', async () => {
+    await test.step('Create plan and verify details page', async () => {
       await wizard.clickNext();
       await wizard.waitForPlanCreation();
-    });
-
-    await test.step('Verify migration type on details page matches review', async () => {
       const planDetailsPage = new PlanDetailsPage(page);
       await planDetailsPage.detailsTab.navigateToDetailsTab();
       await planDetailsPage.detailsTab.verifyMigrationType(MigrationType.WARM);
     });
   });
 
-  test('should verify preserve static IPs default in review step matches details page', async ({
+  test('should verify default settings in review step match details page', async ({
     page,
     testProvider,
     resourceManager,
@@ -64,75 +61,21 @@ test.describe('Plan Wizard-Details Consistency', { tag: '@downstream' }, () => {
     const wizard = new CreatePlanWizardPage(page, resourceManager);
     await wizard.navigate();
     await wizard.waitForWizardLoad();
+    await wizard.navigateToMigrationTypeStep(testData);
+    await wizard.clickSkipToReview();
 
-    await test.step('Navigate through wizard to review step', async () => {
-      await wizard.generalInformation.fillAndComplete(testData);
-      await wizard.clickNext();
-      await wizard.virtualMachines.fillAndComplete(testData.virtualMachines);
-      await wizard.clickNext();
-      await wizard.networkMap.fillAndComplete(testData.networkMap);
-      await wizard.clickNext();
-      await wizard.storageMap.fillAndComplete(testData.storageMap);
-      await wizard.clickNext();
-      await wizard.clickSkipToReview();
-    });
-
-    await test.step('Verify preserve static IPs is Enabled in review (vSphere default)', async () => {
+    await test.step('Verify default values in review step (vSphere)', async () => {
       await wizard.review.verifyStepVisible();
       await wizard.review.verifyPreserveStaticIPs(true);
-    });
-
-    await test.step('Create the plan', async () => {
-      await wizard.clickNext();
-      await wizard.waitForPlanCreation();
-    });
-
-    await test.step('Verify preserve static IPs on details page matches review', async () => {
-      const planDetailsPage = new PlanDetailsPage(page);
-      await planDetailsPage.detailsTab.navigateToDetailsTab();
-      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
-    });
-  });
-
-  test('should verify shared disks default in review step matches details page', async ({
-    page,
-    testProvider,
-    resourceManager,
-  }) => {
-    const testData: PlanTestData = createPlanTestData({
-      sourceProvider: testProvider?.metadata?.name ?? '',
-    });
-    resourceManager.addPlan(testData.planName, testData.planProject);
-
-    const wizard = new CreatePlanWizardPage(page, resourceManager);
-    await wizard.navigate();
-    await wizard.waitForWizardLoad();
-
-    await test.step('Navigate through wizard to review step', async () => {
-      await wizard.generalInformation.fillAndComplete(testData);
-      await wizard.clickNext();
-      await wizard.virtualMachines.fillAndComplete(testData.virtualMachines);
-      await wizard.clickNext();
-      await wizard.networkMap.fillAndComplete(testData.networkMap);
-      await wizard.clickNext();
-      await wizard.storageMap.fillAndComplete(testData.storageMap);
-      await wizard.clickNext();
-      await wizard.clickSkipToReview();
-    });
-
-    await test.step('Verify shared disks is Enabled in review (default)', async () => {
-      await wizard.review.verifyStepVisible();
       await wizard.review.verifySharedDisks(true);
     });
 
-    await test.step('Create the plan', async () => {
+    await test.step('Create plan and verify details page matches review', async () => {
       await wizard.clickNext();
       await wizard.waitForPlanCreation();
-    });
-
-    await test.step('Verify shared disks on details page matches review', async () => {
       const planDetailsPage = new PlanDetailsPage(page);
       await planDetailsPage.detailsTab.navigateToDetailsTab();
+      await planDetailsPage.detailsTab.verifyPreserveStaticIPs(true);
       await planDetailsPage.detailsTab.verifySharedDisks(true);
     });
   });

--- a/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
@@ -33,6 +33,7 @@ test.describe('Provider Creation Tests', () => {
           tag: '@downstream',
         },
         async ({ page }) => {
+          test.setTimeout(240_000);
           if (minVersion) {
             requireVersion(test, minVersion);
           }

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/MigrationTypeStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/MigrationTypeStep.ts
@@ -6,11 +6,13 @@ import type { PlanTestData } from '../../../types/test-data';
 export class MigrationTypeStep {
   private readonly page: Page;
   readonly coldMigrationRadio: Locator;
+  readonly liveMigrationRadio: Locator;
   readonly warmMigrationRadio: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.coldMigrationRadio = page.getByTestId('migration-type-cold');
+    this.liveMigrationRadio = page.getByTestId('migration-type-live');
     this.warmMigrationRadio = page.getByTestId('migration-type-warm');
   }
 
@@ -29,6 +31,8 @@ export class MigrationTypeStep {
       await this.coldMigrationRadio.click();
     } else if (migrationType === MigrationType.WARM) {
       await this.warmMigrationRadio.click();
+    } else if (migrationType === MigrationType.LIVE) {
+      await this.liveMigrationRadio.click();
     }
   }
 

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -147,6 +147,10 @@ export class ReviewStep {
     await expect(this.page.getByTestId('review-migration-type')).toBeVisible();
   }
 
+  async verifyMigrationTypeValue(expectedLabel: string): Promise<void> {
+    await expect(this.page.getByTestId('review-migration-type')).toHaveText(expectedLabel);
+  }
+
   async verifyNetworkMapSection(expectedNetworkMap: NetworkMap): Promise<void> {
     const section = this.page.getByTestId('review-network-map-section');
     await expect(section).toBeVisible();
@@ -184,9 +188,19 @@ export class ReviewStep {
     }
   }
 
+  async verifyPreserveStaticIPs(enabled: boolean): Promise<void> {
+    const expected = enabled ? 'Enabled' : 'Disabled';
+    await expect(this.page.getByTestId('review-preserve-static-ips')).toHaveText(expected);
+  }
+
   async verifyReviewStep(planData: PlanTestData): Promise<void> {
     await this.verifyStepVisible();
     await this.verifyAllSections(planData);
+  }
+
+  async verifySharedDisks(enabled: boolean): Promise<void> {
+    const expected = enabled ? 'Enabled' : 'Disabled';
+    await expect(this.page.getByTestId('review-shared-disks')).toHaveText(expected);
   }
 
   async verifyStepVisible(): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
@@ -11,34 +11,57 @@ import { TargetNodeSelectorModal } from '../modals/TargetNodeSelectorModal';
 
 export class DetailsTab {
   readonly affinityModal: TargetAffinityModal;
+  readonly coldMigrationRadio: Locator;
   readonly descriptionTextbox: Locator;
   readonly editDescriptionModal: Locator;
   readonly editDiskDecryptionModal: Locator;
+  readonly editMigrateSharedDisksModal: Locator;
   readonly editMigrationTypeModal: Locator;
   readonly editPowerStateModal: Locator;
+  readonly editPreserveStaticIPsModal: Locator;
   readonly editSharedDisksCheckbox: Locator;
   readonly editSharedDisksModal: Locator;
   readonly guestConversionModal: GuestConversionModal;
   readonly labelsModal: TargetLabelsModal;
+  readonly liveMigrationRadio: Locator;
+  readonly migrateSharedDisksCheckbox: Locator;
   readonly nodeSelectorModal: TargetNodeSelectorModal;
   protected readonly page: Page;
   readonly powerStateOptionAuto: Locator;
   readonly powerStateOptionOff: Locator;
   readonly powerStateOptionOn: Locator;
+  readonly preserveStaticIPsCheckbox: Locator;
   readonly saveDescriptionButton: Locator;
   readonly saveDiskDecryptionButton: Locator;
+  readonly saveMigrateSharedDisksButton: Locator;
   readonly saveMigrationTypeButton: Locator;
   readonly savePowerStateButton: Locator;
+  readonly savePreserveStaticIPsButton: Locator;
   readonly saveSharedDisksButton: Locator;
   readonly targetPowerStateSelect: Locator;
   readonly useNbdeClevisCheckbox: Locator;
+  readonly warmMigrationRadio: Locator;
+
   constructor(page: Page) {
     this.page = page;
     this.editDescriptionModal = this.page.getByRole('dialog', { name: 'Edit description' });
     this.descriptionTextbox = this.editDescriptionModal.getByRole('textbox');
     this.saveDescriptionButton = this.editDescriptionModal.getByTestId('modal-confirm-button');
     this.editMigrationTypeModal = this.page.getByTestId('edit-migration-type-modal');
+    this.coldMigrationRadio = this.editMigrationTypeModal.getByTestId('migration-type-cold');
+    this.liveMigrationRadio = this.editMigrationTypeModal.getByTestId('migration-type-live');
+    this.warmMigrationRadio = this.editMigrationTypeModal.getByTestId('migration-type-warm');
     this.saveMigrationTypeButton = this.editMigrationTypeModal.getByTestId('modal-confirm-button');
+    this.editPreserveStaticIPsModal = this.page.getByRole('dialog', { name: 'Edit static IPs' });
+    this.preserveStaticIPsCheckbox = this.page.getByTestId('preserve-static-ips-checkbox');
+    this.savePreserveStaticIPsButton =
+      this.editPreserveStaticIPsModal.getByTestId('modal-confirm-button');
+    this.editMigrateSharedDisksModal = this.page.getByRole('dialog', {
+      name: 'Edit shared disks',
+    });
+    this.migrateSharedDisksCheckbox = this.page.getByTestId('migrate-shared-disks-checkbox');
+    this.saveMigrateSharedDisksButton =
+      this.editMigrateSharedDisksModal.getByTestId('modal-confirm-button');
     this.editPowerStateModal = this.page.getByTestId('edit-target-power-state-modal');
     this.savePowerStateButton = this.page.getByTestId('modal-confirm-button');
     this.targetPowerStateSelect = this.editPowerStateModal.getByTestId('target-power-state-select');
@@ -70,32 +93,38 @@ export class DetailsTab {
     await modal.waitForModalToOpen();
   }
 
+  private detailGroupByTitle(title: string): Locator {
+    return this.page.getByRole('term').filter({ hasText: title }).locator('..');
+  }
+
   private async verifyAffinityRulesCount(testId: string, count: number): Promise<void> {
-    const element = this.page.getByTestId(testId);
-    await expect(element).toContainText(`${count} affinity rule`);
+    await expect(this.page.getByTestId(testId)).toContainText(`${count} affinity rule`);
   }
 
   private async verifyDetailItemText(testId: string, expectedText: string): Promise<void> {
-    const text = this.page.getByTestId(testId).getByText(expectedText);
-    await expect(text).toBeVisible();
+    await expect(this.page.getByTestId(testId).getByText(expectedText)).toBeVisible();
   }
 
   private async verifyLabelsCount(testId: string, count: number): Promise<void> {
-    const element = this.page.getByTestId(testId);
+    const el = this.page.getByTestId(testId);
     if (count === 0) {
-      await expect(element).toContainText('No labels defined');
+      await expect(el).toContainText('No labels defined');
     } else {
-      await expect(element).not.toContainText('No labels defined');
+      await expect(el).not.toContainText('No labels defined');
     }
   }
 
   private async verifyNodeSelectorCount(testId: string, count: number): Promise<void> {
-    const element = this.page.getByTestId(testId);
+    const el = this.page.getByTestId(testId);
     if (count === 0) {
-      await expect(element).toContainText('No node selectors defined');
+      await expect(el).toContainText('No node selectors defined');
     } else {
-      await expect(element).not.toContainText('No node selectors defined');
+      await expect(el).not.toContainText('No node selectors defined');
     }
+  }
+
+  get cbtWarningAlert(): Locator {
+    return this.page.getByText('Must enable Changed Block Tracking (CBT) for warm migration');
   }
 
   async clickEditConvertorAffinity(): Promise<void> {
@@ -123,9 +152,19 @@ export class DetailsTab {
     await this.clickEditDetailItem('guest-conversion-mode-detail-item', this.guestConversionModal);
   }
 
+  async clickEditMigrateSharedDisks(): Promise<void> {
+    await this.detailGroupByTitle('Shared disks').locator('dd button').last().click();
+    await expect(this.editMigrateSharedDisksModal).toBeVisible();
+  }
+
   async clickEditMigrationType(): Promise<void> {
     await this.page.getByTestId('migration-type-detail-item').locator('button').click();
     await expect(this.editMigrationTypeModal).toBeVisible();
+  }
+
+  async clickEditPreserveStaticIPs(): Promise<void> {
+    await this.detailGroupByTitle('Preserve static IPs').locator('dd button').last().click();
+    await expect(this.editPreserveStaticIPsModal).toBeVisible();
   }
 
   async clickEditSharedDisks(): Promise<void> {
@@ -157,11 +196,8 @@ export class DetailsTab {
   }
 
   async getCurrentPlanStatus(): Promise<string> {
-    const statusElement = this.page
-      .getByTestId('status-detail-item')
-      .getByTestId('plan-status-label');
-    const statusText = await statusElement.textContent();
-    return statusText?.trim() ?? '';
+    const el = this.page.getByTestId('status-detail-item').getByTestId('plan-status-label');
+    return (await el.textContent())?.trim() ?? '';
   }
 
   migrationTypeRadio(type: MigrationType): Locator {
@@ -169,17 +205,12 @@ export class DetailsTab {
   }
 
   async navigateToDetailsTab(): Promise<void> {
-    const detailsTab = this.page.locator('[data-test-id="horizontal-link-Details"]');
-    await detailsTab.click();
+    await this.page.locator('[data-test-id="horizontal-link-Details"]').click();
   }
 
   powerStateOption(state: 'on' | 'off' | 'auto'): Locator {
-    const optionNames = {
-      auto: 'Retain source VM power state',
-      on: 'Powered on',
-      off: 'Powered off',
-    };
-    return this.page.getByRole('option', { name: optionNames[state], exact: true });
+    const names = { auto: 'Retain source VM power state', off: 'Powered off', on: 'Powered on' };
+    return this.page.getByRole('option', { name: names[state], exact: true });
   }
 
   async saveDescription(): Promise<void> {
@@ -187,13 +218,27 @@ export class DetailsTab {
     await expect(this.editDescriptionModal).not.toBeVisible();
   }
 
+  async saveMigrateSharedDisks(): Promise<void> {
+    await this.saveMigrateSharedDisksButton.click();
+    await expect(this.editMigrateSharedDisksModal).not.toBeVisible();
+  }
+
   async saveMigrationType(): Promise<void> {
     await this.saveMigrationTypeButton.click();
     await expect(this.editMigrationTypeModal).not.toBeVisible();
   }
 
+  async savePreserveStaticIPs(): Promise<void> {
+    await this.savePreserveStaticIPsButton.click();
+    await expect(this.editPreserveStaticIPsModal).not.toBeVisible();
+  }
+
   async selectMigrationType(type: MigrationType): Promise<void> {
     await this.migrationTypeRadio(type).click();
+  }
+
+  get sharedDisksInfoAlert(): Locator {
+    return this.page.getByText('This may slow down the migration process');
   }
 
   sharedDisksDetailItem(text: string): Locator {
@@ -201,9 +246,9 @@ export class DetailsTab {
   }
 
   targetVMPowerState(state: string): Locator {
-    return this.page
-      .getByTestId('target-vm-power-state-detail-item')
-      .getByText(state, { exact: true });
+    return this.page.getByTestId('target-vm-power-state-detail-item').getByText(state, {
+      exact: true,
+    });
   }
 
   get vddkWarningAlert(): Locator {
@@ -214,29 +259,28 @@ export class DetailsTab {
     await this.verifyAffinityRulesCount('convertor-affinity-rules-detail-item', count);
   }
 
-  async verifyConvertorAffinityText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('convertor-affinity-rules-detail-item', expectedText);
+  async verifyConvertorAffinityText(text: string): Promise<void> {
+    await this.verifyDetailItemText('convertor-affinity-rules-detail-item', text);
   }
 
   async verifyConvertorLabelsCount(count: number): Promise<void> {
     await this.verifyLabelsCount('convertor-labels-detail-item', count);
   }
 
-  async verifyConvertorLabelsText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('convertor-labels-detail-item', expectedText);
+  async verifyConvertorLabelsText(text: string): Promise<void> {
+    await this.verifyDetailItemText('convertor-labels-detail-item', text);
   }
 
   async verifyConvertorNodeSelectorCount(count: number): Promise<void> {
     await this.verifyNodeSelectorCount('convertor-node-selector-detail-item', count);
   }
 
-  async verifyConvertorNodeSelectorText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('convertor-node-selector-detail-item', expectedText);
+  async verifyConvertorNodeSelectorText(text: string): Promise<void> {
+    await this.verifyDetailItemText('convertor-node-selector-detail-item', text);
   }
 
-  async verifyDescriptionText(expectedText: string): Promise<void> {
-    const descriptionElement = this.page.getByTestId('description-detail-item');
-    await expect(descriptionElement).toContainText(expectedText);
+  async verifyDescriptionText(text: string): Promise<void> {
+    await expect(this.page.getByTestId('description-detail-item')).toContainText(text);
   }
 
   async verifyDetailsTab(planData: PlanTestData): Promise<void> {
@@ -244,14 +288,12 @@ export class DetailsTab {
     await this.verifyPlanDetails(planData);
   }
 
-  async verifyGuestConversionModeText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('guest-conversion-mode-detail-item', expectedText);
+  async verifyGuestConversionModeText(text: string): Promise<void> {
+    await this.verifyDetailItemText('guest-conversion-mode-detail-item', text);
   }
 
   async verifyGuestConversionModeTexts(texts: string[]): Promise<void> {
-    for (const text of texts) {
-      await this.verifyGuestConversionModeText(text);
-    }
+    for (const text of texts) await this.verifyGuestConversionModeText(text);
   }
 
   async verifyMigrationType(type: MigrationType): Promise<void> {
@@ -261,8 +303,7 @@ export class DetailsTab {
   }
 
   async verifyNavigationTabs(): Promise<void> {
-    const detailsTab = this.page.locator('[data-test-id="horizontal-link-Details"]');
-    await expect(detailsTab).toBeVisible();
+    await expect(this.page.locator('[data-test-id="horizontal-link-Details"]')).toBeVisible();
   }
 
   async verifyPlanDetails(planData: PlanTestData): Promise<void> {
@@ -275,23 +316,18 @@ export class DetailsTab {
     );
     await expect(this.page.getByTestId('created-at-detail-item')).toBeVisible();
     await expect(this.page.getByTestId('owner-detail-item')).toContainText('No owner');
-
     if (isVersionAtLeast(V2_11_0)) {
-      if (planData.description) {
-        await this.verifyDescriptionText(planData.description);
-      } else {
-        await this.verifyDescriptionText('None');
-      }
+      await this.verifyDescriptionText(planData.description ?? 'None');
     }
-
     if (planData.additionalPlanSettings?.targetPowerState) {
-      let powerState = 'Retain source VM power state';
-      if (planData.additionalPlanSettings.targetPowerState === 'on') {
-        powerState = 'Powered on';
-      } else if (planData.additionalPlanSettings.targetPowerState === 'off') {
-        powerState = 'Powered off';
-      }
-      await expect(this.targetVMPowerState(powerState)).toBeVisible();
+      const labels: Record<string, string> = {
+        auto: 'Retain source VM power state',
+        off: 'Powered off',
+        on: 'Powered on',
+      };
+      await expect(
+        this.targetVMPowerState(labels[planData.additionalPlanSettings.targetPowerState]),
+      ).toBeVisible();
     }
   }
 
@@ -299,37 +335,43 @@ export class DetailsTab {
     const statusLocator = this.page.getByTestId('status-detail-item');
 
     const expectFn = expect.configure({ soft });
-
     await expectFn(statusLocator).not.toContainText('Unknown', { timeout: 120000 });
-
     if (expectedStatus === 'Ready for migration') {
-      await expectFn(
-        this.page.getByTestId('status-detail-item').getByTestId('plan-start-button-status'),
-      ).toBeVisible();
+      await expectFn(statusLocator.getByTestId('plan-start-button-status')).toBeVisible();
     }
+  }
+
+  async verifyPreserveStaticIPs(enabled: boolean): Promise<void> {
+    const text = enabled ? 'Preserve static IPs' : 'Do not preserve static IPs';
+    await expect(this.detailGroupByTitle('Preserve static IPs')).toContainText(text);
+  }
+
+  async verifySharedDisks(migrate: boolean): Promise<void> {
+    const text = migrate ? 'Migrate shared disks' : 'Do not migrate shared disks';
+    await expect(this.detailGroupByTitle('Shared disks')).toContainText(text);
   }
 
   async verifyTargetAffinityRulesCount(count: number): Promise<void> {
     await this.verifyAffinityRulesCount('vm-target-affinity-rules-detail-item', count);
   }
 
-  async verifyTargetAffinityText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('vm-target-affinity-rules-detail-item', expectedText);
+  async verifyTargetAffinityText(text: string): Promise<void> {
+    await this.verifyDetailItemText('vm-target-affinity-rules-detail-item', text);
   }
 
   async verifyTargetLabelsCount(count: number): Promise<void> {
     await this.verifyLabelsCount('vm-target-labels-detail-item', count);
   }
 
-  async verifyTargetLabelsText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('vm-target-labels-detail-item', expectedText);
+  async verifyTargetLabelsText(text: string): Promise<void> {
+    await this.verifyDetailItemText('vm-target-labels-detail-item', text);
   }
 
   async verifyTargetNodeSelectorCount(count: number): Promise<void> {
     await this.verifyNodeSelectorCount('vm-target-node-selector-detail-item', count);
   }
 
-  async verifyTargetNodeSelectorText(expectedText: string): Promise<void> {
-    await this.verifyDetailItemText('vm-target-node-selector-detail-item', expectedText);
+  async verifyTargetNodeSelectorText(text: string): Promise<void> {
+    await this.verifyDetailItemText('vm-target-node-selector-detail-item', text);
   }
 }

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -252,7 +252,7 @@ export class VirtualMachinesTable {
   async testConcernButton(): Promise<boolean> {
     const concernButton = this.page.getByTestId(/^concern-badge-/).first();
 
-    if (!(await concernButton.isVisible())) {
+    if (!(await concernButton.isVisible().catch(() => false))) {
       return false;
     }
 

--- a/testing/playwright/types/enums.ts
+++ b/testing/playwright/types/enums.ts
@@ -1,5 +1,6 @@
 export enum MigrationType {
   COLD = 'cold',
+  LIVE = 'live',
   WARM = 'warm',
 }
 


### PR DESCRIPTION
## 📝 Links

https://issues.redhat.com/browse/MTV-3987

## 📝 Description

**New tests:**
- Wizard review step to details page consistency (migration type, preserve static IPs, shared disks)
- Migration type provider gating (Live hidden for vSphere)

**Fixes:**
- Update migration type tests from toggle switch to radio buttons
- Split version gating (V2_11_0 / V2_12_0) in additional settings tests
- Fix `getPlanStatus` archived check order
- Add `PreserveStaticIps` default to form values