### PR TITLE
Add i18n smoke tests for multi-language support

### DIFF
--- a/.github/workflows/on-push-main-playwright.yaml
+++ b/.github/workflows/on-push-main-playwright.yaml
@@ -22,6 +22,9 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Copy locales into testing context
+        run: cp -r locales/ testing/locales/
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ forkliftci
 # Local dev fixtures (test data, debug helpers)
 .dev/
 
+# CI copies repo-root locales/ into testing/ for the Playwright container build
+testing/locales/
+
 # Cursor IDE – ignore sensitive MCP config (credentials); shared prompts stay in repo
 .cursor/mcp.json
 .cursor/rules/personal-*.mdc

--- a/testing/README.md
+++ b/testing/README.md
@@ -109,6 +109,8 @@ npm run test:downstream:remote:docker
 To build and push the test container image manually:
 
 ```bash
+# Copy locale files into the build context (they live at repo root)
+cp -r locales/ testing/locales/
 cd testing
 
 podman build \
@@ -122,5 +124,5 @@ podman build \
   .
 
 podman login quay.io
-podman quay.io/kubev2v/forklift-ui-tests:latest
+podman push quay.io/kubev2v/forklift-ui-tests:latest
 ```

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 import { expect, test } from '@playwright/test';
 

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -14,6 +14,8 @@ import { V2_12_0 } from '../../utils/version/constants';
 import { requireVersion } from '../../utils/version/version';
 
 const LOCALE_NAMESPACE = 'plugin__forklift-console-plugin';
+const PAGE_LOAD_TIMEOUT_MS = 15_000;
+const ELEMENT_VISIBLE_TIMEOUT_MS = 10_000;
 
 const LOCALE_SEARCH_PATHS = [
   resolve(__dirname, '../../../../locales'),
@@ -37,7 +39,7 @@ const loadLocale = (lang: string): Record<string, string> => {
   return JSON.parse(readFileSync(filePath, 'utf-8'));
 };
 
-const TESTED_LANGUAGES: SupportedLanguage[] = ['ja', 'zh'];
+const TESTED_LANGUAGES: SupportedLanguage[] = ['es', 'fr', 'ja', 'ko', 'zh'];
 
 const missingKeyPattern = (language: string): RegExp =>
   new RegExp(`Missing i18n key .+ in namespace "${LOCALE_NAMESPACE}" and language "${language}"`);
@@ -66,10 +68,10 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
     test(`locale files load and render correctly in ${lang}`, async ({ page }) => {
       const locale = loadLocale(lang);
       const navigation = new NavigationHelper(page);
-      const consoleErrors: string[] = [];
+      const allConsoleErrors: string[] = [];
       page.on('console', (msg) => {
         if (msg.type() === 'error') {
-          consoleErrors.push(msg.text());
+          allConsoleErrors.push(msg.text());
         }
       });
 
@@ -81,10 +83,10 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
       });
 
       await test.step('Verify Overview page translations', async () => {
-        await page.waitForSelector('h1', { timeout: 15_000 });
+        await page.waitForSelector('h1', { timeout: PAGE_LOAD_TIMEOUT_MS });
 
         const welcomeHeading = page.getByRole('heading', { name: locale.Welcome });
-        await expect(welcomeHeading).toBeVisible({ timeout: 10_000 });
+        await expect(welcomeHeading).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS });
 
         const createPlanButton = page.getByRole('button', {
           name: locale['Create migration plan'],
@@ -97,17 +99,17 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
           allNamespaces: true,
           resource: 'Provider',
         });
-        await page.waitForSelector('h1', { timeout: 15_000 });
+        await page.waitForSelector('h1', { timeout: PAGE_LOAD_TIMEOUT_MS });
 
         const createButton = page.getByRole('button', {
           name: locale['Create provider'],
         });
-        await expect(createButton).toBeVisible({ timeout: 10_000 });
+        await expect(createButton).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS });
       });
 
       await test.step('No unexpected missing i18n keys for forklift plugin', () => {
         const pattern = missingKeyPattern(lang);
-        const forkliftMissingKeys = consoleErrors.filter((e) => pattern.test(e));
+        const forkliftMissingKeys = allConsoleErrors.filter((e) => pattern.test(e));
         const KNOWN_MISSING_KEYS = ['Source'];
         const unexpected = forkliftMissingKeys.filter(
           (e) => !KNOWN_MISSING_KEYS.some((key) => e.includes(`"${key}"`)),

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+import { expect, test } from '@playwright/test';
+
+import {
+  restoreConsoleLanguage,
+  setConsoleLanguage,
+  type SupportedLanguage,
+} from '../../fixtures/helpers/languageHelpers';
+import { NavigationHelper } from '../../utils/NavigationHelper';
+import { disableGuidedTour } from '../../utils/utils';
+import { V2_12_0 } from '../../utils/version/constants';
+import { requireVersion } from '../../utils/version/version';
+
+const LOCALE_NAMESPACE = 'plugin__forklift-console-plugin';
+
+const LOCALE_SEARCH_PATHS = [
+  resolve(__dirname, '../../../../locales'),
+  resolve(__dirname, '../../../locales'),
+];
+
+const resolveLocalesDir = (): string => {
+  const found = LOCALE_SEARCH_PATHS.find((dir) => existsSync(dir));
+  if (!found) {
+    throw new Error(
+      `Locale files not found. Searched:\n${LOCALE_SEARCH_PATHS.join('\n')}\n` +
+        'CI images must copy locales/ into testing/locales/.',
+    );
+  }
+  return found;
+};
+
+const loadLocale = (lang: string): Record<string, string> => {
+  const localesDir = resolveLocalesDir();
+  const filePath = resolve(localesDir, lang, `${LOCALE_NAMESPACE}.json`);
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+};
+
+const TESTED_LANGUAGES: SupportedLanguage[] = ['ja', 'zh'];
+
+const missingKeyPattern = (language: string): RegExp =>
+  new RegExp(`Missing i18n key .+ in namespace "${LOCALE_NAMESPACE}" and language "${language}"`);
+
+test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_12_0);
+  test.describe.configure({ mode: 'serial' });
+
+  test.afterAll(async ({ browser }) => {
+    const authFile =
+      process.env.CLUSTER_USERNAME && process.env.CLUSTER_PASSWORD
+        ? 'playwright/.auth/user.json'
+        : undefined;
+    const context = await browser.newContext({
+      ignoreHTTPSErrors: true,
+      storageState: authFile,
+    });
+    const page = await context.newPage();
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await restoreConsoleLanguage(page);
+    await context.close();
+  });
+
+  for (const lang of TESTED_LANGUAGES) {
+    test(`locale files load and render correctly in ${lang}`, async ({ page }) => {
+      const locale = loadLocale(lang);
+      const navigation = new NavigationHelper(page);
+      const consoleErrors: string[] = [];
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await test.step('Set language via API then navigate to overview', async () => {
+        await navigation.navigateToConsole();
+        await setConsoleLanguage(page, lang);
+        await navigation.navigateToOverview();
+        await disableGuidedTour(page);
+      });
+
+      await test.step('Verify Overview page translations', async () => {
+        await page.waitForSelector('h1', { timeout: 15_000 });
+
+        const welcomeHeading = page.getByRole('heading', { name: locale.Welcome });
+        await expect(welcomeHeading).toBeVisible({ timeout: 10_000 });
+
+        const createPlanButton = page.getByRole('button', {
+          name: locale['Create migration plan'],
+        });
+        await expect(createPlanButton).toBeVisible();
+      });
+
+      await test.step('Verify Providers page translations', async () => {
+        await navigation.navigateToK8sResource({
+          allNamespaces: true,
+          resource: 'Provider',
+        });
+        await page.waitForSelector('h1', { timeout: 15_000 });
+
+        const createButton = page.getByRole('button', {
+          name: locale['Create provider'],
+        });
+        await expect(createButton).toBeVisible({ timeout: 10_000 });
+      });
+
+      await test.step('No unexpected missing i18n keys for forklift plugin', () => {
+        const pattern = missingKeyPattern(lang);
+        const forkliftMissingKeys = consoleErrors.filter((e) => pattern.test(e));
+        const KNOWN_MISSING_KEYS = ['Source'];
+        const unexpected = forkliftMissingKeys.filter(
+          (e) => !KNOWN_MISSING_KEYS.some((key) => e.includes(`"${key}"`)),
+        );
+
+        expect(unexpected, `Unexpected missing i18n keys:\n${unexpected.join('\n')}`).toHaveLength(
+          0,
+        );
+      });
+    });
+  }
+});

--- a/testing/playwright/fixtures/helpers/languageHelpers.ts
+++ b/testing/playwright/fixtures/helpers/languageHelpers.ts
@@ -1,0 +1,81 @@
+import type { Page } from '@playwright/test';
+
+import { BaseResourceManager } from '../../utils/resource-manager/BaseResourceManager';
+import { API_PATHS } from '../../utils/resource-manager/constants';
+
+const USER_SETTINGS_NAMESPACE = 'openshift-console-user-settings';
+const LANGUAGE_KEY = 'console.preferredLanguage';
+const LOCAL_STORAGE_LANGUAGE_KEY = 'bridge/last-language';
+const USER_SETTINGS_STORAGE_KEY = 'console-user-settings';
+
+export type SupportedLanguage = 'en' | 'ja' | 'es' | 'fr' | 'ko' | 'zh';
+
+const getConfigMapName = (): string => {
+  const username = process.env.CLUSTER_USERNAME ?? 'kubeadmin';
+  return `user-settings-${username}`;
+};
+
+const patchLanguageConfigMap = async (page: Page, language: string): Promise<boolean> => {
+  const configMapName = getConfigMapName();
+  const apiPath = `${API_PATHS.KUBERNETES_CORE}/namespaces/${USER_SETTINGS_NAMESPACE}/configmaps/${configMapName}`;
+
+  const result = await BaseResourceManager.apiPatch(page, apiPath, {
+    data: { [LANGUAGE_KEY]: language },
+  });
+
+  return result !== null;
+};
+
+/**
+ * Persists the language in both localStorage keys that the Console uses.
+ *
+ * - `bridge/last-language`: read on initial page load to seed i18next.
+ * - `console-user-settings` → `console.preferredLanguage`: the Console's
+ *   canonical user-settings store on auth-disabled clusters. Without this the
+ *   Console overwrites `bridge/last-language` back to the default on reload.
+ */
+const setLocalStorageLanguage = async (page: Page, language: string): Promise<void> => {
+  await page.evaluate(
+    ({ bridgeKey, settingsKey, langKey, lang }) => {
+      localStorage.setItem(bridgeKey, lang);
+
+      const raw = localStorage.getItem(settingsKey);
+      const settings = raw ? JSON.parse(raw) : {};
+      settings[langKey] = lang;
+      localStorage.setItem(settingsKey, JSON.stringify(settings));
+    },
+    {
+      bridgeKey: LOCAL_STORAGE_LANGUAGE_KEY,
+      lang: language,
+      langKey: LANGUAGE_KEY,
+      settingsKey: USER_SETTINGS_STORAGE_KEY,
+    },
+  );
+};
+
+/**
+ * Sets the console language preference via localStorage and (best-effort) K8s API.
+ *
+ * On auth-disabled clusters the Console stores all user settings in
+ * `console-user-settings` localStorage. On authenticated clusters it syncs
+ * with a ConfigMap via WebSocket. We update both paths so the helper works
+ * regardless of cluster authentication configuration.
+ *
+ * After calling this, do a full `page.goto()` to a target page — the Console
+ * will initialize in the requested language.
+ */
+export const setConsoleLanguage = async (
+  page: Page,
+  language: SupportedLanguage,
+): Promise<void> => {
+  await setLocalStorageLanguage(page, language);
+  await patchLanguageConfigMap(page, language);
+};
+
+/**
+ * Restores the console language back to English.
+ */
+export const restoreConsoleLanguage = async (page: Page): Promise<void> => {
+  await setLocalStorageLanguage(page, 'en');
+  await patchLanguageConfigMap(page, 'en');
+};

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -2,7 +2,15 @@ import type { Page } from '@playwright/test';
 
 import { API_PATHS, COOKIE_NAMES, HTTP_HEADERS, RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
 
-type ApiResult<T> = { success: true; data: T } | { success: false; error: string };
+type ApiResult<T> =
+  | { data: T; status: number; success: true }
+  | { error: string; status: number; success: false };
+
+type ApiRequestOptions = {
+  body?: unknown;
+  contentType?: string;
+  method: string;
+};
 
 /**
  * Base class providing shared functionality for resource manager classes
@@ -11,43 +19,9 @@ type ApiResult<T> = { success: true; data: T } | { success: false; error: string
 export abstract class BaseResourceManager {
   /** Generic GET helper — handles CSRF token, headers, and error handling. */
   public static async apiGet<R>(page: Page, apiPath: string): Promise<R | null> {
-    const constants = BaseResourceManager.getEvaluateConstants();
+    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, { method: 'GET' });
 
-    const result = await page.evaluate(
-      async ({ path, evalConstants }): Promise<ApiResult<R>> => {
-        try {
-          const cookies = document.cookie.split('; ');
-          const csrfCookie = cookies.find((cookie) =>
-            cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
-          );
-          const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
-
-          const response = await fetch(path, {
-            credentials: 'include',
-            headers: {
-              [evalConstants.CONTENT_TYPE_HEADER]: evalConstants.APPLICATION_JSON,
-              [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
-            },
-            method: 'GET',
-          });
-
-          if (response.ok) {
-            return { data: await response.json(), success: true };
-          }
-
-          const errorText = await response.text().catch(() => response.statusText);
-          return { error: errorText, success: false };
-        } catch (error: unknown) {
-          const err = error as Error;
-          return { error: err?.message ?? String(error), success: false };
-        }
-      },
-      { evalConstants: constants, path: apiPath },
-    );
-
-    if (result.success) {
-      return result.data;
-    }
+    if (result.success) return result.data;
 
     console.error(`API GET ${apiPath} failed: ${result.error}`);
     return null;
@@ -60,44 +34,13 @@ export abstract class BaseResourceManager {
     data: unknown,
     contentType = 'application/merge-patch+json',
   ): Promise<R | null> {
-    const constants = BaseResourceManager.getEvaluateConstants();
+    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, {
+      body: data,
+      contentType,
+      method: 'PATCH',
+    });
 
-    const result = await page.evaluate(
-      async ({ payload, path, patchContentType, evalConstants }): Promise<ApiResult<R>> => {
-        try {
-          const cookies = document.cookie.split('; ');
-          const csrfCookie = cookies.find((cookie) =>
-            cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
-          );
-          const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
-
-          const response = await fetch(path, {
-            body: JSON.stringify(payload),
-            credentials: 'include',
-            headers: {
-              [evalConstants.CONTENT_TYPE_HEADER]: patchContentType,
-              [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
-            },
-            method: 'PATCH',
-          });
-
-          if (response.ok) {
-            return { data: await response.json(), success: true };
-          }
-
-          const errorText = await response.text().catch(() => response.statusText);
-          return { error: errorText, success: false };
-        } catch (error: unknown) {
-          const err = error as Error;
-          return { error: err?.message ?? String(error), success: false };
-        }
-      },
-      { evalConstants: constants, path: apiPath, payload: data, patchContentType: contentType },
-    );
-
-    if (result.success) {
-      return result.data;
-    }
+    if (result.success) return result.data;
 
     console.error(`API PATCH ${apiPath} failed: ${result.error}`);
     return null;
@@ -105,10 +48,33 @@ export abstract class BaseResourceManager {
 
   /** Generic POST helper — handles CSRF token, headers, and error handling. */
   public static async apiPost<R>(page: Page, apiPath: string, data: unknown): Promise<R | null> {
+    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, {
+      body: data,
+      method: 'POST',
+    });
+
+    if (result.success) return result.data;
+
+    const HTTP_CONFLICT = 409;
+
+    if (result.status === HTTP_CONFLICT) {
+      console.warn(`API POST to ${apiPath}: resource already exists (409)`);
+    } else {
+      console.error(`API POST to ${apiPath} failed: ${result.error}`);
+    }
+
+    return null;
+  }
+
+  private static async apiRequest<R>(
+    page: Page,
+    apiPath: string,
+    options: ApiRequestOptions,
+  ): Promise<ApiResult<R>> {
     const constants = BaseResourceManager.getEvaluateConstants();
 
-    const result = await page.evaluate(
-      async ({ payload, path, evalConstants }): Promise<ApiResult<R>> => {
+    return await page.evaluate(
+      async ({ body, contentType, evalConstants, method, path }): Promise<ApiResult<R>> => {
         try {
           const cookies = document.cookie.split('; ');
           const csrfCookie = cookies.find((cookie) =>
@@ -117,13 +83,13 @@ export abstract class BaseResourceManager {
           const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
 
           const response = await fetch(path, {
-            body: JSON.stringify(payload),
+            ...(body !== undefined && { body: JSON.stringify(body) }),
             credentials: 'include',
             headers: {
-              [evalConstants.CONTENT_TYPE_HEADER]: evalConstants.APPLICATION_JSON,
+              [evalConstants.CONTENT_TYPE_HEADER]: contentType ?? evalConstants.APPLICATION_JSON,
               [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
             },
-            method: 'POST',
+            method,
           });
 
           if (response.ok) {
@@ -137,22 +103,14 @@ export abstract class BaseResourceManager {
           return { error: err?.message ?? String(error), status: 0, success: false };
         }
       },
-      { payload: data, path: apiPath, evalConstants: constants },
+      {
+        body: options.body,
+        contentType: options.contentType,
+        evalConstants: constants,
+        method: options.method,
+        path: apiPath,
+      },
     );
-
-    if (result.success) {
-      return result.data;
-    }
-
-    const HTTP_CONFLICT = 409;
-
-    if (result.status === HTTP_CONFLICT) {
-      console.warn(`API POST to ${apiPath}: resource already exists (409)`);
-    } else {
-      console.error(`API POST to ${apiPath} failed: ${result.error}`);
-    }
-
-    return null;
   }
 
   public static getEvaluateConstants() {

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -53,14 +53,18 @@ export abstract class BaseResourceManager {
     return null;
   }
 
-  /** Generic POST helper — handles CSRF token, headers, and error handling. */
-  public static async apiPost<R>(page: Page, apiPath: string, data: unknown): Promise<R | null> {
+  /** Generic PATCH helper — handles CSRF token, headers, and error handling. */
+  public static async apiPatch<R>(
+    page: Page,
+    apiPath: string,
+    data: unknown,
+    contentType = 'application/merge-patch+json',
+  ): Promise<R | null> {
     const constants = BaseResourceManager.getEvaluateConstants();
 
     const result = await page.evaluate(
-      async ({ payload, path, evalConstants }): Promise<ApiResult<R>> => {
+      async ({ payload, path, patchContentType, evalConstants }): Promise<ApiResult<R>> => {
         try {
-          // Get CSRF token from cookies
           const cookies = document.cookie.split('; ');
           const csrfCookie = cookies.find((cookie) =>
             cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
@@ -68,13 +72,58 @@ export abstract class BaseResourceManager {
           const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
 
           const response = await fetch(path, {
-            method: 'POST',
+            body: JSON.stringify(payload),
+            credentials: 'include',
+            headers: {
+              [evalConstants.CONTENT_TYPE_HEADER]: patchContentType,
+              [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
+            },
+            method: 'PATCH',
+          });
+
+          if (response.ok) {
+            return { data: await response.json(), success: true };
+          }
+
+          const errorText = await response.text().catch(() => response.statusText);
+          return { error: errorText, success: false };
+        } catch (error: unknown) {
+          const err = error as Error;
+          return { error: err?.message ?? String(error), success: false };
+        }
+      },
+      { evalConstants: constants, path: apiPath, payload: data, patchContentType: contentType },
+    );
+
+    if (result.success) {
+      return result.data;
+    }
+
+    console.error(`API PATCH ${apiPath} failed: ${result.error}`);
+    return null;
+  }
+
+  /** Generic POST helper — handles CSRF token, headers, and error handling. */
+  public static async apiPost<R>(page: Page, apiPath: string, data: unknown): Promise<R | null> {
+    const constants = BaseResourceManager.getEvaluateConstants();
+
+    const result = await page.evaluate(
+      async ({ payload, path, evalConstants }): Promise<ApiResult<R>> => {
+        try {
+          const cookies = document.cookie.split('; ');
+          const csrfCookie = cookies.find((cookie) =>
+            cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
+          );
+          const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
+
+          const response = await fetch(path, {
+            body: JSON.stringify(payload),
+            credentials: 'include',
             headers: {
               [evalConstants.CONTENT_TYPE_HEADER]: evalConstants.APPLICATION_JSON,
               [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
             },
-            credentials: 'include',
-            body: JSON.stringify(payload),
+            method: 'POST',
           });
 
           if (response.ok) {

--- a/testing/playwright/utils/resource-manager/ResourcePatcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourcePatcher.ts
@@ -2,7 +2,7 @@ import type { V1beta1ForkliftController, V1beta1Provider } from '@forklift-ui/ty
 import type { Page } from '@playwright/test';
 
 import { BaseResourceManager } from './BaseResourceManager';
-import { MTV_NAMESPACE, RESOURCE_KINDS } from './constants';
+import { API_PATHS, MTV_NAMESPACE, RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
 import type { SupportedResource } from './ResourceManager';
 
 /**
@@ -59,12 +59,7 @@ export class ResourcePatcher extends BaseResourceManager {
 
   /**
    * Patches a Kubernetes resource using either merge patch or JSON patch.
-   * @param page - Playwright page
-   * @param options.kind - Resource kind (e.g., 'Plan', 'Provider')
-   * @param options.resourceName - Name of the resource
-   * @param options.namespace - Namespace of the resource
-   * @param options.patch - Patch data (object for merge, array of operations for json)
-   * @param options.patchType - 'merge' (default) or 'json' for array operations
+   * Delegates to {@link BaseResourceManager.apiPatch} after building the path.
    */
   static async patchResource<T extends SupportedResource>(
     page: Page,
@@ -78,78 +73,13 @@ export class ResourcePatcher extends BaseResourceManager {
   ): Promise<T | null> {
     const { kind, resourceName, namespace, patch, patchType = 'merge' } = options;
     const resourceType = ResourcePatcher.getResourceTypeFromKind(kind);
-    const constants = ResourcePatcher.getEvaluateConstants();
     const contentType =
       patchType === 'json' ? 'application/json-patch+json' : 'application/merge-patch+json';
 
-    try {
-      const result = await page.evaluate(
-        async ({ resType, resourceKind, name, ns, patchData, patchContentType, evalConstants }) => {
-          try {
-            const getCsrfTokenFromCookie = () => {
-              const cookies = document.cookie.split('; ');
-              const csrfCookie = cookies.find((cookie) =>
-                cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
-              );
-              return csrfCookie ? csrfCookie.split('=')[1] : '';
-            };
-            const csrfToken = getCsrfTokenFromCookie();
+    const basePath =
+      resourceType === RESOURCE_TYPES.VIRTUAL_MACHINES ? API_PATHS.KUBEVIRT : API_PATHS.FORKLIFT;
+    const apiPath = `${basePath}/namespaces/${namespace}/${resourceType}/${resourceName}`;
 
-            let apiPath = '';
-            if (resType === evalConstants.VIRTUAL_MACHINES_TYPE) {
-              apiPath = `${evalConstants.KUBEVIRT_PATH}/namespaces/${ns}/${resType}/${name}`;
-            } else {
-              apiPath = `${evalConstants.FORKLIFT_PATH}/namespaces/${ns}/${resType}/${name}`;
-            }
-
-            const response = await fetch(apiPath, {
-              method: 'PATCH',
-              headers: {
-                [evalConstants.CONTENT_TYPE_HEADER]: patchContentType,
-                [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
-              },
-              credentials: 'include',
-              body: JSON.stringify(patchData),
-            });
-
-            if (response.ok) {
-              return { success: true, data: await response.json() };
-            }
-
-            if (response.status === 404) {
-              return { success: false, error: `${resourceKind} not found` };
-            }
-
-            const errorText = await response.text().catch(() => response.statusText);
-            return { success: false, error: errorText };
-          } catch (error: unknown) {
-            const err = error as Error;
-            return {
-              success: false,
-              error: err?.message ?? String(error),
-            };
-          }
-        },
-        {
-          resType: resourceType,
-          resourceKind: kind,
-          name: resourceName,
-          ns: namespace,
-          patchData: patch,
-          patchContentType: contentType,
-          evalConstants: constants,
-        },
-      );
-
-      if (result.success && result.data) {
-        return result.data as T;
-      }
-
-      console.error(`Failed to patch ${kind} ${resourceName}: ${result.error}`);
-      return null;
-    } catch (error) {
-      console.error(`Exception while patching ${kind} ${resourceName}:`, error);
-      return null;
-    }
+    return ResourcePatcher.apiPatch<T>(page, apiPath, patch, contentType);
   }
 }


### PR DESCRIPTION
## 📝 Links

[MTV-3921](https://redhat.atlassian.net/browse/MTV-3921)

## 📝 Description

Playwright E2E smoke tests verifying translations render correctly for `ja` and `zh` locales. Includes language-switching helpers, a generic `apiPatch` in BaseResourceManager, and CI changes to bundle locale files in the test container.

[MTV-3921]: https://redhat.atlassian.net/browse/MTV-3921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ