### PR TITLE
MTV-3643 | E2E customization scripts - downstream spec & page objects (part 2)

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
@@ -103,7 +103,7 @@ test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
 
     await test.step('Edit scripts via Edit modal', async () => {
       await planDetailsPage.automationTab.verifyEditButtonVisible();
-      await planDetailsPage.automationTab.editScripts([UPDATED_SCRIPT]);
+      await planDetailsPage.automationTab.replaceScripts([UPDATED_SCRIPT]);
     });
 
     await test.step('Verify updated scripts on Automation tab', async () => {

--- a/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
@@ -1,0 +1,199 @@
+import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
+import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { createPlanTestData, type PlanTestData, type ScriptConfig } from '../../../types/test-data';
+import { disableGuidedTour } from '../../../utils/utils';
+import { V2_11_0 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+const LINUX_FIRSTBOOT_SCRIPT: ScriptConfig = {
+  content: '#!/bin/bash\necho "firstboot setup"\nsystemctl enable my-service',
+  guestType: 'linux',
+  name: 'linux-setup',
+  scriptType: 'firstboot',
+};
+
+const WINDOWS_FIRSTBOOT_SCRIPT: ScriptConfig = {
+  content: 'REM Windows firstboot\nnet user admin P@ssw0rd /add',
+  guestType: 'windows',
+  name: 'win-setup',
+  scriptType: 'firstboot',
+};
+
+const UPDATED_SCRIPT: ScriptConfig = {
+  content: '#!/bin/bash\necho "updated script"\nexit 0',
+  guestType: 'linux',
+  name: 'updated-script',
+  scriptType: 'run',
+};
+
+test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_11_0);
+
+  test('should create plan with new customization scripts and verify on Automation tab', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    await disableGuidedTour(page);
+
+    const testData: PlanTestData = createPlanTestData({
+      customizationScripts: {
+        mode: 'new',
+        scripts: [LINUX_FIRSTBOOT_SCRIPT, WINDOWS_FIRSTBOOT_SCRIPT],
+      },
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    const planDetailsPage = new PlanDetailsPage(page);
+
+    await test.step('Navigate to Customization Scripts step in wizard', async () => {
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.navigateToCustomizationScriptsStep(testData);
+      await wizard.customizationScripts.verifyStepVisible();
+    });
+
+    await test.step('Configure Linux firstboot script', async () => {
+      await wizard.customizationScripts.fillAndComplete({
+        mode: 'new',
+        scripts: [LINUX_FIRSTBOOT_SCRIPT, WINDOWS_FIRSTBOOT_SCRIPT],
+      });
+    });
+
+    await test.step('Verify scripts in review step', async () => {
+      await wizard.clickNext(); // Scripts -> Hooks
+      await wizard.clickNext(); // Hooks -> Review
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifyCustomScriptsSection({
+        mode: 'new',
+        scripts: [LINUX_FIRSTBOOT_SCRIPT, WINDOWS_FIRSTBOOT_SCRIPT],
+      });
+    });
+
+    await test.step('Create plan', async () => {
+      await wizard.clickNext();
+      await wizard.waitForPlanCreation();
+      await disableGuidedTour(page);
+    });
+
+    await test.step('Navigate to Automation tab and verify scripts', async () => {
+      await planDetailsPage.verifyPlanTitle(testData.planName);
+      await planDetailsPage.automationTab.navigateToAutomationTab();
+      await planDetailsPage.automationTab.verifyConfigMapLink();
+      await planDetailsPage.automationTab.verifyScriptDetails(
+        LINUX_FIRSTBOOT_SCRIPT.name,
+        'Linux',
+        'Firstboot',
+      );
+      await planDetailsPage.automationTab.verifyScriptDetails(
+        WINDOWS_FIRSTBOOT_SCRIPT.name,
+        'Windows',
+        'Firstboot',
+      );
+    });
+
+    await test.step('Edit scripts via Edit modal', async () => {
+      await planDetailsPage.automationTab.verifyEditButtonVisible();
+      await planDetailsPage.automationTab.editScripts([UPDATED_SCRIPT]);
+    });
+
+    await test.step('Verify updated scripts on Automation tab', async () => {
+      await planDetailsPage.automationTab.verifyScriptDetails(UPDATED_SCRIPT.name, 'Linux', 'Run');
+    });
+  });
+
+  test('should create plan without scripts and show empty state on Automation tab', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    await disableGuidedTour(page);
+
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    const planDetailsPage = new PlanDetailsPage(page);
+
+    await test.step('Create plan without customization scripts', async () => {
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.fillAndSubmit(testData);
+      await disableGuidedTour(page);
+    });
+
+    await test.step('Navigate to Automation tab and verify empty state', async () => {
+      await planDetailsPage.verifyPlanTitle(testData.planName);
+      await planDetailsPage.automationTab.navigateToAutomationTab();
+      await planDetailsPage.automationTab.verifyNoScripts();
+    });
+  });
+
+  test('should navigate back from Review to edit Customization Scripts', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    await disableGuidedTour(page);
+
+    const testData: PlanTestData = createPlanTestData({
+      customizationScripts: {
+        mode: 'new',
+        scripts: [LINUX_FIRSTBOOT_SCRIPT],
+      },
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+
+    await test.step('Navigate through wizard to Review', async () => {
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.navigateToCustomizationScriptsStep(testData);
+      await wizard.customizationScripts.fillAndComplete({
+        mode: 'new',
+        scripts: [LINUX_FIRSTBOOT_SCRIPT],
+      });
+      await wizard.clickNext(); // Scripts -> Hooks
+      await wizard.clickNext(); // Hooks -> Review
+      await wizard.review.verifyStepVisible();
+    });
+
+    await test.step('Navigate back to Customization Scripts step', async () => {
+      await wizard.clickBack(); // Review -> Hooks
+      await wizard.clickBack(); // Hooks -> Automation
+      await wizard.customizationScripts.verifyStepVisible();
+    });
+
+    await test.step('Modify script and return to Review', async () => {
+      const nameInput = page.getByTestId('script-name-0');
+      await nameInput.clear();
+      await nameInput.fill('modified-script');
+
+      await wizard.clickNext(); // Automation -> Hooks
+      await wizard.clickNext(); // Hooks -> Review
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifyCustomScriptsSection({
+        mode: 'new',
+        scripts: [{ ...LINUX_FIRSTBOOT_SCRIPT, name: 'modified-script' }],
+      });
+    });
+
+    await test.step('Create plan and verify', async () => {
+      await wizard.clickNext();
+      await wizard.waitForPlanCreation();
+      await disableGuidedTour(page);
+
+      const planDetailsPage = new PlanDetailsPage(page);
+      await planDetailsPage.verifyPlanTitle(testData.planName);
+      await planDetailsPage.automationTab.navigateToAutomationTab();
+      await planDetailsPage.automationTab.verifyScriptVisible('modified-script');
+    });
+  });
+});

--- a/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
@@ -3,7 +3,7 @@ import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/Cre
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
 import { createPlanTestData, type PlanTestData, type ScriptConfig } from '../../../types/test-data';
 import { disableGuidedTour } from '../../../utils/utils';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 const LINUX_FIRSTBOOT_SCRIPT: ScriptConfig = {
@@ -28,7 +28,7 @@ const UPDATED_SCRIPT: ScriptConfig = {
 };
 
 test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
-  requireVersion(test, V2_11_0);
+  requireVersion(test, V2_12_0);
 
   test('should create plan with new customization scripts and verify on Automation tab', async ({
     page,

--- a/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
@@ -56,7 +56,7 @@ test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
       await wizard.customizationScripts.verifyStepVisible();
     });
 
-    await test.step('Configure Linux firstboot script', async () => {
+    await test.step('Configure customization scripts', async () => {
       await wizard.customizationScripts.fillAndComplete({
         mode: 'new',
         scripts: [LINUX_FIRSTBOOT_SCRIPT, WINDOWS_FIRSTBOOT_SCRIPT],

--- a/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-customization-scripts.spec.ts
@@ -1,7 +1,13 @@
 import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
 import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
-import { createPlanTestData, type PlanTestData, type ScriptConfig } from '../../../types/test-data';
+import {
+  createPlanTestData,
+  GUEST_TYPE_LABELS,
+  type PlanTestData,
+  SCRIPT_TYPE_LABELS,
+  type ScriptConfig,
+} from '../../../types/test-data';
 import { disableGuidedTour } from '../../../utils/utils';
 import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
@@ -85,13 +91,13 @@ test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
       await planDetailsPage.automationTab.verifyConfigMapLink();
       await planDetailsPage.automationTab.verifyScriptDetails(
         LINUX_FIRSTBOOT_SCRIPT.name,
-        'Linux',
-        'Firstboot',
+        GUEST_TYPE_LABELS[LINUX_FIRSTBOOT_SCRIPT.guestType!],
+        SCRIPT_TYPE_LABELS[LINUX_FIRSTBOOT_SCRIPT.scriptType!],
       );
       await planDetailsPage.automationTab.verifyScriptDetails(
         WINDOWS_FIRSTBOOT_SCRIPT.name,
-        'Windows',
-        'Firstboot',
+        GUEST_TYPE_LABELS[WINDOWS_FIRSTBOOT_SCRIPT.guestType!],
+        SCRIPT_TYPE_LABELS[WINDOWS_FIRSTBOOT_SCRIPT.scriptType!],
       );
     });
 
@@ -101,7 +107,11 @@ test.describe('Plan Customization Scripts', { tag: '@downstream' }, () => {
     });
 
     await test.step('Verify updated scripts on Automation tab', async () => {
-      await planDetailsPage.automationTab.verifyScriptDetails(UPDATED_SCRIPT.name, 'Linux', 'Run');
+      await planDetailsPage.automationTab.verifyScriptDetails(
+        UPDATED_SCRIPT.name,
+        GUEST_TYPE_LABELS[UPDATED_SCRIPT.guestType!],
+        SCRIPT_TYPE_LABELS[UPDATED_SCRIPT.scriptType!],
+      );
     });
   });
 

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/CustomizationScriptsStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/CustomizationScriptsStep.ts
@@ -1,11 +1,13 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import {
-  type CustomizationScriptsTestData,
-  GUEST_TYPE_LABELS,
-  SCRIPT_TYPE_LABELS,
-  type ScriptConfig,
-} from '../../../types/test-data';
+import type { CustomizationScriptsTestData, ScriptConfig } from '../../../types/test-data';
+import { fillScriptFields } from '../../../utils/script-form-helpers';
+
+const WIZARD_FIELD_TEST_IDS = {
+  guestTypeSelect: (i: number): string => `script-guest-type-${i}`,
+  nameInput: (i: number): string => `script-name-${i}`,
+  scriptTypeSelect: (i: number): string => `script-type-${i}`,
+};
 
 export class CustomizationScriptsStep {
   private readonly page: Page;
@@ -22,31 +24,7 @@ export class CustomizationScriptsStep {
   }
 
   private async configureScript(index: number, config: ScriptConfig): Promise<void> {
-    await this.page.getByTestId(`script-name-${index}`).fill(config.name);
-
-    if (config.guestType) {
-      const select = this.page.getByTestId(`script-guest-type-${index}`);
-      await select.click();
-      await this.page.getByRole('option', { name: GUEST_TYPE_LABELS[config.guestType] }).click();
-    }
-
-    if (config.scriptType) {
-      const select = this.page.getByTestId(`script-type-${index}`);
-      await select.click();
-      await this.page.getByRole('option', { name: SCRIPT_TYPE_LABELS[config.scriptType] }).click();
-    }
-
-    if (config.content) {
-      await this.page.evaluate(
-        ({ idx, scriptContent }) => {
-          const editors = (globalThis as any).monaco?.editor?.getEditors?.();
-          if (editors && Array.isArray(editors) && editors.length > idx) {
-            editors[idx].setValue(scriptContent);
-          }
-        },
-        { idx: index, scriptContent: config.content },
-      );
-    }
+    await fillScriptFields(this.page, index, config, WIZARD_FIELD_TEST_IDS);
   }
 
   private async selectConfigMap(name: string): Promise<void> {

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/CustomizationScriptsStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/CustomizationScriptsStep.ts
@@ -1,21 +1,11 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import type {
-  CustomizationScriptsTestData,
-  GuestType,
-  ScriptConfig,
-  ScriptType,
+import {
+  type CustomizationScriptsTestData,
+  GUEST_TYPE_LABELS,
+  SCRIPT_TYPE_LABELS,
+  type ScriptConfig,
 } from '../../../types/test-data';
-
-const GUEST_TYPE_LABELS: Record<GuestType, string> = {
-  linux: 'Linux',
-  windows: 'Windows',
-};
-
-const SCRIPT_TYPE_LABELS: Record<ScriptType, string> = {
-  firstboot: 'Firstboot',
-  run: 'Run',
-};
 
 export class CustomizationScriptsStep {
   private readonly page: Page;

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -5,6 +5,7 @@ import { NavigationHelper } from '../../utils/NavigationHelper';
 import { K8S_RECONCILE_TIMEOUT } from '../../utils/resource-manager/constants';
 import { disableGuidedTour, isEmpty } from '../../utils/utils';
 
+import { AutomationTab } from './tabs/AutomationTab';
 import { DetailsTab } from './tabs/DetailsTab';
 import { HooksTab } from './tabs/HooksTab';
 import { MappingsTab } from './tabs/MappingsTab';
@@ -12,6 +13,7 @@ import { VirtualMachinesTab } from './tabs/VirtualMachinesTab';
 
 export class PlanDetailsPage {
   private readonly navigation: NavigationHelper;
+  public readonly automationTab: AutomationTab;
   public readonly detailsTab: DetailsTab;
   public readonly hooksTab: HooksTab;
   public readonly mappingsTab: MappingsTab;
@@ -20,6 +22,7 @@ export class PlanDetailsPage {
 
   constructor(page: Page) {
     this.page = page;
+    this.automationTab = new AutomationTab(page);
     this.detailsTab = new DetailsTab(page);
     this.hooksTab = new HooksTab(page);
     this.mappingsTab = new MappingsTab(page);

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -1,0 +1,80 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { GuestType, ScriptConfig, ScriptType } from '../../../types/test-data';
+import { BaseModal } from '../../common/BaseModal';
+
+const GUEST_TYPE_LABELS: Record<GuestType, string> = {
+  linux: 'Linux',
+  windows: 'Windows',
+};
+
+const SCRIPT_TYPE_LABELS: Record<ScriptType, string> = {
+  firstboot: 'Firstboot',
+  run: 'Run',
+};
+
+export class ScriptEditModal extends BaseModal {
+  readonly addScriptButton: Locator;
+
+  constructor(page: Page) {
+    super(page, page.getByTestId('script-edit-modal'));
+    this.addScriptButton = this.page.getByTestId('add-script-button');
+  }
+
+  async addScript(): Promise<void> {
+    await this.addScriptButton.click();
+  }
+
+  async configureScript(index: number, config: ScriptConfig): Promise<void> {
+    const nameInput = this.page.getByTestId(`script-name-input-${index}`);
+    await nameInput.clear();
+    await nameInput.fill(config.name);
+
+    if (config.guestType) {
+      const select = this.page.getByTestId(`script-guest-type-select-${index}`);
+      await select.click();
+      await this.page.getByRole('option', { name: GUEST_TYPE_LABELS[config.guestType] }).click();
+    }
+
+    if (config.scriptType) {
+      const select = this.page.getByTestId(`script-type-select-${index}`);
+      await select.click();
+      await this.page.getByRole('option', { name: SCRIPT_TYPE_LABELS[config.scriptType] }).click();
+    }
+
+    if (config.content) {
+      await this.setScriptContent(index, config.content);
+    }
+  }
+
+  async getScriptCount(): Promise<number> {
+    return await this.page.locator('[data-testid^="script-edit-row-"]').count();
+  }
+
+  async removeScript(index: number): Promise<void> {
+    await this.page.getByTestId(`remove-script-${index}`).click();
+  }
+
+  async setScriptContent(index: number, content: string): Promise<void> {
+    const success = await this.page.evaluate(
+      ({ idx, scriptContent }) => {
+        const editors = (globalThis as any).monaco?.editor?.getEditors?.();
+        if (editors && Array.isArray(editors) && editors.length > idx) {
+          editors[idx].setValue(scriptContent);
+          return true;
+        }
+        return false;
+      },
+      { idx: index, scriptContent: content },
+    );
+
+    if (!success) {
+      throw new Error(`Failed to set script content at index ${index} - Monaco editor not found`);
+    }
+  }
+
+  async verifyScriptName(index: number, expectedName: string): Promise<void> {
+    const nameInput = this.page.getByTestId(`script-name-input-${index}`);
+    await expect(nameInput).toHaveValue(expectedName);
+  }
+}

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { GUEST_TYPE_LABELS, SCRIPT_TYPE_LABELS, type ScriptConfig } from '../../../types/test-data';
 import { BaseModal } from '../../common/BaseModal';
@@ -61,10 +61,5 @@ export class ScriptEditModal extends BaseModal {
     if (!success) {
       throw new Error(`Failed to set script content at index ${index} - Monaco editor not found`);
     }
-  }
-
-  async verifyScriptName(index: number, expectedName: string): Promise<void> {
-    const nameInput = this.page.getByTestId(`script-name-input-${index}`);
-    await expect(nameInput).toHaveValue(expectedName);
   }
 }

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -1,17 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import type { GuestType, ScriptConfig, ScriptType } from '../../../types/test-data';
+import { GUEST_TYPE_LABELS, SCRIPT_TYPE_LABELS, type ScriptConfig } from '../../../types/test-data';
 import { BaseModal } from '../../common/BaseModal';
-
-const GUEST_TYPE_LABELS: Record<GuestType, string> = {
-  linux: 'Linux',
-  windows: 'Windows',
-};
-
-const SCRIPT_TYPE_LABELS: Record<ScriptType, string> = {
-  firstboot: 'Firstboot',
-  run: 'Run',
-};
 
 export class ScriptEditModal extends BaseModal {
   readonly addScriptButton: Locator;

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -33,4 +33,22 @@ export class ScriptEditModal extends BaseModal {
   async removeScript(index: number): Promise<void> {
     await this.page.getByTestId(`remove-script-${index}`).click();
   }
+
+  async setScripts(scripts: ScriptConfig[]): Promise<void> {
+    const existingCount = await this.getScriptCount();
+    const reusable = Math.min(existingCount, scripts.length);
+
+    for (let i = 0; i < reusable; i += 1) {
+      await this.configureScript(i, scripts[i]);
+    }
+
+    for (let i = reusable; i < scripts.length; i += 1) {
+      await this.addScript();
+      await this.configureScript(i, scripts[i]);
+    }
+
+    for (let i = existingCount - 1; i >= scripts.length; i -= 1) {
+      await this.removeScript(i);
+    }
+  }
 }

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -1,7 +1,14 @@
 import type { Locator, Page } from '@playwright/test';
 
-import { GUEST_TYPE_LABELS, SCRIPT_TYPE_LABELS, type ScriptConfig } from '../../../types/test-data';
+import type { ScriptConfig } from '../../../types/test-data';
+import { fillScriptFields } from '../../../utils/script-form-helpers';
 import { BaseModal } from '../../common/BaseModal';
+
+const MODAL_FIELD_TEST_IDS = {
+  guestTypeSelect: (i: number): string => `script-guest-type-select-${i}`,
+  nameInput: (i: number): string => `script-name-input-${i}`,
+  scriptTypeSelect: (i: number): string => `script-type-select-${i}`,
+};
 
 export class ScriptEditModal extends BaseModal {
   readonly addScriptButton: Locator;
@@ -16,25 +23,7 @@ export class ScriptEditModal extends BaseModal {
   }
 
   async configureScript(index: number, config: ScriptConfig): Promise<void> {
-    const nameInput = this.page.getByTestId(`script-name-input-${index}`);
-    await nameInput.clear();
-    await nameInput.fill(config.name);
-
-    if (config.guestType) {
-      const select = this.page.getByTestId(`script-guest-type-select-${index}`);
-      await select.click();
-      await this.page.getByRole('option', { name: GUEST_TYPE_LABELS[config.guestType] }).click();
-    }
-
-    if (config.scriptType) {
-      const select = this.page.getByTestId(`script-type-select-${index}`);
-      await select.click();
-      await this.page.getByRole('option', { name: SCRIPT_TYPE_LABELS[config.scriptType] }).click();
-    }
-
-    if (config.content) {
-      await this.setScriptContent(index, config.content);
-    }
+    await fillScriptFields(this.page, index, config, MODAL_FIELD_TEST_IDS);
   }
 
   async getScriptCount(): Promise<number> {
@@ -43,23 +32,5 @@ export class ScriptEditModal extends BaseModal {
 
   async removeScript(index: number): Promise<void> {
     await this.page.getByTestId(`remove-script-${index}`).click();
-  }
-
-  async setScriptContent(index: number, content: string): Promise<void> {
-    const success = await this.page.evaluate(
-      ({ idx, scriptContent }) => {
-        const editors = (globalThis as any).monaco?.editor?.getEditors?.();
-        if (editors && Array.isArray(editors) && editors.length > idx) {
-          editors[idx].setValue(scriptContent);
-          return true;
-        }
-        return false;
-      },
-      { idx: index, scriptContent: content },
-    );
-
-    if (!success) {
-      throw new Error(`Failed to set script content at index ${index} - Monaco editor not found`);
-    }
   }
 }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
@@ -1,0 +1,77 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import type { ScriptConfig } from '../../../types/test-data';
+import { disableGuidedTour } from '../../../utils/utils';
+import { ScriptEditModal } from '../modals/ScriptEditModal';
+
+export class AutomationTab {
+  readonly automationTabLink: Locator;
+  protected readonly page: Page;
+  readonly scriptEditModal: ScriptEditModal;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.automationTabLink = this.page.locator('[data-test-id="horizontal-link-Automation"]');
+    this.scriptEditModal = new ScriptEditModal(page);
+  }
+
+  async editScripts(scripts: ScriptConfig[]): Promise<void> {
+    await this.openScriptEditModal();
+
+    const existingCount = await this.scriptEditModal.getScriptCount();
+
+    for (let i = existingCount - 1; i > 0; i -= 1) {
+      await this.scriptEditModal.removeScript(i);
+    }
+
+    for (let i = 0; i < scripts.length; i += 1) {
+      if (i > 0) {
+        await this.scriptEditModal.addScript();
+      }
+      await this.scriptEditModal.configureScript(i, scripts[i]);
+    }
+
+    await this.scriptEditModal.save();
+  }
+
+  async navigateToAutomationTab(): Promise<void> {
+    await disableGuidedTour(this.page);
+    await this.automationTabLink.click();
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async openScriptEditModal(): Promise<void> {
+    await this.page.getByTestId('scripts-section-edit-button').click();
+    await this.scriptEditModal.waitForModalToOpen();
+  }
+
+  async verifyConfigMapLink(): Promise<void> {
+    await expect(this.page.getByTestId('scripts-configmap')).toBeVisible();
+  }
+
+  async verifyEditButtonDisabled(): Promise<void> {
+    await expect(this.page.getByTestId('scripts-section-edit-button')).toBeDisabled();
+  }
+
+  async verifyEditButtonVisible(): Promise<void> {
+    await expect(this.page.getByTestId('scripts-section-edit-button')).toBeVisible();
+  }
+
+  async verifyNoScripts(): Promise<void> {
+    await expect(this.page.getByTestId('scripts-none')).toContainText('None');
+  }
+
+  async verifyScriptDetails(
+    scriptName: string,
+    guestType: string,
+    scriptType: string,
+  ): Promise<void> {
+    await expect(this.page.getByTestId(`script-name-${scriptName}`)).toContainText(scriptName);
+    await expect(this.page.getByTestId(`script-guest-type-${scriptName}`)).toContainText(guestType);
+    await expect(this.page.getByTestId(`script-type-${scriptName}`)).toContainText(scriptType);
+  }
+
+  async verifyScriptVisible(scriptName: string): Promise<void> {
+    await expect(this.page.getByTestId(`script-name-${scriptName}`)).toBeVisible();
+  }
+}

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
@@ -15,6 +15,8 @@ export class AutomationTab {
     this.scriptEditModal = new ScriptEditModal(page);
   }
 
+  // The modal always keeps at least one script row, so we remove all but
+  // the first, reuse row 0 for the first new script, then add + configure the rest.
   async editScripts(scripts: ScriptConfig[]): Promise<void> {
     await this.openScriptEditModal();
 

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
@@ -15,28 +15,6 @@ export class AutomationTab {
     this.scriptEditModal = new ScriptEditModal(page);
   }
 
-  async editScripts(scripts: ScriptConfig[]): Promise<void> {
-    await this.openScriptEditModal();
-
-    const existingCount = await this.scriptEditModal.getScriptCount();
-    const reusable = Math.min(existingCount, scripts.length);
-
-    for (let i = 0; i < reusable; i += 1) {
-      await this.scriptEditModal.configureScript(i, scripts[i]);
-    }
-
-    for (let i = reusable; i < scripts.length; i += 1) {
-      await this.scriptEditModal.addScript();
-      await this.scriptEditModal.configureScript(i, scripts[i]);
-    }
-
-    for (let i = existingCount - 1; i >= scripts.length; i -= 1) {
-      await this.scriptEditModal.removeScript(i);
-    }
-
-    await this.scriptEditModal.save();
-  }
-
   async navigateToAutomationTab(): Promise<void> {
     await disableGuidedTour(this.page);
     await this.automationTabLink.click();
@@ -45,6 +23,12 @@ export class AutomationTab {
   async openScriptEditModal(): Promise<void> {
     await this.page.getByTestId('scripts-section-edit-button').click();
     await this.scriptEditModal.waitForModalToOpen();
+  }
+
+  async replaceScripts(scripts: ScriptConfig[]): Promise<void> {
+    await this.openScriptEditModal();
+    await this.scriptEditModal.setScripts(scripts);
+    await this.scriptEditModal.save();
   }
 
   async verifyConfigMapLink(): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
@@ -15,22 +15,23 @@ export class AutomationTab {
     this.scriptEditModal = new ScriptEditModal(page);
   }
 
-  // The modal always keeps at least one script row, so we remove all but
-  // the first, reuse row 0 for the first new script, then add + configure the rest.
   async editScripts(scripts: ScriptConfig[]): Promise<void> {
     await this.openScriptEditModal();
 
     const existingCount = await this.scriptEditModal.getScriptCount();
+    const reusable = Math.min(existingCount, scripts.length);
 
-    for (let i = existingCount - 1; i > 0; i -= 1) {
-      await this.scriptEditModal.removeScript(i);
+    for (let i = 0; i < reusable; i += 1) {
+      await this.scriptEditModal.configureScript(i, scripts[i]);
     }
 
-    for (let i = 0; i < scripts.length; i += 1) {
-      if (i > 0) {
-        await this.scriptEditModal.addScript();
-      }
+    for (let i = reusable; i < scripts.length; i += 1) {
+      await this.scriptEditModal.addScript();
       await this.scriptEditModal.configureScript(i, scripts[i]);
+    }
+
+    for (let i = existingCount - 1; i >= scripts.length; i -= 1) {
+      await this.scriptEditModal.removeScript(i);
     }
 
     await this.scriptEditModal.save();

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/AutomationTab.ts
@@ -37,7 +37,6 @@ export class AutomationTab {
   async navigateToAutomationTab(): Promise<void> {
     await disableGuidedTour(this.page);
     await this.automationTabLink.click();
-    await this.page.waitForLoadState('networkidle');
   }
 
   async openScriptEditModal(): Promise<void> {
@@ -47,10 +46,6 @@ export class AutomationTab {
 
   async verifyConfigMapLink(): Promise<void> {
     await expect(this.page.getByTestId('scripts-configmap')).toBeVisible();
-  }
-
-  async verifyEditButtonDisabled(): Promise<void> {
-    await expect(this.page.getByTestId('scripts-section-edit-button')).toBeDisabled();
   }
 
   async verifyEditButtonVisible(): Promise<void> {

--- a/testing/playwright/types/test-data.ts
+++ b/testing/playwright/types/test-data.ts
@@ -109,6 +109,16 @@ export interface HookConfig {
 export type GuestType = 'linux' | 'windows';
 export type ScriptType = 'firstboot' | 'run';
 
+export const GUEST_TYPE_LABELS: Record<GuestType, string> = {
+  linux: 'Linux',
+  windows: 'Windows',
+};
+
+export const SCRIPT_TYPE_LABELS: Record<ScriptType, string> = {
+  firstboot: 'Firstboot',
+  run: 'Run',
+};
+
 export type ScriptConfig = {
   content?: string;
   guestType?: GuestType;

--- a/testing/playwright/utils/script-form-helpers.ts
+++ b/testing/playwright/utils/script-form-helpers.ts
@@ -1,0 +1,58 @@
+import type { Page } from '@playwright/test';
+
+import { GUEST_TYPE_LABELS, SCRIPT_TYPE_LABELS, type ScriptConfig } from '../types/test-data';
+
+type ScriptFieldTestIds = {
+  guestTypeSelect: (index: number) => string;
+  nameInput: (index: number) => string;
+  scriptTypeSelect: (index: number) => string;
+};
+
+const setMonacoEditorContent = async (
+  page: Page,
+  index: number,
+  content: string,
+): Promise<void> => {
+  const success = await page.evaluate(
+    ({ idx, scriptContent }) => {
+      const editors = (globalThis as any).monaco?.editor?.getEditors?.();
+      if (editors && Array.isArray(editors) && editors.length > idx) {
+        editors[idx].setValue(scriptContent);
+        return true;
+      }
+      return false;
+    },
+    { idx: index, scriptContent: content },
+  );
+
+  if (!success) {
+    throw new Error(`Failed to set script content at index ${index} - Monaco editor not found`);
+  }
+};
+
+export const fillScriptFields = async (
+  page: Page,
+  index: number,
+  config: ScriptConfig,
+  testIds: ScriptFieldTestIds,
+): Promise<void> => {
+  const nameInput = page.getByTestId(testIds.nameInput(index));
+  await nameInput.clear();
+  await nameInput.fill(config.name);
+
+  if (config.guestType) {
+    const select = page.getByTestId(testIds.guestTypeSelect(index));
+    await select.click();
+    await page.getByRole('option', { name: GUEST_TYPE_LABELS[config.guestType] }).click();
+  }
+
+  if (config.scriptType) {
+    const select = page.getByTestId(testIds.scriptTypeSelect(index));
+    await select.click();
+    await page.getByRole('option', { name: SCRIPT_TYPE_LABELS[config.scriptType] }).click();
+  }
+
+  if (config.content) {
+    await setMonacoEditorContent(page, index, config.content);
+  }
+};


### PR DESCRIPTION
## 📝 Links

- [MTV-3643](https://redhat.atlassian.net/browse/MTV-3643)
- Part 1: #2293

## 📝 Description

Adds downstream Playwright E2E tests for the customization scripts feature, complementing the page objects introduced in part 1.

**New files:**
- `plan-customization-scripts.spec.ts` — 3 downstream tests (create with scripts, empty state, back-navigation edit)
- `AutomationTab.ts` — Plan Details Automation tab page object
- `ScriptEditModal.ts` — Script edit modal page object

**Modified:**
- `PlanDetailsPage.ts` — wired `AutomationTab`
- `CustomizationScriptsStep.ts` — fixed heading text to match actual wizard step title

## 🎥 Demo



[MTV-3643]: https://redhat.atlassian.net/browse/MTV-3643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ