### PR TITLE
Resolves: MTV-4449 | Add Playwright E2E tests for Lightspeed integration

### DIFF
--- a/.cursor/rules/workflows/playwright-testing.mdc
+++ b/.cursor/rules/workflows/playwright-testing.mdc
@@ -146,16 +146,20 @@ test.describe('Network Maps', { tag: '@upstream' }, () => {
 
 ---
 
-## 5. Page Objects
+## 5. Page Objects & Navigation
 
 Reuse page objects from `testing/playwright/page-objects/` for common interactions:
 
 ```typescript
 export class ProviderListPage {
-  constructor(private page: Page) {}
+  private readonly navigation: NavigationHelper;
 
-  async navigateTo(): Promise<void> {
-    await this.page.goto('/mtv/providers');
+  constructor(private page: Page) {
+    this.navigation = new NavigationHelper(page);
+  }
+
+  async navigateDirectly(): Promise<void> {
+    await this.navigation.navigateToProviders();
   }
 
   async clickAddProvider(): Promise<void> {
@@ -165,6 +169,23 @@ export class ProviderListPage {
 ```
 
 Create new page objects when adding tests for new pages or complex flows.
+
+### Navigation — Use Page Object Methods, Not Raw `page.goto`
+
+**Always use page object navigation methods** (e.g., `overviewPage.navigateDirectly()`, `providerListPage.navigateTo()`) instead of calling `page.goto(...)` directly in specs. These methods wrap `NavigationHelper` and handle guided-tour dismissal, `waitForLoadState`, and page-load assertions consistently.
+
+```typescript
+// ✅ Good — uses page object navigation
+const overviewPage = new OverviewPage(page);
+await overviewPage.navigateDirectly();
+
+// ❌ Bad — raw page.goto duplicates logic and skips guided-tour handling
+await page.goto('/mtv/overview');
+await disableGuidedTour(page);
+await overviewPage.waitForPageLoad();
+```
+
+Raw `page.goto` should only appear **inside** page objects or `NavigationHelper` — never in spec files.
 
 ---
 

--- a/ci/deploy-console.sh
+++ b/ci/deploy-console.sh
@@ -21,6 +21,11 @@ echo "deploy console CRDs"
 kubectl apply -f ${script_dir}/yaml/crds/console
 
 echo ""
+echo "deploy operator CRDs"
+
+kubectl apply -f ${script_dir}/yaml/crds/operators
+
+echo ""
 echo "deploy OKD console"
 
 cat ${OKD_CONSOLE_YAML} | \

--- a/ci/yaml/crds/README.md
+++ b/ci/yaml/crds/README.md
@@ -20,3 +20,12 @@ Mimic an installed Forklift operator API
 | ----------- | ----------------------------------------------------------------------- |
 | Source      | https://github.com/kubev2v/forklift/tree/main/operator/config/crd/bases |
 | PR ref      | https://github.com/kubev2v/forklift/pull/121                            |
+
+## Operators CRDs
+
+Minimal OLM Subscription CRD so upstream E2E tests can mock
+Lightspeed operator presence via `useK8sWatchResource`.
+
+| API version | v1alpha1                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| Source      | https://github.com/operator-framework/api/tree/master/crds (simplified for test use only)   |

--- a/ci/yaml/crds/operators/operators.coreos.com_subscriptions.yaml
+++ b/ci/yaml/crds/operators/operators.coreos.com_subscriptions.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.operators.coreos.com
+spec:
+  group: operators.coreos.com
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Minimal Subscription CRD for upstream E2E tests.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: true

--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.58.0-noble
+FROM mcr.microsoft.com/playwright:v1.59.0-noble
 
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown

--- a/testing/e2e.env.template
+++ b/testing/e2e.env.template
@@ -6,3 +6,6 @@ VSPHERE_PROVIDER=vsphere-8.0.1
 # Forklift version for version-gated tests. Auto-detected from cluster CSV if not set.
 # Set explicitly to override auto-detection. Use "latest" to always run version-gated tests.
 # FORKLIFT_VERSION=
+
+# Set to "true" to enable Lightspeed integration tests (requires OLS operator on the cluster).
+# LIGHTSPEED_INSTALLED=

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -12,9 +12,9 @@
         "@forklift-ui/types": "1.0.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.0",
+        "@playwright/test": "^1.59.0",
         "@types/node": "^20.0.0",
-        "playwright": "1.58.0",
+        "playwright": "1.59.0",
         "typescript": "^5.8.2"
       }
     },
@@ -26,14 +26,48 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.0",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.0"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -49,7 +83,10 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
+      "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -60,13 +97,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
+      "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.59.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -79,9 +116,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
+      "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/testing/package.json
+++ b/testing/package.json
@@ -15,9 +15,9 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.58.0",
+    "@playwright/test": "^1.59.0",
     "@types/node": "^20.0.0",
-    "playwright": "1.58.0",
+    "playwright": "1.59.0",
     "typescript": "^5.8.2"
   },
   "dependencies": {

--- a/testing/playwright/e2e/downstream/lightspeed-integration.spec.ts
+++ b/testing/playwright/e2e/downstream/lightspeed-integration.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+
+import { TIPS_AND_TRICKS_TOPICS } from '../../fixtures/overview-page-topics';
+import { AI_PROMPT_QUESTIONS } from '../../page-objects/LearningExperienceDrawer';
+import { OverviewPage } from '../../page-objects/OverviewPage';
+import { requireLightspeed } from '../../utils/lightspeed/lightspeed';
+import { V2_12_0 } from '../../utils/version/constants';
+import { requireVersion } from '../../utils/version/version';
+
+const TROUBLESHOOTING_TOPIC = TIPS_AND_TRICKS_TOPICS.at(-1);
+
+test.describe(
+  'Lightspeed Integration - Ask AI Assistant',
+  {
+    tag: '@downstream',
+  },
+  () => {
+    requireVersion(test, V2_12_0);
+    requireLightspeed(test);
+
+    test('should show Ask AI section in the Troubleshooting topic', async ({ page }) => {
+      const overviewPage = new OverviewPage(page);
+      const { learningExperience } = overviewPage;
+
+      await test.step('Navigate to MTV Overview and open drawer', async () => {
+        await overviewPage.navigateDirectly();
+        await learningExperience.open();
+      });
+
+      await test.step('Navigate to Troubleshooting topic', async () => {
+        await learningExperience.selectTopicByCard(TROUBLESHOOTING_TOPIC);
+      });
+
+      await test.step('Verify Ask AI assistant section is visible', async () => {
+        await expect(learningExperience.askAIHeading).toBeVisible();
+        await expect(learningExperience.commonQuestionsToggle).toBeVisible();
+      });
+    });
+
+    test('should expand and show pre-canned troubleshooting questions', async ({ page }) => {
+      const overviewPage = new OverviewPage(page);
+      const { learningExperience } = overviewPage;
+
+      await test.step('Navigate to Troubleshooting topic', async () => {
+        await overviewPage.navigateDirectly();
+        await learningExperience.open();
+        await learningExperience.selectTopicByCard(TROUBLESHOOTING_TOPIC);
+      });
+
+      await test.step('Expand Common troubleshooting questions', async () => {
+        await learningExperience.commonQuestionsToggle.click();
+      });
+
+      await test.step('Verify all 3 pre-canned questions are visible', async () => {
+        for (const question of AI_PROMPT_QUESTIONS) {
+          await expect(learningExperience.getQuestionButton(question)).toBeVisible();
+        }
+      });
+
+      await test.step('Collapse questions', async () => {
+        await learningExperience.commonQuestionsToggle.click();
+        await expect(
+          learningExperience.getQuestionButton(AI_PROMPT_QUESTIONS[0]),
+        ).not.toBeVisible();
+      });
+    });
+
+    test('should open OLS panel with pre-filled prompt when clicking a question', async ({
+      page,
+    }) => {
+      const overviewPage = new OverviewPage(page);
+      const { learningExperience } = overviewPage;
+      const [, testQuestion] = AI_PROMPT_QUESTIONS;
+
+      await test.step('Navigate to Troubleshooting topic and expand questions', async () => {
+        await overviewPage.navigateDirectly();
+        await learningExperience.open();
+        await learningExperience.selectTopicByCard(TROUBLESHOOTING_TOPIC);
+        await learningExperience.commonQuestionsToggle.click();
+      });
+
+      await test.step('Click a pre-canned question', async () => {
+        await learningExperience.getQuestionButton(testQuestion).click();
+      });
+
+      await test.step('Verify OLS panel opens with the question pre-filled', async () => {
+        await expect(learningExperience.olsPanel).toBeVisible();
+        await expect(learningExperience.olsInputField).toHaveValue(testQuestion);
+      });
+    });
+  },
+);

--- a/testing/playwright/e2e/upstream/lightspeed-mcp-warning.spec.ts
+++ b/testing/playwright/e2e/upstream/lightspeed-mcp-warning.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 
 import { setupForkliftIntercepts, setupLightspeedIntercepts } from '../../intercepts';
 import { OverviewPage } from '../../page-objects/OverviewPage';
-import { disableGuidedTour } from '../../utils/utils';
 
 test.describe(
   'Lightspeed MCP Warning Banner',
@@ -22,9 +21,7 @@ test.describe(
       const overviewPage = new OverviewPage(page);
 
       await test.step('Navigate to MTV Overview page', async () => {
-        await page.goto('/mtv/overview');
-        await disableGuidedTour(page);
-        await overviewPage.waitForPageLoad();
+        await overviewPage.navigateDirectly();
       });
 
       await test.step('Verify warning banner is visible with correct text', async () => {
@@ -53,9 +50,7 @@ test.describe(
       const overviewPage = new OverviewPage(page);
 
       await test.step('Navigate to MTV Overview page', async () => {
-        await page.goto('/mtv/overview');
-        await disableGuidedTour(page);
-        await overviewPage.waitForPageLoad();
+        await overviewPage.navigateDirectly();
       });
 
       await test.step('Verify warning banner is not visible', async () => {
@@ -65,17 +60,12 @@ test.describe(
 
     test('should not show warning when Lightspeed is not installed', async ({ page }) => {
       await setupForkliftIntercepts(page);
-      await setupLightspeedIntercepts(page, {
-        hasLightspeedSubscription: false,
-        hasMcpService: false,
-      });
+      await setupLightspeedIntercepts(page);
 
       const overviewPage = new OverviewPage(page);
 
       await test.step('Navigate to MTV Overview page', async () => {
-        await page.goto('/mtv/overview');
-        await disableGuidedTour(page);
-        await overviewPage.waitForPageLoad();
+        await overviewPage.navigateDirectly();
       });
 
       await test.step('Verify warning banner is not visible', async () => {

--- a/testing/playwright/e2e/upstream/lightspeed-mcp-warning.spec.ts
+++ b/testing/playwright/e2e/upstream/lightspeed-mcp-warning.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+import { setupForkliftIntercepts, setupLightspeedIntercepts } from '../../intercepts';
+import { OverviewPage } from '../../page-objects/OverviewPage';
+import { disableGuidedTour } from '../../utils/utils';
+
+test.describe(
+  'Lightspeed MCP Warning Banner',
+  {
+    tag: '@upstream',
+  },
+  () => {
+    test('should show warning when Lightspeed is installed but MCP service is missing', async ({
+      page,
+    }) => {
+      await setupForkliftIntercepts(page);
+      await setupLightspeedIntercepts(page, {
+        hasLightspeedSubscription: true,
+        hasMcpService: false,
+      });
+
+      const overviewPage = new OverviewPage(page);
+
+      await test.step('Navigate to MTV Overview page', async () => {
+        await page.goto('/mtv/overview');
+        await disableGuidedTour(page);
+        await overviewPage.waitForPageLoad();
+      });
+
+      await test.step('Verify warning banner is visible with correct text', async () => {
+        await expect(overviewPage.mcpWarningBanner).toBeVisible();
+        await expect(overviewPage.mcpWarningBanner).toContainText(
+          'Reinstall or update the MTV operator',
+        );
+      });
+
+      await test.step('Verify "Go to Installed Operators" link is present', async () => {
+        await expect(overviewPage.mcpWarningLink).toBeVisible();
+        await expect(overviewPage.mcpWarningLink).toHaveAttribute(
+          'href',
+          '/k8s/ns/openshift-mtv/operators.coreos.com~v1alpha1~ClusterServiceVersion',
+        );
+      });
+    });
+
+    test('should not show warning when both Lightspeed and MCP service exist', async ({ page }) => {
+      await setupForkliftIntercepts(page);
+      await setupLightspeedIntercepts(page, {
+        hasLightspeedSubscription: true,
+        hasMcpService: true,
+      });
+
+      const overviewPage = new OverviewPage(page);
+
+      await test.step('Navigate to MTV Overview page', async () => {
+        await page.goto('/mtv/overview');
+        await disableGuidedTour(page);
+        await overviewPage.waitForPageLoad();
+      });
+
+      await test.step('Verify warning banner is not visible', async () => {
+        await expect(overviewPage.mcpWarningBanner).not.toBeVisible();
+      });
+    });
+
+    test('should not show warning when Lightspeed is not installed', async ({ page }) => {
+      await setupForkliftIntercepts(page);
+      await setupLightspeedIntercepts(page, {
+        hasLightspeedSubscription: false,
+        hasMcpService: false,
+      });
+
+      const overviewPage = new OverviewPage(page);
+
+      await test.step('Navigate to MTV Overview page', async () => {
+        await page.goto('/mtv/overview');
+        await disableGuidedTour(page);
+        await overviewPage.waitForPageLoad();
+      });
+
+      await test.step('Verify warning banner is not visible', async () => {
+        await expect(overviewPage.mcpWarningBanner).not.toBeVisible();
+      });
+    });
+  },
+);

--- a/testing/playwright/intercepts/index.ts
+++ b/testing/playwright/intercepts/index.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 export { setupCoreKubernetesIntercepts } from './core';
 export { setupDatastoresIntercepts } from './datastores';
 export { setupHostsIntercepts } from './hosts';
+export { setupLightspeedIntercepts } from './lightspeed';
 export { setupNetworkMapsIntercepts } from './networkMaps';
 export { setupPlanDetailsIntercepts } from './planDetails';
 export { setupPlansIntercepts } from './plans';

--- a/testing/playwright/intercepts/lightspeed.ts
+++ b/testing/playwright/intercepts/lightspeed.ts
@@ -1,0 +1,109 @@
+import type { Page } from '@playwright/test';
+
+const MTV_NAMESPACE = 'openshift-mtv';
+const MCP_SERVICE_NAME = 'kubectl-mtv-mcp-server';
+
+type LightspeedInterceptOptions = {
+  hasLightspeedSubscription: boolean;
+  hasMcpService: boolean;
+};
+
+const DEFAULT_OPTIONS: LightspeedInterceptOptions = {
+  hasLightspeedSubscription: false,
+  hasMcpService: false,
+};
+
+const buildSubscriptionList = (hasLightspeed: boolean): object => ({
+  apiVersion: 'operators.coreos.com/v1alpha1',
+  kind: 'SubscriptionList',
+  metadata: { resourceVersion: '99999' },
+  items: hasLightspeed
+    ? [
+        {
+          apiVersion: 'operators.coreos.com/v1alpha1',
+          kind: 'Subscription',
+          metadata: {
+            name: 'lightspeed-operator',
+            namespace: 'openshift-lightspeed',
+            uid: 'lightspeed-sub-uid',
+          },
+          spec: {
+            channel: 'stable',
+            name: 'lightspeed-operator',
+            source: 'redhat-operators',
+            sourceNamespace: 'openshift-marketplace',
+          },
+          status: { state: 'AtLatestKnown' },
+        },
+      ]
+    : [],
+});
+
+const buildMcpService = (): object => ({
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    labels: { 'app.kubernetes.io/name': MCP_SERVICE_NAME },
+    name: MCP_SERVICE_NAME,
+    namespace: MTV_NAMESPACE,
+    resourceVersion: '88888',
+    uid: 'mcp-service-uid',
+  },
+  spec: {
+    ports: [{ port: 8080, protocol: 'TCP', targetPort: 8080 }],
+    selector: { app: MCP_SERVICE_NAME },
+  },
+});
+
+export const setupLightspeedIntercepts = async (
+  page: Page,
+  options: LightspeedInterceptOptions = DEFAULT_OPTIONS,
+): Promise<void> => {
+  const subscriptionList = buildSubscriptionList(options.hasLightspeedSubscription);
+
+  // Block WebSocket watches for subscriptions and services so the SDK
+  // relies on the intercepted HTTP responses below.
+  await page.routeWebSocket('**/operators.coreos.com/v1alpha1/subscriptions**', (ws) => {
+    ws.close();
+  });
+  await page.routeWebSocket(`**/api/v1/namespaces/${MTV_NAMESPACE}/services**`, (ws) => {
+    ws.close();
+  });
+
+  await page.route('**/operators.coreos.com/v1alpha1/subscriptions**', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify(subscriptionList),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+
+  await page.route(`**/api/v1/namespaces/${MTV_NAMESPACE}/services**`, async (route) => {
+    const url = route.request().url();
+
+    if (!url.includes(MCP_SERVICE_NAME)) {
+      await route.continue();
+      return;
+    }
+
+    if (options.hasMcpService) {
+      await route.fulfill({
+        body: JSON.stringify(buildMcpService()),
+        contentType: 'application/json',
+        status: 200,
+      });
+    } else {
+      await route.fulfill({
+        body: JSON.stringify({
+          apiVersion: 'v1',
+          kind: 'Status',
+          message: `services "${MCP_SERVICE_NAME}" not found`,
+          reason: 'NotFound',
+          status: 'Failure',
+        }),
+        contentType: 'application/json',
+        status: 404,
+      });
+    }
+  });
+};

--- a/testing/playwright/page-objects/LearningExperienceDrawer.ts
+++ b/testing/playwright/page-objects/LearningExperienceDrawer.ts
@@ -3,6 +3,12 @@ import { expect, type Locator, type Page } from '@playwright/test';
 import { EXTERNAL_LINKS, PROVIDER_TYPES_LIST } from '../fixtures/overview-page-topics';
 import { NavigationHelper } from '../utils/NavigationHelper';
 
+export const AI_PROMPT_QUESTIONS = [
+  'How do I check network mapping for a failed migration?',
+  'Why is my warm migration stuck?',
+  "Why aren't my VMs working after migration?",
+] as const;
+
 export interface TopicConfig {
   name: string;
   description: string;
@@ -28,6 +34,10 @@ export class LearningExperienceDrawer {
     }
   }
 
+  get askAIHeading(): Locator {
+    return this.page.getByRole('heading', { name: 'Ask AI assistant', level: 4 });
+  }
+
   async close(): Promise<void> {
     await this.closeDrawerButton.click();
     await expect(this.drawerTitle).not.toBeVisible();
@@ -35,6 +45,10 @@ export class LearningExperienceDrawer {
 
   get closeDrawerButton(): Locator {
     return this.page.getByRole('button', { name: 'Close drawer panel' });
+  }
+
+  get commonQuestionsToggle(): Locator {
+    return this.page.getByRole('button', { name: 'Common troubleshooting questions' });
   }
 
   get drawerTitle(): Locator {
@@ -61,6 +75,10 @@ export class LearningExperienceDrawer {
     return this.page.getByRole('menuitem', { name: providerName });
   }
 
+  getQuestionButton(questionText: string): Locator {
+    return this.page.getByRole('button', { name: questionText });
+  }
+
   getQuickReferenceHeading(): Locator {
     return this.page.getByRole('heading', { name: 'Quick reference', level: 3 });
   }
@@ -81,6 +99,14 @@ export class LearningExperienceDrawer {
   async navigateToTopic(nextTopicName: string): Promise<void> {
     await this.selectTopicButton.click();
     await this.page.getByRole('option', { name: nextTopicName }).click();
+  }
+
+  get olsInputField(): Locator {
+    return this.page.getByRole('textbox', { name: 'Send a message...' });
+  }
+
+  get olsPanel(): Locator {
+    return this.page.getByRole('region', { name: 'Red Hat OpenShift Lightspeed' });
   }
 
   async open(): Promise<void> {

--- a/testing/playwright/page-objects/OverviewPage/OverviewPage.ts
+++ b/testing/playwright/page-objects/OverviewPage/OverviewPage.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 import { NavigationHelper } from '../../utils/NavigationHelper';
 import { LearningExperienceDrawer } from '../LearningExperienceDrawer';
@@ -31,6 +31,16 @@ export class OverviewPage {
 
   async getTransferNetworkCurrentValue(): Promise<string | null> {
     return this.settingsTab.getTransferNetworkCurrentValue();
+  }
+
+  get mcpWarningBanner(): Locator {
+    return this.page.locator('.pf-v6-c-alert').filter({
+      hasText: 'AI assistant not connected to Lightspeed',
+    });
+  }
+
+  get mcpWarningLink(): Locator {
+    return this.mcpWarningBanner.getByRole('link', { name: 'Go to Installed Operators' });
   }
 
   get modalConfirmButton() {

--- a/testing/playwright/utils/lightspeed/constants.ts
+++ b/testing/playwright/utils/lightspeed/constants.ts
@@ -1,0 +1,3 @@
+export const LIGHTSPEED_ENV_VAR = 'LIGHTSPEED_INSTALLED';
+
+export const LIGHTSPEED_GATE_TAG = '[lightspeed-gated]';

--- a/testing/playwright/utils/lightspeed/lightspeed.ts
+++ b/testing/playwright/utils/lightspeed/lightspeed.ts
@@ -1,0 +1,19 @@
+import type { SkippableTest } from '../version/types';
+
+import { LIGHTSPEED_ENV_VAR, LIGHTSPEED_GATE_TAG } from './constants';
+
+const isLightspeedInstalled = (): boolean =>
+  process.env[LIGHTSPEED_ENV_VAR]?.trim().toLowerCase() === 'true';
+
+/**
+ * Skip tests when the cluster does not have OpenShift Lightspeed installed.
+ * Set LIGHTSPEED_INSTALLED=true in e2e.env to enable these tests.
+ *
+ *   requireLightspeed(test);
+ */
+export const requireLightspeed = (testObj: SkippableTest): void => {
+  testObj.skip(
+    !isLightspeedInstalled(),
+    `${LIGHTSPEED_GATE_TAG} Requires LIGHTSPEED_INSTALLED=true`,
+  );
+};

--- a/testing/run-e2e-docker.sh
+++ b/testing/run-e2e-docker.sh
@@ -17,5 +17,5 @@ docker run --rm -it \
   --env LC_ALL=en_US.UTF-8 \
   --env LANG=en_US.UTF-8 \
   --env LANGUAGE=en_US.UTF-8 \
-  mcr.microsoft.com/playwright:v1.54.0-noble \
+  mcr.microsoft.com/playwright:v1.59.0-noble \
   bash -c "npm install && npx playwright test --grep @downstream"


### PR DESCRIPTION
## 📝 Links

- [MTV-4449](https://redhat.atlassian.net/browse/MTV-4449)

## 📝 Description

Add Playwright E2E tests for the Lightspeed integration feature:

**Upstream (mock-based):**
- 3 tests for the MCP warning banner visibility based on Lightspeed Subscription and MCP Service state, using `page.route` intercepts with WebSocket blocking for reliable mock isolation.

**Downstream (cluster-gated):**
- 3 tests for OLS panel integration via the Learning Experience drawer (Ask AI section, pre-canned questions, OLS panel opening). Gated by `LIGHTSPEED_INSTALLED` env var and Forklift version >= 2.12.

**Infrastructure:**
- Lightspeed intercept module with configurable Subscription/Service mocks
- `requireLightspeed` skip guard and `LIGHTSPEED_INSTALLED` env template entry
- PF6-compatible locators for `OverviewPage` and `LearningExperienceDrawer`

## 🎥 Demo


Downstream tests skip when `LIGHTSPEED_INSTALLED` is not set (expected for CI without OLS).

## 📝 CC://

[MTV-4449]: https://redhat.atlassian.net/browse/MTV-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ