### PR TITLE
Resolves: MTV-4994 | Skip map resource watch when plan has empty map refs

### DIFF
--- a/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
+++ b/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
@@ -29,21 +29,31 @@ const DuplicateModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
   const name = getName(plan);
   const [newName, setNewName] = useState<string>(`copy-of-${name}`);
 
-  const [networkMap] = useK8sWatchResource<V1beta1NetworkMap>({
-    groupVersionKind: NetworkMapModelGroupVersionKind,
-    isList: false,
-    name: getPlanNetworkMapName(plan),
-    namespace: getPlanNetworkMapNamespace(plan),
-    namespaced: true,
-  });
+  const networkMapName = getPlanNetworkMapName(plan);
+  const [networkMap] = useK8sWatchResource<V1beta1NetworkMap>(
+    networkMapName
+      ? {
+          groupVersionKind: NetworkMapModelGroupVersionKind,
+          isList: false,
+          name: networkMapName,
+          namespace: getPlanNetworkMapNamespace(plan),
+          namespaced: true,
+        }
+      : null,
+  );
 
-  const [storageMap] = useK8sWatchResource<V1beta1StorageMap>({
-    groupVersionKind: StorageMapModelGroupVersionKind,
-    isList: false,
-    name: getPlanStorageMapName(plan),
-    namespace: getPlanStorageMapNamespace(plan),
-    namespaced: true,
-  });
+  const storageMapName = getPlanStorageMapName(plan);
+  const [storageMap] = useK8sWatchResource<V1beta1StorageMap>(
+    storageMapName
+      ? {
+          groupVersionKind: StorageMapModelGroupVersionKind,
+          isList: false,
+          name: storageMapName,
+          namespace: getPlanStorageMapNamespace(plan),
+          namespaced: true,
+        }
+      : null,
+  );
 
   const onChange = (value: string): void => {
     setNewName(value);

--- a/src/plans/details/hooks/usePlanMappingData.ts
+++ b/src/plans/details/hooks/usePlanMappingData.ts
@@ -33,14 +33,22 @@ export const usePlanMappingData = ({
   sourceProvider,
   storageMaps,
 }: UsePlanMappingDataOptions) => {
+  const planNetworkMapName = getPlanNetworkMapName(plan);
   const planNetworkMap = useMemo(
-    () => networkMaps.find((map) => getName(map) === getPlanNetworkMapName(plan)),
-    [networkMaps, plan],
+    () =>
+      planNetworkMapName
+        ? networkMaps.find((map) => getName(map) === planNetworkMapName)
+        : undefined,
+    [networkMaps, planNetworkMapName],
   );
 
+  const planStorageMapName = getPlanStorageMapName(plan);
   const planStorageMap = useMemo(
-    () => storageMaps.find((map) => getName(map) === getPlanStorageMapName(plan)),
-    [storageMaps, plan],
+    () =>
+      planStorageMapName
+        ? storageMaps.find((map) => getName(map) === planStorageMapName)
+        : undefined,
+    [storageMaps, planStorageMapName],
   );
 
   const sourceStorages = useMemo(() => {

--- a/src/plans/details/tabs/Mappings/hooks/usePlanNetworkMapResources.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanNetworkMapResources.ts
@@ -42,12 +42,17 @@ export const usePlanNetworkMapResources: UsePlanNetworkMapResources = ({
   sourceProvider,
   targetProvider,
 }) => {
-  const networkMapResult = useK8sWatchResource<V1beta1NetworkMap>({
-    groupVersionKind: NetworkMapModelGroupVersionKind,
-    isList: false,
-    name: getPlanNetworkMapName(plan),
-    namespace: getPlanNetworkMapNamespace(plan),
-  });
+  const networkMapName = getPlanNetworkMapName(plan);
+  const networkMapResult = useK8sWatchResource<V1beta1NetworkMap>(
+    networkMapName
+      ? {
+          groupVersionKind: NetworkMapModelGroupVersionKind,
+          isList: false,
+          name: networkMapName,
+          namespace: getPlanNetworkMapNamespace(plan),
+        }
+      : null,
+  );
 
   const sourceNetworksResult = useSourceNetworks(sourceProvider);
   const targetNetworksResult = useOpenShiftNetworks(targetProvider);

--- a/src/plans/details/tabs/Mappings/hooks/usePlanStorageMapResources.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanStorageMapResources.ts
@@ -44,12 +44,17 @@ export const usePlanStorageMapResources: UsePlanStorageMapResources = ({
   targetProvider,
   vms,
 }) => {
-  const storageMapResult = useK8sWatchResource<V1beta1StorageMap>({
-    groupVersionKind: StorageMapModelGroupVersionKind,
-    isList: false,
-    name: getPlanStorageMapName(plan),
-    namespace: getPlanStorageMapNamespace(plan),
-  });
+  const storageMapName = getPlanStorageMapName(plan);
+  const storageMapResult = useK8sWatchResource<V1beta1StorageMap>(
+    storageMapName
+      ? {
+          groupVersionKind: StorageMapModelGroupVersionKind,
+          isList: false,
+          name: storageMapName,
+          namespace: getPlanStorageMapNamespace(plan),
+        }
+      : null,
+  );
 
   const sourceStoragesResult = useSourceStorages(sourceProvider);
   const targetStoragesResult = useTargetStorages(targetProvider, getPlanTargetNamespace(plan));


### PR DESCRIPTION
## Summary

- When a Plan has `.spec.map.storage: {}` (empty object with no `name`/`namespace`), the UI incorrectly displays an unrelated storage map from a different plan/namespace
- Root cause: `useK8sWatchResource` was called with `name: undefined`, which does **not** short-circuit - it actively watches and can return cached/arbitrary resources
- Fix: pass `null` to `useK8sWatchResource` when the map name is falsy, which is the SDK's documented pattern for disabling a watch
- Applied the same guard to network map watches and `.find()` lookups for consistency
