### PR TITLE
[release-2.11] Fix critical and high CVEs in dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,10 +25,10 @@
         "classnames": "^2.5.1",
         "i18next": "^25.3.2",
         "immer": "^10.1.1",
-        "immutable": "^5.1.1",
+        "immutable": "^5.1.5",
         "js-base64": "^3.7.7",
         "jsonpath-plus": "^10.3.0",
-        "jsrsasign": "11.1.0",
+        "jsrsasign": "11.1.2",
         "luxon": "^3.5.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -8589,9 +8589,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9752,13 +9752,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11455,9 +11448,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-      "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -13628,13 +13621,10 @@
       }
     },
     "node_modules/jsrsasign": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
-      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/kjur/jsrsasign#donations"
-      }
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.2.tgz",
+      "integrity": "sha512-GJuqiU/Grs6BaBBXMAZM9kxhsBrksZE0pF3qIfpkopMd7OMJ9zZmE/+CpV//97srfEyyyq1Ec0ELQtSlW/gPTA==",
+      "license": "MIT"
     },
     "node_modules/jss": {
       "version": "10.10.0",
@@ -14225,9 +14215,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -15591,19 +15581,14 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
     "classnames": "^2.5.1",
     "i18next": "^25.3.2",
     "immer": "^10.1.1",
-    "immutable": "^5.1.1",
+    "immutable": "^5.1.5",
     "js-base64": "^3.7.7",
     "jsonpath-plus": "^10.3.0",
-    "jsrsasign": "11.1.0",
+    "jsrsasign": "11.1.2",
     "luxon": "^3.5.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -149,9 +149,11 @@
   "overrides": {
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
-    "lodash": "4.17.23",
+    "dompurify": ">=3.3.2",
+    "lodash": "4.18.1",
     "monaco-editor": "^0.52.2",
     "node-forge": "^1.3.2",
+    "path-to-regexp": ">=0.1.13",
     "qs": "6.14.1"
   }
 }


### PR DESCRIPTION
## Links

> References:
> - CVE-2026-4598, CVE-2026-4599, CVE-2026-4600, CVE-2026-4601, CVE-2026-4602 (jsrsasign)
> - CVE-2026-4800 (lodash)
> - CVE-2026-29063 (immutable)
> - GHSA-37ch-88jc-xwx2 (path-to-regexp)

> Related: https://github.com/kubev2v/forklift-console-plugin/pull/2355 (main branch fix)

## Description

Backport of CVE fixes from main to release-2.11.

**Changes in `package.json`:**

| Package | Change | CVEs Fixed |
|---------|--------|------------|
| jsrsasign | `11.1.0` → `11.1.2` (dependency bump) | CVE-2026-4598, 4599, 4600, 4601, 4602 |
| immutable | `^5.1.1` → `^5.1.5` (dependency bump) | CVE-2026-29063 |
| lodash | override `4.17.23` → `4.18.1` | CVE-2026-4800 |
| dompurify | new override `>=3.3.2` | XSS/prototype pollution advisories |
| path-to-regexp | new override `>=0.1.13` | GHSA-37ch-88jc-xwx2 |

**Verification:** 331 tests passed, npm audit down to 23 (all dev-only).

## CC://


Made with [Cursor](https://cursor.com)