### PR TITLE
Resolves: MTV-4907 | Add CNV version gating and post-migration VM smoke test (part 2)

### DIFF
--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -48,7 +48,7 @@ get_plugin_subdir() {
 # ============================================================================
 
 USE_AUTH=false
-EXTRA_PLUGINS=""
+EXTRA_PLUGINS="${DEFAULT_PLUGINS:-}"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -76,6 +76,11 @@ while [[ $# -gt 0 ]]; do
             echo "  --auth                Use OpenShift OAuth instead of bearer token"
             echo "  --plugins <list|all>  Load additional console plugins alongside forklift"
             echo "                        Comma-separated list, or 'all' for every plugin"
+            echo ""
+            echo "Environment variables:"
+            echo "  DEFAULT_PLUGINS       Plugins to load when --plugins is not specified"
+            echo "                        Same format as --plugins (comma-separated or 'all')"
+            echo "                        --plugins overrides DEFAULT_PLUGINS when both are set"
             echo ""
             echo "Available plugins:"
             for p in $AVAILABLE_PLUGINS; do

--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -20,9 +20,8 @@ WORKDIR /test-runner
 
 USER root
 
-# Install system dependencies (retry apt-get update to tolerate transient mirror syncs)
-RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
-    && apt-get install -y --no-install-recommends \
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates python3 python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -20,8 +20,9 @@ WORKDIR /test-runner
 
 USER root
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install system dependencies (retry apt-get update to tolerate transient mirror syncs)
+RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
+    && apt-get install -y --no-install-recommends \
     curl ca-certificates python3 python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/testing/e2e.env.template
+++ b/testing/e2e.env.template
@@ -7,5 +7,9 @@ VSPHERE_PROVIDER=vsphere-8.0.1
 # Set explicitly to override auto-detection. Use "latest" to always run version-gated tests.
 # FORKLIFT_VERSION=
 
+# CNV (OpenShift Virtualization) version for CNV-gated tests. Auto-detected from cluster CSV if not set.
+# Set explicitly to override auto-detection. Tests run by default when CNV version is unknown.
+# CNV_VERSION=
+
 # Set to "true" to enable Lightspeed integration tests (requires OLS operator on the cluster).
 # LIGHTSPEED_INSTALLED=

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@playwright/test": "^1.59.0",
         "@types/node": "^20.0.0",
-        "playwright": "1.59.0",
+        "playwright": "^1.59.1",
         "typescript": "^5.8.2"
       }
     },
@@ -36,38 +36,6 @@
       },
       "bin": {
         "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -97,13 +65,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.0.tgz",
-      "integrity": "sha512-wihGScriusvATUxmhfENxg0tj1vHEFeIwxlnPFKQTOQVd7aG08mUfvvniRP/PtQOC+2Bs52kBOC/Up1jTXeIbw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.0"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -116,9 +84,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.0.tgz",
-      "integrity": "sha512-PW/X/IoZ6BMUUy8rpwHEZ8Kc0IiLIkgKYGNFaMs5KmQhcfLILNx9yCQD0rnWeWfz1PNeqcFP1BsihQhDOBCwZw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/testing/package.json
+++ b/testing/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@playwright/test": "^1.59.0",
     "@types/node": "^20.0.0",
-    "playwright": "1.59.0",
+    "playwright": "^1.59.1",
     "typescript": "^5.8.2"
   },
   "dependencies": {

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -88,7 +88,8 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
         const welcomeHeading = page.getByRole('heading', { name: locale.Welcome });
         await expect(welcomeHeading).toBeVisible({ timeout: ELEMENT_VISIBLE_TIMEOUT_MS });
 
-        const migrationPlansCard = page.getByText(locale['Migration plans']);
+        const mainContent = page.locator('main');
+        const migrationPlansCard = mainContent.getByText(locale['Migration plans']);
         await expect(migrationPlansCard.first()).toBeVisible({
           timeout: ELEMENT_VISIBLE_TIMEOUT_MS,
         });

--- a/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
+++ b/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
@@ -11,6 +11,7 @@ if (!existsSync(providersPath)) {
 }
 
 import * as providers from '../../../.providers.json';
+import { VirtualMachineDetailsPage } from '../../page-objects/CNV/VirtualMachineDetailsPage';
 import { CreatePlanWizardPage } from '../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
 import { CreateProviderPage } from '../../page-objects/CreateProviderPage';
 import { OverviewPage } from '../../page-objects/OverviewPage';
@@ -24,10 +25,10 @@ import {
   type ProviderData,
   SourceNetworks,
 } from '../../types/test-data';
-import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
+import { ELEMENT_TIMEOUT, MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 import { ResourceManager } from '../../utils/resource-manager/ResourceManager';
-import { V2_10_5, V2_12_0 } from '../../utils/version/constants';
-import { isVersionInStreams, requireVersion } from '../../utils/version/version';
+import { CNV_4_21_0, V2_10_5, V2_12_0 } from '../../utils/version/constants';
+import { isVersionInStreams, requireCNVVersion, requireVersion } from '../../utils/version/version';
 
 const targetProjectName = `test-project-${Date.now()}`;
 
@@ -176,6 +177,54 @@ test.describe.serial('Plans - VSphere to Host Happy Path Cold Migration', () => 
         expect(vmResource).not.toBeNull();
         expect(vmResource?.metadata?.name).toBe(migratedVMName);
         expect(vmResource?.metadata?.namespace).toBe(testPlanData.targetProject.name);
+      }
+    },
+  );
+
+  test(
+    'should verify migrated VMs on CNV overview page',
+    {
+      tag: ['@downstream'],
+    },
+    async ({ page }) => {
+      const TEST_TIMEOUT = 120_000;
+
+      requireCNVVersion(test, CNV_4_21_0);
+      test.setTimeout(TEST_TIMEOUT);
+
+      const planDetailsPage = new PlanDetailsPage(page);
+      const plansPage = new PlansListPage(page);
+      const cnvVMPage = new VirtualMachineDetailsPage(page);
+
+      await test.step('Navigate to plan VM tab', async () => {
+        await plansPage.navigateFromMainMenu();
+        await plansPage.waitForPageLoad();
+        await plansPage.navigateToPlan(planName);
+        await planDetailsPage.verifyPlanTitle(planName);
+        await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
+      });
+
+      const vmsToVerify = (testPlanData.virtualMachines ?? [])
+        .map((vm) => vm.targetName ?? vm.sourceName)
+        .filter((name): name is string => Boolean(name));
+
+      expect(vmsToVerify.length).toBeGreaterThan(0);
+
+      for (const vmName of vmsToVerify) {
+        await test.step(`Click VM "${vmName}" link and verify CNV overview`, async () => {
+          const vmLink = page.getByRole('link', { name: vmName, exact: true });
+          await expect(vmLink).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+          await vmLink.click();
+
+          await cnvVMPage.waitForPageLoad(vmName);
+          await cnvVMPage.verifySmokeOverview(vmName);
+
+          await plansPage.navigateFromMainMenu();
+          await plansPage.waitForPageLoad();
+          await plansPage.navigateToPlan(planName);
+          await planDetailsPage.verifyPlanTitle(planName);
+          await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
+        });
       }
     },
   );

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -5,7 +5,7 @@ import { chromium, type FullConfig, type Page } from '@playwright/test';
 import { LoginPage } from './page-objects/LoginPage';
 import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
-import { VERSION_ENV_VAR } from './utils/version/constants';
+import { CNV_VERSION_ENV_VAR, VERSION_ENV_VAR } from './utils/version/constants';
 
 const RESOURCES_FILE = 'playwright/.resources.json';
 
@@ -24,6 +24,25 @@ const detectForkliftVersion = async (page: Page): Promise<void> => {
     console.error(`🔍 Auto-detected Forklift version: ${detectedVersion}`);
   } else {
     console.error('⚠️ Could not auto-detect Forklift version from cluster');
+  }
+};
+
+/**
+ * Auto-detect the CNV (OpenShift Virtualization) operator version from the cluster CSV.
+ * When CNV_VERSION is already set (manual override), the pre-set value wins.
+ * Unlike Forklift, CNV version is optional — tests run when it's unknown.
+ */
+const detectCnvVersion = async (page: Page): Promise<void> => {
+  const detectedVersion = await ResourceFetcher.fetchCnvVersion(page);
+
+  const existing = process.env[CNV_VERSION_ENV_VAR];
+  if (existing) {
+    console.error(`📌 Using pre-set CNV version: ${existing}`);
+  } else if (detectedVersion) {
+    process.env[CNV_VERSION_ENV_VAR] = detectedVersion;
+    console.error(`🔍 Auto-detected CNV version: ${detectedVersion}`);
+  } else {
+    console.error('⚠️ Could not auto-detect CNV version from cluster (CNV gating will be skipped)');
   }
 };
 
@@ -46,7 +65,6 @@ const globalSetup = async (config: FullConfig) => {
     const browser = await chromium.launch();
     const page = await browser.newPage({ ignoreHTTPSErrors: true });
 
-    // Listen to page errors
     page.on('pageerror', (error) => {
       console.error(`🚨 Page error: ${error.message}`);
     });
@@ -61,6 +79,7 @@ const globalSetup = async (config: FullConfig) => {
       console.error('✅ Authentication completed successfully');
 
       await detectForkliftVersion(page);
+      await detectCnvVersion(page);
     } catch (error) {
       console.error('❌ Login failed in global setup:', error);
       throw error;
@@ -69,12 +88,24 @@ const globalSetup = async (config: FullConfig) => {
     }
   } else {
     console.error('⚠️ No credentials provided, skipping authentication setup');
-    console.error(`📌 Forklift version: ${process.env[VERSION_ENV_VAR]}`);
 
-    if (!process.env[VERSION_ENV_VAR]) {
-      process.env[VERSION_ENV_VAR] = 'latest';
-      console.error('📌 No credentials and no FORKLIFT_VERSION set, defaulting to "latest"');
+    const browser = await chromium.launch();
+    const page = await browser.newPage({ ignoreHTTPSErrors: true });
+
+    try {
+      await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+      await detectForkliftVersion(page);
+      await detectCnvVersion(page);
+    } catch {
+      console.error('⚠️ Could not reach cluster for version detection, using env vars/defaults');
+    } finally {
+      await browser.close();
     }
+  }
+
+  if (!process.env[VERSION_ENV_VAR]) {
+    process.env[VERSION_ENV_VAR] = 'latest';
+    console.error('📌 No FORKLIFT_VERSION detected or set, defaulting to "latest"');
   }
 };
 

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -33,16 +33,22 @@ const detectForkliftVersion = async (page: Page): Promise<void> => {
  * Unlike Forklift, CNV version is optional — tests run when it's unknown.
  */
 const detectCnvVersion = async (page: Page): Promise<void> => {
-  const detectedVersion = await ResourceFetcher.fetchCnvVersion(page);
+  try {
+    const detectedVersion = await ResourceFetcher.fetchCnvVersion(page);
 
-  const existing = process.env[CNV_VERSION_ENV_VAR];
-  if (existing) {
-    console.error(`📌 Using pre-set CNV version: ${existing}`);
-  } else if (detectedVersion) {
-    process.env[CNV_VERSION_ENV_VAR] = detectedVersion;
-    console.error(`🔍 Auto-detected CNV version: ${detectedVersion}`);
-  } else {
-    console.error('⚠️ Could not auto-detect CNV version from cluster (CNV gating will be skipped)');
+    const existing = process.env[CNV_VERSION_ENV_VAR];
+    if (existing) {
+      console.error(`📌 Using pre-set CNV version: ${existing}`);
+    } else if (detectedVersion) {
+      process.env[CNV_VERSION_ENV_VAR] = detectedVersion;
+      console.error(`🔍 Auto-detected CNV version: ${detectedVersion}`);
+    } else {
+      console.error(
+        '⚠️ Could not auto-detect CNV version from cluster (CNV gating will be skipped)',
+      );
+    }
+  } catch (error) {
+    console.error('⚠️ CNV version detection failed (CNV gating will be skipped):', error);
   }
 };
 

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -101,11 +101,11 @@ const globalSetup = async (config: FullConfig) => {
     } finally {
       await browser.close();
     }
-  }
 
-  if (!process.env[VERSION_ENV_VAR]) {
-    process.env[VERSION_ENV_VAR] = 'latest';
-    console.error('📌 No FORKLIFT_VERSION detected or set, defaulting to "latest"');
+    if (!process.env[VERSION_ENV_VAR]) {
+      process.env[VERSION_ENV_VAR] = 'latest';
+      console.error('📌 No credentials and no FORKLIFT_VERSION set, defaulting to "latest"');
+    }
   }
 };
 

--- a/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
+++ b/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
@@ -1,0 +1,50 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { PAGE_LOAD_TIMEOUT } from '../../utils/resource-manager/constants';
+import { disableGuidedTour } from '../../utils/utils';
+
+const CNV_VM_URL_PATTERN = /kubevirt\.io~v1~VirtualMachine/;
+
+/**
+ * Page object for the kubevirt-enhanced VirtualMachine details page.
+ * Tabs: Overview, Metrics, YAML, Configuration, Events, Console, Snapshots, Diagnostics
+ */
+export class VirtualMachineDetailsPage {
+  protected readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  private get main(): Locator {
+    return this.page.locator('main');
+  }
+
+  get overviewTab(): Locator {
+    return this.main.getByRole('link', { name: 'Overview', exact: true });
+  }
+
+  async verifySmokeOverview(expectedName: string): Promise<void> {
+    await expect(this.main.getByText(expectedName).first()).toBeVisible();
+
+    await expect(this.main.locator('dt').filter({ hasText: 'Name' }).first()).toBeVisible();
+    await expect(this.main.locator('dt').filter({ hasText: 'Status' }).first()).toBeVisible();
+    await expect(this.main.locator('dt').filter({ hasText: 'CPU | Memory' }).first()).toBeVisible();
+
+    await expect(this.main.getByRole('link', { name: /Network \(\d+\)/ })).toBeVisible();
+    await expect(this.main.getByRole('link', { name: /Storage \([1-9]\d*\)/ })).toBeVisible();
+  }
+
+  async waitForPageLoad(vmName?: string): Promise<void> {
+    await expect(this.page).toHaveURL(CNV_VM_URL_PATTERN, { timeout: PAGE_LOAD_TIMEOUT });
+    await disableGuidedTour(this.page);
+    await expect(this.overviewTab).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+    if (vmName) {
+      await expect(this.main.getByText(vmName).first()).toBeVisible({
+        timeout: PAGE_LOAD_TIMEOUT,
+      });
+    }
+  }
+}
+
+export default VirtualMachineDetailsPage;

--- a/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
+++ b/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
@@ -27,9 +27,24 @@ export class VirtualMachineDetailsPage {
   async verifySmokeOverview(expectedName: string): Promise<void> {
     await expect(this.main.getByText(expectedName).first()).toBeVisible();
 
-    await expect(this.main.locator('dt').filter({ hasText: 'Name' }).first()).toBeVisible();
-    await expect(this.main.locator('dt').filter({ hasText: 'Status' }).first()).toBeVisible();
-    await expect(this.main.locator('dt').filter({ hasText: 'CPU | Memory' }).first()).toBeVisible();
+    await expect(
+      this.main
+        .locator('dt')
+        .filter({ hasText: /^Name$/ })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      this.main
+        .locator('dt')
+        .filter({ hasText: /^Status$/ })
+        .first(),
+    ).toBeVisible();
+    await expect(
+      this.main
+        .locator('dt')
+        .filter({ hasText: /^CPU \| Memory$/ })
+        .first(),
+    ).toBeVisible();
 
     await expect(this.main.getByRole('link', { name: /Network \(\d+\)/ })).toBeVisible();
     await expect(this.main.getByRole('link', { name: /Storage \([1-9]\d*\)/ })).toBeVisible();

--- a/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
+++ b/testing/playwright/page-objects/CNV/VirtualMachineDetailsPage.ts
@@ -25,7 +25,7 @@ export class VirtualMachineDetailsPage {
   }
 
   async verifySmokeOverview(expectedName: string): Promise<void> {
-    await expect(this.main.getByText(expectedName).first()).toBeVisible();
+    await expect(this.main.getByText(expectedName, { exact: true }).first()).toBeVisible();
 
     await expect(
       this.main
@@ -55,7 +55,7 @@ export class VirtualMachineDetailsPage {
     await disableGuidedTour(this.page);
     await expect(this.overviewTab).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     if (vmName) {
-      await expect(this.main.getByText(vmName).first()).toBeVisible({
+      await expect(this.main.getByText(vmName, { exact: true }).first()).toBeVisible({
         timeout: PAGE_LOAD_TIMEOUT,
       });
     }

--- a/testing/playwright/utils/resource-manager/ResourceFetcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourceFetcher.ts
@@ -7,7 +7,14 @@ import type {
 import type { Page } from '@playwright/test';
 
 import { BaseResourceManager } from './BaseResourceManager';
-import { API_PATHS, MTV_NAMESPACE, OPERATOR_CSV_PREFIXES, RESOURCE_KINDS } from './constants';
+import {
+  API_PATHS,
+  CNV_NAMESPACE,
+  CNV_OPERATOR_CSV_PREFIXES,
+  MTV_NAMESPACE,
+  OPERATOR_CSV_PREFIXES,
+  RESOURCE_KINDS,
+} from './constants';
 import type { SupportedResource } from './ResourceManager';
 
 /**
@@ -15,6 +22,38 @@ import type { SupportedResource } from './ResourceManager';
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResourceFetcher extends BaseResourceManager {
+  /**
+   * Fetches the CNV (OpenShift Virtualization) operator version from the cluster
+   * by reading the ClusterServiceVersion (CSV) resource created by OLM.
+   *
+   * Looks for a CSV whose name starts with "kubevirt-hyperconverged-operator"
+   * (downstream) or "community-kubevirt-hyperconverged" (upstream).
+   *
+   * @returns The semver version string (e.g. "4.18.0") or null if not found.
+   */
+  static async fetchCnvVersion(page: Page, namespace = CNV_NAMESPACE): Promise<string | null> {
+    type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
+    type CsvList = { items?: CsvItem[] };
+
+    const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
+    const data = await ResourceFetcher.apiGet<CsvList>(page, apiPath);
+
+    if (!data?.items) {
+      return null;
+    }
+
+    const operatorCsv = data.items.find((csv) =>
+      CNV_OPERATOR_CSV_PREFIXES.some((prefix) => csv.metadata?.name?.startsWith(prefix)),
+    );
+
+    if (!operatorCsv?.spec?.version) {
+      console.error('CNV operator CSV not found among cluster service versions');
+      return null;
+    }
+
+    return operatorCsv.spec.version;
+  }
+
   static async fetchForkliftController(
     page: Page,
     controllerName: string,

--- a/testing/playwright/utils/resource-manager/constants.ts
+++ b/testing/playwright/utils/resource-manager/constants.ts
@@ -1,6 +1,8 @@
 // Shared constants for resource management
 
-export const K8S_RECONCILE_TIMEOUT = 40000;
+export const ELEMENT_TIMEOUT = 15_000;
+export const K8S_RECONCILE_TIMEOUT = 40_000;
+export const PAGE_LOAD_TIMEOUT = 30_000;
 export const MTV_NAMESPACE = 'openshift-mtv';
 
 export const RESOURCE_KINDS = {
@@ -55,6 +57,13 @@ export const API_PATHS = {
 
 // Prefixes used to identify the MTV/Forklift operator ClusterServiceVersion
 export const OPERATOR_CSV_PREFIXES = ['mtv-operator', 'forklift-operator'] as const;
+
+// CNV (OpenShift Virtualization) operator detection
+export const CNV_NAMESPACE = 'openshift-cnv';
+export const CNV_OPERATOR_CSV_PREFIXES = [
+  'kubevirt-hyperconverged-operator',
+  'community-kubevirt-hyperconverged',
+] as const;
 
 // HTTP headers and other constants
 export const HTTP_HEADERS = {

--- a/testing/playwright/utils/version/constants.ts
+++ b/testing/playwright/utils/version/constants.ts
@@ -3,10 +3,21 @@ import type { VersionTuple } from './types';
 /** Environment variable name for the Forklift version. Auto-detected from the cluster CSV; set explicitly to override. */
 export const VERSION_ENV_VAR = 'FORKLIFT_VERSION';
 
+/** Environment variable name for the CNV (OpenShift Virtualization) version. Auto-detected from the cluster CSV; set explicitly to override. */
+export const CNV_VERSION_ENV_VAR = 'CNV_VERSION';
+
 /** Marker checked by check-version-gating.sh to distinguish version skips from other skips. */
 export const VERSION_GATE_TAG = '[version-gated]';
 
-/** Pre-parsed version constants — avoids repeated string parsing. */
+/** Marker for CNV version-gated skips — distinct from VERSION_GATE_TAG so check-version-gating.sh does not flag these. */
+export const CNV_VERSION_GATE_TAG = '[cnv-version-gated]';
+
+/** Pre-parsed Forklift version constants — avoids repeated string parsing. */
 export const V2_10_5: VersionTuple = [2, 10, 5];
 export const V2_11_0: VersionTuple = [2, 11, 0];
 export const V2_12_0: VersionTuple = [2, 12, 0];
+
+/** Pre-parsed CNV (OpenShift Virtualization) version constants. */
+export const CNV_4_17_0: VersionTuple = [4, 17, 0];
+export const CNV_4_18_0: VersionTuple = [4, 18, 0];
+export const CNV_4_21_0: VersionTuple = [4, 21, 0];

--- a/testing/playwright/utils/version/version.ts
+++ b/testing/playwright/utils/version/version.ts
@@ -1,5 +1,14 @@
-import { VERSION_ENV_VAR, VERSION_GATE_TAG } from './constants';
+import {
+  CNV_VERSION_ENV_VAR,
+  CNV_VERSION_GATE_TAG,
+  VERSION_ENV_VAR,
+  VERSION_GATE_TAG,
+} from './constants';
 import type { SkippableTest, VersionTuple } from './types';
+
+// ---------------------------------------------------------------------------
+// Generic version parsing and comparison
+// ---------------------------------------------------------------------------
 
 const isLatest = (versionString: string): boolean =>
   versionString.trim().toLowerCase() === 'latest';
@@ -19,48 +28,63 @@ const parseVersion = (versionString: string): VersionTuple | null => {
 const resolveTuple = (version: VersionTuple | string): VersionTuple | null =>
   Array.isArray(version) ? version : parseVersion(version);
 
-const getForkliftVersion = (): string | undefined =>
-  process.env[VERSION_ENV_VAR]?.trim() ?? undefined;
-
-const getForkliftVersionTuple = (): VersionTuple | null => {
-  const versionString = getForkliftVersion();
-  return versionString && !isLatest(versionString) ? parseVersion(versionString) : null;
-};
-
 const compareTuples = (a: VersionTuple, b: VersionTuple): number => {
   if (a[0] !== b[0]) return a[0] - b[0];
   if (a[1] !== b[1]) return a[1] - b[1];
   return a[2] - b[2];
 };
 
-/** True if the current Forklift version >= minimumVersion. Unset version returns false. */
-export const isVersionAtLeast = (minimumVersion: VersionTuple | string): boolean => {
-  const versionString = getForkliftVersion();
-  if (!versionString) return false;
+const formatVersion = (tuple: VersionTuple): string => tuple.join('.');
+
+// ---------------------------------------------------------------------------
+// Generic helpers parameterized by env var
+// ---------------------------------------------------------------------------
+
+const getVersionString = (envVar: string): string | undefined =>
+  process.env[envVar]?.trim() ?? undefined;
+
+const getVersionTuple = (envVar: string): VersionTuple | null => {
+  const versionString = getVersionString(envVar);
+  return versionString && !isLatest(versionString) ? parseVersion(versionString) : null;
+};
+
+/**
+ * Check if the version from `envVar` is >= `minimumVersion`.
+ *
+ * @param whenUnset - value to return when the env var is unset.
+ *   Forklift uses `false` (unset = skip), CNV uses `true` (unset = run).
+ */
+const versionAtLeast = (
+  envVar: string,
+  minimumVersion: VersionTuple | string,
+  whenUnset: boolean,
+): boolean => {
+  const versionString = getVersionString(envVar);
+  if (!versionString) return whenUnset;
   if (isLatest(versionString)) return true;
-  const currentVersion = getForkliftVersionTuple();
-  if (!currentVersion) return false;
+  const currentVersion = getVersionTuple(envVar);
+  if (!currentVersion) return whenUnset;
   const resolvedMinimum = resolveTuple(minimumVersion);
   if (!resolvedMinimum) return false;
   return compareTuples(currentVersion, resolvedMinimum) >= 0;
 };
 
 /**
- * True if the current version satisfies any of the per-stream minimums.
- * Useful for backported features where different minor streams have different minimum patches.
+ * Check if the version from `envVar` satisfies any of the per-stream minimums.
  *
- * Example: isVersionInStreams([V2_10_5, [2, 11, 1]]) means:
- *   - 2.10.5+ on the 2.10.x stream  -> true
- *   - 2.11.0                         -> false (below 2.11.1 minimum)
- *   - 2.11.1+                        -> true
- *   - 2.12.x+                        -> true (higher than any listed stream)
+ * @param whenUnset - value to return when the env var is unset.
  */
-export const isVersionInStreams = (streamMinimums: readonly (VersionTuple | string)[]): boolean => {
-  const currentVersion = getForkliftVersionTuple();
+const versionInStreams = (
+  envVar: string,
+  streamMinimums: readonly (VersionTuple | string)[],
+  whenUnset: boolean,
+): boolean => {
+  const currentVersion = getVersionTuple(envVar);
 
   if (!currentVersion) {
-    const versionString = getForkliftVersion();
-    return versionString ? isLatest(versionString) : false;
+    const versionString = getVersionString(envVar);
+    if (!versionString) return whenUnset;
+    return isLatest(versionString);
   }
 
   const parsedMinimums = streamMinimums
@@ -74,7 +98,7 @@ export const isVersionInStreams = (streamMinimums: readonly (VersionTuple | stri
   );
 
   if (matchingStreamMinimum) {
-    return isVersionAtLeast(matchingStreamMinimum);
+    return versionAtLeast(envVar, matchingStreamMinimum, whenUnset);
   }
 
   const highestStreamMinimum = parsedMinimums.reduce(
@@ -83,29 +107,43 @@ export const isVersionInStreams = (streamMinimums: readonly (VersionTuple | stri
     parsedMinimums[0],
   );
 
-  return isVersionAtLeast(highestStreamMinimum);
+  return versionAtLeast(envVar, highestStreamMinimum, whenUnset);
 };
 
 // ---------------------------------------------------------------------------
-// requireVersion — describe-level and test-level version gating
+// Forklift (MTV) version gating — unset version → skip (mandatory gating)
 // ---------------------------------------------------------------------------
 
-const formatVersion = (tuple: VersionTuple): string => tuple.join('.');
+/** True if the current Forklift version >= minimumVersion. Unset version returns false. */
+export const isVersionAtLeast = (minimumVersion: VersionTuple | string): boolean =>
+  versionAtLeast(VERSION_ENV_VAR, minimumVersion, false);
 
-const buildSkipMessage = (version: VersionTuple | readonly VersionTuple[]): string => {
+/**
+ * True if the current Forklift version satisfies any of the per-stream minimums.
+ *
+ * Example: isVersionInStreams([V2_10_5, [2, 11, 1]]) means:
+ *   - 2.10.5+ on the 2.10.x stream  -> true
+ *   - 2.11.0                         -> false (below 2.11.1 minimum)
+ *   - 2.11.1+                        -> true
+ *   - 2.12.x+                        -> true (higher than any listed stream)
+ */
+export const isVersionInStreams = (streamMinimums: readonly (VersionTuple | string)[]): boolean =>
+  versionInStreams(VERSION_ENV_VAR, streamMinimums, false);
+
+const buildForkliftSkipMessage = (version: VersionTuple | readonly VersionTuple[]): string => {
   const reason = Array.isArray(version[0])
     ? `Requires Forklift version in streams: ${(version as readonly VersionTuple[]).map(formatVersion).join(', ')}`
     : `Requires Forklift ${formatVersion(version as VersionTuple)}+`;
   return `${VERSION_GATE_TAG} ${reason}`;
 };
 
-const shouldSkip = (version: VersionTuple | readonly VersionTuple[]): boolean =>
+const shouldSkipForklift = (version: VersionTuple | readonly VersionTuple[]): boolean =>
   Array.isArray(version[0])
     ? !isVersionInStreams(version as readonly VersionTuple[])
     : !isVersionAtLeast(version as VersionTuple);
 
 /**
- * Skip tests when the cluster version is below the minimum.
+ * Skip tests when the cluster Forklift version is below the minimum.
  * Works at both describe-level and inside a test body.
  *
  *   requireVersion(test, V2_11_0);
@@ -115,5 +153,48 @@ export const requireVersion = (
   testObj: SkippableTest,
   version: VersionTuple | readonly VersionTuple[],
 ): void => {
-  testObj.skip(shouldSkip(version), buildSkipMessage(version));
+  testObj.skip(shouldSkipForklift(version), buildForkliftSkipMessage(version));
+};
+
+// ---------------------------------------------------------------------------
+// CNV (OpenShift Virtualization) version gating — unset version → run (optional gating)
+// ---------------------------------------------------------------------------
+
+/** True if the current CNV version >= minimumVersion. Unset version returns true (tests run by default). */
+export const isCNVVersionAtLeast = (minimumVersion: VersionTuple | string): boolean =>
+  versionAtLeast(CNV_VERSION_ENV_VAR, minimumVersion, true);
+
+/**
+ * True if the current CNV version satisfies any of the per-stream minimums.
+ * Unset version returns true (tests run by default).
+ */
+export const isCNVVersionInStreams = (
+  streamMinimums: readonly (VersionTuple | string)[],
+): boolean => versionInStreams(CNV_VERSION_ENV_VAR, streamMinimums, true);
+
+const buildCNVSkipMessage = (version: VersionTuple | readonly VersionTuple[]): string => {
+  const reason = Array.isArray(version[0])
+    ? `Requires CNV version in streams: ${(version as readonly VersionTuple[]).map(formatVersion).join(', ')}`
+    : `Requires CNV ${formatVersion(version as VersionTuple)}+`;
+  return `${CNV_VERSION_GATE_TAG} ${reason}`;
+};
+
+const shouldSkipCNV = (version: VersionTuple | readonly VersionTuple[]): boolean =>
+  Array.isArray(version[0])
+    ? !isCNVVersionInStreams(version as readonly VersionTuple[])
+    : !isCNVVersionAtLeast(version as VersionTuple);
+
+/**
+ * Skip tests when the cluster CNV version is below the minimum.
+ * Unlike requireVersion, this is optional — tests run when CNV version is unknown.
+ * Works at both describe-level and inside a test body.
+ *
+ *   requireCNVVersion(test, CNV_4_18_0);
+ *   requireCNVVersion(test, [CNV_4_17_0, CNV_4_18_0]);  // multi-stream
+ */
+export const requireCNVVersion = (
+  testObj: SkippableTest,
+  version: VersionTuple | readonly VersionTuple[],
+): void => {
+  testObj.skip(shouldSkipCNV(version), buildCNVSkipMessage(version));
 };

--- a/testing/playwright/utils/version/version.ts
+++ b/testing/playwright/utils/version/version.ts
@@ -63,7 +63,7 @@ const versionAtLeast = (
   if (!versionString) return whenUnset;
   if (isLatest(versionString)) return true;
   const currentVersion = getVersionTuple(envVar);
-  if (!currentVersion) return whenUnset;
+  if (!currentVersion) return false;
   const resolvedMinimum = resolveTuple(minimumVersion);
   if (!resolvedMinimum) return false;
   return compareTuples(currentVersion, resolvedMinimum) >= 0;

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -67,6 +67,7 @@ export CLUSTER_USERNAME="kubeadmin"
 export CLUSTER_PASSWORD=${CLUSTER_PASSWORD}
 export VSPHERE_PROVIDER=${VSPHERE_PROVIDER}
 export FORKLIFT_VERSION=${FORKLIFT_VERSION}
+export CNV_VERSION=${CNV_VERSION}
 
 log "Running Playwright tests..."
 echo "  Cluster: ${CLUSTER_NAME}"


### PR DESCRIPTION
## 📝 Links

- [MTV-4907](https://issues.redhat.com/browse/MTV-4907)

## 📝 Description

Part 2 for MTV-4907 — adds CNV version gating to the Playwright E2E framework and a post-migration smoke test that verifies migrated VMs on the kubevirt VM details page.

- Add `requireCNVVersion()` with optional semantics (tests run when CNV version is unknown, unlike MTV gating)
- Auto-detect CNV version from cluster CSV during global setup
- New `VirtualMachineDetailsPage` page object for kubevirt VM pages
- Smoke test verifies each migrated VM: name, status, CPU|Memory, Network, Storage sections
- Support `DEFAULT_PLUGINS` env var in `start-console.sh`

## 🎥 Demo

<!-- Please add a video or an image of the behavior/changes -->

## 📝 CC://

[MTV-4907]: https://redhat.atlassian.net/browse/MTV-4907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for CNV operator version auto-detection in testing infrastructure
  * Introduced end-to-end test coverage for CNV-specific virtual machine migration verification

* **Bug Fixes**
  * Improved translation text lookup to scope to main page content area

* **Documentation**
  * CLI help text now documents `DEFAULT_PLUGINS` environment variable as an alternative source for plugin configuration

* **Tests**
  * Updated Playwright testing framework
  * Enhanced test infrastructure with automatic OpenShift Virtualization version detection and conditional test gating
<!-- end of auto-generated comment: release notes by coderabbit.ai -->