### PR TITLE
Resolves: MTV-4881 | Warn when shared disk migration is disabled without VDDK

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -376,6 +376,7 @@
   "Details": "Details",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.",
   "Disabled": "Disabled",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "Disk counter",
   "Disk decryption": "Disk decryption",
   "Disk decryption passphrases": "Disk decryption passphrases",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -380,6 +380,7 @@
   "Details": "Detalles",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "Determina la frecuencia con la que el sistema comprueba el estado de la creación o eliminación de instantáneas durante la migración en caliente de oVirt. El valor predeterminado es 10 segundos.",
   "Disabled": "Desactivado",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "Contador de discos",
   "Disk decryption": "Descifrado de disco",
   "Disk decryption passphrases": "Frases de paso para descifrado de disco",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -380,6 +380,7 @@
   "Details": "Détails",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "Détermine la fréquence à laquelle le système vérifie l'état de création ou de suppression des snapshots lors d'une migration à chaud oVirt. La valeur par défaut est de 10 secondes.",
   "Disabled": "Désactivé",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "Compteur de disque",
   "Disk decryption": "Déchiffrement du disque",
   "Disk decryption passphrases": "Phrases de passe de décryptage de disque",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -376,6 +376,7 @@
   "Details": "詳細",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "oVirt ウォームマイグレーション中にシステムがスナップショットの作成または削除のステータスを確認する頻度を指定します。デフォルト値は 10 秒です。",
   "Disabled": "無効",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "ディスクカウンター",
   "Disk decryption": "ディスク復号",
   "Disk decryption passphrases": "ディスク復号パスフレーズ",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -376,6 +376,7 @@
   "Details": "세부 정보",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "oVirt 웜 마이그레이션 중에 시스템이 스냅샷 생성 또는 제거 상태를 확인하는 빈도를 결정합니다. 기본값은 10초입니다.",
   "Disabled": "비활성화됨",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "디스크 수",
   "Disk decryption": "디스크 복호화",
   "Disk decryption passphrases": "디스크 복호화 암호문",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -376,6 +376,7 @@
   "Details": "详情",
   "Determines the frequency with which the system checks the status of snapshot creation or removal during oVirt warm migration. The default value is 10 seconds.": "决定在 oVirt warm 迁移期间系统检查快照创建或删除状态的频率。默认值为 10 秒。",
   "Disabled": "禁用",
+  "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.": "Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.",
   "Disk counter": "磁盘计数器",
   "Disk decryption": "磁盘解密",
   "Disk decryption passphrases": "磁盘解密密码短语",

--- a/src/plans/components/PlanVddkForSharedDisksWarningAlert.tsx
+++ b/src/plans/components/PlanVddkForSharedDisksWarningAlert.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react';
+
+import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
+import { Alert, AlertVariant, Stack } from '@patternfly/react-core';
+import { CREATE_VDDK_HELP_LINK } from '@utils/constants';
+import { useForkliftTranslation } from '@utils/i18n';
+
+const PlanVddkForSharedDisksWarningAlert: FC = () => {
+  const { t } = useForkliftTranslation();
+
+  return (
+    <Alert
+      isInline
+      title={t('Must enable VMware Virtual Disk Development Kit')}
+      variant={AlertVariant.warning}
+      className="pf-v6-u-mt-sm pf-v6-u-ml-lg"
+    >
+      <Stack hasGutter>
+        {t(
+          'Disabling shared disk migration requires VDDK to be configured on the VMware provider. Without VDDK, the migration will stall. Either enable VDDK on the provider or keep shared disk migration enabled.',
+        )}
+
+        <ExternalLink isInline hideIcon href={CREATE_VDDK_HELP_LINK}>
+          {t('Learn more about VDDK')}
+        </ExternalLink>
+      </Stack>
+    </Alert>
+  );
+};
+
+export default PlanVddkForSharedDisksWarningAlert;

--- a/src/plans/create/steps/other-settings/SharedDisksField.tsx
+++ b/src/plans/create/steps/other-settings/SharedDisksField.tsx
@@ -1,11 +1,15 @@
 import type { FC } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, useWatch } from 'react-hook-form';
+import PlanVddkForSharedDisksWarningAlert from 'src/plans/components/PlanVddkForSharedDisksWarningAlert';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import { Checkbox, FormGroup, FormHelperText, Stack } from '@patternfly/react-core';
+import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
+import { GeneralFormFieldId } from '../general-information/constants';
 
 import { otherFormFieldLabels, OtherSettingsFormFieldId } from './constants';
 
@@ -14,6 +18,14 @@ const SharedDisksField: FC = () => {
   const { control } = useCreatePlanFormContext();
   const fieldId = OtherSettingsFormFieldId.MigrateSharedDisks;
   const label = otherFormFieldLabels[fieldId];
+
+  const [migrateSharedDisks, sourceProvider] = useWatch({
+    control,
+    name: [fieldId, GeneralFormFieldId.SourceProvider],
+  });
+  const isVddkInitImageNotSet =
+    sourceProvider?.spec?.type === PROVIDER_TYPES.vsphere &&
+    isEmpty(sourceProvider?.spec?.settings?.vddkInitImage);
 
   return (
     <FormGroup
@@ -45,6 +57,8 @@ const SharedDisksField: FC = () => {
             />
           )}
         />
+
+        {!migrateSharedDisks && isVddkInitImageNotSet && <PlanVddkForSharedDisksWarningAlert />}
       </Stack>
     </FormGroup>
   );

--- a/src/plans/details/tabs/Details/components/SettingsSection/SettingsSection.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/SettingsSection.tsx
@@ -8,6 +8,7 @@ import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
 import { DescriptionList } from '@patternfly/react-core';
 import { FEATURE_NAMES } from '@utils/constants';
 import { getNamespace } from '@utils/crds/common/selectors';
+import { isEmpty } from '@utils/helpers';
 import { useFeatureFlags } from '@utils/hooks/useFeatureFlags';
 
 import usePlanSourceProvider from '../../../../hooks/usePlanSourceProvider';
@@ -46,6 +47,7 @@ const SettingsSection: FC<SettingsSectionProps> = ({ plan }) => {
   const isVsphere = sourceProvider?.spec?.type === 'vsphere';
   const isOvirt = sourceProvider?.spec?.type === 'ovirt';
   const migrationType = getPlanMigrationType(plan);
+  const isVddkInitImageNotSet = isEmpty(sourceProvider?.spec?.settings?.vddkInitImage);
 
   const isTransferNetworkVisible =
     !hasLiveMigrationProviderType(sourceProvider) ||
@@ -64,7 +66,12 @@ const SettingsSection: FC<SettingsSectionProps> = ({ plan }) => {
         shouldRender={isVsphere}
       />
       <RootDiskDetailsItem plan={plan} canPatch={canPatch} shouldRender={isVsphere} />
-      <SharedDisksDetailsItem plan={plan} canPatch={canPatch} shouldRender={isVsphere} />
+      <SharedDisksDetailsItem
+        plan={plan}
+        canPatch={canPatch}
+        shouldRender={isVsphere}
+        isVddkInitImageNotSet={isVddkInitImageNotSet}
+      />
       <PVCNameTemplateDetailsItem plan={plan} canPatch={canPatch} shouldRender={isVsphere} />
       <TransferNetworkDetailsItem
         plan={plan}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import PlanVddkForSharedDisksWarningAlert from 'src/plans/components/PlanVddkForSharedDisksWarningAlert';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import ModalForm from '@components/ModalForm/ModalForm';
@@ -10,7 +11,11 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { getMigrateSharedDisksValue, onConfirmMigrateSharedDisks } from './utils/utils';
 
-const EditMigrateSharedDisks: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditMigrateSharedDisks: ModalComponent<EditPlanProps> = ({
+  isVddkInitImageNotSet,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(getMigrateSharedDisksValue(resource));
 
@@ -48,6 +53,11 @@ const EditMigrateSharedDisks: ModalComponent<EditPlanProps> = ({ resource, ...re
               variant={AlertVariant.info}
               title={t('This may slow down the migration process')}
             />
+          </StackItem>
+        )}
+        {!value && isVddkInitImageNotSet && (
+          <StackItem>
+            <PlanVddkForSharedDisksWarningAlert />
           </StackItem>
         )}
       </Stack>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import PlanVddkForSharedDisksWarningAlert from 'src/plans/components/PlanVddkForSharedDisksWarningAlert';
+import usePlanSourceProvider from 'src/plans/details/hooks/usePlanSourceProvider';
 import type { EnhancedPlanSpecVms } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
@@ -6,6 +8,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { Alert, AlertVariant, Radio, Stack, StackItem } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
+import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import type { EditPlanProps } from '../../utils/types';
@@ -26,6 +29,8 @@ const EditVmMigrateSharedDisks: ModalComponent<EditVmMigrateSharedDisksProps> = 
   ...rest
 }) => {
   const { t } = useForkliftTranslation();
+  const { sourceProvider } = usePlanSourceProvider(resource);
+  const isVddkInitImageNotSet = isEmpty(sourceProvider?.spec?.settings?.vddkInitImage);
   const vm = getPlanVirtualMachines(resource)[index] as EnhancedPlanSpecVms | undefined;
   const currentVmValue = getVmMigrateSharedDisks(vm);
   const planValue = getMigrateSharedDisksValue(resource);
@@ -83,6 +88,9 @@ const EditVmMigrateSharedDisks: ModalComponent<EditVmMigrateSharedDisksProps> = 
             data-testid="shared-disks-option-inherit"
           />
           {isInherit && planValue && sharedDisksSlowdownAlert}
+          {isInherit && !planValue && isVddkInitImageNotSet && (
+            <PlanVddkForSharedDisksWarningAlert />
+          )}
         </StackItem>
         <StackItem>
           <Radio
@@ -108,6 +116,9 @@ const EditVmMigrateSharedDisks: ModalComponent<EditVmMigrateSharedDisksProps> = 
             }}
             data-testid="shared-disks-option-disabled"
           />
+          {!isInherit && !resolvedValue && isVddkInitImageNotSet && (
+            <PlanVddkForSharedDisksWarningAlert />
+          )}
         </StackItem>
       </Stack>
     </ModalForm>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
@@ -12,7 +12,12 @@ import type { EditableDetailsItemProps } from '../../../utils/types';
 import { getMigrateSharedDisksValue } from './utils/utils';
 import EditMigrateSharedDisks from './EditMigrateSharedDisks';
 
-const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan, shouldRender }) => {
+const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({
+  canPatch,
+  isVddkInitImageNotSet,
+  plan,
+  shouldRender,
+}) => {
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
@@ -31,7 +36,7 @@ const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan, 
       }
       crumbs={['spec', 'migrateSharedDisks']}
       onEdit={() => {
-        launcher<EditPlanProps>(EditMigrateSharedDisks, { resource: plan });
+        launcher<EditPlanProps>(EditMigrateSharedDisks, { isVddkInitImageNotSet, resource: plan });
       }}
       canEdit={canPatch && isPlanEditable(plan)}
     />


### PR DESCRIPTION
## 📝 Links

- [MTV-4881](https://redhat.atlassian.net/browse/MTV-4881)

## 📝 Description

When "Migrate Shared Disks" is disabled on a VMware plan, the backend falls back to CDI-based disk transfer which requires VDDK. If the provider has no VDDK image configured, the migration silently stalls at 20% ([`ShouldUseV2vForTransfer`](https://github.com/kubev2v/forklift/blob/main/pkg/apis/forklift/v1beta1/plan.go#L424-L447) returns `false` when `migrateSharedDisks` is `false`, forcing the [CDI/VDDK path](https://github.com/kubev2v/forklift/blob/main/pkg/controller/plan/adapter/vsphere/builder.go#L580-L598) which creates a DataVolume with an empty `InitImageURL`). The backend [`validateVddkImage`](https://github.com/kubev2v/forklift/blob/main/pkg/controller/plan/validation.go#L1629-L1672) is also missing this check (only covers warm migration and `skipGuestConversion`).

This PR adds a warning alert to inform the user that VDDK must be configured when disabling shared disk migration:

- **Plan creation wizard**: warning shown below the "Migrate Shared Disks" checkbox when unchecked and VDDK is missing
- **Plan details edit modal**: warning shown in the `EditMigrateSharedDisks` modal when the checkbox is unchecked
- **Per-VM edit modal**: warning shown in the `EditVmMigrateSharedDisks` modal when the resolved value (inherit or explicit) disables shared disks

## 🎥 Demo

<img width="939" height="572" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/f9d70445-9309-4d3b-b148-08d8e18afaed" />
<img width="1491" height="534" alt="Screenshot (1)" src="https://github.com/user-attachments/assets/14812eaa-8f20-482a-be42-d06577930809" />
<img width="1163" height="762" alt="Screenshot" src="https://github.com/user-attachments/assets/ef0dbd44-fac4-4d8e-8453-43a98e701100" />


## 📝 CC://


Made with [Cursor](https://cursor.com)

[MTV-4881]: https://redhat.atlassian.net/browse/MTV-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ