### PR TITLE
Resolves: MTV-4676 | Decode base64 Ansible playbooks on review step

### DIFF
--- a/src/plans/create/steps/review/HooksReviewSection.tsx
+++ b/src/plans/create/steps/review/HooksReviewSection.tsx
@@ -1,8 +1,11 @@
 import type { FC } from 'react';
 import { useWatch } from 'react-hook-form';
+import { Base64 } from 'js-base64';
 
 import ExpandableReviewSection from '@components/ExpandableReviewSection/ExpandableReviewSection';
 import {
+  CodeBlock,
+  CodeBlockCode,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
@@ -73,7 +76,15 @@ const HooksReviewSection: FC = () => {
                     {hooksFormFieldLabels[MigrationHookFieldId.AnsiblePlaybook]}
                   </DescriptionListTerm>
                   <DescriptionListDescription data-testid="review-pre-migration-hook-ansible-playbook">
-                    {preMigration[MigrationHookFieldId.AnsiblePlaybook] ?? t('None')}
+                    {preMigration[MigrationHookFieldId.AnsiblePlaybook] ? (
+                      <CodeBlock>
+                        <CodeBlockCode>
+                          {Base64.decode(preMigration[MigrationHookFieldId.AnsiblePlaybook])}
+                        </CodeBlockCode>
+                      </CodeBlock>
+                    ) : (
+                      t('None')
+                    )}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               </>
@@ -124,7 +135,15 @@ const HooksReviewSection: FC = () => {
                     {hooksFormFieldLabels[MigrationHookFieldId.AnsiblePlaybook]}
                   </DescriptionListTerm>
                   <DescriptionListDescription data-testid="review-post-migration-hook-ansible-playbook">
-                    {postMigration[MigrationHookFieldId.AnsiblePlaybook] ?? t('None')}
+                    {postMigration[MigrationHookFieldId.AnsiblePlaybook] ? (
+                      <CodeBlock>
+                        <CodeBlockCode>
+                          {Base64.decode(postMigration[MigrationHookFieldId.AnsiblePlaybook])}
+                        </CodeBlockCode>
+                      </CodeBlock>
+                    ) : (
+                      t('None')
+                    )}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               </>

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -45,8 +45,10 @@ export class ReviewStep {
 
       const playbookLocator = this.page.getByTestId(`${prefix}-ansible-playbook`);
       await expect(playbookLocator).toBeVisible();
-      // TODO: Skipping exact value assertion — review page shows base64 instead of
-      // decoded YAML due to SdkYamlEditor switch in PR #2283. Bug filed upstream.
+
+      if (hookConfig.ansiblePlaybook) {
+        await expect(playbookLocator).toContainText(hookConfig.ansiblePlaybook);
+      }
     }
   }
 


### PR DESCRIPTION
## 📝 Links

- [MTV-4676](https://redhat.atlassian.net/browse/MTV-4676)

## 📝 Description

The `SdkYamlEditor` stores Ansible playbook content as base64 in the react-hook-form state, but `HooksReviewSection` rendered the raw encoded value on the plan wizard review step. This decodes the value with `Base64.decode()` and wraps it in a `CodeBlock` component, matching the pattern already used on the plan details page.

- Decode base64 playbook content for both pre-migration and post-migration hooks in the review step
- Wrap decoded playbook in `CodeBlock`/`CodeBlockCode` for proper YAML formatting
- Update Playwright `ReviewStep` page object to assert decoded playbook content (removes workaround TODO)

## 🎥 Demo


https://github.com/user-attachments/assets/fd0114b8-c797-4d20-be15-1c6531f9c415



## 📝 CC://

[MTV-4676]: https://redhat.atlassian.net/browse/MTV-4676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Ansible playbooks in migration hook configurations are now displayed as formatted code blocks in the review step, improving readability and visual presentation of automation scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->