### PR TITLE
Resolves MTV-5078 : Add E2E tests for per-VM instance type selection

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
@@ -1,0 +1,125 @@
+import { expect } from '@playwright/test';
+
+import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
+import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
+import { V2_12_0 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+const VM_RHEL = 'mtv-func-rhel9';
+const VM_WIN = 'mtv-func-win2019';
+
+test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_12_0);
+
+  test('should set instance types during plan creation and verify in review', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+      virtualMachines: [
+        { folder: 'vm', sourceName: VM_RHEL },
+        { folder: 'vm', sourceName: VM_WIN },
+      ],
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    const wizard = new CreatePlanWizardPage(page, resourceManager);
+    await wizard.navigate();
+    await wizard.waitForWizardLoad();
+    await wizard.navigateToAdditionalSettings(testData);
+
+    const { additionalSettings } = wizard;
+    await additionalSettings.verifyStepVisible();
+    await expect(additionalSettings.instanceTypesSection).toBeVisible({ timeout: 30_000 });
+    await additionalSettings.verifyInstanceTypeDropdownCount(2);
+
+    const rhelLabel = await additionalSettings.selectNonNoneInstanceTypeByIndex(VM_RHEL, 0);
+    const winLabel = await additionalSettings.selectNonNoneInstanceTypeByIndex(VM_WIN, 1);
+    testData.additionalPlanSettings = {
+      instanceTypes: {
+        [VM_RHEL]: rhelLabel,
+        [VM_WIN]: winLabel,
+      },
+    };
+
+    await wizard.clickSkipToReview();
+    await wizard.review.verifyReviewStep(testData);
+    await wizard.clickNext();
+    await wizard.waitForPlanCreation();
+
+    const planDetailsPage = new PlanDetailsPage(page);
+    await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
+    await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
+
+    await planDetailsPage.virtualMachinesTab.waitForVMInstanceType(VM_RHEL, rhelLabel);
+    await planDetailsPage.virtualMachinesTab.waitForVMInstanceType(VM_WIN, winLabel);
+  });
+
+  test('should edit instance type from plan details VM kebab menu', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    await test.step('Create plan via wizard', async () => {
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.fillAndSubmit(testData);
+    });
+
+    const planDetailsPage = new PlanDetailsPage(page);
+    await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
+    await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
+
+    const vmName = testData.virtualMachines?.[0]?.sourceName ?? '';
+
+    let picked = '';
+
+    await test.step('Set instance type from modal', async () => {
+      const { virtualMachinesTab } = planDetailsPage;
+      await virtualMachinesTab.openInstanceTypeDialog(vmName);
+      await expect(virtualMachinesTab.editInstanceTypeModal).toBeVisible();
+      await expect(virtualMachinesTab.instanceTypeModalSelect).toBeVisible();
+      await expect(virtualMachinesTab.instanceTypeModalSaveButton).toBeDisabled();
+
+      await virtualMachinesTab.instanceTypeModalSelect.click();
+      const listbox = page.getByRole('listbox');
+      await expect(listbox).toBeVisible();
+      const secondOption = listbox.getByRole('option').nth(1);
+      picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
+      await secondOption.click();
+      await virtualMachinesTab.instanceTypeModalSaveButton.click();
+      await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
+      await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
+    });
+
+    await test.step('Cancel discards changes', async () => {
+      const { virtualMachinesTab } = planDetailsPage;
+      await virtualMachinesTab.openInstanceTypeDialog(vmName);
+      await virtualMachinesTab.instanceTypeModalSelect.click();
+      await page.getByRole('option', { name: /^None/ }).click();
+      await page.getByTestId('modal-cancel-button').click();
+      await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
+      await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
+    });
+
+    await test.step('Clear instance type to None', async () => {
+      const { virtualMachinesTab } = planDetailsPage;
+      await virtualMachinesTab.openInstanceTypeDialog(vmName);
+      await virtualMachinesTab.instanceTypeModalSelect.click();
+      await page.getByRole('option', { name: /^None/ }).click();
+      await virtualMachinesTab.instanceTypeModalSaveButton.click();
+      await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
+      await virtualMachinesTab.waitForVMInstanceType(vmName, '-');
+    });
+  });
+});

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
@@ -1,10 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import {
-  INSTANCE_TYPE_FIRST_AVAILABLE,
-  INSTANCE_TYPE_SECOND_AVAILABLE,
-  type PlanTestData,
-} from '../../../types/test-data';
+import type { PlanTestData } from '../../../types/test-data';
 import { isEmpty } from '../../../utils/utils';
 
 export class AdditionalSettingsStep {
@@ -24,20 +20,6 @@ export class AdditionalSettingsStep {
     this.useNbdeClevisCheckbox = page.getByTestId('use-nbde-clevis-checkbox');
   }
 
-  private async applyInstanceTypeSelections(instanceTypes: Record<string, string>): Promise<void> {
-    for (const [vmName, spec] of Object.entries(instanceTypes)) {
-      if (spec === INSTANCE_TYPE_FIRST_AVAILABLE) {
-        await this.selectNonNoneInstanceTypeByIndex(vmName, 0);
-      } else if (spec === INSTANCE_TYPE_SECOND_AVAILABLE) {
-        await this.selectNonNoneInstanceTypeByIndex(vmName, 1);
-      } else if (spec === '') {
-        await this.selectNoneInstanceType(vmName);
-      } else {
-        await this.selectInstanceTypeByLabel(vmName, spec);
-      }
-    }
-  }
-
   async fillAndComplete(
     additionalPlanSettings: PlanTestData['additionalPlanSettings'],
   ): Promise<void> {
@@ -49,7 +31,9 @@ export class AdditionalSettingsStep {
       await this.useNbdeClevisCheckbox.check();
     }
     if (additionalPlanSettings?.instanceTypes && !isEmpty(additionalPlanSettings.instanceTypes)) {
-      await this.applyInstanceTypeSelections(additionalPlanSettings.instanceTypes);
+      for (const [vmName, label] of Object.entries(additionalPlanSettings.instanceTypes)) {
+        await this.selectInstanceTypeByLabel(vmName, label);
+      }
     }
   }
 

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
@@ -1,6 +1,11 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import type { PlanTestData } from '../../../types/test-data';
+import {
+  INSTANCE_TYPE_FIRST_AVAILABLE,
+  INSTANCE_TYPE_SECOND_AVAILABLE,
+  type PlanTestData,
+} from '../../../types/test-data';
+import { isEmpty } from '../../../utils/utils';
 
 export class AdditionalSettingsStep {
   private readonly page: Page;
@@ -19,6 +24,20 @@ export class AdditionalSettingsStep {
     this.useNbdeClevisCheckbox = page.getByTestId('use-nbde-clevis-checkbox');
   }
 
+  private async applyInstanceTypeSelections(instanceTypes: Record<string, string>): Promise<void> {
+    for (const [vmName, spec] of Object.entries(instanceTypes)) {
+      if (spec === INSTANCE_TYPE_FIRST_AVAILABLE) {
+        await this.selectNonNoneInstanceTypeByIndex(vmName, 0);
+      } else if (spec === INSTANCE_TYPE_SECOND_AVAILABLE) {
+        await this.selectNonNoneInstanceTypeByIndex(vmName, 1);
+      } else if (spec === '') {
+        await this.selectNoneInstanceType(vmName);
+      } else {
+        await this.selectInstanceTypeByLabel(vmName, spec);
+      }
+    }
+  }
+
   async fillAndComplete(
     additionalPlanSettings: PlanTestData['additionalPlanSettings'],
   ): Promise<void> {
@@ -29,10 +48,72 @@ export class AdditionalSettingsStep {
     if (additionalPlanSettings?.useNbdeClevis) {
       await this.useNbdeClevisCheckbox.check();
     }
+    if (additionalPlanSettings?.instanceTypes && !isEmpty(additionalPlanSettings.instanceTypes)) {
+      await this.applyInstanceTypeSelections(additionalPlanSettings.instanceTypes);
+    }
+  }
+
+  instanceTypeSelectToggle(vmName: string): Locator {
+    return this.page
+      .locator('.instance-type-field__vm-name', { hasText: vmName })
+      .locator('..')
+      .getByRole('button', { name: 'Select menu toggle' });
+  }
+
+  get instanceTypesSection(): Locator {
+    return this.page.locator('[data-testid^="instance-type-select-"]').first();
   }
 
   powerStateOption(state: 'on' | 'off' | 'auto'): Locator {
     return this.page.getByTestId(`power-state-option-${state}`);
+  }
+
+  async selectInstanceTypeByLabel(vmName: string, optionLabel: string): Promise<void> {
+    const toggle = this.instanceTypeSelectToggle(vmName);
+    await expect(toggle).toBeEnabled({ timeout: 120_000 });
+    await toggle.click();
+    await this.page.getByRole('option', { name: optionLabel, exact: true }).click();
+  }
+
+  async selectNoneInstanceType(vmName: string): Promise<void> {
+    const toggle = this.instanceTypeSelectToggle(vmName);
+    await expect(toggle).toBeEnabled({ timeout: 120_000 });
+    await toggle.click();
+    await this.page.getByRole('option', { name: /^None/ }).click();
+  }
+
+  /**
+   * Picks the n-th cluster instance type option (0 = first non-None) and returns its label.
+   */
+  async selectNonNoneInstanceTypeByIndex(vmName: string, index: number): Promise<string> {
+    const toggle = this.instanceTypeSelectToggle(vmName);
+    await expect(toggle).toBeEnabled({ timeout: 120_000 });
+    await toggle.click();
+    const listbox = this.page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+    const options = listbox.getByRole('option');
+    let nonNoneOrdinal = 0;
+    const count = await options.count();
+
+    for (let i = 0; i < count; i += 1) {
+      const opt = options.nth(i);
+      const name = (await opt.innerText()).split('\n')[0]?.trim() ?? '';
+
+      if (name !== 'None') {
+        if (nonNoneOrdinal === index) {
+          await opt.click();
+          return name;
+        }
+
+        nonNoneOrdinal += 1;
+      }
+    }
+
+    throw new Error(`No non-None instance type at index ${index} for VM "${vmName}"`);
+  }
+
+  async verifyInstanceTypeDropdownCount(expected: number): Promise<void> {
+    await expect(this.page.locator('[data-testid^="instance-type-select-"]')).toHaveCount(expected);
   }
 
   async verifyStepVisible(): Promise<void> {

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -1,12 +1,15 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import type {
-  CustomizationScriptsTestData,
-  HookConfig,
-  NetworkMap,
-  PlanTestData,
-  StorageMap,
+import {
+  type CustomizationScriptsTestData,
+  type HookConfig,
+  INSTANCE_TYPE_FIRST_AVAILABLE,
+  INSTANCE_TYPE_SECOND_AVAILABLE,
+  type NetworkMap,
+  type PlanTestData,
+  type StorageMap,
 } from '../../../types/test-data';
+import { isEmpty } from '../../../utils/utils';
 import { V2_11_0 } from '../../../utils/version/constants';
 import { isVersionAtLeast } from '../../../utils/version/version';
 
@@ -187,6 +190,25 @@ export class ReviewStep {
       const expectedLabel = powerStateLabels[additionalPlanSettings.targetPowerState];
 
       await expect(this.page.getByTestId('review-target-power-state')).toHaveText(expectedLabel);
+    }
+
+    const instanceTypes = additionalPlanSettings?.instanceTypes;
+    if (instanceTypes && !isEmpty(Object.keys(instanceTypes))) {
+      const reviewBlock = this.page.getByTestId('review-instance-types');
+      const resolvedEntries = Object.entries(instanceTypes).filter(
+        ([, label]) =>
+          Boolean(label) &&
+          label !== INSTANCE_TYPE_FIRST_AVAILABLE &&
+          label !== INSTANCE_TYPE_SECOND_AVAILABLE,
+      );
+
+      if (isEmpty(resolvedEntries)) {
+        await expect(reviewBlock).toHaveText('None');
+      } else {
+        for (const [vmName, label] of resolvedEntries) {
+          await expect(reviewBlock).toContainText(`${vmName}: ${label}`);
+        }
+      }
     }
   }
 

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -1,13 +1,11 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
-import {
-  type CustomizationScriptsTestData,
-  type HookConfig,
-  INSTANCE_TYPE_FIRST_AVAILABLE,
-  INSTANCE_TYPE_SECOND_AVAILABLE,
-  type NetworkMap,
-  type PlanTestData,
-  type StorageMap,
+import type {
+  CustomizationScriptsTestData,
+  HookConfig,
+  NetworkMap,
+  PlanTestData,
+  StorageMap,
 } from '../../../types/test-data';
 import { isEmpty } from '../../../utils/utils';
 import { V2_11_0 } from '../../../utils/version/constants';
@@ -195,19 +193,9 @@ export class ReviewStep {
     const instanceTypes = additionalPlanSettings?.instanceTypes;
     if (instanceTypes && !isEmpty(Object.keys(instanceTypes))) {
       const reviewBlock = this.page.getByTestId('review-instance-types');
-      const resolvedEntries = Object.entries(instanceTypes).filter(
-        ([, label]) =>
-          Boolean(label) &&
-          label !== INSTANCE_TYPE_FIRST_AVAILABLE &&
-          label !== INSTANCE_TYPE_SECOND_AVAILABLE,
-      );
 
-      if (isEmpty(resolvedEntries)) {
-        await expect(reviewBlock).toHaveText('None');
-      } else {
-        for (const [vmName, label] of resolvedEntries) {
-          await expect(reviewBlock).toContainText(`${vmName}: ${label}`);
-        }
+      for (const [vmName, label] of Object.entries(instanceTypes)) {
+        await expect(reviewBlock).toContainText(`${vmName}: ${label}`);
       }
     }
   }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/PlanVmInstanceTypeModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/PlanVmInstanceTypeModal.ts
@@ -1,0 +1,36 @@
+import type { Locator, Page } from '@playwright/test';
+
+/** Edit instance type modal opened from Plan details → VMs tab kebab menu */
+export class PlanVmInstanceTypeModal {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  get confirmButton(): Locator {
+    return this.root.getByTestId('modal-confirm-button');
+  }
+
+  async openFromKebab(
+    vmName: string,
+    getVmActionsMenu: (name: string) => Locator,
+    dismissOpenModals: () => Promise<void>,
+  ): Promise<void> {
+    await dismissOpenModals();
+    await getVmActionsMenu(vmName).click();
+    const menuItem = this.page.getByTestId('edit-vm-instance-type-menu-item');
+    await menuItem.waitFor({ state: 'visible' });
+    await this.page.waitForTimeout(200);
+    await menuItem.click({ force: true });
+    await this.root.waitFor({ state: 'visible' });
+  }
+
+  get root(): Locator {
+    return this.page.getByTestId('edit-instance-type-modal');
+  }
+
+  get selectToggle(): Locator {
+    return this.root.getByTestId('instance-type-select');
+  }
+}

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
@@ -5,14 +5,17 @@ import { VirtualMachinesTable } from '../../common/VirtualMachinesTable';
 import { AddVirtualMachinesModal } from '../modals/AddVirtualMachinesModal';
 
 import { ConcernsHelpers } from './ConcernsHelpers';
+import { PlanVmInstanceTypeModal } from './PlanVmInstanceTypeModal';
 
 /** VirtualMachines tab for Plan Details page (flat grid, no folder hierarchy). */
 export class VirtualMachinesTab extends VirtualMachinesTable {
   readonly concerns: ConcernsHelpers;
+  readonly editVmInstanceTypeModal: PlanVmInstanceTypeModal;
 
   constructor(page: Page) {
     super(page, page.locator('main'));
     this.concerns = new ConcernsHelpers(page);
+    this.editVmInstanceTypeModal = new PlanVmInstanceTypeModal(page);
   }
 
   private async dismissOpenModals(): Promise<void> {
@@ -56,6 +59,10 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     await this.page.waitForTimeout(300);
   }
 
+  get editInstanceTypeModal() {
+    return this.editVmInstanceTypeModal.root;
+  }
+
   get editSharedDisksModal() {
     return this.page.getByTestId('edit-vm-shared-disks-modal');
   }
@@ -72,6 +79,7 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     const btn = this.page.getByRole('button', { name: 'Show Filters' });
     if (await btn.isVisible()) await btn.click();
   }
+
   async expandFirstVMDetailsRow(): Promise<void> {
     const btn = this.page.getByRole('button', { name: 'Details' }).first();
     await expect(btn).toBeVisible();
@@ -87,7 +95,6 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     const vmName = await nameCell.textContent();
     return vmName?.trim() ?? '';
   }
-
   async getRowCount(): Promise<number> {
     const paginationNav = this.rootLocator.getByRole('navigation', { name: 'Pagination' }).first();
 
@@ -112,6 +119,11 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     return this.table.getRow({ Name: vmName }).getByTestId('vm-actions-menu-toggle');
   }
 
+  async getVMInstanceType(vmName: string): Promise<string> {
+    const cell = await this.table.getCell('Name', vmName, 'Instance type');
+    return (await cell.textContent())?.trim() ?? '';
+  }
+
   async getVMPowerState(vmName: string): Promise<string> {
     const cell = await this.table.getCell('Name', vmName, 'Target power state');
     return (await cell.textContent())?.trim() ?? '';
@@ -122,9 +134,25 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     return (await cell.textContent())?.trim() ?? '';
   }
 
+  get instanceTypeModalSaveButton() {
+    return this.editVmInstanceTypeModal.confirmButton;
+  }
+
+  get instanceTypeModalSelect() {
+    return this.editVmInstanceTypeModal.selectToggle;
+  }
+
   async navigateToVirtualMachinesTab(): Promise<void> {
     await this.page.locator('[data-test-id="horizontal-link-Virtual machines"]').click();
     await this.page.waitForURL((url) => url.toString().endsWith('/vms'));
+  }
+
+  async openInstanceTypeDialog(vmName: string): Promise<void> {
+    await this.editVmInstanceTypeModal.openFromKebab(
+      vmName,
+      (name) => this.getVMActionsMenu(name),
+      async () => this.dismissOpenModals(),
+    );
   }
 
   async openPowerStateDialog(vmName: string): Promise<void> {
@@ -273,6 +301,11 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     for (const vm of planData.virtualMachines ?? []) {
       if (vm.sourceName) await this.verifyRowIsVisible({ Name: vm.sourceName });
     }
+  }
+
+  async waitForVMInstanceType(vmName: string, expected: string): Promise<void> {
+    const cell = await this.table.getCell('Name', vmName, 'Instance type');
+    await expect(cell).toHaveText(expected);
   }
 
   async waitForVMPowerState(vmName: string, expectedPowerState: string): Promise<void> {

--- a/testing/playwright/types/test-data.ts
+++ b/testing/playwright/types/test-data.ts
@@ -82,6 +82,12 @@ export const StorageProductK8sValues = {
 
 export const ALL_STORAGE_PRODUCTS = Object.values(StorageProducts);
 
+/** Select the first non-None cluster instance type in the wizard Other settings step (per-VM). */
+export const INSTANCE_TYPE_FIRST_AVAILABLE = '__INSTANCE_TYPE_FIRST__';
+
+/** Select the second non-None cluster instance type in the wizard Other settings step (per-VM). */
+export const INSTANCE_TYPE_SECOND_AVAILABLE = '__INSTANCE_TYPE_SECOND__';
+
 /**
  * Target network options for network mapping
  */
@@ -151,6 +157,8 @@ export interface PlanTestData {
   additionalPlanSettings?: {
     targetPowerState?: 'on' | 'off' | 'auto';
     useNbdeClevis?: boolean;
+    /** VM display name → instance type label, or `INSTANCE_TYPE_FIRST_AVAILABLE` / `INSTANCE_TYPE_SECOND_AVAILABLE` */
+    instanceTypes?: Record<string, string>;
   };
   customizationScripts?: CustomizationScriptsTestData;
   preMigrationHook?: HookConfig;

--- a/testing/playwright/types/test-data.ts
+++ b/testing/playwright/types/test-data.ts
@@ -82,12 +82,6 @@ export const StorageProductK8sValues = {
 
 export const ALL_STORAGE_PRODUCTS = Object.values(StorageProducts);
 
-/** Select the first non-None cluster instance type in the wizard Other settings step (per-VM). */
-export const INSTANCE_TYPE_FIRST_AVAILABLE = '__INSTANCE_TYPE_FIRST__';
-
-/** Select the second non-None cluster instance type in the wizard Other settings step (per-VM). */
-export const INSTANCE_TYPE_SECOND_AVAILABLE = '__INSTANCE_TYPE_SECOND__';
-
 /**
  * Target network options for network mapping
  */
@@ -157,7 +151,7 @@ export interface PlanTestData {
   additionalPlanSettings?: {
     targetPowerState?: 'on' | 'off' | 'auto';
     useNbdeClevis?: boolean;
-    /** VM display name → instance type label, or `INSTANCE_TYPE_FIRST_AVAILABLE` / `INSTANCE_TYPE_SECOND_AVAILABLE` */
+    /** VM display name → resolved instance type label */
     instanceTypes?: Record<string, string>;
   };
   customizationScripts?: CustomizationScriptsTestData;


### PR DESCRIPTION
## Summary
- Adds Playwright E2E tests for the per-VM instance type feature ([MTV-1661](https://redhat.atlassian.net/browse/MTV-1661))
- Wizard flow: sets different instance types on two VMs, verifies review step and plan details persistence
- Plan details kebab menu: Save disabled when unchanged, Cancel discards changes, clear to None

Resolves: [MTV-5078](https://redhat.atlassian.net/browse/MTV-5078)

[MTV-1661]: https://redhat.atlassian.net/browse/MTV-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-5078]: https://redhat.atlassian.net/browse/MTV-5078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for per-VM instance type selection during plan creation in the wizard's additional settings step.
  * Added test coverage for instance type review, persistence, and editing from the Plan Details page.
  * Extended test helpers to support instance type dropdown interactions and verification throughout the plan management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->