### PR TITLE
Resolves: MTV-5081 | Add E2E regression tests for plan status consistency (MTV-4995)

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
@@ -1,0 +1,218 @@
+import type { V1beta1Plan } from '@forklift-ui/types';
+import { expect, type Page } from '@playwright/test';
+
+import { sharedProviderFixtures as test } from '../../../fixtures/resourceFixtures';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
+import type { ResourceManager } from '../../../utils/resource-manager/ResourceManager';
+import { V2_11_3 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+/**
+ * MTV-4995 regression: Plan UI showed "Cannot start" while Plan YAML showed Ready.
+ * Root cause: stale cached read in Plan reconciliation (fix: kubev2v/forklift@d376131).
+ */
+
+type Condition = { category?: string; message?: string; status?: string; type?: string };
+
+const CONDITION_TRUE = 'True';
+const CRITICAL = 'Critical';
+const READY = 'Ready';
+
+const activeConditions = (conditions: Condition[]): Condition[] =>
+  conditions.filter((cond) => cond.status === CONDITION_TRUE);
+
+const hasCritical = (conditions: Condition[]): boolean =>
+  activeConditions(conditions).some((cond) => cond.category === CRITICAL);
+
+const hasReady = (conditions: Condition[]): boolean =>
+  activeConditions(conditions).some((cond) => cond.type === READY);
+
+const findStaleMapCondition = (conditions: Condition[], mapKind: string): Condition | undefined =>
+  activeConditions(conditions).find(
+    (cond) =>
+      cond.category === CRITICAL &&
+      cond.message?.toLowerCase().includes(mapKind) &&
+      cond.message?.toLowerCase().includes('ready'),
+  );
+
+type MapVerifyOptions = {
+  fallbackNamespace: string;
+  mapKind: 'network' | 'storage';
+  page: Page;
+  planConditions: Condition[];
+  ref: { name?: string; namespace?: string } | undefined;
+  resourceManager: ResourceManager;
+};
+
+const verifyMapNotStale = async (opts: MapVerifyOptions): Promise<void> => {
+  const { fallbackNamespace, mapKind, page, planConditions, ref, resourceManager } = opts;
+  if (!ref?.name) return;
+
+  const fetchMethod = mapKind === 'network' ? 'fetchNetworkMap' : 'fetchStorageMap';
+  const mapResource = await resourceManager[fetchMethod](
+    page,
+    ref.name,
+    ref.namespace ?? fallbackNamespace,
+  );
+  expect(mapResource).not.toBeNull();
+
+  const mapConditions = (mapResource?.status?.conditions ?? []) as Condition[];
+  const mapReady = hasReady(mapConditions);
+
+  expect
+    .soft(mapReady, `${mapKind}Map "${ref.name}" is not Ready — would legitimately block the plan`)
+    .toBe(true);
+
+  if (mapReady) {
+    const stale = findStaleMapCondition(planConditions, mapKind);
+    expect
+      .soft(stale, `${mapKind}Map is Ready but Plan has stale condition: "${stale?.message}"`)
+      .toBeUndefined();
+  }
+};
+
+test.describe(
+  'Plan Status Consistency — UI matches YAML (MTV-4995 regression)',
+  { tag: '@downstream' },
+  () => {
+    requireVersion(test, V2_11_3);
+
+    test('should show consistent status between UI and Plan CR after wizard creation', async ({
+      page,
+      testPlan,
+      testProvider: _testProvider,
+      resourceManager,
+    }) => {
+      test.setTimeout(120_000);
+
+      if (!testPlan) throw new Error('testPlan fixture is required');
+
+      const { name: planName, namespace: planNamespace } = testPlan.metadata;
+      const planDetailsPage = new PlanDetailsPage(page);
+
+      await test.step('Navigate to plan details', async () => {
+        await planDetailsPage.navigate(planName, planNamespace);
+        await planDetailsPage.detailsTab.navigateToDetailsTab();
+      });
+
+      const uiStatus = await test.step('Read UI status', async () => {
+        const { status } = await planDetailsPage.getMigrationStatus();
+        return status;
+      });
+
+      const plan = await test.step('Fetch Plan CR via API', async () => {
+        const fetched = await resourceManager.fetchPlan(page, planName, planNamespace);
+        expect(fetched).not.toBeNull();
+        return fetched as V1beta1Plan;
+      });
+
+      const planConditions = (plan.status?.conditions ?? []) as Condition[];
+
+      await test.step('Verify Ready + Critical never coexist on Plan', () => {
+        if (hasReady(planConditions) && hasCritical(planConditions)) {
+          const messages = activeConditions(planConditions)
+            .filter((cond) => cond.category === CRITICAL)
+            .map((cond) => `${cond.type}: ${cond.message}`);
+
+          expect
+            .soft(false, `Ready + Critical coexist (MTV-4995 signature): [${messages.join('; ')}]`)
+            .toBe(true);
+        }
+      });
+
+      await test.step('Verify UI status matches YAML conditions', () => {
+        const uiLower = uiStatus.toLowerCase();
+        const isCritical = hasCritical(planConditions);
+        const isReady = hasReady(planConditions);
+
+        if (isReady && !isCritical) {
+          expect.soft(uiLower, `YAML is Ready but UI shows "${uiStatus}"`).toContain('ready');
+        }
+        if (isCritical) {
+          expect
+            .soft(uiLower, `YAML has Critical but UI shows "${uiStatus}"`)
+            .toContain('cannot start');
+        }
+      });
+
+      await test.step('Verify maps are Ready with no stale plan conditions', async () => {
+        const common = { fallbackNamespace: planNamespace, page, planConditions, resourceManager };
+        await verifyMapNotStale({ ...common, mapKind: 'network', ref: plan.spec?.map?.network });
+        await verifyMapNotStale({ ...common, mapKind: 'storage', ref: plan.spec?.map?.storage });
+      });
+    });
+
+    test('should clear stale conditions after patching a temporarily broken NetworkMap', async ({
+      page,
+      testPlan,
+      testProvider: _testProvider,
+      resourceManager,
+    }) => {
+      test.setTimeout(120_000);
+
+      if (!testPlan) throw new Error('testPlan fixture is required');
+
+      const { name: planName, namespace: planNamespace } = testPlan.metadata;
+      const planDetailsPage = new PlanDetailsPage(page);
+
+      const plan = await test.step('Fetch Plan CR', async () => {
+        const fetched = await resourceManager.fetchPlan(page, planName, planNamespace);
+        expect(fetched).not.toBeNull();
+        return fetched as V1beta1Plan;
+      });
+
+      const networkMapRef = plan.spec?.map?.network;
+      if (!networkMapRef?.name) {
+        test.skip(true, 'Plan has no referenced NetworkMap');
+        return;
+      }
+
+      const nmNamespace = networkMapRef.namespace ?? planNamespace;
+
+      await test.step('Break NetworkMap by pointing to non-existent provider', async () => {
+        const patched = await resourceManager.patchResource(page, {
+          kind: 'NetworkMap',
+          resourceName: networkMapRef.name!,
+          namespace: nmNamespace,
+          patch: {
+            spec: {
+              provider: { source: { name: 'non-existent-provider', namespace: MTV_NAMESPACE } },
+            },
+          },
+        });
+        expect(patched).not.toBeNull();
+      });
+
+      await test.step('Wait for Plan to show Cannot start', async () => {
+        await planDetailsPage.navigate(planName, planNamespace);
+        await planDetailsPage.waitForPlanStatus('Cannot start');
+      });
+
+      await test.step('Restore NetworkMap to original provider', async () => {
+        const source = plan.spec?.provider?.source;
+        const patched = await resourceManager.patchResource(page, {
+          kind: 'NetworkMap',
+          resourceName: networkMapRef.name!,
+          namespace: nmNamespace,
+          patch: {
+            spec: { provider: { source: { name: source?.name, namespace: source?.namespace } } },
+          },
+        });
+        expect(patched).not.toBeNull();
+      });
+
+      await test.step('Verify Plan recovers to Ready (MTV-4995 core assertion)', async () => {
+        await page.reload();
+        await planDetailsPage.waitForPlanStatus('Ready for migration');
+
+        const refreshed = await resourceManager.fetchPlan(page, planName, planNamespace);
+        expect(refreshed).not.toBeNull();
+
+        const conditions = ((refreshed as V1beta1Plan).status?.conditions ?? []) as Condition[];
+        expect(hasReady(conditions)).toBe(true);
+        expect(hasCritical(conditions)).toBe(false);
+      });
+    });
+  },
+);

--- a/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
@@ -96,11 +96,6 @@ test.describe(
         await planDetailsPage.detailsTab.navigateToDetailsTab();
       });
 
-      const uiStatus = await test.step('Read UI status', async () => {
-        const { status } = await planDetailsPage.getMigrationStatus();
-        return status;
-      });
-
       const plan = await test.step('Fetch Plan CR via API', async () => {
         const fetched = await resourceManager.fetchPlan(page, planName, planNamespace);
         expect(fetched).not.toBeNull();
@@ -121,15 +116,20 @@ test.describe(
         }
       });
 
-      await test.step('Verify UI status matches YAML conditions', () => {
-        const uiLower = uiStatus.toLowerCase();
+      await test.step('Verify UI status matches YAML conditions', async () => {
         const isCritical = hasCritical(planConditions);
         const isReady = hasReady(planConditions);
 
         if (isReady && !isCritical) {
+          await planDetailsPage.waitForPlanStatus('Ready for migration');
+          const { status: uiStatus } = await planDetailsPage.getMigrationStatus();
+          const uiLower = uiStatus.toLowerCase();
           expect.soft(uiLower, `YAML is Ready but UI shows "${uiStatus}"`).toContain('ready');
         }
         if (isCritical) {
+          await planDetailsPage.waitForPlanStatus('Cannot start');
+          const { status: uiStatus } = await planDetailsPage.getMigrationStatus();
+          const uiLower = uiStatus.toLowerCase();
           expect
             .soft(uiLower, `YAML has Critical but UI shows "${uiStatus}"`)
             .toContain('cannot start');
@@ -170,37 +170,52 @@ test.describe(
 
       const nmNamespace = networkMapRef.namespace ?? planNamespace;
 
-      await test.step('Break NetworkMap by pointing to non-existent provider', async () => {
-        const patched = await resourceManager.patchResource(page, {
-          kind: 'NetworkMap',
-          resourceName: networkMapRef.name!,
-          namespace: nmNamespace,
-          patch: {
-            spec: {
-              provider: { source: { name: 'non-existent-provider', namespace: MTV_NAMESPACE } },
+      const originalNetworkMap = await resourceManager.fetchNetworkMap(
+        page,
+        networkMapRef.name,
+        nmNamespace,
+      );
+      expect(originalNetworkMap).not.toBeNull();
+
+      const originalProvider = originalNetworkMap?.spec?.provider;
+      if (!originalProvider?.source?.name) {
+        test.skip(true, 'NetworkMap has no source provider to restore');
+        return;
+      }
+
+      const missingProviderName = `missing-provider-${Date.now()}`;
+
+      try {
+        await test.step('Break NetworkMap by pointing to non-existent provider', async () => {
+          const patched = await resourceManager.patchResource(page, {
+            kind: 'NetworkMap',
+            resourceName: networkMapRef.name!,
+            namespace: nmNamespace,
+            patch: {
+              spec: {
+                provider: { source: { name: missingProviderName, namespace: MTV_NAMESPACE } },
+              },
             },
-          },
+          });
+          expect(patched).not.toBeNull();
         });
-        expect(patched).not.toBeNull();
-      });
 
-      await test.step('Wait for Plan to show Cannot start', async () => {
-        await planDetailsPage.navigate(planName, planNamespace);
-        await planDetailsPage.waitForPlanStatus('Cannot start');
-      });
-
-      await test.step('Restore NetworkMap to original provider', async () => {
-        const source = plan.spec?.provider?.source;
-        const patched = await resourceManager.patchResource(page, {
-          kind: 'NetworkMap',
-          resourceName: networkMapRef.name!,
-          namespace: nmNamespace,
-          patch: {
-            spec: { provider: { source: { name: source?.name, namespace: source?.namespace } } },
-          },
+        await test.step('Wait for Plan to show Cannot start', async () => {
+          await planDetailsPage.navigate(planName, planNamespace);
+          await planDetailsPage.waitForPlanStatus('Cannot start');
         });
-        expect(patched).not.toBeNull();
-      });
+      } finally {
+        await test.step('Restore NetworkMap to original provider', async () => {
+          await resourceManager.patchResource(page, {
+            kind: 'NetworkMap',
+            resourceName: networkMapRef.name!,
+            namespace: nmNamespace,
+            patch: {
+              spec: { provider: originalProvider },
+            },
+          });
+        });
+      }
 
       await test.step('Verify Plan recovers to Ready (MTV-4995 core assertion)', async () => {
         await page.reload();

--- a/testing/playwright/utils/resource-manager/ResourceFetcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourceFetcher.ts
@@ -1,7 +1,9 @@
 import type {
   V1beta1ForkliftController,
+  V1beta1NetworkMap,
   V1beta1Plan,
   V1beta1Provider,
+  V1beta1StorageMap,
   V1VirtualMachine,
 } from '@forklift-ui/types';
 import type { Page } from '@playwright/test';
@@ -59,6 +61,18 @@ export class ResourceFetcher extends BaseResourceManager {
     return operatorCsv.spec.version;
   }
 
+  static async fetchNetworkMap(
+    page: Page,
+    networkMapName: string,
+    namespace = MTV_NAMESPACE,
+  ): Promise<V1beta1NetworkMap | null> {
+    return ResourceFetcher.fetchResource<V1beta1NetworkMap>(page, {
+      kind: RESOURCE_KINDS.NETWORK_MAP,
+      resourceName: networkMapName,
+      namespace,
+    });
+  }
+
   static async fetchPlan(
     page: Page,
     planName: string,
@@ -95,6 +109,18 @@ export class ResourceFetcher extends BaseResourceManager {
     const apiPath = `${basePath}/namespaces/${namespace}/${resourceType}/${resourceName}`;
 
     return ResourceFetcher.apiGet<T>(page, apiPath);
+  }
+
+  static async fetchStorageMap(
+    page: Page,
+    storageMapName: string,
+    namespace = MTV_NAMESPACE,
+  ): Promise<V1beta1StorageMap | null> {
+    return ResourceFetcher.fetchResource<V1beta1StorageMap>(page, {
+      kind: RESOURCE_KINDS.STORAGE_MAP,
+      resourceName: storageMapName,
+      namespace,
+    });
   }
 
   static async fetchVirtualMachine(

--- a/testing/playwright/utils/resource-manager/ResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/ResourceManager.ts
@@ -219,6 +219,14 @@ export class ResourceManager {
     return ResourceFetcher.fetchForkliftController(page, controllerName, namespace);
   }
 
+  async fetchNetworkMap(
+    page: Page,
+    networkMapName: string,
+    namespace = MTV_NAMESPACE,
+  ): Promise<V1beta1NetworkMap | null> {
+    return ResourceFetcher.fetchNetworkMap(page, networkMapName, namespace);
+  }
+
   async fetchPlan(
     page: Page,
     planName: string,
@@ -237,6 +245,14 @@ export class ResourceManager {
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
     return ResourceFetcher.fetchProvider(page, providerName, namespace);
+  }
+
+  async fetchStorageMap(
+    page: Page,
+    storageMapName: string,
+    namespace = MTV_NAMESPACE,
+  ): Promise<V1beta1StorageMap | null> {
+    return ResourceFetcher.fetchStorageMap(page, storageMapName, namespace);
   }
 
   async fetchVirtualMachine(

--- a/testing/playwright/utils/version/constants.ts
+++ b/testing/playwright/utils/version/constants.ts
@@ -9,4 +9,5 @@ export const VERSION_GATE_TAG = '[version-gated]';
 /** Pre-parsed version constants — avoids repeated string parsing. */
 export const V2_10_5: VersionTuple = [2, 10, 5];
 export const V2_11_0: VersionTuple = [2, 11, 0];
+export const V2_11_3: VersionTuple = [2, 11, 3];
 export const V2_12_0: VersionTuple = [2, 12, 0];


### PR DESCRIPTION
## Summary
- Add two downstream Playwright E2E tests that verify Plan status consistency between the UI and YAML conditions, targeting the MTV-4995 stale-cache regression.
- Extend `ResourceFetcher` and `ResourceManager` with `fetchNetworkMap` and `fetchStorageMap` methods needed by the new tests.
- Add `V2_11_3` version constant for version-gating the tests to the fix release.

## Test plan
- [ ] Run `npm run test:downstream` against a cluster with Forklift >= 2.11.3
- [ ] Verify both tests in `plan-status-consistency.spec.ts` pass
- [ ] Verify tests are skipped on Forklift < 2.11.3

Resolves: MTV-5081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a downstream regression spec ensuring Plan status (CR conditions) matches UI migration status, covering stale map detection and an induced “Cannot start” scenario.

* **Chores**
  * Enhanced test utilities for fetching/managing network and storage maps.
  * Added a new pre-parsed version constant for test gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->