### PR TITLE
Make E2E tests retrocompatible with 2.11.z

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
@@ -5,14 +5,14 @@ import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/Cre
 import { createPlanTestData, OffloadPlugins, StorageProducts } from '../../../types/test-data';
 import { createOffloadTestSecret } from '../../../utils/offload-helpers';
 import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe(
   'Storage Offloading - Plan Wizard with Offload + Review',
   { tag: '@downstream' },
   () => {
-    requireVersion(test, V2_11_0);
+    requireVersion(test, V2_12_0);
 
     test('should configure offload in plan wizard and display it correctly in review', async ({
       page,

--- a/testing/playwright/e2e/downstream/providers/certificate-validation.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/certificate-validation.spec.ts
@@ -13,7 +13,7 @@ import { ProviderDetailsPage } from '../../../page-objects/ProviderDetailsPage/P
 import { ProviderType } from '../../../types/enums';
 import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
 import { ResourceManager } from '../../../utils/resource-manager/ResourceManager';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_11_0, V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 import { createProviderData } from './creation-scenarios';
@@ -105,6 +105,8 @@ test.describe('vSphere Provider Certificate Validation', () => {
       tag: '@downstream',
     },
     async ({ page }) => {
+      requireVersion(test, V2_12_0);
+
       const createProvider = new CreateProviderPage(page, resourceManager);
       const testData = createProviderData(ProviderType.VSPHERE, VSPHERE_KEY, {
         skipVddk: true,

--- a/testing/playwright/e2e/downstream/providers/credentials-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/credentials-edit.spec.ts
@@ -3,11 +3,11 @@ import { expect } from '@playwright/test';
 import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
 import { ProviderDetailsPage } from '../../../page-objects/ProviderDetailsPage/ProviderDetailsPage';
 import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe('Provider Credentials - Editing', { tag: '@downstream' }, () => {
-  requireVersion(test, V2_11_0);
+  requireVersion(test, V2_12_0);
 
   test('should test credential editing interactions', async ({ page, testProvider }) => {
     const providerDetailsPage = new ProviderDetailsPage(page);

--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -7,14 +7,14 @@ import { StorageMapsListPage } from '../../../page-objects/StorageMapsListPage';
 import { ALL_STORAGE_PRODUCTS, OffloadPlugins, StorageProducts } from '../../../types/test-data';
 import { createOffloadTestSecret } from '../../../utils/offload-helpers';
 import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe(
   'Storage Offloading - Create, Verify & Edit Storage Map',
   { tag: '@downstream' },
   () => {
-    requireVersion(test, V2_11_0);
+    requireVersion(test, V2_12_0);
 
     test('should create storage map with offload, verify details, and edit offload options', async ({
       page,

--- a/testing/playwright/e2e/downstream/storage-maps/storage-map-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/storage-map-edit.spec.ts
@@ -2,11 +2,11 @@ import { expect } from '@playwright/test';
 
 import { sharedProviderStorageMapFixtures as test } from '../../../fixtures/resourceFixtures';
 import { StorageMapDetailsPage } from '../../../page-objects/StorageMapDetailsPage';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 test.describe('Storage Map Details - Editing', { tag: '@downstream' }, () => {
-  requireVersion(test, V2_11_0);
+  requireVersion(test, V2_12_0);
 
   test('should test storage map editing interactions', async ({
     page,

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -8,7 +8,7 @@ import type {
   StorageMap,
 } from '../../../types/test-data';
 import { isEmpty } from '../../../utils/utils';
-import { V2_11_0 } from '../../../utils/version/constants';
+import { V2_11_0, V2_12_0 } from '../../../utils/version/constants';
 import { isVersionAtLeast } from '../../../utils/version/version';
 
 export class ReviewStep {
@@ -90,7 +90,9 @@ export class ReviewStep {
     await this.verifyStorageMapSection(planData.storageMap);
     await this.verifyMigrationTypeSection();
     await this.verifyOtherSettingsSection(planData.additionalPlanSettings);
-    await this.verifyCustomScriptsSection(planData.customizationScripts);
+    if (isVersionAtLeast(V2_12_0)) {
+      await this.verifyCustomScriptsSection(planData.customizationScripts);
+    }
     await this.verifyHooksSection();
   }
 

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
@@ -37,7 +37,9 @@ export abstract class BaseMappingEditModal extends BaseModal {
     await this.page.waitForTimeout(FORM_SETTLE_MS);
     await selectLocator.click();
     await expect(selectLocator).toHaveAttribute('aria-expanded', 'true');
-    const option = this.page.locator('[role="option"]:enabled').nth(nth);
+    const listbox = this.page.locator('[role="listbox"]:visible').last();
+    await expect(listbox).toBeVisible();
+    const option = listbox.locator('[role="option"]:enabled').nth(nth);
     await expect(option).toBeVisible();
     await option.click();
   }
@@ -48,7 +50,9 @@ export abstract class BaseMappingEditModal extends BaseModal {
     await this.page.waitForTimeout(FORM_SETTLE_MS);
     await selectLocator.click();
     await expect(selectLocator).toHaveAttribute('aria-expanded', 'true');
-    const option = this.page.getByRole('option', { name: optionText, exact: true }).first();
+    const listbox = this.page.locator('[role="listbox"]:visible').last();
+    await expect(listbox).toBeVisible();
+    const option = listbox.getByRole('option', { name: optionText, exact: true }).first();
     await expect(option).toBeVisible();
     await option.click();
   }


### PR DESCRIPTION
## Summary

- **ReviewStep page object**: Version-gate the Customization Scripts section check with `V2_12_0`, making `verifyAllSections()` backwards compatible — the section was added in 2.12 and doesn't exist in 2.11.x builds (fixes 10 failing tests)
- **Storage offload specs**: Gate `create-storage-map-offload` and `plan-wizard-offload` to `V2_12_0` — offloading is a 2.12-only feature
- **Storage map edit, credentials edit, certificate validation specs**: Gate to `V2_12_0` — the `data-testid` attributes these tests depend on (`storage-map-edit-button`, `credentials-reveal-button`, `ca-certificate-helper-error`) were added in commit `8fed4f01d` which is 2.12-only
- For certificate validation, only the invalid-cert test is gated to 2.12 (test 1 works on 2.11)

## Context

Running the downstream Playwright suite against a 2.11.3 cluster produced 15 failures across 5 categories. All stem from UI elements or `data-testid` attributes that only exist in 2.12 builds. None of the open PRs (#2362–#2372) address these.

## Test plan

- [ ] Run with `FORKLIFT_VERSION=2.11.3` — gated tests should skip with `[version-gated]` message
- [ ] Run with `FORKLIFT_VERSION=2.12.0` or `latest` — all tests should execute normally
- [ ] Verify `check-version-gating.sh` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test requirements to v2.12.0 for migration plans, provider credentials, certificate validation, and storage map scenarios.
  * Constrained specific tests to run only on v2.12.0+ where applicable.
  * Customization-scripts verification now gated by v2.12.0.

* **Refactor**
  * Improved mapping modal dropdown handling for more reliable option visibility and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->