### PR TITLE
Resolves: MTV-4864 | Add E2E coverage for copy-offload UX enhancements

### DIFF
--- a/src/storageMaps/components/OffloadStorageIndexedForm/OffloadStorageIndexedForm.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/OffloadStorageIndexedForm.tsx
@@ -117,7 +117,9 @@ const OffloadStorageIndexedForm: FC<OffloadStorageIndexedFormProps> = ({
               <StorageProductField fieldId={productFieldId} suggestedProduct={suggestedProduct} />
               {offloadError && (
                 <HelperText>
-                  <HelperTextItem variant="error">{offloadError}</HelperTextItem>
+                  <HelperTextItem data-testid="offload-validation-error" variant="error">
+                    {offloadError}
+                  </HelperTextItem>
                 </HelperText>
               )}
               {hasAnyOffloadValue && !offloadError && (

--- a/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
@@ -52,6 +52,20 @@ test.describe('Storage Offloading - Plan Details Mappings Tab', { tag: '@downstr
       await modal.cancel();
     });
 
+    await test.step('Verify partial offload triggers validation error in modal', async () => {
+      const modal = await planDetailsPage.mappingsTab.openStorageMapEditModal();
+
+      await modal.offload.expandOffloadOptions(0);
+      await modal.offload.selectOffloadPlugin(0, OffloadPlugins.VSPHERE_XCOPY);
+      await modal.offload.verifyValidationError('must be set when configuring offload');
+      await modal.verifySaveButtonDisabled();
+
+      await modal.offload.clickClearOffloadOptions(0);
+      await modal.offload.verifyNoValidationError();
+
+      await modal.cancel();
+    });
+
     await test.step('Configure offload options and save', async () => {
       const modal = await planDetailsPage.mappingsTab.openStorageMapEditModal();
 

--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -81,11 +81,11 @@ test.describe(
         await createPage.offload.verifyClearButtonEnabled(0);
         await createPage.offload.clickClearOffloadOptions(0);
 
-        const pluginText = await createPage.offload.getOffloadPluginText(0);
-        expect(pluginText).not.toContain(OffloadPlugins.VSPHERE_XCOPY);
-
         await createPage.offload.verifyClearButtonDisabled(0);
         await createPage.offload.verifyNoValidationError();
+
+        const pluginText = await createPage.offload.getOffloadPluginText(0);
+        expect(pluginText).not.toContain(OffloadPlugins.VSPHERE_XCOPY);
       });
 
       await test.step('Configure offload options on first mapping row', async () => {

--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -62,6 +62,32 @@ test.describe(
         await createPage.offload.verifyDropdownOptions(0, 'storageProduct', ALL_STORAGE_PRODUCTS);
       });
 
+      await test.step('Verify clear button is disabled when no offload values set', async () => {
+        await createPage.offload.verifyClearButtonDisabled(0);
+      });
+
+      await test.step('Set only offload plugin and verify validation error', async () => {
+        await createPage.offload.selectOffloadPlugin(0, OffloadPlugins.VSPHERE_XCOPY);
+        await createPage.offload.verifyValidationError('must be set when configuring offload');
+      });
+
+      await test.step('Fill remaining fields and verify validation error clears', async () => {
+        await createPage.offload.selectStorageSecret(0, secretName);
+        await createPage.offload.selectStorageProduct(0, StorageProducts.NETAPP_ONTAP);
+        await createPage.offload.verifyNoValidationError();
+      });
+
+      await test.step('Verify clear button works and resets all fields', async () => {
+        await createPage.offload.verifyClearButtonEnabled(0);
+        await createPage.offload.clickClearOffloadOptions(0);
+
+        const pluginText = await createPage.offload.getOffloadPluginText(0);
+        expect(pluginText).not.toContain(OffloadPlugins.VSPHERE_XCOPY);
+
+        await createPage.offload.verifyClearButtonDisabled(0);
+        await createPage.offload.verifyNoValidationError();
+      });
+
       await test.step('Configure offload options on first mapping row', async () => {
         await createPage.offload.selectOffloadPlugin(0, OffloadPlugins.VSPHERE_XCOPY);
         const pluginText = await createPage.offload.getOffloadPluginText(0);
@@ -149,6 +175,36 @@ test.describe(
         expect(productText).toContain(StorageProducts.HITACHI_VANTARA);
 
         await modal.cancel();
+      });
+    });
+
+    test('should hide offload options for non-vSphere providers', async ({
+      page,
+      createCustomProvider,
+    }) => {
+      const listPage = new StorageMapsListPage(page);
+      const createPage = new StorageMapCreatePage(page);
+
+      const ovaProviderKey = process.env.OVA_PROVIDER ?? 'ova';
+      const ovaProvider = await createCustomProvider({
+        providerKey: ovaProviderKey,
+        namePrefix: 'offload-ova',
+      });
+
+      await test.step('Navigate to Create Storage Map form', async () => {
+        await listPage.navigate(MTV_NAMESPACE);
+        await listPage.clickCreateWithFormButton();
+        await createPage.waitForPageLoad();
+      });
+
+      await test.step('Select OVA source provider and verify no offload toggle', async () => {
+        await createPage.fillMapName(`gating-sm-${crypto.randomUUID().slice(0, 8)}`);
+        await createPage.selectProject(MTV_NAMESPACE);
+        await createPage.selectSourceProvider(ovaProvider.metadata.name);
+        await createPage.selectTargetProvider('host');
+        await createPage.waitForMappingTableReady();
+
+        await createPage.offload.verifyOffloadToggleNotVisible(0);
       });
     });
   },

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -156,7 +156,7 @@ export class OffloadOptions {
   }
 
   async verifyNoValidationError(): Promise<void> {
-    const error = this.container.locator('.pf-m-error');
+    const error = this.container.getByTestId('offload-validation-error');
     await expect(error).not.toBeVisible();
   }
 
@@ -170,7 +170,9 @@ export class OffloadOptions {
   }
 
   async verifyValidationError(partialText: string): Promise<void> {
-    const error = this.container.locator('.pf-m-error', { hasText: partialText });
+    const error = this.container
+      .getByTestId('offload-validation-error')
+      .filter({ hasText: partialText });
     await expect(error).toBeVisible();
   }
 }

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -12,6 +12,7 @@ const OFFLOAD_FIELD = {
 } as const;
 
 const EXPANDABLE_TOGGLE_TEXT = 'Offload options (optional)';
+const CLEAR_BUTTON_TEXT = 'Clear offload options';
 
 /**
  * Page object for interacting with the offload options expandable section
@@ -54,6 +55,12 @@ export class OffloadOptions {
     const option = listbox.getByRole('option', { name: optionText });
     await expect(option).toBeVisible();
     await option.click();
+  }
+
+  async clickClearOffloadOptions(mappingIndex: number): Promise<void> {
+    const btn = this.container.getByRole('button', { name: CLEAR_BUTTON_TEXT }).nth(mappingIndex);
+    await expect(btn).toBeVisible();
+    await btn.click();
   }
 
   async collapseOffloadOptions(mappingIndex: number): Promise<void> {
@@ -113,6 +120,18 @@ export class OffloadOptions {
     await expect(productBtn).toBeVisible();
   }
 
+  async verifyClearButtonDisabled(mappingIndex: number): Promise<void> {
+    const btn = this.container.getByRole('button', { name: CLEAR_BUTTON_TEXT }).nth(mappingIndex);
+    await expect(btn).toBeVisible();
+    await expect(btn).toBeDisabled();
+  }
+
+  async verifyClearButtonEnabled(mappingIndex: number): Promise<void> {
+    const btn = this.container.getByRole('button', { name: CLEAR_BUTTON_TEXT }).nth(mappingIndex);
+    await expect(btn).toBeVisible();
+    await expect(btn).toBeEnabled();
+  }
+
   async verifyDropdownOptions(
     mappingIndex: number,
     field: 'offloadPlugin' | 'storageProduct' | 'storageSecret',
@@ -136,6 +155,11 @@ export class OffloadOptions {
     await toggle.click();
   }
 
+  async verifyNoValidationError(): Promise<void> {
+    const error = this.container.locator('.pf-m-error');
+    await expect(error).not.toBeVisible();
+  }
+
   async verifyOffloadToggleNotVisible(mappingIndex: number): Promise<void> {
     await expect(this.expandableToggle(mappingIndex)).not.toBeVisible();
   }
@@ -143,5 +167,10 @@ export class OffloadOptions {
   async verifyOffloadToggleVisible(mappingIndex: number): Promise<void> {
     const toggle = this.expandableToggle(mappingIndex);
     await expect(toggle).toBeVisible();
+  }
+
+  async verifyValidationError(partialText: string): Promise<void> {
+    const error = this.container.locator('.pf-m-error', { hasText: partialText });
+    await expect(error).toBeVisible();
   }
 }


### PR DESCRIPTION
## 📝 Links

- https://redhat.atlassian.net/browse/MTV-4864
#2322

## 📝 Description

Extend existing offload Playwright specs with missing UX coverage: all-or-nothing validation, clear button, and non-vSphere provider gating. Adds reusable methods to the `OffloadOptions` page object.

## 🎥 Demo

N/A — test-only changes

## 📝 CC://

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end coverage for offload configuration validation, including modal behavior when required fields are missing and Save stays disabled
  * Added checks that Clear-offload control state is enforced and that clearing resets offload UI and validation
  * Added gating tests to hide offload options for non-vSphere providers
  * Extended test helpers to assert offload UI and validation states more robustly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->