### PR TITLE
MTV-4725 | Add hilight for NetApp Shift supported storage classes

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -781,6 +781,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "Navigate to the directory where you want to store the must-gather data.",
   "NBDE/Clevis enabled": "NBDE/Clevis enabled",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "Network attachment definitions",
   "Network for data transfer": "Network for data transfer",
   "Network interfaces": "Network interfaces",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -785,6 +785,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "Navegue hasta el directorio donde desea almacenar los datos que debe recopilar.",
   "NBDE/Clevis enabled": "NBDE/Clevis habilitado",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "Definiciones de archivos adjuntos de red",
   "Network for data transfer": "Red para transferencia de datos",
   "Network interfaces": "Interfaces de red",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -785,6 +785,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "Accédez au répertoire où vous souhaitez stocker les données à collecter absolument.",
   "NBDE/Clevis enabled": "NBDE/Clevis activé",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "Définitions des connexions réseau",
   "Network for data transfer": "Réseau pour le transfert de données",
   "Network interfaces": "Interfaces réseau",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -781,6 +781,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "must-gather データを保存するディレクトリーに移動します。",
   "NBDE/Clevis enabled": "NBDE/Clevis 有効",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "ネットワークアタッチメント定義",
   "Network for data transfer": "データ転送用ネットワーク",
   "Network interfaces": "ネットワークインターフェイス",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -781,6 +781,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "must-gather 데이터를 저장할 디렉토리로 이동하세요.",
   "NBDE/Clevis enabled": "NBDE/Clevis 활성화됨",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "네트워크 연결 정의",
   "Network for data transfer": "데이터 전송 네트워크",
   "Network interfaces": "네트워크 인터페이스",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -781,6 +781,7 @@
   "Navigate to the directory where you want to store the must-gather data.": "进入到要存储 must-gather 数据的目录。",
   "NBDE/Clevis enabled": "启用了 NBDE/Clevis",
   "NetApp ONTAP": "NetApp ONTAP",
+  "NetApp Shift": "NetApp Shift",
   "Network attachment definitions": "网络附加定义",
   "Network for data transfer": "用于数据传输的网络",
   "Network interfaces": "网络接口",

--- a/src/plans/create/CreatePlanWizard.tsx
+++ b/src/plans/create/CreatePlanWizard.tsx
@@ -6,6 +6,7 @@ import { CreationMethod, TELEMETRY_EVENTS } from '@utils/analytics/constants';
 import { useForkliftAnalytics } from '@utils/analytics/hooks/useForkliftAnalytics';
 import { FEATURE_NAMES } from '@utils/constants';
 import { useFeatureFlags } from '@utils/hooks/useFeatureFlags';
+import useTargetStorages from '@utils/hooks/useTargetStorages';
 
 import { useCreatePlanForm } from './hooks/useCreatePlanForm';
 import { useSourceProviderFromSearchParams } from './hooks/useSourceProviderFromSearchParams';
@@ -48,14 +49,17 @@ const CreatePlanWizard: FC = () => {
 
   useSourceProviderFromSearchParams(setValue, sourceProviderName, searchPlanProject);
 
-  const [planName, planProject, sourceProvider] = useWatch({
+  const [planName, planProject, sourceProvider, targetProvider, targetProject] = useWatch({
     control,
     name: [
       GeneralFormFieldId.PlanName,
       GeneralFormFieldId.PlanProject,
       GeneralFormFieldId.SourceProvider,
+      GeneralFormFieldId.TargetProvider,
+      GeneralFormFieldId.TargetProject,
     ],
   });
+  const [targetStorages] = useTargetStorages(targetProvider, targetProject);
 
   const onSubmit = async () => {
     const formData = getValues();
@@ -73,7 +77,7 @@ const CreatePlanWizard: FC = () => {
     };
 
     try {
-      await submitMigrationPlan(formData, trackPlanWizardEvent);
+      await submitMigrationPlan(formData, trackPlanWizardEvent, targetStorages);
 
       navigate(getCreatedPlanPath(planName, planProject));
     } catch (error) {

--- a/src/plans/create/utils/submitMigrationPlan.ts
+++ b/src/plans/create/utils/submitMigrationPlan.ts
@@ -1,4 +1,5 @@
 import { createStorageMap } from 'src/storageMaps/create/utils/createStorageMap';
+import type { TargetStorage } from 'src/storageMaps/utils/types';
 
 import type {
   IoK8sApiCoreV1ConfigMap,
@@ -28,6 +29,7 @@ import { resolveScriptsConfigMap } from './resolveScriptsConfigMap';
 export const submitMigrationPlan = async (
   formData: CreatePlanFormData,
   trackEvent?: (eventType: string, properties?: Record<string, unknown>) => void,
+  targetStorages?: TargetStorage[],
 ): Promise<void> => {
   const {
     customScripts,
@@ -91,6 +93,7 @@ export const submitMigrationPlan = async (
           project: planProject,
           sourceProvider,
           targetProvider,
+          targetStorages,
           trackEvent,
         }),
 

--- a/src/storageMaps/components/TargetStorageField.tsx
+++ b/src/storageMaps/components/TargetStorageField.tsx
@@ -7,9 +7,12 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Label,
   SelectGroup,
   SelectList,
   SelectOption,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -23,6 +26,19 @@ type TargetStorageFieldProps = {
   testId?: string;
   suggestedVendorProduct?: StorageVendorProduct;
 };
+
+const renderStorageOption = (storage: TargetStorage, t: (k: string) => string) => (
+  <Split hasGutter>
+    <SplitItem isFilled>{storage.name}</SplitItem>
+    {storage.isNetAppShift && (
+      <SplitItem>
+        <Label isCompact color="blue">
+          {t('NetApp Shift')}
+        </Label>
+      </SplitItem>
+    )}
+  </Split>
+);
 
 const TargetStorageField: FC<TargetStorageFieldProps> = ({
   fieldId,
@@ -86,7 +102,7 @@ const TargetStorageField: FC<TargetStorageFieldProps> = ({
                   <SelectList>
                     {recommended.map((storage) => (
                       <SelectOption key={storage.id} value={storage}>
-                        {storage.name}
+                        {renderStorageOption(storage, t)}
                       </SelectOption>
                     ))}
                   </SelectList>
@@ -101,7 +117,7 @@ const TargetStorageField: FC<TargetStorageFieldProps> = ({
                     ) : (
                       others.map((storage) => (
                         <SelectOption key={storage.id} value={storage}>
-                          {storage.name}
+                          {renderStorageOption(storage, t)}
                         </SelectOption>
                       ))
                     )}
@@ -117,7 +133,7 @@ const TargetStorageField: FC<TargetStorageFieldProps> = ({
                 ) : (
                   targetStorages.map((storage) => (
                     <SelectOption key={storage.id} value={storage}>
-                      {storage.name}
+                      {renderStorageOption(storage, t)}
                     </SelectOption>
                   ))
                 )}

--- a/src/storageMaps/create/CreateStorageMapForm.tsx
+++ b/src/storageMaps/create/CreateStorageMapForm.tsx
@@ -19,6 +19,7 @@ import {
 import { CreationMethod } from '@utils/analytics/constants';
 import { useForkliftAnalytics } from '@utils/analytics/hooks/useForkliftAnalytics';
 import { getResourceUrl } from '@utils/getResourceUrl';
+import useTargetStorages from '@utils/hooks/useTargetStorages';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import { defaultStorageMapping } from '../utils/constants';
@@ -51,10 +52,11 @@ const CreateStorageMapForm: React.FC = () => {
     handleSubmit,
   } = form;
   const [createError, setCreateError] = useState<Error>();
-  const project = useWatch({
+  const [project, targetProvider] = useWatch({
     control,
-    name: StorageMapFieldId.Project,
+    name: [StorageMapFieldId.Project, StorageMapFieldId.TargetProvider],
   });
+  const [targetStorages] = useTargetStorages(targetProvider, project);
 
   const { error } = getFieldState(StorageMapFieldId.StorageMap);
 
@@ -66,7 +68,7 @@ const CreateStorageMapForm: React.FC = () => {
   const onSubmit = async () => {
     setCreateError(undefined);
 
-    const { mapName, sourceProvider, storageMap, targetProvider } = getValues();
+    const { mapName, sourceProvider, storageMap } = getValues();
 
     const trackStorageMapEvent = (eventType: string, properties = {}) => {
       trackEvent(eventType, { ...properties, creationMethod: CreationMethod.Form });
@@ -79,6 +81,7 @@ const CreateStorageMapForm: React.FC = () => {
         project,
         sourceProvider,
         targetProvider,
+        targetStorages,
         trackEvent: trackStorageMapEvent,
       });
 

--- a/src/storageMaps/create/utils/createStorageMap.ts
+++ b/src/storageMaps/create/utils/createStorageMap.ts
@@ -1,3 +1,5 @@
+import { getNetAppShiftLabels } from 'src/storageMaps/utils/netAppShift';
+
 import {
   StorageMapModel,
   type V1beta1Provider,
@@ -8,7 +10,7 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { TELEMETRY_EVENTS } from '@utils/analytics/constants';
 import { getObjectRef } from '@utils/helpers/getObjectRef';
 
-import type { StorageMapping } from '../../utils/types';
+import type { StorageMapping, TargetStorage } from '../../utils/types';
 
 import { buildStorageMappings } from './buildStorageMappings';
 
@@ -18,6 +20,7 @@ type CreateStorageMapParams = {
   sourceProvider: V1beta1Provider | undefined;
   targetProvider: V1beta1Provider | undefined;
   name?: string;
+  targetStorages?: TargetStorage[];
   trackEvent?: (eventType: string, properties?: Record<string, unknown>) => void;
 };
 
@@ -39,6 +42,7 @@ export const createStorageMap = async ({
   project,
   sourceProvider,
   targetProvider,
+  targetStorages,
   trackEvent,
 }: CreateStorageMapParams) => {
   const sourceProviderName = sourceProvider?.metadata?.name;
@@ -52,12 +56,17 @@ export const createStorageMap = async ({
   });
 
   try {
+    const netAppShiftLabels = targetStorages
+      ? getNetAppShiftLabels(mappings, targetStorages)
+      : undefined;
+
     const storageMap: V1beta1StorageMap = {
       apiVersion: 'forklift.konveyor.io/v1beta1',
       kind: 'StorageMap',
       metadata: {
         name,
         ...(!name && sourceProviderName && { generateName: `${sourceProvider?.metadata?.name}-` }),
+        ...(netAppShiftLabels && { labels: netAppShiftLabels }),
         namespace: project,
       },
       spec: {

--- a/src/storageMaps/utils/__tests__/netAppShift.test.ts
+++ b/src/storageMaps/utils/__tests__/netAppShift.test.ts
@@ -1,0 +1,68 @@
+import {
+  getNetAppShiftLabels,
+  isNetAppShiftStorageClassAnnotations,
+  NETAPP_SHIFT_STORAGE_CLASS_TYPE_VALUE,
+} from '../netAppShift';
+import { StorageClassAnnotation, StorageMapFieldId, type TargetStorage } from '../types';
+
+describe('isNetAppShiftStorageClassAnnotations', () => {
+  it('is true when annotation is shift', () => {
+    expect(
+      isNetAppShiftStorageClassAnnotations({
+        [StorageClassAnnotation.NetAppShiftStorageClassType]: 'shift',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when annotation is missing or not shift', () => {
+    expect(isNetAppShiftStorageClassAnnotations(undefined)).toBe(false);
+    expect(
+      isNetAppShiftStorageClassAnnotations({
+        [StorageClassAnnotation.NetAppShiftStorageClassType]: 'other',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getNetAppShiftLabels', () => {
+  const shiftStorage: TargetStorage = {
+    id: 'sc-1',
+    isDefault: false,
+    isNetAppShift: true,
+    name: 'netapp-sc',
+  };
+
+  const regularStorage: TargetStorage = {
+    id: 'sc-2',
+    isDefault: true,
+    name: 'standard-sc',
+  };
+
+  it('returns labels when a mapped target has isNetAppShift', () => {
+    const mappings = [
+      {
+        [StorageMapFieldId.SourceStorage]: { name: 'src' },
+        [StorageMapFieldId.TargetStorage]: { name: 'netapp-sc' },
+      },
+    ];
+
+    expect(getNetAppShiftLabels(mappings, [shiftStorage, regularStorage])).toEqual({
+      [StorageClassAnnotation.NetAppShiftStorageClassType]: NETAPP_SHIFT_STORAGE_CLASS_TYPE_VALUE,
+    });
+  });
+
+  it('returns undefined when no mapped target has isNetAppShift', () => {
+    const mappings = [
+      {
+        [StorageMapFieldId.SourceStorage]: { name: 'src' },
+        [StorageMapFieldId.TargetStorage]: { name: 'standard-sc' },
+      },
+    ];
+
+    expect(getNetAppShiftLabels(mappings, [shiftStorage, regularStorage])).toBeUndefined();
+  });
+
+  it('returns undefined for empty mappings', () => {
+    expect(getNetAppShiftLabels([], [shiftStorage])).toBeUndefined();
+  });
+});

--- a/src/storageMaps/utils/netAppShift.ts
+++ b/src/storageMaps/utils/netAppShift.ts
@@ -1,0 +1,34 @@
+import {
+  StorageClassAnnotation,
+  type StorageMapping,
+  type TargetStorage,
+} from 'src/storageMaps/utils/types';
+
+/** Value matching pkg/apis/forklift/v1beta1.ValueNetAppShiftStorageClassType */
+export const NETAPP_SHIFT_STORAGE_CLASS_TYPE_VALUE = 'shift';
+
+export const isNetAppShiftStorageClassAnnotations = (
+  annotations: Record<string, string> | undefined,
+): boolean =>
+  annotations?.[StorageClassAnnotation.NetAppShiftStorageClassType] ===
+  NETAPP_SHIFT_STORAGE_CLASS_TYPE_VALUE;
+
+/**
+ * Returns labels to apply to a StorageMap when any mapped target storage class
+ * carries the NetApp Shift annotation.
+ */
+export const getNetAppShiftLabels = (
+  mappings: StorageMapping[],
+  targetStorages: TargetStorage[],
+): Record<string, string> | undefined => {
+  const hasNetAppShift = mappings?.some(
+    (mapping) =>
+      targetStorages.find((ts) => ts.name === mapping.targetStorage?.name)?.isNetAppShift,
+  );
+
+  return hasNetAppShift
+    ? {
+        [StorageClassAnnotation.NetAppShiftStorageClassType]: NETAPP_SHIFT_STORAGE_CLASS_TYPE_VALUE,
+      }
+    : undefined;
+};

--- a/src/storageMaps/utils/types.ts
+++ b/src/storageMaps/utils/types.ts
@@ -11,11 +11,13 @@ export type TargetStorage = {
   id: string;
   name: string;
   isDefault: boolean;
+  isNetAppShift?: boolean;
   provisioner?: string;
 };
 
 export enum StorageClassAnnotation {
   IsDefault = 'storageclass.kubernetes.io/is-default-class',
+  NetAppShiftStorageClassType = 'shift.netapp.io/storage-class-type',
 }
 
 export type StorageMappingValue = { id?: string; name: string };

--- a/src/utils/hooks/useTargetStorages.ts
+++ b/src/utils/hooks/useTargetStorages.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { isNetAppShiftStorageClassAnnotations } from 'src/storageMaps/utils/netAppShift';
 import { StorageClassAnnotation, type TargetStorage } from 'src/storageMaps/utils/types';
 import { useOpenShiftStorages } from 'src/utils/hooks/useStorages';
 
@@ -15,11 +16,12 @@ const useTargetStorages = (
     () =>
       availableTargetStorages?.reduce((acc: TargetStorage[], storage) => {
         if (storage.namespace === targetProject || !storage.namespace) {
-          const isDefault =
-            storage?.object?.metadata?.annotations?.[StorageClassAnnotation.IsDefault] === 'true';
+          const scAnnotations = storage?.object?.metadata?.annotations;
+          const isDefault = scAnnotations?.[StorageClassAnnotation.IsDefault] === 'true';
           const targetStorage: TargetStorage = {
             id: storage.uid,
             isDefault,
+            isNetAppShift: isNetAppShiftStorageClassAnnotations(scAnnotations),
             name: storage.name,
             provisioner: storage?.object?.provisioner,
           };


### PR DESCRIPTION
MTV-4725 | Highlight NetApp Shift storage classes in target storage dropdown Storage classes with the shift.netapp.io/storage-class-type: shift annotation are now shown in the "Recommended" group in the target storage dropdown, alongside vendor-matched entries.

<img width="1920" height="1200" alt="Screenshot From 2026-04-27 17-46-52" src="https://github.com/user-attachments/assets/96c497a2-1562-4b13-a674-1ff0e3043cb0" />

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Links

<!---
> References: <Jira ticket urls>

> Add more JIRA, Docs, and other PR/Issue links
-->

## 📝 Description

<!---
> Add a brief description
-->

## 🎥 Demo

<!---
> Please add a video or an image of the behavior/changes
-->

## 📝 CC://

<!---
> @tag as needed
-->

---

<details>
<summary>Merge automation commands</summary>

| Command | Description |
|---------|-------------|
| `/lgtm` or `/approve` | Add the `approved` label — PR will auto-merge when all checks pass |
| `/retest` | Re-trigger **Konflux** pipelines (handled by Pipelines as Code) |
| `/retest-gh` | Re-run **failed** GitHub Actions jobs |
| `/retest-gh-all` | Re-run **all** GitHub Actions workflows from scratch |
| `/retest-all` | Re-run failed GitHub Actions jobs **+** Konflux pipelines |
| `/hold` | Prevent auto-merge even if approved and checks pass |
| `/unhold` | Remove the hold and allow auto-merge again |

Submitting a **GitHub review approval** (Approve) also adds the `approved` label.

When checks fail on an approved PR, the bot automatically retries failed GitHub Actions up to **3 times**.
Konflux pipeline failures require a manual `/retest` to re-trigger.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI and create flows detect NetApp Shift-capable target storage, propagate that info through storage selection, plan submission, and storage map creation; storage options show a compact "NetApp Shift" label.

* **Localization**
  * Added "NetApp Shift" translations for English, Spanish, French, Japanese, Korean, and Simplified Chinese.

* **Tests**
  * Added tests validating NetApp Shift detection and label generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->