### PR TITLE
chore: bump @forklift-ui/types to 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@forklift-ui/types": "^1.0.8",
+        "@forklift-ui/types": "^1.0.10",
         "@openshift-console/dynamic-plugin-sdk": "^4.20.0",
         "@patternfly/patternfly": "6.4.0",
         "@patternfly/quickstarts": "6.4.0",
@@ -2182,9 +2182,9 @@
       }
     },
     "node_modules/@forklift-ui/types": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@forklift-ui/types/-/types-1.0.8.tgz",
-      "integrity": "sha512-rOxdnluZ6s/h6yFMzZku/9OxUhCsyvrsIacuAldIMvjZzfM6BEdzX8YDtjei4/ExLizeW4TWgwHlMZX3iQHlvQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@forklift-ui/types/-/types-1.0.10.tgz",
+      "integrity": "sha512-vLCSUy38MdYoOFTfgX5l+Y+o4eR2tlq9UmTr1HKTonW77GCsT95wnTRzS/P0QtVYPZUFYjI37aqLu3dIKuu6Tw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postinstall": "husky"
   },
   "dependencies": {
-    "@forklift-ui/types": "^1.0.8",
+    "@forklift-ui/types": "^1.0.10",
     "@openshift-console/dynamic-plugin-sdk": "^4.20.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/quickstarts": "6.4.0",

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -24,8 +24,6 @@ type ValidateNetworkMapParams = {
   oVirtNicProfiles: OVirtNicProfile[];
 };
 
-import type { EnhancedOvaVM } from '@utils/crds/plans/type-enhancements';
-
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {
@@ -50,7 +48,7 @@ const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
       }, []);
     }
     case PROVIDER_TYPES.ova: {
-      return (vm as EnhancedOvaVM)?.networks?.map((network) => network.ID) ?? [];
+      return vm?.networks?.map((network) => network.id) ?? [];
     }
     case PROVIDER_TYPES.hyperv:
       return vm?.networks?.map((network) => network?.id) ?? [];

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -54,14 +54,12 @@ type VsphereVirtualMachine = VSphereVM & {
   changeTrackingEnabled: boolean;
 };
 
-type OvaVirtualMachine = Omit<OvaVM, 'changeTrackingEnabled'>;
-
 export type ProviderVirtualMachine =
   | VsphereVirtualMachine
   | OpenshiftVM
   | OVirtVM
   | OpenstackVM
-  | OvaVirtualMachine;
+  | OvaVM;
 
 export type CreatePlanFormData = FieldValues & {
   [GeneralFormFieldId.PlanName]: string;

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -27,19 +27,7 @@ const getNetworksForVM = (vm: ProviderVirtualMachine) => {
     case PROVIDER_TYPES.hyperv:
       return vm?.networks?.map((network) => network?.id) ?? [];
     case PROVIDER_TYPES.ova: {
-      const networks = vm?.Networks;
-
-      if (!networks || !Array.isArray(networks)) {
-        return [];
-      }
-
-      return networks.map((network: unknown) => {
-        if (network && typeof network === 'object') {
-          return Object.values(network as Record<string, unknown>)[0];
-        }
-
-        return null;
-      });
+      return vm?.networks?.map((network) => network?.id) ?? [];
     }
 
     default:

--- a/src/plans/details/tabs/Resources/utils/utils.ts
+++ b/src/plans/details/tabs/Resources/utils/utils.ts
@@ -160,8 +160,8 @@ const getOpenstackPlanResources = (planInventory: OpenstackVM[]): PlanResourcesT
 const getK8sCPU = (vm: V1VirtualMachine) =>
   vm?.spec?.template?.spec?.domain?.cpu?.cores ?? EMPTY_CPU;
 const getK8sVMMemory = (vm: V1VirtualMachine): string =>
-  (vm?.spec?.template?.spec?.domain?.resources?.requests as Record<string, string>)?.memory ??
-  EMPTY_MEMORY;
+  (vm?.spec?.template?.spec?.domain?.resources?.requests as unknown as Record<string, string>)
+    ?.memory ?? EMPTY_MEMORY;
 
 const k8sMemoryToBytes = (quantity: string, fallback: number | null = null): number | null => {
   const input = quantity.trim();

--- a/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
@@ -14,7 +14,7 @@ import { VMNameCellRenderer } from './components/VMNameCellRenderer';
 const cellRenderers: Record<string, FC<VMCellProps>> = {
   concerns: VMConcernsCellRenderer,
   name: VMNameCellRenderer,
-  ovaPath: ({ data }) => <TableCell>{(data?.vm as OvaVM)?.OvaPath}</TableCell>,
+  ovaPath: ({ data }) => <TableCell>{(data?.vm as OvaVM)?.ovfPath}</TableCell>,
 };
 
 const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {

--- a/src/storageMaps/utils/getSourceStorageValues.ts
+++ b/src/storageMaps/utils/getSourceStorageValues.ts
@@ -55,7 +55,7 @@ const getVSphereStorageIds = (vm: ProviderVirtualMachine): string[] => {
  * Extracts storage IDs from OVA VMs
  */
 const getOvaStorageIds = (vm: EnhancedOvaVM): string[] =>
-  vm.disks?.reduce<string[]>((acc, disk) => (disk.ID ? [...acc, disk.ID] : acc), []) ?? [];
+  vm.disks?.reduce<string[]>((acc, disk) => (disk.id ? [...acc, disk.id] : acc), []) ?? [];
 
 /**
  * Extracts storage IDs from Hyper-V VMs

--- a/src/utils/crds/plans/type-enhancements.ts
+++ b/src/utils/crds/plans/type-enhancements.ts
@@ -1,19 +1,7 @@
-import type { HypervVM, OvaDisk, OvaNetwork, OvaVM } from '@forklift-ui/types';
-
-type OvaID = {
-  ID: string;
-};
-
-type EnhancedOvaDisk = OvaDisk & OvaID;
-
-type EnhancedOvaNetwork = OvaNetwork & OvaID;
+import type { HypervVM, OvaVM } from '@forklift-ui/types';
 
 export type EnhancedOvaVM = OvaVM & {
   powerState: string;
-  disks: EnhancedOvaDisk[];
-  networks: EnhancedOvaNetwork[];
-  memoryMB: number;
-  cpuCount: number;
 };
 
 export type EnhancedHypervVM = HypervVM & {

--- a/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
@@ -28,7 +28,9 @@ test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
       await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).toBeVisible();
       await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeVisible();
       await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.WARM)).toBeChecked();
-      await expect(planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD)).not.toBeChecked();
+      await expect(
+        planDetailsPage.detailsTab.migrationTypeRadio(MigrationType.COLD),
+      ).not.toBeChecked();
     });
 
     await test.step('Select cold migration and save', async () => {

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
@@ -24,7 +24,7 @@ export class NetworkMapStep {
     if (isVersionAtLeast(V2_11_0)) {
       return {
         rows: this.page.getByTestId(/^field-row-\d+$/),
-        getRowText: (row: Locator) => row.textContent(),
+        getRowText: async (row: Locator) => row.textContent(),
         getTargetSelect: (row: Locator) => row.getByTestId('network-map-target-network-select'),
       };
     }
@@ -33,7 +33,7 @@ export class NetworkMapStep {
     const bodyRowGroup = grid.getByRole('rowgroup').nth(1);
     return {
       rows: bodyRowGroup.getByRole('row'),
-      getRowText: (row: Locator) => row.getByRole('gridcell').first().textContent(),
+      getRowText: async (row: Locator) => row.getByRole('gridcell').first().textContent(),
       getTargetSelect: (row: Locator) => row.getByRole('gridcell').nth(1).getByRole('button'),
     };
   }

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/StorageMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/StorageMapStep.ts
@@ -27,7 +27,7 @@ export class StorageMapStep {
     if (isVersionAtLeast(V2_11_0)) {
       return {
         rows: this.page.getByTestId(/^field-row-\d+$/),
-        getSourceText: (row: Locator) => row.locator('td').first().textContent(),
+        getSourceText: async (row: Locator) => row.locator('td').first().textContent(),
         getTargetSelect: (row: Locator) => row.getByTestId('target-storage-select'),
       };
     }
@@ -36,7 +36,7 @@ export class StorageMapStep {
     const bodyRowGroup = grid.getByRole('rowgroup').nth(1);
     return {
       rows: bodyRowGroup.getByRole('row'),
-      getSourceText: (row: Locator) => row.getByRole('gridcell').first().textContent(),
+      getSourceText: async (row: Locator) => row.getByRole('gridcell').first().textContent(),
       getTargetSelect: (row: Locator) => row.getByRole('gridcell').nth(1).getByRole('button'),
     };
   }

--- a/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
+++ b/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
@@ -38,15 +38,15 @@ export class SettingsEditModal extends BaseModal {
   }
 
   async getControllerCpuLimitValue(): Promise<string | null> {
-    return await this.controllerCpuLimitDropdown.textContent();
+    return this.controllerCpuLimitDropdown.textContent();
   }
 
   async getControllerMemoryLimitValue(): Promise<string | null> {
-    return await this.controllerMemoryLimitDropdown.textContent();
+    return this.controllerMemoryLimitDropdown.textContent();
   }
 
   async getInventoryMemoryLimitValue(): Promise<string | null> {
-    return await this.inventoryMemoryLimitDropdown.textContent();
+    return this.inventoryMemoryLimitDropdown.textContent();
   }
 
   async getMaxVmInFlightValue(): Promise<string> {
@@ -54,15 +54,15 @@ export class SettingsEditModal extends BaseModal {
   }
 
   async getPrecopyIntervalValue(): Promise<string | null> {
-    return await this.preCopyIntervalDropdown.textContent();
+    return this.preCopyIntervalDropdown.textContent();
   }
 
   async getSnapshotPollingIntervalValue(): Promise<string | null> {
-    return await this.snapshotPollingIntervalDropdown.textContent();
+    return this.snapshotPollingIntervalDropdown.textContent();
   }
 
   async getTransferNetworkCurrentValue(): Promise<string | null> {
-    return await this.controllerTransferNetworkDropdown.textContent();
+    return this.controllerTransferNetworkDropdown.textContent();
   }
 
   async incrementMaxVmInFlight(): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -136,7 +136,7 @@ export class PlanDetailsPage {
    * Checks if the critical concerns alert is visible.
    */
   async hasCriticalConcernsAlert(): Promise<boolean> {
-    return await this.criticalConcernsAlert.isVisible({ timeout: 3000 }).catch(() => false);
+    return this.criticalConcernsAlert.isVisible({ timeout: 3000 }).catch(() => false);
   }
 
   async navigate(planName: string, namespace: string, tab?: string): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
@@ -48,7 +48,7 @@ export abstract class BaseMappingEditModal extends BaseModal {
       return 0;
     }
 
-    return await rows.count();
+    return rows.count();
   }
 
   async getSourceAtIndex(index: number): Promise<string> {

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -27,7 +27,7 @@ export class ScriptEditModal extends BaseModal {
   }
 
   async getScriptCount(): Promise<number> {
-    return await this.modal.locator('[data-testid^="field-row-"]').count();
+    return this.modal.locator('[data-testid^="field-row-"]').count();
   }
 
   async removeScript(index: number): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
@@ -237,12 +237,12 @@ export class DetailsTab {
     await this.migrationTypeRadio(type).click();
   }
 
-  get sharedDisksInfoAlert(): Locator {
-    return this.page.getByText('This may slow down the migration process');
-  }
-
   sharedDisksDetailItem(text: string): Locator {
     return this.page.getByTestId('shared-disks-detail-item').getByText(text, { exact: false });
+  }
+
+  get sharedDisksInfoAlert(): Locator {
+    return this.page.getByText('This may slow down the migration process');
   }
 
   targetVMPowerState(state: string): Locator {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/MappingsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/MappingsTab.ts
@@ -127,7 +127,7 @@ export class MappingsTab {
   }
 
   async getNetworkMappingCountFromReviewTable(): Promise<number> {
-    return await this.networkMapReviewTable.locator('tbody tr').count();
+    return this.networkMapReviewTable.locator('tbody tr').count();
   }
 
   async getStorageMapName(): Promise<string> {
@@ -141,7 +141,7 @@ export class MappingsTab {
 
   async getStorageMappingCountFromReviewTable(): Promise<number> {
     await this.storageMapReviewTable.locator('tbody tr').first().waitFor({ state: 'visible' });
-    return await this.storageMapReviewTable.locator('tbody tr').count();
+    return this.storageMapReviewTable.locator('tbody tr').count();
   }
 
   async navigateToMappingsTab(): Promise<void> {

--- a/testing/playwright/page-objects/ProviderDetailsPage/modals/CredentialEditModal.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/modals/CredentialEditModal.ts
@@ -83,7 +83,7 @@ export class CredentialEditModal extends BaseModal {
   }
 
   async isConfigureCertificateSelected(): Promise<boolean> {
-    return await this.configureCertificateRadio.isChecked();
+    return this.configureCertificateRadio.isChecked();
   }
 
   async isPasswordVisible(): Promise<boolean> {
@@ -92,7 +92,7 @@ export class CredentialEditModal extends BaseModal {
   }
 
   async isSkipCertificateSelected(): Promise<boolean> {
-    return await this.skipCertificateRadio.isChecked();
+    return this.skipCertificateRadio.isChecked();
   }
 
   override async save(): Promise<void> {

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -40,7 +40,7 @@ export class OffloadOptions {
   }
 
   private async isOffloadExpanded(mappingIndex: number): Promise<boolean> {
-    return await this.fieldToggleButton(OFFLOAD_FIELD.offloadPlugin(mappingIndex)).isVisible();
+    return this.fieldToggleButton(OFFLOAD_FIELD.offloadPlugin(mappingIndex)).isVisible();
   }
 
   private async selectFromDropdown(fieldId: string, optionText: string): Promise<void> {

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -73,7 +73,7 @@ export abstract class BaseResourceManager {
   ): Promise<ApiResult<R>> {
     const constants = BaseResourceManager.getEvaluateConstants();
 
-    return await page.evaluate(
+    return page.evaluate(
       async ({ body, contentType, evalConstants, method, path }): Promise<ApiResult<R>> => {
         try {
           const cookies = document.cookie.split('; ');


### PR DESCRIPTION
## Summary

- Bumps `@forklift-ui/types` from `1.0.8` to `1.0.10`
- Sources updated: Forklift (main @ 3f95f17), Kubernetes (v1.36.0), KubeVirt (v1.8.2), CDI (v1.65.0)
- Fixes OVA inventory type field casing (`OvaPath` → `ovfPath`, `disk.ID` → `disk.id`)
- v1.0.10 includes the ObjectMeta timestamp fix (Date → string) for SDK compatibility

## Links

> Types PRs: https://github.com/kubev2v/forklift-console-types/pull/25, https://github.com/kubev2v/forklift-console-types/pull/26
> Jira: https://issues.redhat.com/browse/MTV-5199

Resolves: MTV-5199