### PR TITLE
chore: update types-update skill with lessons from 1.0.10 bump

### DIFF
--- a/.cursor/skills/types-update/SKILL.md
+++ b/.cursor/skills/types-update/SKILL.md
@@ -1,0 +1,555 @@
+---
+name: types-update
+description: >-
+  Automates the full lifecycle of updating @forklift-ui/types: discovers
+  upstream versions, creates a Jira ticket, runs type generation scripts in
+  the forked types repo, handles KubeVirt/CDI conflicts, creates a PR and
+  GitHub release, waits for npm publish, then bumps the consumer project
+  and monitors CI. Use when the user asks to update types, bump types,
+  update forklift-ui/types, types package update, or regenerate types.
+---
+
+# Types Update Skill
+
+Updates `@forklift-ui/types` from upstream sources (Forklift, Kubernetes, KubeVirt, CDI), publishes a new version, and bumps the consumer project.
+
+For conflict resolution rules, Jira payload template, CRD verification, and edge cases see [reference.md](reference.md).
+
+## Prerequisites
+
+- `gh` CLI authenticated with access to `kubev2v/forklift-console-types`
+- User's fork of `kubev2v/forklift-console-types` cloned locally (or clonable)
+- `~/.jira-creds` configured (see `~/.cursor/rules/jira-api.mdc`)
+- `curl`, `jq`, `npm`, `node >= 20` installed
+- Java runtime (required by `openapi-generator-cli` in the types repo)
+
+## Permissions — Cross-Project File Access
+
+The types repo (`forklift-console-types`) lives **outside** the current workspace. The Cursor sandbox blocks writes to paths outside the workspace, which causes repeated permission prompts.
+
+**Rules for all phases that touch the types repo (Phases 2.5, 3, 4):**
+
+1. **Always use `required_permissions: ["all"]`** on every Shell call whose `working_directory` is the types repo.
+2. **Use Shell for file edits in the types repo** — do NOT use the Write or StrReplace tools for files outside the workspace. Instead write files via shell (e.g. `cat <<'CONTENT' > path/to/file.ts ... CONTENT`). This avoids per-file permission prompts.
+3. **Batch operations** — combine multiple related edits into a single Shell call when possible to minimise approval prompts.
+4. Phases that only run in the consumer project (this workspace) do not need special permissions.
+
+---
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+Types Update Progress:
+- [ ] Phase 1: Setup and discovery
+- [ ] Phase 2: Create Jira ticket
+- [ ] Phase 2.5: Update inventory types from Go source
+- [ ] Phase 3: Update generated types in forked repo
+- [ ] GATE 1: User approves conflict resolution (if any)
+- [ ] Phase 4: Version bump, tracking update, and PR
+- [ ] GATE 2: User confirms types PR is merged
+- [ ] Phase 5: Create GitHub release and wait for npm publish
+- [ ] Phase 6: Update consumer project (forklift-console-plugin)
+- [ ] Phase 7: Monitor CI on consumer PR
+```
+
+---
+
+## Phase 1: Setup and Discovery
+
+### 1a. Locate the types repo
+
+Check if the types repo is already cloned locally. Common locations:
+- Sibling directory: `../forklift-console-types`
+- User home: `~/Workspace/forklift-console-types`
+
+If not found, clone the user's fork:
+```bash
+gh repo clone <user>/forklift-console-types ~/Workspace/forklift-console-types
+```
+
+Store the path as `TYPES_REPO_DIR` for the rest of the workflow.
+
+### 1b. Read current versions
+
+Parse the Version Tracking table in `$TYPES_REPO_DIR/MAINTENANCE.md`. Extract the "Current Version" column for each source (Forklift, Kubernetes, KubeVirt, CDI).
+
+Also read the current package version from `$TYPES_REPO_DIR/package.json`.
+
+### 1c. Fetch latest upstream versions
+
+Run the helper script:
+```bash
+.cursor/skills/types-update/scripts/check-upstream.sh
+```
+
+This outputs the latest commit SHA on `main` for Forklift, and the latest release tag for the other sources.
+
+**Forklift always targets `main`** (never a tagged release) because the UI needs the most recent CRD and inventory type changes. The commit SHA is recorded in MAINTENANCE.md for reproducibility. Kubernetes, KubeVirt, and CDI use stable tagged releases.
+
+### 1d. Present comparison and ask user
+
+Present a table:
+```
+Types Update Discovery
+=======================
+Package version: 1.0.8
+
+| Source     | Current              | Latest Available       |
+|------------|----------------------|------------------------|
+| Forklift   | main (abc1234)       | main (def5678)         |
+| Kubernetes | v1.29.0              | v1.30.0                |
+| KubeVirt   | v1.2.0               | v1.3.0                 |
+| CDI        | v1.58.0              | v1.59.0                |
+```
+
+Use the AskQuestion tool to ask:
+1. Which sources to update (default: all four). Options: "All four", "Let me pick"
+2. If "Let me pick", present each source as a multi-select checkbox (Forklift is always included since it targets `main`)
+
+Then ask for target versions for Kubernetes, KubeVirt, and CDI (default: the latest available shown above). Forklift always uses the latest `main` commit.
+
+---
+
+## Phase 2: Create Jira Ticket
+
+Source Jira credentials:
+```bash
+source ~/.jira-creds
+```
+
+Determine the new package version (current patch + 1, e.g. `1.0.8` -> `1.0.9`). Ask user if they want a different bump level (minor/major).
+
+Create the ticket:
+```bash
+curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "fields": {
+      "project": {"key": "MTV"},
+      "issuetype": {"name": "Task"},
+      "summary": "UI types package bump from <OLD_VERSION> to <NEW_VERSION>",
+      "description": "Updating @forklift-ui/types package.\n\nSources updated:\n- Forklift: <version> (CRDs + inventory types)\n- Kubernetes: <version>\n- KubeVirt: <version>\n- CDI: <version>",
+      "components": [{"name": "User Interface"}],
+      "labels": ["user-interface"]
+    }
+  }' \
+  "${JIRA_BASE_URL}/rest/api/2/issue/"
+```
+
+Parse the response to extract the ticket key (e.g. `MTV-5432`). Store it as `JIRA_KEY` for commits and PR descriptions.
+
+If the API call fails (auth error, missing fields), show the error and ask the user to fix credentials or provide the component/label IDs manually. See [reference.md](reference.md) for the full payload template and fallback field discovery commands.
+
+---
+
+## Phase 2.5: Update Inventory Types from Go Source
+
+The hand-written inventory types in `$TYPES_REPO_DIR/src/types/` mirror Go structs from the Forklift repo. The agent reads the Go source files and regenerates the TypeScript interfaces to match.
+
+> **Permissions reminder:** This phase edits files in the types repo (outside workspace). Use Shell with `required_permissions: ["all"]` for all commands and file writes. See the **Permissions** section above.
+
+**Scope**: `src/types/provider/` (per-provider types) and `src/types/provider/base/` (shared model types). The `src/types/secret/` and `src/types/k8s/` directories are NOT derivable from Go and remain manual.
+
+See [reference.md](reference.md) for the complete Go source file map, type mapping table, and edge cases.
+
+### 2.5a. Fetch Go source files
+
+For each provider, download the Go source files from GitHub at the same Forklift version/branch selected in Phase 1. Use the GitHub raw content URL:
+
+```
+https://raw.githubusercontent.com/kubev2v/forklift/<VERSION>/pkg/controller/provider/web/<provider>/<file>.go
+https://raw.githubusercontent.com/kubev2v/forklift/<VERSION>/pkg/controller/provider/model/<provider>/model.go
+```
+
+Start with the base model:
+```bash
+curl -sfL "https://raw.githubusercontent.com/kubev2v/forklift/<VERSION>/pkg/controller/provider/model/base/model.go"
+```
+
+Then fetch each provider's web layer files. The Go source directory for each provider:
+
+| TypeScript provider dir | Go web dir | Go model dir |
+|---|---|---|
+| `provider/base/` | -- | `model/base/model.go` |
+| `provider/vsphere/` | `web/vsphere/*.go` | `model/vsphere/model.go` |
+| `provider/ovirt/` | `web/ovirt/*.go` | `model/ovirt/model.go` |
+| `provider/openshift/` | `web/ocp/*.go` | `model/ocp/model.go` |
+| `provider/openstack/` | `web/openstack/*.go` | `model/openstack/model.go` |
+| `provider/ova/` | `web/ova/*.go` | -- |
+| `provider/hyperv/` | `web/hyperv/*.go` | `model/hyperv/model.go` |
+
+To discover files in a Go web directory, list them via the GitHub API:
+```bash
+curl -sf "https://api.github.com/repos/kubev2v/forklift/contents/pkg/controller/provider/web/<provider>?ref=<VERSION>" | jq -r '.[].name'
+```
+
+### 2.5b. Parse Go structs and translate to TypeScript
+
+For each Go source file, identify exported struct definitions and their fields. Apply the Go-to-TypeScript type mapping from [reference.md](reference.md).
+
+Key rules:
+- **Struct field with `json:"fieldName"`** -> TypeScript property `fieldName: <mapped-type>`
+- **Struct field with `json:"-"`** -> skip (not serialized)
+- **Struct field with `json:"fieldName,omitempty"`** -> optional property `fieldName?: <mapped-type>`
+- **Pointer field (`*T`)** -> optional property (`T | undefined` or `?`)
+- **Embedded struct** -> TypeScript `extends` (e.g., `type VM struct { Base; ... }` becomes `interface VM extends Base { ... }`)
+- **Go `api.Provider`** (imported from Forklift API package) -> `V1beta1Provider` from `../../../generated`
+
+### 2.5c. Write the TypeScript files
+
+Overwrite the existing TypeScript files in `$TYPES_REPO_DIR/src/types/provider/` with the regenerated interfaces. Preserve:
+
+1. **File structure**: same file names and directory layout as existing
+2. **Source URL comment**: include `// https://github.com/kubev2v/forklift/tree/<VERSION>/pkg/controller/provider/web/<provider>/<file>.go` at the top
+3. **Go field comments**: include the original Go field definition as a comment above each TypeScript property (matching existing style)
+4. **Import paths**: maintain correct relative imports to base types and generated CRD types
+5. **Union types**: after regenerating individual provider types, regenerate `ProviderInventory.ts`, `ProviderVM.ts`, `ProviderHost.ts`, and `ProvidersInventoryList.ts` to include all providers
+
+### 2.5d. Verify inventory types build
+
+```bash
+cd $TYPES_REPO_DIR
+npm run build
+```
+
+If the build fails due to inventory type issues (missing imports, wrong type references), fix them before proceeding. Common issues:
+- **Missing base type**: a Go struct embeds a type from a different package. Check if the base type exists in `provider/base/model.ts` or another provider's types.
+- **CRD type reference changed**: if a Go struct references an API type that was renamed in the generated types, update the import.
+- **New provider added upstream**: if a new provider directory appears in the Go source, create the corresponding TypeScript directory under `provider/` and add it to `provider/index.ts` and the union types.
+
+---
+
+## Phase 3: Update Generated Types in Forked Repo
+
+> **Permissions reminder:** This phase runs in the types repo (outside workspace). Use Shell with `required_permissions: ["all"]` for all commands. See the **Permissions** section above.
+
+### 3a. Prepare the branch (skip if already done in Phase 2.5)
+
+```bash
+cd $TYPES_REPO_DIR
+git fetch origin
+git checkout main
+git pull origin main
+git checkout -b chore/types-update-<NEW_VERSION>
+npm ci --ignore-scripts
+```
+
+### 3b. Verify Forklift CRD list (if updating Forklift)
+
+Before running the Forklift update script, compare the hardcoded CRD list in `scripts/update-forklift.sh` against the actual upstream directory. See [reference.md](reference.md) for the verification procedure. If new CRDs exist upstream, add them to the `CRDS` array before running.
+
+### 3c. Run update scripts
+
+Run each selected source's update script in this order:
+
+```bash
+npm run update:forklift -- main
+npm run update:kubernetes -- <version>
+npm run update:kubevirt -- <version>
+npm run update:cdi -- <version>
+```
+
+Forklift always uses `main`. Record the commit SHA from Phase 1 in MAINTENANCE.md for reproducibility.
+
+**macOS compatibility note**: The update scripts use `sed -i` which behaves differently on macOS (BSD sed) vs Linux (GNU sed). If running locally on macOS and `sed` errors occur, set `PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"` or install `gnu-sed` via Homebrew.
+
+### 3d. Check for KubeVirt/CDI conflicts
+
+After updating KubeVirt or CDI, run:
+```bash
+npm run check:conflicts
+```
+
+Parse the output:
+- **"No conflicts found"**: proceed to build verification
+- **Conflicts found**: the script lists conflicting type names
+
+If conflicts are found, update `src/generated/index.ts`:
+1. Read the current selective export block for kubevirt
+2. Remove any newly conflicting types from the named export list
+3. Add any new KubeVirt-only types that the application needs
+
+See [reference.md](reference.md) for the conflict resolution rules and which type categories to include/exclude.
+
+### GATE 1: Conflict resolution approval
+
+If conflicts required changes to `src/generated/index.ts`, present the diff to the user:
+```bash
+git diff src/generated/index.ts
+```
+
+Use AskQuestion:
+- "Approve changes" -> proceed
+- "Let me review" -> wait for user edits
+- "Cancel" -> abort workflow
+
+If no conflicts were found, skip this gate.
+
+### 3e. Fix ObjectMeta timestamp types
+
+The `openapi-generator` maps OpenAPI `date-time` fields to TypeScript `Date`, but the Kubernetes API returns ISO 8601 strings and `@openshift-console/dynamic-plugin-sdk` expects `creationTimestamp` and `deletionTimestamp` as `string`. After running the update scripts, this **must** be fixed.
+
+Run the post-generation fix script (if it exists):
+```bash
+npm run fix:timestamps
+```
+
+If the script does not exist, manually fix all ObjectMeta types:
+```bash
+for f in $(grep -rl "Timestamp?: Date" src/generated/); do
+  sed -i '' \
+    -e 's/creationTimestamp?: Date;/creationTimestamp?: string;/' \
+    -e 's/deletionTimestamp?: Date;/deletionTimestamp?: string;/' \
+    -e "s/(new Date(json\['creationTimestamp'\]))/json['creationTimestamp']/" \
+    -e "s/(new Date(json\['deletionTimestamp'\]))/json['deletionTimestamp']/" \
+    -e "s/((value\['creationTimestamp'\]).toISOString())/value['creationTimestamp']/" \
+    -e "s/((value\['deletionTimestamp'\]).toISOString())/value['deletionTimestamp']/" \
+    "$f"
+  echo "Fixed: $f"
+done
+```
+
+**This step is mandatory.** Skipping it causes ~370 TypeScript errors in the consumer project where Forklift CRD types become incompatible with the Console SDK's `K8sResourceCommon`.
+
+### 3f. Build verification
+
+```bash
+npm run build
+npm run lint
+```
+
+If the build fails with "Duplicate identifier" errors:
+1. Parse the error to identify the conflicting type name
+2. Remove it from the kubevirt selective export in `src/generated/index.ts`
+3. Rebuild
+
+Repeat until the build passes or a non-conflict error is encountered.
+
+If a non-conflict error occurs, present it to the user and stop for manual resolution.
+
+---
+
+## Phase 4: Version Bump, Tracking, and PR
+
+### 4a. Bump version
+
+Edit `$TYPES_REPO_DIR/package.json` to increment the version (default: patch bump).
+
+### 4b. Update Version Tracking
+
+Edit `$TYPES_REPO_DIR/MAINTENANCE.md`, updating the Version Tracking table. For each source that was updated, set:
+- **Current Version**: the version/tag used. For Forklift, use `main (<short-sha>)` (e.g. `main (a1b2c3d)`) to record the exact commit.
+- **Last Updated**: today's date in `YYYY-MMM-DD` format (e.g. `2026-APR-28`)
+- **Updated By**: `aturgema (made with cursor)`
+
+### 4c. Commit
+
+Collect git user info:
+```bash
+GIT_NAME=$(git config user.name)
+GIT_EMAIL=$(git config user.email)
+```
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore: update types to <NEW_VERSION>
+
+Updated sources:
+- Forklift: <version> (CRDs + inventory types)
+- Kubernetes: <version>
+- KubeVirt: <version>
+- CDI: <version>
+
+Resolves: <JIRA_KEY>
+Signed-off-by: <GIT_NAME> <<GIT_EMAIL>>
+EOF
+)"
+```
+
+### 4d. Push and create PR
+
+```bash
+git push -u origin chore/types-update-<NEW_VERSION>
+```
+
+```bash
+gh pr create \
+  --repo kubev2v/forklift-console-types \
+  --base main \
+  --title "chore: update types to <NEW_VERSION>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Updated @forklift-ui/types from <OLD_VERSION> to <NEW_VERSION>
+- Sources updated: Forklift (<ver>), Kubernetes (<ver>), KubeVirt (<ver>), CDI (<ver>)
+
+## Verification
+
+- [x] `npm run build` passes
+- [x] `npm run lint` passes
+- [x] `npm run check:conflicts` shows no unresolved conflicts
+
+## Links
+
+> Jira: https://issues.redhat.com/browse/<JIRA_KEY>
+
+Resolves: <JIRA_KEY>
+EOF
+)"
+```
+
+### GATE 2: Wait for types PR merge
+
+Present the PR URL to the user. Ask:
+- "PR is merged, proceed with release" -> continue to Phase 5
+- "Still waiting" -> pause and remind later
+- "Cancel" -> abort
+
+**Do NOT proceed to Phase 5 until the user explicitly confirms the PR is merged.**
+
+---
+
+## Phase 5: Create GitHub Release and Wait for npm
+
+### 5a. Create the release
+
+```bash
+gh release create "v<NEW_VERSION>" \
+  --repo kubev2v/forklift-console-types \
+  --title "v<NEW_VERSION>" \
+  --generate-notes
+```
+
+This creates a tag and publishes a release, which triggers the `release.yml` GitHub Action to publish to npm.
+
+### 5b. Wait for npm publish
+
+Run the polling script:
+```bash
+.cursor/skills/types-update/scripts/poll-npm.sh <NEW_VERSION>
+```
+
+This polls `npm view @forklift-ui/types version` every 30 seconds for up to 10 minutes.
+
+If the poll times out, notify the user:
+```
+The new version <NEW_VERSION> has not appeared on npm after 10 minutes.
+Check the GitHub Action logs:
+https://github.com/kubev2v/forklift-console-types/actions/workflows/release.yml
+```
+
+If the version appears, proceed to Phase 6.
+
+---
+
+## Phase 6: Update Consumer Project (forklift-console-plugin)
+
+### 6a. Create branch
+
+```bash
+cd /path/to/forklift-console-plugin
+git checkout main
+git pull upstream main
+git checkout -b chore/bump-types-<NEW_VERSION>
+```
+
+### 6b. Install new version
+
+```bash
+npm install @forklift-ui/types@<NEW_VERSION>
+```
+
+### 6c. Verify no breaking changes
+
+```bash
+npm run lint
+npx tsc --noEmit
+```
+
+### If errors occur
+
+**Do NOT create a PR.** Instead:
+
+1. Present the full error output to the user
+2. Analyze the errors -- common causes:
+   - Removed type: a type was dropped from the package. Search for its usage and suggest the replacement.
+   - Changed field: a field was renamed or its type changed. Show the old vs new type definition.
+   - New required field: a type now requires a field that wasn't there before.
+3. Suggest fixes if possible
+4. Wait for user to resolve. After resolution, re-run verification.
+
+### If clean
+
+Commit and create PR:
+
+```bash
+git add package.json package-lock.json
+git commit -m "$(cat <<'EOF'
+chore: bump @forklift-ui/types to <NEW_VERSION>
+
+Resolves: <JIRA_KEY>
+EOF
+)"
+git push -u origin chore/bump-types-<NEW_VERSION>
+```
+
+```bash
+gh pr create \
+  --title "chore: bump @forklift-ui/types to <NEW_VERSION>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Bumps `@forklift-ui/types` from `<OLD_VERSION>` to `<NEW_VERSION>`
+- No breaking changes detected (lint and tsc pass)
+
+## Links
+
+> Types PR: <types-pr-url>
+> Jira: https://issues.redhat.com/browse/<JIRA_KEY>
+
+Resolves: <JIRA_KEY>
+EOF
+)"
+```
+
+---
+
+## Phase 7: Monitor CI
+
+### 7a. Initial wait
+
+Sleep for 10 minutes after creating the consumer PR:
+```bash
+sleep 600
+```
+
+### 7b. Check PR status
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+### 7c. Act on results
+
+- **All checks passing**: Notify the user that the PR is ready for review/merge.
+- **Any check failing**: Gather details:
+  ```bash
+  gh pr checks <PR_NUMBER> --json name,state,conclusion,detailsUrl
+  ```
+  For each failed check, fetch the log URL and summarize the failure. Suggest fixes if possible.
+- **Checks still running**: Sleep another 10 minutes and repeat from 7b.
+
+Continue the check loop until all checks have a terminal state (pass or fail).
+
+---
+
+## Important Notes
+
+- The types repo uses **npm Trusted Publishing** (`--provenance`). No npm token is needed; the GitHub Action handles auth via OIDC.
+- **Forklift always targets `main`** (never a tagged release) to pick up the latest CRD and inventory type changes. Record the commit SHA in MAINTENANCE.md for reproducibility.
+- Kubernetes, KubeVirt, and CDI use **stable tagged releases**. Kubernetes defaults to the **`master`** branch naming convention for its tags.
+- The `openapi-generator-cli` requires a **Java runtime**. If `npx openapi-generator-cli` fails with a Java error, the user needs to install JDK 11+.
+- After updating, `swagger.json` files are kept in the repo (they are large but committed). This is intentional for reproducibility.

--- a/.cursor/skills/types-update/SKILL.md
+++ b/.cursor/skills/types-update/SKILL.md
@@ -534,15 +534,32 @@ gh pr checks <PR_NUMBER>
 
 ### 7c. Act on results
 
-- **All checks passing**: Notify the user that the PR is ready for review/merge.
-- **Any check failing**: Gather details:
+- **All checks passing**: Notify the user that the PR is ready for review/merge. Done.
+- **Checks still running**: Sleep another 10 minutes and repeat from 7b.
+- **Any check failing**: Gather details and present a summary:
   ```bash
   gh pr checks <PR_NUMBER> --json name,state,conclusion,detailsUrl
   ```
-  For each failed check, fetch the log URL and summarize the failure. Suggest fixes if possible.
-- **Checks still running**: Sleep another 10 minutes and repeat from 7b.
+  For each failed check, fetch the log URL and summarize the failure.
 
-Continue the check loop until all checks have a terminal state (pass or fail).
+### 7d. Handle failures
+
+After presenting the failure summary, use the AskQuestion tool to ask the user:
+
+1. **"Fix it for me"** -- The agent enters a fix-verify loop:
+   - Analyze the failure logs and identify the root cause
+   - Apply the fix (edit code, update config, etc.)
+   - Run local verification (`npm run lint`, `npx tsc --noEmit`, `npm test` as appropriate)
+   - Commit, push, and go back to **step 7a** (wait then re-check CI)
+   - If the fix attempt fails or the agent cannot determine a fix, fall back to presenting the error and asking again
+
+2. **"I'll fix it myself"** -- The agent pauses and waits for the user to signal readiness:
+   - Present the failure details and stop
+   - When the user indicates they are done (clicks the option or sends a message), go back to **step 7a** (wait then re-check CI)
+
+3. **"Skip / Stop monitoring"** -- End Phase 7. The PR is left as-is for manual handling.
+
+Continue the fix-verify loop until all checks pass or the user chooses to stop.
 
 ---
 

--- a/.cursor/skills/types-update/SKILL.md
+++ b/.cursor/skills/types-update/SKILL.md
@@ -40,7 +40,7 @@ The types repo (`forklift-console-types`) lives **outside** the current workspac
 
 Copy this checklist and track progress:
 
-```
+```text
 Types Update Progress:
 - [ ] Phase 1: Setup and discovery
 - [ ] Phase 2: Create Jira ticket
@@ -91,7 +91,7 @@ This outputs the latest commit SHA on `main` for Forklift, and the latest releas
 ### 1d. Present comparison and ask user
 
 Present a table:
-```
+```text
 Types Update Discovery
 =======================
 Package version: 1.0.8
@@ -158,7 +158,7 @@ See [reference.md](reference.md) for the complete Go source file map, type mappi
 
 For each provider, download the Go source files from GitHub at the same Forklift version/branch selected in Phase 1. Use the GitHub raw content URL:
 
-```
+```text
 https://raw.githubusercontent.com/kubev2v/forklift/<VERSION>/pkg/controller/provider/web/<provider>/<file>.go
 https://raw.githubusercontent.com/kubev2v/forklift/<VERSION>/pkg/controller/provider/model/<provider>/model.go
 ```
@@ -435,7 +435,7 @@ Run the polling script:
 This polls `npm view @forklift-ui/types version` every 30 seconds for up to 10 minutes.
 
 If the poll times out, notify the user:
-```
+```text
 The new version <NEW_VERSION> has not appeared on npm after 10 minutes.
 Check the GitHub Action logs:
 https://github.com/kubev2v/forklift-console-types/actions/workflows/release.yml
@@ -567,6 +567,6 @@ Continue the fix-verify loop until all checks pass or the user chooses to stop.
 
 - The types repo uses **npm Trusted Publishing** (`--provenance`). No npm token is needed; the GitHub Action handles auth via OIDC.
 - **Forklift always targets `main`** (never a tagged release) to pick up the latest CRD and inventory type changes. Record the commit SHA in MAINTENANCE.md for reproducibility.
-- Kubernetes, KubeVirt, and CDI use **stable tagged releases**. Kubernetes defaults to the **`master`** branch naming convention for its tags.
+- Kubernetes, KubeVirt, and CDI use **stable tagged releases** (e.g., `v1.32.0`).
 - The `openapi-generator-cli` requires a **Java runtime**. If `npx openapi-generator-cli` fails with a Java error, the user needs to install JDK 11+.
 - After updating, `swagger.json` files are kept in the repo (they are large but committed). This is intentional for reproducibility.

--- a/.cursor/skills/types-update/reference.md
+++ b/.cursor/skills/types-update/reference.md
@@ -1,0 +1,404 @@
+# Types Update Reference
+
+Detailed reference for the types-update skill. Read sections on-demand as needed during the workflow.
+
+---
+
+## KubeVirt/CDI Conflict Resolution
+
+### Background
+
+KubeVirt and CDI both generate types from Kubernetes base types but with different naming conventions:
+- **CDI** uses: `V1Affinity`, `V1NodeSelector`, `V1ResourceRequirements`
+- **KubeVirt** uses: `K8sIoApiCoreV1Affinity`, `K8sIoApiCoreV1NodeSelector`, etc.
+
+The types package exports ALL types from CDI, Forklift, and Kubernetes via `export *`, but exports only **selected** types from KubeVirt via a named export block. This avoids "Duplicate identifier" TypeScript errors.
+
+### Rules for the KubeVirt selective export
+
+In `src/generated/index.ts`, the KubeVirt export block follows these rules:
+
+**INCLUDE (safe to export):**
+- `V1VirtualMachine*` -- KubeVirt-specific VM types
+- `V1alpha1*` -- KubeVirt alpha types (snapshots, clones, pools, exports, migration policies)
+- `V1beta1VirtualMachine*` -- KubeVirt beta VM types (instancetype, preference)
+- `V1beta1CPU*`, `V1beta1Clock*`, `V1beta1Device*`, `V1beta1Feature*`, `V1beta1Firmware*`, `V1beta1Machine*`, `V1beta1Memory*`, `V1beta1Volume*`, `V1beta1Preference*` -- KubeVirt preference/instancetype subtypes
+- `K8sIoApiCoreV1*` types that do NOT exist in CDI's export list
+- `K8sIoApimachineryPkgApisMetaV1*` types that do NOT exist in CDI's export list
+- `V1` types that are KubeVirt-specific (e.g. `V1CPU`, `V1Disk`, `V1Network`, `V1Volume`)
+
+**EXCLUDE (conflict with CDI or Kubernetes):**
+- `V1beta1DataVolume*` -- conflicts with CDI
+- `V1beta1StorageSpec` -- conflicts with CDI
+- Any type name that appears in BOTH `src/generated/kubevirt/models/index.ts` AND `src/generated/containerized-data-importer/models/index.ts`
+- Generic K8s types already exported from `kubernetes` or `containerized-data-importer`
+
+### Conflict resolution procedure
+
+1. Run `npm run check:conflicts` and capture the output
+2. Parse the "Potential Conflicts" section for the list of conflicting type names
+3. For each conflicting type, check if it currently appears in the named export block in `src/generated/index.ts`
+4. If it does, remove it from the export block
+5. Parse the "KubeVirt-Only Types" section for new types that might be needed
+6. Check if any new KubeVirt-only types are used by the consumer project (`forklift-console-plugin`). Search for imports from `@forklift-ui/types` that reference KubeVirt type names.
+7. Add any needed new types to the export block
+8. Run `npm run build` to verify
+
+### Auto-fix for Duplicate identifier errors
+
+If `npm run build` fails with errors like:
+```
+error TS2300: Duplicate identifier 'V1beta1SomeType'.
+```
+
+Extract the type name from the error, remove it from the kubevirt export block in `src/generated/index.ts`, and rebuild. Repeat until clean or a non-conflict error appears.
+
+---
+
+## Forklift CRD List Verification
+
+The `scripts/update-forklift.sh` script has a hardcoded `CRDS` array. New CRDs added upstream are silently missed.
+
+### Verification procedure
+
+Fetch the upstream CRD directory listing:
+```bash
+curl -s "https://api.github.com/repos/kubev2v/forklift/contents/operator/config/crd/bases?ref=<VERSION>" | jq -r '.[].name'
+```
+
+Compare against the `CRDS` array in `scripts/update-forklift.sh`. If new `.yaml` files exist upstream that are not in the array, add them before running the update.
+
+### Current known CRDs (as of 1.0.10)
+
+```
+forklift.konveyor.io_forkliftcontrollers.yaml
+forklift.konveyor.io_hooks.yaml
+forklift.konveyor.io_hosts.yaml
+forklift.konveyor.io_hypervproviderservers.yaml
+forklift.konveyor.io_migrations.yaml
+forklift.konveyor.io_networkmaps.yaml
+forklift.konveyor.io_openstackvolumepopulators.yaml
+forklift.konveyor.io_ovaproviderservers.yaml
+forklift.konveyor.io_ovirtvolumepopulators.yaml
+forklift.konveyor.io_plans.yaml
+forklift.konveyor.io_providers.yaml
+forklift.konveyor.io_storagemaps.yaml
+forklift.konveyor.io_vspherexcopyvolumepopulators.yaml
+```
+
+---
+
+## Jira Ticket Creation
+
+### Required fields
+
+| Field | Value |
+|-------|-------|
+| Project | `MTV` |
+| Issue Type | `Task` |
+| Summary | `UI types package bump from <OLD> to <NEW>` |
+| Component | `User Interface` |
+| Label | `user-interface` |
+| Description | Source update details (see template below) |
+
+### Full payload template
+
+```json
+{
+  "fields": {
+    "project": {"key": "MTV"},
+    "issuetype": {"name": "Task"},
+    "summary": "UI types package bump from 1.0.8 to 1.0.9",
+    "description": "Updating @forklift-ui/types package with latest upstream types.\n\nSources updated:\n- Forklift: main\n- Kubernetes: v1.30.0\n- KubeVirt: v1.3.0\n- CDI: v1.59.0\n\nThis is a routine maintenance update to keep TypeScript types in sync with upstream CRDs and APIs.",
+    "components": [{"name": "User Interface"}],
+    "labels": ["user-interface"]
+  }
+}
+```
+
+### Fallback: discovering field IDs
+
+If the create call fails with "Field X is required" or "Component not found", discover available values:
+
+```bash
+# List project components
+curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+  "${JIRA_BASE_URL}/rest/api/2/project/MTV/components" | jq '.[].name'
+
+# List issue types for project
+curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+  "${JIRA_BASE_URL}/rest/api/2/project/MTV" | jq '.issueTypes[].name'
+
+# Get createmeta for required fields
+curl -s -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+  "${JIRA_BASE_URL}/rest/api/2/issue/createmeta?projectKeys=MTV&issuetypeNames=Task&expand=projects.issuetypes.fields"
+```
+
+---
+
+## macOS Compatibility
+
+### sed -i difference
+
+The update scripts use GNU `sed -i` syntax. On macOS (BSD sed), this requires an empty string argument: `sed -i '' 's/...'`.
+
+**Fix options:**
+1. Install GNU sed: `brew install gnu-sed` and prepend to PATH:
+   ```bash
+   export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
+   ```
+2. Or run the scripts inside a Docker container with the repo mounted
+
+### Java for openapi-generator
+
+`openapi-generator-cli` requires Java 11+. On macOS:
+```bash
+brew install openjdk@17
+```
+
+---
+
+## Version Tracking Table Format
+
+The table in `MAINTENANCE.md` looks like:
+
+```markdown
+| Source | Current Version | Last Updated | Updated By |
+|--------|-----------------|--------------|------------|
+| Forklift | main | 2026-JAN-21 | |
+| Kubernetes | master | YYYY-MM-DD | |
+| KubeVirt | main | YYYY-MM-DD | |
+| CDI | main | YYYY-MM-DD | |
+```
+
+Update only the rows for sources that were actually updated. Use the format `YYYY-MMM-DD` (e.g. `2026-APR-28`) for dates. Set "Updated By" to `aturgema (made with cursor)`.
+
+---
+
+## Inventory Types: Go-to-TypeScript Translation
+
+### Go-to-TypeScript type mapping
+
+| Go Type | TypeScript Type | Notes |
+|---------|----------------|-------|
+| `string` | `string` | |
+| `int`, `int32`, `int64` | `number` | |
+| `float32`, `float64` | `number` | |
+| `bool` | `boolean` | |
+| `[]T` | `T[]` | |
+| `map[string]T` | `Record<string, T>` | |
+| `map[string]string` | `Record<string, string>` | |
+| `*T` | `T` with `?` (optional) | Pointer means the field may be absent |
+| `interface{}` / `any` | `unknown` | |
+| `json.RawMessage` | `unknown` | |
+| `time.Time` | `string` | JSON serializes as ISO 8601 string |
+| `api.Provider` | `V1beta1Provider` | Import from `../../../generated` |
+| `api.Plan` | `V1beta1Plan` | Import from `../../../generated` |
+| `model.Ref` | `Ref` | Import from `../base/model` |
+| `model.Concern` | `Concern` | Import from `../base/model` |
+
+### json tag rules
+
+- `json:"fieldName"` -> property `fieldName: Type`
+- `json:"fieldName,omitempty"` -> optional property `fieldName?: Type`
+- `json:"-"` -> skip (not serialized to JSON)
+- No json tag -> use Go field name as-is (lowercase first letter for TypeScript convention, but check existing patterns)
+
+### Embedded struct handling
+
+Go struct embedding maps to TypeScript `extends`:
+
+```go
+// Go
+type VM struct {
+    Base
+    RevisionValidated int64 `json:"revisionValidated"`
+}
+```
+
+```typescript
+// TypeScript
+export interface VM extends Base {
+    revisionValidated: number;
+}
+```
+
+If a struct embeds multiple types, extend the first and flatten the rest as inline properties:
+
+```go
+type Foo struct {
+    Base
+    Extra
+    Name string `json:"name"`
+}
+```
+
+```typescript
+export interface Foo extends Base {
+    // Fields from Extra
+    extraField1: string;
+    extraField2: number;
+    // Own fields
+    name: string;
+}
+```
+
+### Go source file map
+
+**Base / shared types:**
+
+| TypeScript File | Go Source |
+|---|---|
+| `src/types/provider/base/model.ts` | `pkg/controller/provider/model/base/model.go` |
+| `src/types/provider/base/TreeNode.ts` | Derived from web layer tree endpoints |
+
+**vSphere:**
+
+| TypeScript File | Go Source |
+|---|---|
+| `provider/vsphere/Provider.ts` | `web/vsphere/provider.go` |
+| `provider/vsphere/VM.ts` | `web/vsphere/vm.go` |
+| `provider/vsphere/Network.ts` | `web/vsphere/network.go` |
+| `provider/vsphere/DataStore.ts` | `web/vsphere/datastore.go` |
+| `provider/vsphere/Host.ts` | `web/vsphere/host.go` |
+| `provider/vsphere/Resource.ts` | `web/vsphere/resource.go` |
+| `provider/vsphere/model.ts` | `model/vsphere/model.go` (Disk, NIC, etc.) |
+
+**oVirt:** Same pattern -- `web/ovirt/*.go` + `model/ovirt/model.go`
+
+**OpenShift:** `web/ocp/*.go` + `model/ocp/model.go`
+
+**OpenStack:** `web/openstack/*.go` + `model/openstack/model.go`
+
+**OVA:** `web/ova/*.go` (no separate model dir)
+
+**Hyper-V:** `web/hyperv/*.go` + `model/hyperv/model.go`
+
+All Go paths are relative to `pkg/controller/provider/` in the forklift repo.
+
+### CRD type cross-references
+
+Some inventory types embed or reference Kubernetes CRD objects. In Go, these appear as imports from the Forklift API package:
+
+```go
+import api "github.com/kubev2v/forklift/pkg/apis/forklift/v1beta1"
+
+type Provider struct {
+    Object api.Provider `json:"object"`
+}
+```
+
+Map these to the generated TypeScript types:
+
+| Go API Type | TypeScript Type | Import Path |
+|---|---|---|
+| `api.Provider` | `V1beta1Provider` | `../../../generated` |
+| `api.Plan` | `V1beta1Plan` | `../../../generated` |
+| `api.Migration` | `V1beta1Migration` | `../../../generated` |
+| `api.NetworkMap` | `V1beta1NetworkMap` | `../../../generated` |
+| `api.StorageMap` | `V1beta1StorageMap` | `../../../generated` |
+| `api.Hook` | `V1beta1Hook` | `../../../generated` |
+| `api.Host` | `V1beta1Host` | `../../../generated` |
+
+### TypeScript file style conventions
+
+Match the existing style in the types repo:
+
+```typescript
+import { V1beta1Provider } from '../../../generated';
+import { OpenshiftResource } from '../openshift/Resource';
+
+// https://github.com/kubev2v/forklift/tree/main/pkg/controller/provider/web/vsphere/provider.go
+export interface VSphereProvider extends OpenshiftResource {
+  // Type string `json:"type"`
+  type: string;
+  // Object api.Provider `json:"object"`
+  object: V1beta1Provider;
+}
+```
+
+Rules:
+1. First line: source URL as a comment
+2. Each field: Go field definition as a comment above, then the TypeScript property
+3. Imports at the top: generated types, then base/shared types, then sibling types
+4. One interface per file (matching existing pattern)
+5. Export the interface directly (`export interface`)
+
+### Union and aggregation types
+
+After regenerating per-provider types, update these aggregation files:
+
+- **`ProviderInventory.ts`**: union of all `*Provider` types
+- **`ProviderVM.ts`**: union of all `*VM` types
+- **`ProviderHost.ts`**: union of host types (`OVirtHost | VSphereHost`)
+- **`ProvidersInventoryList.ts`**: object with optional arrays per provider
+
+If a new provider is added upstream (e.g., `ec2`), add it to all union types and to `provider/index.ts`.
+
+### Files to leave untouched
+
+- `src/types/secret/` -- K8s Secret data shapes, not derivable from Go inventory structs
+- `src/types/k8s/` -- small K8s helper types (`K8sResourceCommon`, `K8sResourceCondition`, `V1NetworkAttachmentDefinition`)
+- `src/types/Modify.ts` -- utility type
+- `src/types/MustGatherResponse.ts` -- must-gather API response, not from inventory
+- `src/types/constants/` -- UI constants
+
+### Inventory types edge cases
+
+- **New provider appears upstream**: create the provider directory, add to `provider/index.ts`, add to all union types
+- **Struct field removed upstream**: remove from TypeScript interface. Check consumer project for usage before proceeding.
+- **Struct field type changed**: update the TypeScript type. Flag to user if it might be a breaking change.
+- **Go struct uses non-JSON tags only (`sql:` without `json:`)**: skip those fields -- they are DB-only and not serialized to JSON.
+- **Anonymous/embedded struct from external package**: if the embedded type comes from an external Go package (not the forklift repo), check if a matching TypeScript type exists in `generated/` or `types/k8s/`.
+
+---
+
+## Edge Cases
+
+### Package not on npm after release
+
+If `poll-npm.sh` times out:
+1. Check the GitHub Action at `https://github.com/kubev2v/forklift-console-types/actions/workflows/release.yml`
+2. Common failures:
+   - **npm Trusted Publishing not configured**: the npm package must have GitHub Actions as a trusted publisher in npm settings
+   - **Version already exists**: if the version was somehow already published (e.g. re-release), npm rejects it. Bump to the next patch.
+   - **Build failure in CI**: the release workflow runs `npm ci && npm run build` before publishing
+
+### Consumer project has TS errors after bump
+
+Common patterns:
+- **Type removed**: search the diff between old and new `src/generated/index.ts` for removed exports. The consumer needs to either stop using that type or define it locally.
+- **Field type changed**: compare the old and new model file for the specific type. Common changes: `string | undefined` becoming `string`, optional fields becoming required, enum values changing.
+- **New type conflicts in consumer**: if the consumer defines a local type with the same name as a new export, rename the local type.
+
+### ObjectMeta `creationTimestamp: Date` breaks SDK compatibility
+
+**Root cause**: The `openapi-generator` maps OpenAPI `date-time` format to TypeScript `Date`. Kubernetes ObjectMeta fields `creationTimestamp` and `deletionTimestamp` are `date-time` in the spec, so the generator produces `Date`. However, the Kubernetes API returns ISO 8601 strings, and `@openshift-console/dynamic-plugin-sdk` types these as `string` in its `ObjectMetadata`.
+
+**Symptom**: ~370 TS errors like `Type 'Date | undefined' is not assignable to type 'string | undefined'` on every `useK8sWatchResource`, `k8sPatch`, `getName`, etc. call that touches a Forklift CRD type.
+
+**Affected files**: All `ObjectMeta` types across Kubernetes, KubeVirt, and CDI:
+- `src/generated/kubernetes/models/IoK8sApimachineryPkgApisMetaV1ObjectMeta.ts`
+- `src/generated/kubevirt/models/K8sIoApimachineryPkgApisMetaV1ObjectMeta.ts`
+- `src/generated/containerized-data-importer/models/V1ObjectMeta.ts`
+
+**Fix**: Run `npm run fix:timestamps` after every update script run. See Phase 3 step 3e in the skill. This was introduced after the Kubernetes v1.36.0 update (types repo PR #26).
+
+### Inventory type field casing changes
+
+When updating Forklift inventory types (Phase 2.5), the Go source may use different field casing than the previous TypeScript types. The `json:` struct tags in Go define the actual JSON field names. Common renames to watch for:
+- `OvaPath` → `ovfPath` (from `json:"ovfPath"`)
+- `ID` → `id` (from `json:"id"`)
+
+After updating inventory types, run a search in the consumer project for the old field names to find breakages.
+
+### Upstream spec download fails
+
+If `curl` fails to download a swagger.json or CRD file:
+1. Verify the version/tag exists: `gh api repos/<owner>/<repo>/tags --jq '.[].name' | head -20`
+2. The URL pattern may have changed for that version. Check the upstream repo structure at the specific tag.
+3. For Kubernetes, note that very old tags may not have `api/openapi-spec/swagger.json` at the expected path.
+
+### openapi-generator produces different output
+
+The `openapi-generator-cli` version is pinned in `devDependencies` but the actual generator binary version may differ. If generated output looks significantly different (different file names, different type naming), check `node_modules/.openapi-generator/VERSION` and compare with what was used previously.

--- a/.cursor/skills/types-update/reference.md
+++ b/.cursor/skills/types-update/reference.md
@@ -47,7 +47,7 @@ In `src/generated/index.ts`, the KubeVirt export block follows these rules:
 ### Auto-fix for Duplicate identifier errors
 
 If `npm run build` fails with errors like:
-```
+```text
 error TS2300: Duplicate identifier 'V1beta1SomeType'.
 ```
 
@@ -70,7 +70,7 @@ Compare against the `CRDS` array in `scripts/update-forklift.sh`. If new `.yaml`
 
 ### Current known CRDs (as of 1.0.10)
 
-```
+```text
 forklift.konveyor.io_forkliftcontrollers.yaml
 forklift.konveyor.io_hooks.yaml
 forklift.konveyor.io_hosts.yaml
@@ -165,10 +165,10 @@ The table in `MAINTENANCE.md` looks like:
 ```markdown
 | Source | Current Version | Last Updated | Updated By |
 |--------|-----------------|--------------|------------|
-| Forklift | main | 2026-JAN-21 | |
-| Kubernetes | master | YYYY-MM-DD | |
-| KubeVirt | main | YYYY-MM-DD | |
-| CDI | main | YYYY-MM-DD | |
+| Forklift | main (<short-sha>) | 2026-APR-28 | aturgema (made with cursor) |
+| Kubernetes | v1.32.0 | 2026-APR-28 | aturgema (made with cursor) |
+| KubeVirt | v1.5.0 | 2026-APR-28 | aturgema (made with cursor) |
+| CDI | v1.62.0 | 2026-APR-28 | aturgema (made with cursor) |
 ```
 
 Update only the rows for sources that were actually updated. Use the format `YYYY-MMM-DD` (e.g. `2026-APR-28`) for dates. Set "Updated By" to `aturgema (made with cursor)`.

--- a/.cursor/skills/types-update/scripts/check-upstream.sh
+++ b/.cursor/skills/types-update/scripts/check-upstream.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Fetch latest upstream versions for each type source.
+#
+# Usage: .cursor/skills/types-update/scripts/check-upstream.sh
+#
+# Outputs a summary table of latest available versions from each upstream repo.
+# Uses the GitHub API (unauthenticated by default; set GITHUB_TOKEN for higher rate limits).
+#
+
+set -euo pipefail
+
+AUTH_HEADER=""
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  AUTH_HEADER="-H Authorization: token ${GITHUB_TOKEN}"
+fi
+
+fetch_latest_tag() {
+  local repo="$1"
+  local result
+  result=$(curl -sf ${AUTH_HEADER} \
+    "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null \
+    | jq -r '.tag_name // empty') || true
+  echo "${result:-N/A}"
+}
+
+fetch_forklift_main_sha() {
+  local result
+  result=$(curl -sf ${AUTH_HEADER} \
+    "https://api.github.com/repos/kubev2v/forklift/commits/main" 2>/dev/null \
+    | jq -r '.sha[:7] // empty') || true
+  echo "${result:-N/A}"
+}
+
+FORKLIFT_SHA=$(fetch_forklift_main_sha)
+K8S_TAG=$(fetch_latest_tag "kubernetes/kubernetes")
+KV_TAG=$(fetch_latest_tag "kubevirt/kubevirt")
+CDI_TAG=$(fetch_latest_tag "kubevirt/containerized-data-importer")
+
+echo "Latest Upstream Versions"
+echo "========================"
+echo ""
+printf "%-14s %s\n" "Source" "Latest"
+printf "%-14s %s\n" "----------" "----------"
+printf "%-14s %s\n" "Forklift" "main ($FORKLIFT_SHA)"
+printf "%-14s %s\n" "Kubernetes" "$K8S_TAG"
+printf "%-14s %s\n" "KubeVirt" "$KV_TAG"
+printf "%-14s %s\n" "CDI" "$CDI_TAG"

--- a/.cursor/skills/types-update/scripts/check-upstream.sh
+++ b/.cursor/skills/types-update/scripts/check-upstream.sh
@@ -10,15 +10,15 @@
 
 set -euo pipefail
 
-AUTH_HEADER=""
+AUTH_ARGS=()
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-  AUTH_HEADER="-H Authorization: token ${GITHUB_TOKEN}"
+  AUTH_ARGS=(-H "Authorization: token ${GITHUB_TOKEN}")
 fi
 
 fetch_latest_tag() {
   local repo="$1"
   local result
-  result=$(curl -sf ${AUTH_HEADER} \
+  result=$(curl -sf "${AUTH_ARGS[@]}" \
     "https://api.github.com/repos/${repo}/releases/latest" 2>/dev/null \
     | jq -r '.tag_name // empty') || true
   echo "${result:-N/A}"
@@ -26,7 +26,7 @@ fetch_latest_tag() {
 
 fetch_forklift_main_sha() {
   local result
-  result=$(curl -sf ${AUTH_HEADER} \
+  result=$(curl -sf "${AUTH_ARGS[@]}" \
     "https://api.github.com/repos/kubev2v/forklift/commits/main" 2>/dev/null \
     | jq -r '.sha[:7] // empty') || true
   echo "${result:-N/A}"

--- a/.cursor/skills/types-update/scripts/poll-npm.sh
+++ b/.cursor/skills/types-update/scripts/poll-npm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Poll the npm registry until a specific version of @forklift-ui/types appears.
+#
+# Usage: .cursor/skills/types-update/scripts/poll-npm.sh <target-version>
+#
+# Example:
+#   .cursor/skills/types-update/scripts/poll-npm.sh 1.0.9
+#
+# Polls every 30 seconds for up to 10 minutes (20 attempts).
+# Exit 0 if version found, exit 1 on timeout.
+#
+
+set -euo pipefail
+
+PACKAGE="@forklift-ui/types"
+TARGET_VERSION="${1:?Usage: poll-npm.sh <target-version>}"
+INTERVAL_SECONDS=30
+MAX_ATTEMPTS=20
+
+echo "Waiting for ${PACKAGE}@${TARGET_VERSION} to appear on npm..."
+echo "Polling every ${INTERVAL_SECONDS}s (timeout: $((INTERVAL_SECONDS * MAX_ATTEMPTS))s)"
+echo ""
+
+for ((i = 1; i <= MAX_ATTEMPTS; i++)); do
+  CURRENT=$(npm view "${PACKAGE}" version 2>/dev/null || echo "fetch-error")
+
+  if [ "$CURRENT" = "$TARGET_VERSION" ]; then
+    echo "Version ${TARGET_VERSION} is now live on npm!"
+    echo "https://www.npmjs.com/package/${PACKAGE}/v/${TARGET_VERSION}"
+    exit 0
+  fi
+
+  echo "  Attempt ${i}/${MAX_ATTEMPTS}: latest is ${CURRENT} (waiting for ${TARGET_VERSION})"
+  sleep "$INTERVAL_SECONDS"
+done
+
+echo ""
+echo "TIMEOUT: Version ${TARGET_VERSION} did not appear after $((INTERVAL_SECONDS * MAX_ATTEMPTS)) seconds."
+echo "Check the GitHub Action: https://github.com/kubev2v/forklift-console-types/actions/workflows/release.yml"
+exit 1


### PR DESCRIPTION
## Summary

- Updates the `types-update` skill based on lessons learned from the 1.0.8 → 1.0.10 bump
- Forklift always targets `main` (commit SHA recorded for reproducibility)
- Adds mandatory step 3e: fix ObjectMeta `Date` → `string` after generation
- Documents cross-project file access permissions for Cursor sandbox
- Adds edge cases: timestamp incompatibility, inventory field casing changes
- Updates CRD list to 13 (added `hypervproviderservers`, `ovaproviderservers`)
- Updates `check-upstream.sh` to fetch Forklift main commit SHA instead of release tag

Resolves: None

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Types Update" workflow and reference guide covering version discovery, Jira/create-release steps, type regeneration and conflict resolution, verification/checklist, timestamp fixes, CI monitoring, and troubleshooting.
* **Chores**
  * Added utility scripts to check upstream component versions and to poll npm for published package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->