### PR TITLE
Resolves: MTV-5187 | Add missing EC2 support in plan wizard and VM tables

### DIFF
--- a/.cursor/rules/agents/forklift-expert.mdc
+++ b/.cursor/rules/agents/forklift-expert.mdc
@@ -38,7 +38,7 @@ Your approach:
 - `openstack` - OpenStack (requires Keystone auth URL and credentials)
 - `ova` - OVA file uploads (requires NFS or similar storage)
 - `hyperv` - Microsoft Hyper-V (requires SMB share access)
-- `ec2` - AWS EC2 (backend only, not yet in UI plugin)
+- `ec2` - AWS EC2 (available on AWS-platform clusters, gated by `useClusterIsAwsPlatform`)
 - `openshift` - OpenShift Virtualization/KubeVirt 
 
 **Target Provider**

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -24,7 +24,7 @@ All CRDs belong to group `forklift.konveyor.io`, version `v1beta1`. Types are im
 ### Provider
 Represents a source or target infrastructure connection.
 
-- **Source types**: `vsphere` (VMware), `ovirt` (RHV), `openstack`, `ova` (file uploads), `hyperv` (Hyper-V), `ec2` (AWS EC2 -- backend only, not yet in UI)
+- **Source types**: `vsphere` (VMware), `ovirt` (RHV), `openstack`, `ova` (file uploads), `hyperv` (Hyper-V), `ec2` (AWS EC2 -- available on AWS-platform clusters only, gated by `useClusterIsAwsPlatform`)
 - **Target type**: `openshift` (OpenShift Virtualization)
 - **Backend phases** (Go controller): Ready, Staging, ValidationFailed, ConnectionFailed
 - **Frontend additions** (UI enum in `src/utils/types.ts`): ApplianceManagementEnabled, Unknown

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -25,6 +25,8 @@ type ValidateNetworkMapParams = {
 };
 
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
+  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return [];
+
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {
       return vm?.networks?.map((network) => network?.id) ?? [];

--- a/src/plans/create/steps/virtual-machines/VirtualMachinesTable.tsx
+++ b/src/plans/create/steps/virtual-machines/VirtualMachinesTable.tsx
@@ -2,6 +2,7 @@ import { type FC, useMemo } from 'react';
 import { type ControllerRenderProps, useWatch } from 'react-hook-form';
 import type { ProviderVirtualMachinesListProps } from 'src/providers/details/tabs/VirtualMachines/components/utils/types';
 import type { VmData } from 'src/providers/details/tabs/VirtualMachines/components/VMCellProps';
+import { Ec2VirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesList';
 import { HypervVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/HypervVirtualMachinesList';
 import { OpenShiftVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList';
 import { OpenStackVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/OpenStackVirtualMachinesList';
@@ -104,6 +105,8 @@ const VirtualMachinesTable: FC<VirtualMachinesTableProps> = ({
       return <HypervVirtualMachinesList {...tableProps} />;
     case PROVIDER_TYPES.vsphere:
       return <VSphereVirtualMachinesList {...tableProps} />;
+    case PROVIDER_TYPES.ec2:
+      return <Ec2VirtualMachinesList {...tableProps} />;
     case undefined:
     default:
       return <></>;

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -4,6 +4,8 @@ import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 import type { OVirtNicProfile, ProviderVirtualMachine } from '@forklift-ui/types';
 
 const getNetworksForVM = (vm: ProviderVirtualMachine) => {
+  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return [];
+
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {
       return vm?.networks?.map((network) => network?.id) ?? [];
@@ -29,7 +31,6 @@ const getNetworksForVM = (vm: ProviderVirtualMachine) => {
     case PROVIDER_TYPES.ova: {
       return vm?.networks?.map((network) => network?.id) ?? [];
     }
-
     default:
       return [];
   }

--- a/src/plans/details/tabs/Resources/utils/utils.ts
+++ b/src/plans/details/tabs/Resources/utils/utils.ts
@@ -254,6 +254,13 @@ export const getPlanResourcesTableProps = (
       return getOVAPlanResources(planInventory as EnhancedOvaVM[]);
     case PROVIDER_TYPES.hyperv:
       return getHypervPlanResources(planInventory as EnhancedHypervVM[]);
+    case PROVIDER_TYPES.ec2:
+      return {
+        planInventoryRunningSize: planInventory?.length,
+        planInventorySize: planInventory?.length,
+        totalResources: {} as VMResources,
+        totalResourcesRunning: {} as VMResources,
+      };
     case undefined:
     default:
       return null;

--- a/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/components/AddVirtualMachinesTable.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/components/AddVirtualMachinesTable.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import type { ProviderVirtualMachinesListProps } from 'src/providers/details/tabs/VirtualMachines/components/utils/types';
 import type { VmData } from 'src/providers/details/tabs/VirtualMachines/components/VMCellProps';
+import { Ec2VirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesList';
 import { HypervVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/HypervVirtualMachinesList';
 import { OpenShiftVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/OpenShiftVirtualMachinesList';
 import { OpenStackVirtualMachinesList } from 'src/providers/details/tabs/VirtualMachines/OpenStackVirtualMachinesList';
@@ -76,6 +77,8 @@ const AddVirtualMachinesTable = memo<AddVirtualMachinesTableProps>(
         return <HypervVirtualMachinesList {...tableProps} />;
       case PROVIDER_TYPES.vsphere:
         return <VSphereVirtualMachinesList {...tableProps} />;
+      case PROVIDER_TYPES.ec2:
+        return <Ec2VirtualMachinesList {...tableProps} />;
       case undefined:
       default:
         return (

--- a/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesList.tsx
+++ b/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesList.tsx
@@ -8,7 +8,6 @@ import { t } from '@utils/i18n';
 
 import { ProviderVirtualMachinesList } from './components/ProviderVirtualMachinesList';
 import type { VmData } from './components/VMCellProps';
-import { getConcernsResourceField } from './utils/helpers/getConcernsResourceField';
 import { getVmPowerState } from './utils/helpers/getVmPowerState';
 import { getVmTableResourceFields } from './utils/helpers/getVmTableResourceFields';
 import { getEc2VM } from './utils/types/Ec2VM';
@@ -27,7 +26,6 @@ const ec2VmFieldsMetadataFactory: ResourceField[] = [
     resourceFieldId: 'name',
     sortable: true,
   },
-  getConcernsResourceField(),
   {
     filter: {
       placeholderLabel: t('Filter by status'),

--- a/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesRow.tsx
@@ -7,7 +7,6 @@ import { renderResourceRowCells } from '@utils/renderResourceRowCells';
 
 import { PowerStateCellRenderer } from './components/PowerStateCellRenderer';
 import type { VMCellProps, VmData } from './components/VMCellProps';
-import { VMConcernsCellRenderer } from './components/VMConcernsCellRenderer';
 import { VMNameCellRenderer } from './components/VMNameCellRenderer';
 import { getEc2VM } from './utils/types/Ec2VM';
 
@@ -23,7 +22,6 @@ const Ec2AvailabilityZoneCellRenderer: FC<VMCellProps> = ({ data }) => {
 
 const cellRenderers: Record<string, FC<VMCellProps>> = {
   availabilityZone: Ec2AvailabilityZoneCellRenderer,
-  concerns: VMConcernsCellRenderer,
   instanceType: Ec2InstanceTypeCellRenderer,
   name: VMNameCellRenderer,
   status: PowerStateCellRenderer,

--- a/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -9,7 +9,7 @@ import type { ResourceField } from '@components/common/utils/types';
 import ConcernsAndConditionsTable from '@components/ConcernsAndConditionsTable/ConcernsAndConditionsTable';
 import { EmptyState, EmptyStateVariant, Spinner, Title } from '@patternfly/react-core';
 import { getNamespace } from '@utils/crds/common/selectors';
-import { isProviderOpenshift } from '@utils/resources';
+import { isProviderEc2, isProviderOpenshift } from '@utils/resources';
 
 import { getVmId } from '../utils/helpers/vmProps';
 
@@ -72,16 +72,18 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   }
 
   const getStandardPageProps = () => {
+    const ec2 = isProviderEc2(provider);
+
     if (handleSelectedIds) {
       return {
-        expandedIds: [],
+        ...(ec2 ? {} : { expandedIds: [] }),
         onSelect: handleSelectedIds,
         selectedIds: initialSelectedIds,
         toId: getVmId,
       };
     }
 
-    if (!isProviderOpenshift(provider)) {
+    if (!isProviderOpenshift(provider) && !ec2) {
       return {
         expandedIds: [],
         onExpand: () => undefined,
@@ -106,7 +108,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
       extraSupportedMatchers={extraSupportedMatchers}
       {...getStandardPageProps()}
       expanded={
-        isProviderOpenshift(provider)
+        isProviderOpenshift(provider) || isProviderEc2(provider)
           ? undefined
           : (props) => <ConcernsAndConditionsTable vmData={props.resourceData} />
       }

--- a/src/providers/list/utils/getProvidersInventoryByNamespace.tsx
+++ b/src/providers/list/utils/getProvidersInventoryByNamespace.tsx
@@ -79,6 +79,12 @@ export const getProvidersInventoryByNamespace = async (
                   newInventoryProvider as HypervProvider,
                 ];
                 break;
+              case PROVIDER_TYPES.ec2: {
+                const extended = newInventory as ProvidersInventoryList &
+                  Record<string, ProviderInventory[]>;
+                extended.ec2 = [...(extended.ec2 ?? []), newInventoryProvider as ProviderInventory];
+                break;
+              }
               default:
                 break;
             }

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -11,3 +11,6 @@ export const isProviderLocalOpenshift = (provider: V1beta1Provider | undefined):
  */
 export const isProviderOpenshift = (provider: V1beta1Provider | undefined): boolean =>
   provider?.spec?.type === 'openshift';
+
+export const isProviderEc2 = (provider: V1beta1Provider | undefined): boolean =>
+  provider?.spec?.type === 'ec2';


### PR DESCRIPTION
## Summary

- Add EC2 provider case to plan create wizard VM table and plan details Add VMs dialog (fixes blank/spinner when EC2 is the source provider)
- Add EC2 handling to plan resource utilities (network mapping, storage resources)
- Remove concerns column and expand toggle for EC2 VMs (backend does not populate concerns for EC2)
- Add EC2 to per-namespace inventory aggregation fallback
- Add `isProviderEc2` shared helper

## Test plan

- [x] Create an EC2 provider on an AWS-platform cluster, wait for Ready
- [x] Navigate to provider details > Virtual Machines tab -- VMs should show without expand arrows or concerns column
- [x] Create a new migration plan selecting the EC2 provider as source -- VM selection step should render `Ec2VirtualMachinesList` with selectable VMs
- [x] Open an existing EC2 plan > Virtual Machines tab > Add VMs -- dialog should show VMs (not infinite spinner)

Resolves: MTV-5187

Made with [Cursor](https://cursor.com)