### PR TITLE
Resolves: MTV-5227 | Skip network/storage mapping wizard steps for EC2

### DIFF
--- a/src/plans/create/CreatePlanWizardInner.tsx
+++ b/src/plans/create/CreatePlanWizardInner.tsx
@@ -1,4 +1,5 @@
 import { type FC, useState } from 'react';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type { V1beta1Provider } from '@forklift-ui/types';
 import { Wizard, WizardStep } from '@patternfly/react-core';
@@ -39,6 +40,11 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
   const { currentStep, handleStepChange, hasStepErrors } = useStepNavigation();
 
   const hasCreatePlanError = Boolean(createPlanError?.message);
+  const isEc2 = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
+
+  const skippedStepIds = new Set<PlanWizardStepId>(
+    isEc2 ? [PlanWizardStepId.NetworkMap, PlanWizardStepId.StorageMap] : [],
+  );
 
   const handleSubmit = async () => {
     setCreatePlanError(undefined);
@@ -55,7 +61,7 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
       isSubmitting ||
       hasCreatePlanError ||
       (planStepOrder[id] > planStepOrder[currentStep.id as PlanWizardStepId] &&
-        hasPreviousStepErrors(id, hasStepErrors)),
+        hasPreviousStepErrors(id, hasStepErrors, skippedStepIds)),
     name: planStepNames[id],
   });
 
@@ -85,12 +91,14 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
           <WizardStep
             key={PlanWizardStepId.NetworkMap}
             {...getStepProps(PlanWizardStepId.NetworkMap)}
+            isHidden={isEc2}
           >
             <NetworkMapStep />
           </WizardStep>,
           <WizardStep
             key={PlanWizardStepId.StorageMap}
             {...getStepProps(PlanWizardStepId.StorageMap)}
+            isHidden={isEc2}
           >
             <StorageMapStep />
           </WizardStep>,

--- a/src/plans/create/CreatePlanWizardInner.tsx
+++ b/src/plans/create/CreatePlanWizardInner.tsx
@@ -1,9 +1,9 @@
 import { type FC, useState } from 'react';
-import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type { V1beta1Provider } from '@forklift-ui/types';
 import { Wizard, WizardStep } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
+import { isProviderEc2 } from '@utils/resources';
 
 import { useStepNavigation } from './hooks/useStepNavigation';
 import CustomScriptsStep from './steps/customization-scripts/CustomScriptsStep';
@@ -40,7 +40,7 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
   const { currentStep, handleStepChange, hasStepErrors } = useStepNavigation();
 
   const hasCreatePlanError = Boolean(createPlanError?.message);
-  const isEc2 = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
+  const isEc2 = isProviderEc2(sourceProvider);
 
   const skippedStepIds = new Set<PlanWizardStepId>(
     isEc2 ? [PlanWizardStepId.NetworkMap, PlanWizardStepId.StorageMap] : [],

--- a/src/plans/create/steps/review/ReviewStep.tsx
+++ b/src/plans/create/steps/review/ReviewStep.tsx
@@ -1,4 +1,6 @@
 import type { FC } from 'react';
+import { useWatch } from 'react-hook-form';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import WizardStepContainer from '@components/common/WizardStepContainer';
 import { EmptyState, Spinner } from '@patternfly/react-core';
@@ -6,6 +8,7 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import { planStepNames, PlanWizardStepId } from '../../constants';
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
+import { GeneralFormFieldId } from '../general-information/constants';
 
 import CustomScriptsReviewSection from './CustomScriptsReviewSection';
 import GeneralInfoReviewSection from './GeneralInfoReviewSection';
@@ -30,8 +33,11 @@ const ReviewStep: FC<ReviewStepProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
   const {
+    control,
     formState: { isSubmitting },
   } = useCreatePlanFormContext();
+  const sourceProvider = useWatch({ control, name: GeneralFormFieldId.SourceProvider });
+  const isEc2 = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
 
   if (isSubmitting) {
     return (
@@ -58,8 +64,8 @@ const ReviewStep: FC<ReviewStepProps> = ({
     >
       <GeneralInfoReviewSection />
       <VirtualMachinesReviewSection />
-      <NetworkMapReviewSection />
-      <StorageMapReviewSection />
+      {!isEc2 && <NetworkMapReviewSection />}
+      {!isEc2 && <StorageMapReviewSection />}
       <MigrationTypeReviewSection isLiveMigrationFeatureEnabled={isLiveMigrationFeatureEnabled} />
       <OtherSettingsReviewSection isLiveMigrationFeatureEnabled={isLiveMigrationFeatureEnabled} />
       <CustomScriptsReviewSection />

--- a/src/plans/create/utils/createNetworkMap.ts
+++ b/src/plans/create/utils/createNetworkMap.ts
@@ -105,7 +105,8 @@ export const createNetworkMap = async ({
         namespace: project,
       },
       spec: {
-        map: mappings?.reduce(
+        // EC2 plans skip the mapping step entirely, producing an empty array
+        map: (mappings ?? []).reduce(
           (acc: V1beta1NetworkMapSpecMap[], { sourceNetwork, targetNetwork }) => {
             if (sourceNetwork.name) {
               acc.push({

--- a/src/plans/create/utils/hasPreviousStepErrors.ts
+++ b/src/plans/create/utils/hasPreviousStepErrors.ts
@@ -3,11 +3,14 @@ import { planStepOrder, type PlanWizardStepId } from '../constants';
 export const hasPreviousStepErrors = (
   targetStepId: PlanWizardStepId,
   hasStepErrors: (stepId: PlanWizardStepId) => boolean,
+  skippedStepIds?: Set<PlanWizardStepId>,
 ): boolean => {
   const targetStepOrder = planStepOrder[targetStepId];
 
   return Object.entries(planStepOrder).some(
     ([stepId, stepOrder]) =>
-      stepOrder < targetStepOrder && hasStepErrors(stepId as PlanWizardStepId),
+      stepOrder < targetStepOrder &&
+      !skippedStepIds?.has(stepId as PlanWizardStepId) &&
+      hasStepErrors(stepId as PlanWizardStepId),
   );
 };


### PR DESCRIPTION
## Summary

- Hide Network Map and Storage Map wizard steps when the source provider is EC2 (using the existing `isHidden` pattern from the Migration Type step)
- Skip hidden steps in `hasPreviousStepErrors` validation so they don't block wizard navigation
- Hide mapping review sections in the Review step for EC2
- Empty mapping CRs are still auto-created on submit (backend requires map refs on the Plan)

EC2 migrations use EBS snapshots directly and don't need traditional network/storage mappings. The wizard now goes: General -> VMs -> Additional Setup -> Review -> Create for EC2 providers.

## Test plan

- [x] Create a plan with an EC2 source provider -- Network Map and Storage Map steps should not appear in the wizard sidebar
- [x] Navigate through the wizard -- steps should not be blocked by hidden step validation
- [x] Review step should not show Network Map or Storage Map sections
- [x] Plan creation should succeed and produce empty NetworkMap/StorageMap CRs
- [x] Non-EC2 providers should still see all wizard steps as before

Resolves: MTV-5227

Made with [Cursor](https://cursor.com)