### PR TITLE
Resolves: MTV-1736 | Show 'Pending' status for plans waiting on inflight slots

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -956,6 +956,7 @@
   "Path": "Path",
   "paused": "paused",
   "Paused": "Paused",
+  "Pending": "Pending",
   "Performance characteristics": "Performance characteristics",
   "Persistent storage": "Persistent storage",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -961,6 +961,7 @@
   "Path": "Ruta",
   "paused": "en pausa",
   "Paused": "En pausa",
+  "Pending": "Pending",
   "Performance characteristics": "Características de rendimiento",
   "Persistent storage": "Almacenamiento persistente",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "El almacenamiento persistente contiene los discos de máquina virtual migrados, lo que garantiza la integridad y disponibilidad de los datos.",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -961,6 +961,7 @@
   "Path": "Chemin",
   "paused": "En pause",
   "Paused": "En pause",
+  "Pending": "Pending",
   "Performance characteristics": "Caractéristiques de performance",
   "Persistent storage": "Stockage persistant",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "Le stockage persistant conserve les disques des machines virtuelles migrées, garantissant ainsi l'intégrité et la disponibilité des données.",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -955,6 +955,7 @@
   "Path": "パス",
   "paused": "一時停止",
   "Paused": "一時停止",
+  "Pending": "Pending",
   "Performance characteristics": "パフォーマンス特性",
   "Persistent storage": "永続ストレージ",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "永続ストレージは、移行済みの仮想マシンのディスクを格納し、データの整合性と可用性を確保します。",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -955,6 +955,7 @@
   "Path": "경로",
   "paused": "일시 중지됨",
   "Paused": "일시 중지됨",
+  "Pending": "Pending",
   "Performance characteristics": "성능 특성",
   "Persistent storage": "영구 스토리지",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "영구 스토리지는 마이그레이션된 VM 디스크를 저장하여 데이터 무결성과 가용성을 보장합니다.",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -955,6 +955,7 @@
   "Path": "路径",
   "paused": "暂停",
   "Paused": "暂停",
+  "Pending": "Pending",
   "Performance characteristics": "性能特性",
   "Persistent storage": "持久性存储",
   "Persistent storage holds the migrated VM disks, ensuring data integrity and availability.": "持久性存储包含迁移的虚拟机磁盘，确保数据完整性和可用性。",

--- a/src/plans/actions/PlanActionsDropdownItems.tsx
+++ b/src/plans/actions/PlanActionsDropdownItems.tsx
@@ -53,7 +53,8 @@ const PlanActionsDropdownItems: FC<PlanActionsDropdownItemsProps> = ({ plan }) =
   const isWarmAndExecuting = getPlanIsWarm(plan) && isPlanExecuting(plan);
   const isArchived = isPlanArchived(plan);
   const buttonStartLabel = canReStart ? t('Restart') : t('Start');
-  const canScheduleCutover = isWarmAndExecuting && !isArchived;
+  const canScheduleCutover =
+    isWarmAndExecuting && !isArchived && planStatus !== PlanStatuses.Pending;
 
   const [activeMigration] = usePlanMigration(plan);
   const hasCutover = canScheduleCutover && Boolean(activeMigration?.spec?.cutover);
@@ -90,9 +91,12 @@ const PlanActionsDropdownItems: FC<PlanActionsDropdownItemsProps> = ({ plan }) =
           navigate(planURL);
         }}
         description={getEditDescription(planStatus)}
-        isDisabled={[PlanStatuses.Executing, PlanStatuses.Paused, PlanStatuses.Archived].some(
-          (status) => status === planStatus,
-        )}
+        isDisabled={[
+          PlanStatuses.Executing,
+          PlanStatuses.Paused,
+          PlanStatuses.Pending,
+          PlanStatuses.Archived,
+        ].some((status) => status === planStatus)}
       >
         {t('Edit')}
       </DropdownItem>

--- a/src/plans/actions/PlanEditCutoverButton.tsx
+++ b/src/plans/actions/PlanEditCutoverButton.tsx
@@ -10,7 +10,12 @@ import { CalendarAltIcon } from '@patternfly/react-icons';
 import { getPlanIsWarm } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
 
-import { isPlanArchived, isPlanExecuting } from '../details/components/PlanStatus/utils/utils';
+import { PlanStatuses } from '../details/components/PlanStatus/utils/types';
+import {
+  getPlanStatus,
+  isPlanArchived,
+  isPlanExecuting,
+} from '../details/components/PlanStatus/utils/utils';
 
 import type { PlanModalProps } from './components/types';
 
@@ -25,7 +30,12 @@ const PlanEditCutoverButton: FC<PlanEditCutoverButtonProps> = ({ plan, variant }
   const cutoverButtonRef = useRef<HTMLButtonElement>(null);
   const [activeMigration] = usePlanMigration(plan);
 
-  if (!getPlanIsWarm(plan) || !isPlanExecuting(plan) || isPlanArchived(plan)) {
+  if (
+    !getPlanIsWarm(plan) ||
+    !isPlanExecuting(plan) ||
+    isPlanArchived(plan) ||
+    getPlanStatus(plan) === PlanStatuses.Pending
+  ) {
     return null;
   }
 

--- a/src/plans/actions/components/ArchiveModal.tsx
+++ b/src/plans/actions/components/ArchiveModal.tsx
@@ -27,7 +27,7 @@ const ArchiveModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
   }, [plan]);
 
   const status = getPlanStatus(plan);
-  const isPlanRunning = status === PlanStatuses.Executing;
+  const isPlanRunning = status === PlanStatuses.Executing || status === PlanStatuses.Pending;
 
   return (
     <ModalForm

--- a/src/plans/actions/components/PlanDeleteModal.tsx
+++ b/src/plans/actions/components/PlanDeleteModal.tsx
@@ -56,7 +56,7 @@ const PlanDeleteModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
           </ForkliftTrans>
         </StackItem>
         <StackItem>
-          {status === PlanStatuses.Executing && (
+          {(status === PlanStatuses.Executing || status === PlanStatuses.Pending) && (
             <Alert
               variant="danger"
               title={t('Plan is currently running')}

--- a/src/plans/actions/utils/utils.ts
+++ b/src/plans/actions/utils/utils.ts
@@ -10,6 +10,7 @@ const partialStartDescription: Partial<StartDescriptionMap> = {
   [PlanStatuses.Completed]: t('All VMs were migrated'),
   [PlanStatuses.Executing]: t('The plan is currently in progress'),
   [PlanStatuses.Paused]: t('The plan is currently in progress'),
+  [PlanStatuses.Pending]: t('The plan is currently in progress'),
 };
 
 export const startDescription: StartDescriptionMap = Object.values(PlanStatuses).reduce(
@@ -26,7 +27,11 @@ export const getDuplicateDescription = (planStatus: PlanStatuses): string | null
 };
 
 export const getEditDescription = (planStatus: PlanStatuses): string | null => {
-  if (planStatus === PlanStatuses.Executing || planStatus === PlanStatuses.Paused)
+  if (
+    planStatus === PlanStatuses.Executing ||
+    planStatus === PlanStatuses.Paused ||
+    planStatus === PlanStatuses.Pending
+  )
     return t('Plans cannot be modified during migration');
   if (planStatus === PlanStatuses.Archived) return t('Archived plans cannot be edited');
   return null;

--- a/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
@@ -71,6 +71,16 @@ export const planStatusLabelMapper: Record<PlanStatuses, ReactNode> = {
       {t('Paused')}
     </Label>
   ),
+  [PlanStatuses.Pending]: (
+    <Label
+      className="forklift-plan-status__gold-label"
+      isCompact
+      variant="filled"
+      data-testid="plan-status-label"
+    >
+      {t('Pending')}
+    </Label>
+  ),
   [PlanStatuses.Ready]: (
     <Label
       className="forklift-plan-status__grey-label"

--- a/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
@@ -72,12 +72,7 @@ export const planStatusLabelMapper: Record<PlanStatuses, ReactNode> = {
     </Label>
   ),
   [PlanStatuses.Pending]: (
-    <Label
-      className="forklift-plan-status__gold-label"
-      isCompact
-      variant="filled"
-      data-testid="plan-status-label"
-    >
+    <Label color="yellow" isCompact variant="filled" data-testid="plan-status-label">
       {t('Pending')}
     </Label>
   ),

--- a/src/plans/details/components/PlanStatus/utils/types.ts
+++ b/src/plans/details/components/PlanStatus/utils/types.ts
@@ -43,6 +43,7 @@ export enum PlanStatuses {
   CannotStart = 'CannotStart',
   Incomplete = 'Incomplete',
   Paused = 'Paused',
+  Pending = 'Pending',
   Executing = 'Executing',
   Ready = 'Ready',
 }

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -138,6 +138,14 @@ const isPlanWaitingForCutover = (plan: V1beta1Plan) =>
   isPlanExecuting(plan) &&
   getPlanIsWarm(plan);
 
+const isPlanPendingExecution = (plan: V1beta1Plan): boolean => {
+  if (!isPlanExecuting(plan)) return false;
+
+  const vms = getPlanVirtualMachinesMigrationStatus(plan);
+
+  return isEmpty(vms) || vms.every((vm) => !vm?.started);
+};
+
 export const isPlanArchived = (plan: V1beta1Plan) => {
   const conditions = getConditions(plan);
   return (
@@ -184,6 +192,10 @@ export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
 
   if (conditions.includes(CATEGORY_TYPES.FAILED) || vmError) {
     return PlanStatuses.Incomplete;
+  }
+
+  if (isPlanPendingExecution(plan)) {
+    return PlanStatuses.Pending;
   }
 
   if (isPlanExecuting(plan)) {

--- a/src/plans/list/components/PlanRowFields/PlanStatus/PlanStatus.tsx
+++ b/src/plans/list/components/PlanRowFields/PlanStatus/PlanStatus.tsx
@@ -80,7 +80,9 @@ const PlanStatus: FC<PlanFieldProps> = ({ plan }) => {
       flexWrap={{ default: 'nowrap' }}
     >
       <FlexItem className="plan-status-cell-label-section">
-        {isPlanRunning && PlanStatuses.Paused !== planStatus ? (
+        {isPlanRunning &&
+        PlanStatuses.Paused !== planStatus &&
+        PlanStatuses.Pending !== planStatus ? (
           <Split hasGutter>
             <Spinner size="md" data-testid="plan-progress-spinner" />
             <span className="pf-v6-u-font-size-sm" data-testid="plan-progress-percentage">

--- a/src/plans/list/utils/planFields.ts
+++ b/src/plans/list/utils/planFields.ts
@@ -23,6 +23,7 @@ const planPhases: { id: PlanStatuses; label: string }[] = [
   { id: PlanStatuses.Executing, label: t('Running') },
   { id: PlanStatuses.Incomplete, label: t('Incomplete') },
   { id: PlanStatuses.Paused, label: t('Paused') },
+  { id: PlanStatuses.Pending, label: t('Pending') },
   { id: PlanStatuses.Ready, label: t('Ready to start') },
 ];
 


### PR DESCRIPTION
## Links

- [MTV-1736](https://redhat.atlassian.net/browse/MTV-1736)

## Description

When multiple migration plans compete for inflight VM slots (`max_vms_inflight`), plans whose VMs haven't started processing incorrectly display "Running" with a spinner at 0%. This fix adds a new `Pending` plan status that distinguishes plans waiting for slots from plans actively migrating.

- Added `Pending` to the `PlanStatuses` enum
- Added `isPlanPendingExecution` helper that detects when a plan has the `Executing` condition but none of its VMs have a `started` timestamp
- Pending plans show a gold "Pending" label instead of the spinner + 0%
- Updated all action guards (edit, cutover, archive, delete) to handle the new status
- Added "Pending" to the plans list filter options

## Demo
Before:
<img width="1404" height="422" alt="Screenshot (17)" src="https://github.com/user-attachments/assets/799d8b9c-a6ee-4975-9622-af89bdae18e6" />
After:

<img width="1563" height="298" alt="Screenshot (18)" src="https://github.com/user-attachments/assets/6af18108-ee11-4c49-ba51-1c04508a6903" />

Resolves: MTV-1736

Made with [Cursor](https://cursor.com)

[MTV-1736]: https://redhat.atlassian.net/browse/MTV-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for a new "Pending" status for plans with multilingual display across six languages.
  * Updated status filtering to include the new Pending status option.

* **Bug Fixes**
  * Disabled plan editing and cutover scheduling when plans are in Pending status.
  * Updated archive and delete modals to properly recognize Pending plans as running.
  * Corrected progress indicator display to exclude Pending status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->