### PR TITLE
Resolves: MTV-5248 | Un-hide EC2 network/storage mapping steps in plan wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ testing/locales/
 .cursor/skills/personal-*/
 .cursor/hooks/personal-*
 .cursor/hooks.json
+
+# Playwright MCP artifacts (browser snapshots, console logs, screenshots)
+.playwright-mcp/

--- a/src/plans/create/CreatePlanWizardInner.tsx
+++ b/src/plans/create/CreatePlanWizardInner.tsx
@@ -3,7 +3,6 @@ import { type FC, useState } from 'react';
 import type { V1beta1Provider } from '@forklift-ui/types';
 import { Wizard, WizardStep } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
-import { isProviderEc2 } from '@utils/resources';
 
 import { useStepNavigation } from './hooks/useStepNavigation';
 import CustomScriptsStep from './steps/customization-scripts/CustomScriptsStep';
@@ -40,11 +39,6 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
   const { currentStep, handleStepChange, hasStepErrors } = useStepNavigation();
 
   const hasCreatePlanError = Boolean(createPlanError?.message);
-  const isEc2 = isProviderEc2(sourceProvider);
-
-  const skippedStepIds = new Set<PlanWizardStepId>(
-    isEc2 ? [PlanWizardStepId.NetworkMap, PlanWizardStepId.StorageMap] : [],
-  );
 
   const handleSubmit = async () => {
     setCreatePlanError(undefined);
@@ -61,7 +55,7 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
       isSubmitting ||
       hasCreatePlanError ||
       (planStepOrder[id] > planStepOrder[currentStep.id as PlanWizardStepId] &&
-        hasPreviousStepErrors(id, hasStepErrors, skippedStepIds)),
+        hasPreviousStepErrors(id, hasStepErrors)),
     name: planStepNames[id],
   });
 
@@ -91,14 +85,12 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
           <WizardStep
             key={PlanWizardStepId.NetworkMap}
             {...getStepProps(PlanWizardStepId.NetworkMap)}
-            isHidden={isEc2}
           >
             <NetworkMapStep />
           </WizardStep>,
           <WizardStep
             key={PlanWizardStepId.StorageMap}
             {...getStepProps(PlanWizardStepId.StorageMap)}
-            isHidden={isEc2}
           >
             <StorageMapStep />
           </WizardStep>,

--- a/src/plans/create/steps/__tests__/getMapResourceLabel.ec2.test.ts
+++ b/src/plans/create/steps/__tests__/getMapResourceLabel.ec2.test.ts
@@ -1,0 +1,41 @@
+import type { InventoryStorage } from 'src/utils/hooks/useStorages';
+
+import { describe, expect, it } from '@jest/globals';
+
+import type { ProviderNetwork } from '../../types';
+import { getMapResourceLabel } from '../utils';
+
+describe('getMapResourceLabel - EC2', () => {
+  it('returns name for EC2 network', () => {
+    const network: ProviderNetwork = {
+      id: 'subnet-abc123',
+      name: 'my-subnet',
+      providerType: 'ec2',
+    };
+    expect(getMapResourceLabel(network)).toBe('my-subnet');
+  });
+
+  it('returns name for EC2 storage (volume type)', () => {
+    const storage = {
+      id: 'gp3',
+      name: 'gp3',
+      providerType: 'ec2',
+      revision: 1,
+      selfLink: '/providers/ec2/uid/storages/gp3',
+    } as unknown as InventoryStorage;
+    expect(getMapResourceLabel(storage)).toBe('gp3');
+  });
+
+  it('returns empty string for EC2 resource with no name', () => {
+    const network: ProviderNetwork = {
+      id: 'subnet-abc123',
+      name: '',
+      providerType: 'ec2',
+    };
+    expect(getMapResourceLabel(network)).toBe('');
+  });
+
+  it('returns empty string for undefined resource', () => {
+    expect(getMapResourceLabel(undefined)).toBe('');
+  });
+});

--- a/src/plans/create/steps/__tests__/getMapResourceLabel.ec2.test.ts
+++ b/src/plans/create/steps/__tests__/getMapResourceLabel.ec2.test.ts
@@ -11,18 +11,20 @@ describe('getMapResourceLabel - EC2', () => {
       id: 'subnet-abc123',
       name: 'my-subnet',
       providerType: 'ec2',
+      revision: 1,
+      selfLink: '/providers/ec2/uid/networks/subnet-abc123',
     };
     expect(getMapResourceLabel(network)).toBe('my-subnet');
   });
 
   it('returns name for EC2 storage (volume type)', () => {
-    const storage = {
+    const storage: InventoryStorage = {
       id: 'gp3',
       name: 'gp3',
       providerType: 'ec2',
       revision: 1,
       selfLink: '/providers/ec2/uid/storages/gp3',
-    } as unknown as InventoryStorage;
+    };
     expect(getMapResourceLabel(storage)).toBe('gp3');
   });
 
@@ -31,6 +33,8 @@ describe('getMapResourceLabel - EC2', () => {
       id: 'subnet-abc123',
       name: '',
       providerType: 'ec2',
+      revision: 1,
+      selfLink: '',
     };
     expect(getMapResourceLabel(network)).toBe('');
   });

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -9,6 +9,7 @@ import type {
 import { DEFAULT_NETWORK, Namespace } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
+import type { Ec2VmObject } from '@utils/types/ec2Inventory';
 
 import type { CategorizedSourceMappings, MappingValue, ProviderNetwork } from '../../types';
 import { hasMultiplePodNetworkMappings } from '../../utils/hasMultiplePodNetworkMappings';
@@ -24,8 +25,22 @@ type ValidateNetworkMapParams = {
   oVirtNicProfiles: OVirtNicProfile[];
 };
 
+const getEc2SubnetIds = (vm: ProviderVirtualMachine): string[] => {
+  const { object } = vm as unknown as { object?: Ec2VmObject };
+  const interfaces = object?.NetworkInterfaces;
+
+  if (interfaces?.length) {
+    return interfaces.reduce<string[]>(
+      (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
+      [],
+    );
+  }
+
+  return object?.SubnetId ? [object.SubnetId] : [];
+};
+
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
-  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return [];
+  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return getEc2SubnetIds(vm);
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -25,22 +25,28 @@ type ValidateNetworkMapParams = {
   oVirtNicProfiles: OVirtNicProfile[];
 };
 
-const getEc2SubnetIds = (vm: ProviderVirtualMachine): string[] => {
-  const { object } = vm as unknown as { object?: Ec2VmObject };
-  const interfaces = object?.NetworkInterfaces;
+type Ec2VmLike = ProviderVirtualMachine & { object?: Ec2VmObject };
+
+// ProviderVirtualMachine from @forklift-ui/types does not include 'ec2' yet
+const isEc2Vm = (vm: ProviderVirtualMachine): vm is Ec2VmLike =>
+  (vm.providerType as string) === PROVIDER_TYPES.ec2;
+
+const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
+  const interfaces = vm.object?.NetworkInterfaces;
 
   if (interfaces?.length) {
-    return interfaces.reduce<string[]>(
+    const subnetIds = interfaces.reduce<string[]>(
       (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
       [],
     );
+    if (!isEmpty(subnetIds)) return subnetIds;
   }
 
-  return object?.SubnetId ? [object.SubnetId] : [];
+  return vm.object?.SubnetId ? [vm.object.SubnetId] : [];
 };
 
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
-  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return getEc2SubnetIds(vm);
+  if (isEc2Vm(vm)) return getEc2SubnetIds(vm);
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -9,7 +9,7 @@ import type {
 import { DEFAULT_NETWORK, Namespace } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
-import type { Ec2VmObject } from '@utils/types/ec2Inventory';
+import { getEc2SubnetIds, isEc2Vm } from '@utils/types/ec2Inventory';
 
 import type { CategorizedSourceMappings, MappingValue, ProviderNetwork } from '../../types';
 import { hasMultiplePodNetworkMappings } from '../../utils/hasMultiplePodNetworkMappings';
@@ -23,26 +23,6 @@ type ValidateNetworkMapParams = {
   usedSourceNetworks: MappingValue[];
   vms: Record<string, ProviderVirtualMachine>;
   oVirtNicProfiles: OVirtNicProfile[];
-};
-
-type Ec2VmLike = ProviderVirtualMachine & { object?: Ec2VmObject };
-
-// ProviderVirtualMachine from @forklift-ui/types does not include 'ec2' yet
-const isEc2Vm = (vm: ProviderVirtualMachine): vm is Ec2VmLike =>
-  (vm.providerType as string) === PROVIDER_TYPES.ec2;
-
-const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
-  const interfaces = vm.object?.NetworkInterfaces;
-
-  if (interfaces?.length) {
-    const subnetIds = interfaces.reduce<string[]>(
-      (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
-      [],
-    );
-    if (!isEmpty(subnetIds)) return subnetIds;
-  }
-
-  return vm.object?.SubnetId ? [vm.object.SubnetId] : [];
 };
 
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {

--- a/src/plans/create/steps/review/ReviewStep.tsx
+++ b/src/plans/create/steps/review/ReviewStep.tsx
@@ -1,6 +1,4 @@
 import type { FC } from 'react';
-import { useWatch } from 'react-hook-form';
-import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import WizardStepContainer from '@components/common/WizardStepContainer';
 import { EmptyState, Spinner } from '@patternfly/react-core';
@@ -8,7 +6,6 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import { planStepNames, PlanWizardStepId } from '../../constants';
 import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
-import { GeneralFormFieldId } from '../general-information/constants';
 
 import CustomScriptsReviewSection from './CustomScriptsReviewSection';
 import GeneralInfoReviewSection from './GeneralInfoReviewSection';
@@ -33,11 +30,8 @@ const ReviewStep: FC<ReviewStepProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
   const {
-    control,
     formState: { isSubmitting },
   } = useCreatePlanFormContext();
-  const sourceProvider = useWatch({ control, name: GeneralFormFieldId.SourceProvider });
-  const isEc2 = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
 
   if (isSubmitting) {
     return (
@@ -64,8 +58,8 @@ const ReviewStep: FC<ReviewStepProps> = ({
     >
       <GeneralInfoReviewSection />
       <VirtualMachinesReviewSection />
-      {!isEc2 && <NetworkMapReviewSection />}
-      {!isEc2 && <StorageMapReviewSection />}
+      <NetworkMapReviewSection />
+      <StorageMapReviewSection />
       <MigrationTypeReviewSection isLiveMigrationFeatureEnabled={isLiveMigrationFeatureEnabled} />
       <OtherSettingsReviewSection isLiveMigrationFeatureEnabled={isLiveMigrationFeatureEnabled} />
       <CustomScriptsReviewSection />

--- a/src/plans/create/steps/utils.ts
+++ b/src/plans/create/steps/utils.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 import type { InventoryStorage } from 'src/utils/hooks/useStorages';
 
 import type { ProviderNetwork } from '../types';
@@ -17,20 +18,20 @@ export const getMapResourceLabel = (
   }
 
   switch (resource.providerType) {
-    case 'openshift': {
-      // OpenShift resources have namespace from OpenshiftResource base type
+    case PROVIDER_TYPES.openshift: {
       if (resource.namespace) {
         return `${resource.namespace}/${resource.name}`;
       }
       return resource.name;
     }
-    case 'hyperv':
-    case 'ova':
-    case 'vsphere':
-    case 'openstack': {
+    case PROVIDER_TYPES.ec2:
+    case PROVIDER_TYPES.hyperv:
+    case PROVIDER_TYPES.ova:
+    case PROVIDER_TYPES.vsphere:
+    case PROVIDER_TYPES.openstack: {
       return resource.name || '';
     }
-    case 'ovirt': {
+    case PROVIDER_TYPES.ovirt: {
       // Use path for oVirt if available, fall back to name for storage resources
       if ('path' in resource && resource.path) {
         return resource.path;

--- a/src/plans/create/types.ts
+++ b/src/plans/create/types.ts
@@ -3,6 +3,7 @@ import type { TargetPowerState, TargetPowerStateValue } from 'src/plans/constant
 import type { StorageMapping, TargetStorage } from 'src/storageMaps/utils/types';
 import type { InventoryNetwork } from 'src/utils/hooks/useNetworks';
 import type { InventoryStorage } from 'src/utils/hooks/useStorages';
+import type { Ec2Network } from 'src/utils/types/ec2Inventory';
 
 import type {
   HypervNetwork,
@@ -53,7 +54,8 @@ export type ProviderNetwork =
   | OVirtNetwork
   | VSphereNetwork
   | OvaNetwork
-  | HypervNetwork;
+  | HypervNetwork
+  | Ec2Network;
 
 type VsphereVirtualMachine = VSphereVM & {
   changeTrackingEnabled: boolean;

--- a/src/plans/create/utils/createNetworkMap.ts
+++ b/src/plans/create/utils/createNetworkMap.ts
@@ -105,7 +105,6 @@ export const createNetworkMap = async ({
         namespace: project,
       },
       spec: {
-        // EC2 plans skip the mapping step entirely, producing an empty array
         map: (mappings ?? []).reduce(
           (acc: V1beta1NetworkMapSpecMap[], { sourceNetwork, targetNetwork }) => {
             if (sourceNetwork.name) {

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -2,24 +2,31 @@ import { DefaultNetworkLabel } from 'src/plans/details/tabs/Mappings/utils/const
 import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type { OVirtNicProfile, ProviderVirtualMachine } from '@forklift-ui/types';
+import { isEmpty } from '@utils/helpers';
 import type { Ec2VmObject } from '@utils/types/ec2Inventory';
 
-const getEc2SubnetIds = (vm: ProviderVirtualMachine): string[] => {
-  const { object } = vm as unknown as { object?: Ec2VmObject };
-  const interfaces = object?.NetworkInterfaces;
+type Ec2VmLike = ProviderVirtualMachine & { object?: Ec2VmObject };
+
+// ProviderVirtualMachine from @forklift-ui/types does not include 'ec2' yet
+const isEc2Vm = (vm: ProviderVirtualMachine): vm is Ec2VmLike =>
+  (vm.providerType as string) === PROVIDER_TYPES.ec2;
+
+const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
+  const interfaces = vm.object?.NetworkInterfaces;
 
   if (interfaces?.length) {
-    return interfaces.reduce<string[]>(
+    const subnetIds = interfaces.reduce<string[]>(
       (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
       [],
     );
+    if (!isEmpty(subnetIds)) return subnetIds;
   }
 
-  return object?.SubnetId ? [object.SubnetId] : [];
+  return vm.object?.SubnetId ? [vm.object.SubnetId] : [];
 };
 
 const getNetworksForVM = (vm: ProviderVirtualMachine) => {
-  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return getEc2SubnetIds(vm);
+  if (isEc2Vm(vm)) return getEc2SubnetIds(vm);
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -2,9 +2,24 @@ import { DefaultNetworkLabel } from 'src/plans/details/tabs/Mappings/utils/const
 import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type { OVirtNicProfile, ProviderVirtualMachine } from '@forklift-ui/types';
+import type { Ec2VmObject } from '@utils/types/ec2Inventory';
+
+const getEc2SubnetIds = (vm: ProviderVirtualMachine): string[] => {
+  const { object } = vm as unknown as { object?: Ec2VmObject };
+  const interfaces = object?.NetworkInterfaces;
+
+  if (interfaces?.length) {
+    return interfaces.reduce<string[]>(
+      (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
+      [],
+    );
+  }
+
+  return object?.SubnetId ? [object.SubnetId] : [];
+};
 
 const getNetworksForVM = (vm: ProviderVirtualMachine) => {
-  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return [];
+  if (vm.providerType === (PROVIDER_TYPES.ec2 as string)) return getEc2SubnetIds(vm);
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -2,28 +2,7 @@ import { DefaultNetworkLabel } from 'src/plans/details/tabs/Mappings/utils/const
 import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type { OVirtNicProfile, ProviderVirtualMachine } from '@forklift-ui/types';
-import { isEmpty } from '@utils/helpers';
-import type { Ec2VmObject } from '@utils/types/ec2Inventory';
-
-type Ec2VmLike = ProviderVirtualMachine & { object?: Ec2VmObject };
-
-// ProviderVirtualMachine from @forklift-ui/types does not include 'ec2' yet
-const isEc2Vm = (vm: ProviderVirtualMachine): vm is Ec2VmLike =>
-  (vm.providerType as string) === PROVIDER_TYPES.ec2;
-
-const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
-  const interfaces = vm.object?.NetworkInterfaces;
-
-  if (interfaces?.length) {
-    const subnetIds = interfaces.reduce<string[]>(
-      (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
-      [],
-    );
-    if (!isEmpty(subnetIds)) return subnetIds;
-  }
-
-  return vm.object?.SubnetId ? [vm.object.SubnetId] : [];
-};
+import { getEc2SubnetIds, isEc2Vm } from '@utils/types/ec2Inventory';
 
 const getNetworksForVM = (vm: ProviderVirtualMachine) => {
   if (isEc2Vm(vm)) return getEc2SubnetIds(vm);

--- a/src/providers/details/tabs/VirtualMachines/utils/types/Ec2VM.ts
+++ b/src/providers/details/tabs/VirtualMachines/utils/types/Ec2VM.ts
@@ -9,6 +9,8 @@ export type Ec2InstanceDetails = {
   PrivateIpAddress?: string;
   VpcId?: string;
   SubnetId?: string;
+  NetworkInterfaces?: { SubnetId?: string }[];
+  BlockDeviceMappings?: { Ebs?: { VolumeType?: string } }[];
 };
 
 // EC2 VM as returned by the inventory API (/providers/ec2/{uid}/vms).

--- a/src/storageMaps/create/utils/__tests__/buildStorageMappings.ec2.test.ts
+++ b/src/storageMaps/create/utils/__tests__/buildStorageMappings.ec2.test.ts
@@ -1,0 +1,91 @@
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
+import { StorageMapFieldId, type StorageMapping } from 'src/storageMaps/utils/types';
+
+import type { V1beta1Provider, V1beta1StorageMapSpecMapSource } from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+
+import { buildStorageMappings, getStorageMappingValues } from '../buildStorageMappings';
+
+const makeProvider = (type: string): V1beta1Provider =>
+  ({ spec: { type } }) as unknown as V1beta1Provider;
+
+const makeMapping = (sourceName: string, targetName: string): StorageMapping => ({
+  [StorageMapFieldId.SourceStorage]: { id: sourceName, name: sourceName },
+  [StorageMapFieldId.TargetStorage]: { name: targetName },
+});
+
+describe('buildStorageMappings - EC2', () => {
+  const ec2Provider = makeProvider(PROVIDER_TYPES.ec2);
+
+  it('uses name-based source mapping for EC2 provider', () => {
+    const mappings = [makeMapping('gp3', 'gp3-csi')];
+    const result = buildStorageMappings(mappings, ec2Provider);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toEqual({ name: 'gp3' });
+    expect(result[0].destination).toEqual({ storageClass: 'gp3-csi' });
+  });
+
+  it('does not include id in EC2 source mapping', () => {
+    const mappings = [makeMapping('io1', 'io1-csi')];
+    const result = buildStorageMappings(mappings, ec2Provider);
+
+    expect(result[0].source).not.toHaveProperty('id');
+  });
+
+  it('does not include offload plugin for EC2', () => {
+    const mappings = [makeMapping('gp2', 'standard')];
+    const result = buildStorageMappings(mappings, ec2Provider);
+
+    expect(result[0]).not.toHaveProperty('offloadPlugin');
+  });
+
+  it('skips mappings with empty source name', () => {
+    const mappings = [makeMapping('', 'standard')];
+    const result = buildStorageMappings(mappings, ec2Provider);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles multiple EC2 volume type mappings', () => {
+    const mappings = [makeMapping('gp3', 'gp3-csi'), makeMapping('io1', 'io1-csi')];
+    const result = buildStorageMappings(mappings, ec2Provider);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].source).toEqual({ name: 'gp3' });
+    expect(result[1].source).toEqual({ name: 'io1' });
+  });
+
+  it('uses id-based mapping for non-EC2 provider (vsphere)', () => {
+    const vsphereProvider = makeProvider(PROVIDER_TYPES.vsphere);
+    const mappings = [makeMapping('datastore-1', 'thin')];
+    const result = buildStorageMappings(mappings, vsphereProvider);
+
+    expect(result[0].source).toEqual({ id: 'datastore-1' });
+    expect(result[0].source).not.toHaveProperty('name');
+  });
+});
+
+describe('getStorageMappingValues - EC2', () => {
+  const ec2Provider = makeProvider(PROVIDER_TYPES.ec2);
+  const emptyStorages = new Map();
+
+  it('resolves EC2 source storage from spec name', () => {
+    const specMappings = [
+      {
+        destination: { storageClass: 'gp3-csi' },
+        source: { name: 'gp3' } as V1beta1StorageMapSpecMapSource,
+      },
+    ];
+    const result = getStorageMappingValues(specMappings, ec2Provider, emptyStorages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0][StorageMapFieldId.SourceStorage]).toEqual({ name: 'gp3' });
+    expect(result[0][StorageMapFieldId.TargetStorage]).toEqual({ name: 'gp3-csi' });
+  });
+
+  it('returns empty array for undefined spec mappings', () => {
+    const result = getStorageMappingValues(undefined, ec2Provider, emptyStorages);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/storageMaps/create/utils/buildStorageMappings.ts
+++ b/src/storageMaps/create/utils/buildStorageMappings.ts
@@ -131,7 +131,8 @@ const getSourceStorage = (
   }
 
   if (isEc2Provider) {
-    return { name: source.name ?? '' };
+    const inventoryLabel = getMapResourceLabel(sourceStorages.get(source?.id ?? ''));
+    return { name: source.name ?? inventoryLabel ?? source.id ?? '' };
   }
 
   return {

--- a/src/storageMaps/create/utils/buildStorageMappings.ts
+++ b/src/storageMaps/create/utils/buildStorageMappings.ts
@@ -62,6 +62,7 @@ export const buildStorageMappings = (
 
     const offloadPluginConfig = createOffloadPluginConfig(mapping);
     const isOpenShiftProvider = sourceProvider?.spec?.type === PROVIDER_TYPES.openshift;
+    const isEc2Provider = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
     const isGlanceStorage = sourceStorage.name === STORAGE_NAMES.GLANCE;
 
     // OpenShift provider: uses name-based mapping
@@ -73,6 +74,17 @@ export const buildStorageMappings = (
         },
       };
       acc.push(createStorageMapping(baseMapping, offloadPluginConfig));
+    }
+
+    // EC2 provider: backend FindStorageClass matches Source.Name against EBS volume type
+    if (isEc2Provider) {
+      const baseMapping = {
+        destination: { storageClass: targetStorage.name },
+        source: {
+          name: sourceStorage.name,
+        },
+      };
+      acc.push(createStorageMapping(baseMapping));
     }
 
     // Glance storage: uses name-based mapping
@@ -87,7 +99,7 @@ export const buildStorageMappings = (
     }
 
     // Default storage mapping: uses id-based mapping
-    if (!isOpenShiftProvider && !isGlanceStorage) {
+    if (!isOpenShiftProvider && !isEc2Provider && !isGlanceStorage) {
       const defaultBaseMapping = {
         destination: { storageClass: targetStorage.name },
         source: {
@@ -107,6 +119,7 @@ const getSourceStorage = (
   sourceStorages: Map<string, InventoryStorage>,
 ): StorageMappingValue => {
   const isOpenShiftProvider = sourceProvider?.spec?.type === PROVIDER_TYPES.openshift;
+  const isEc2Provider = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
   const isGlanceStorage = source.name === STORAGE_NAMES.GLANCE;
 
   if (isOpenShiftProvider) {
@@ -115,6 +128,10 @@ const getSourceStorage = (
 
   if (isGlanceStorage) {
     return { name: STORAGE_NAMES.GLANCE };
+  }
+
+  if (isEc2Provider) {
+    return { name: source.name ?? '' };
   }
 
   return {

--- a/src/storageMaps/utils/getSourceStorageValues.ts
+++ b/src/storageMaps/utils/getSourceStorageValues.ts
@@ -200,8 +200,10 @@ const filterStoragesByVmUsage = (
 };
 
 /**
- * Categorizes source storages with OVA provider filtering.
+ * Categorizes source storages with provider-specific filtering.
  * For OVA: only shows storages used by the provided VMs.
+ * For EC2: all storage types are treated as "used" since the backend validates
+ * that every EBS volume type has a mapping.
  * For other providers: shows all storages categorized by usage.
  */
 export const getSourceStorageValuesForSelectedVms = (
@@ -210,6 +212,16 @@ export const getSourceStorageValuesForSelectedVms = (
   vms: ProviderVirtualMachine[] | null,
 ): CategorizedSourceMappings => {
   const sourceProviderType = sourceProvider?.spec?.type;
+
+  if (sourceProviderType === PROVIDER_TYPES.ec2) {
+    return {
+      other: [],
+      used: availableSourceStorages.map((storage) => ({
+        id: storage.id,
+        name: getMapResourceLabel(storage),
+      })),
+    };
+  }
 
   // For OVA providers, filter storages to only those used by the provided VMs
   const relevantStorages =

--- a/src/utils/hooks/useNetworks.ts
+++ b/src/utils/hooks/useNetworks.ts
@@ -11,6 +11,7 @@ import type {
   VSphereNetwork,
 } from '@forklift-ui/types';
 import { DEFAULT_NETWORK, POD } from '@utils/constants';
+import type { Ec2Network } from '@utils/types/ec2Inventory';
 
 import useProviderInventory from './useProviderInventory';
 
@@ -32,7 +33,8 @@ export type InventoryNetwork =
   | OpenstackNetwork
   | OVirtNetwork
   | VSphereNetwork
-  | OvaNetwork;
+  | OvaNetwork
+  | Ec2Network;
 
 export const useSourceNetworks = (
   provider: V1beta1Provider | undefined,

--- a/src/utils/hooks/useStorages.ts
+++ b/src/utils/hooks/useStorages.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import type {
   OpenShiftStorageClass,
@@ -10,6 +11,7 @@ import type {
   VSphereDataStore,
 } from '@forklift-ui/types';
 import { STORAGE_NAMES } from '@utils/constants';
+import type { Ec2Storage } from '@utils/types/ec2Inventory';
 
 import useProviderInventory from './useProviderInventory';
 
@@ -25,13 +27,14 @@ const glanceStorage: InventoryStorage = {
   selfLink: '',
 };
 
-const subPath: Record<ProviderType, string> = {
-  hyperv: 'storages?detail=1',
-  openshift: 'storageclasses?detail=1',
-  openstack: 'volumetypes',
-  ova: 'storages?detail=1',
-  ovirt: 'storagedomains',
-  vsphere: 'datastores',
+const subPath: Record<string, string> = {
+  [PROVIDER_TYPES.ec2]: 'storages',
+  [PROVIDER_TYPES.hyperv]: 'storages?detail=1',
+  [PROVIDER_TYPES.openshift]: 'storageclasses?detail=1',
+  [PROVIDER_TYPES.openstack]: 'volumetypes',
+  [PROVIDER_TYPES.ova]: 'storages?detail=1',
+  [PROVIDER_TYPES.ovirt]: 'storagedomains',
+  [PROVIDER_TYPES.vsphere]: 'datastores',
 };
 
 export type InventoryStorage =
@@ -39,7 +42,8 @@ export type InventoryStorage =
   | OVirtStorageDomain
   | OpenstackVolumeType
   | OpenShiftStorageClass
-  | TypedOvaResource;
+  | TypedOvaResource
+  | Ec2Storage;
 
 export const useSourceStorages = (
   provider: V1beta1Provider | undefined,

--- a/src/utils/types/__tests__/ec2Inventory.test.ts
+++ b/src/utils/types/__tests__/ec2Inventory.test.ts
@@ -1,0 +1,74 @@
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
+
+import type { ProviderVirtualMachine } from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+
+import { type Ec2VmLike, getEc2SubnetIds, isEc2Vm } from '../ec2Inventory';
+
+const makeVm = (providerType: string, object?: Record<string, unknown>): ProviderVirtualMachine =>
+  ({ object, providerType }) as unknown as ProviderVirtualMachine;
+
+describe('isEc2Vm', () => {
+  it('returns true for ec2 provider type', () => {
+    expect(isEc2Vm(makeVm(PROVIDER_TYPES.ec2))).toBe(true);
+  });
+
+  it('returns false for vsphere provider type', () => {
+    expect(isEc2Vm(makeVm(PROVIDER_TYPES.vsphere))).toBe(false);
+  });
+
+  it('returns false for openshift provider type', () => {
+    expect(isEc2Vm(makeVm(PROVIDER_TYPES.openshift))).toBe(false);
+  });
+});
+
+describe('getEc2SubnetIds', () => {
+  const makeEc2Vm = (object?: Record<string, unknown>): Ec2VmLike =>
+    ({ object, providerType: PROVIDER_TYPES.ec2 }) as unknown as Ec2VmLike;
+
+  it('extracts subnet IDs from NetworkInterfaces', () => {
+    const vm = makeEc2Vm({
+      NetworkInterfaces: [{ SubnetId: 'subnet-aaa' }, { SubnetId: 'subnet-bbb' }],
+      SubnetId: 'subnet-ccc',
+    });
+    expect(getEc2SubnetIds(vm)).toEqual(['subnet-aaa', 'subnet-bbb']);
+  });
+
+  it('falls back to top-level SubnetId when no NetworkInterfaces', () => {
+    const vm = makeEc2Vm({ SubnetId: 'subnet-abc' });
+    expect(getEc2SubnetIds(vm)).toEqual(['subnet-abc']);
+  });
+
+  it('falls back to top-level SubnetId when interfaces exist but have no SubnetId', () => {
+    const vm = makeEc2Vm({
+      NetworkInterfaces: [{ SubnetId: undefined }, {}],
+      SubnetId: 'subnet-fallback',
+    });
+    expect(getEc2SubnetIds(vm)).toEqual(['subnet-fallback']);
+  });
+
+  it('returns empty array when no subnet info available', () => {
+    const vm = makeEc2Vm({});
+    expect(getEc2SubnetIds(vm)).toEqual([]);
+  });
+
+  it('returns empty array when object is undefined', () => {
+    const vm = makeEc2Vm(undefined);
+    expect(getEc2SubnetIds(vm)).toEqual([]);
+  });
+
+  it('skips interfaces with missing SubnetId', () => {
+    const vm = makeEc2Vm({
+      NetworkInterfaces: [{ SubnetId: 'subnet-111' }, {}, { SubnetId: 'subnet-333' }],
+    });
+    expect(getEc2SubnetIds(vm)).toEqual(['subnet-111', 'subnet-333']);
+  });
+
+  it('falls back when NetworkInterfaces is empty array', () => {
+    const vm = makeEc2Vm({
+      NetworkInterfaces: [],
+      SubnetId: 'subnet-top',
+    });
+    expect(getEc2SubnetIds(vm)).toEqual(['subnet-top']);
+  });
+});

--- a/src/utils/types/ec2Inventory.ts
+++ b/src/utils/types/ec2Inventory.ts
@@ -1,7 +1,10 @@
 // EC2 inventory types — defined locally because @forklift-ui/types
 // does not include EC2 inventory types yet.
 
-import type { PROVIDER_TYPES } from 'src/providers/utils/constants';
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
+
+import type { ProviderVirtualMachine } from '@forklift-ui/types';
+import { isEmpty } from '@utils/helpers';
 
 // EC2 networks are AWS subnets, identified by SubnetId.
 export type Ec2Network = {
@@ -27,4 +30,29 @@ export type Ec2VmObject = {
   SubnetId?: string;
   NetworkInterfaces?: { SubnetId?: string }[];
   BlockDeviceMappings?: { Ebs?: { VolumeType?: string } }[];
+};
+
+export type Ec2VmLike = ProviderVirtualMachine & { object?: Ec2VmObject };
+
+// ProviderVirtualMachine from @forklift-ui/types does not include 'ec2' yet
+export const isEc2Vm = (vm: ProviderVirtualMachine): vm is Ec2VmLike =>
+  (vm.providerType as string) === PROVIDER_TYPES.ec2;
+
+/**
+ * Extracts subnet IDs from an EC2 VM.
+ * Prefers NetworkInterfaces entries; falls back to top-level SubnetId
+ * when interfaces are absent or contain no subnet IDs.
+ */
+export const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
+  const interfaces = vm.object?.NetworkInterfaces;
+
+  if (interfaces?.length) {
+    const subnetIds = interfaces.reduce<string[]>(
+      (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
+      [],
+    );
+    if (!isEmpty(subnetIds)) return subnetIds;
+  }
+
+  return vm.object?.SubnetId ? [vm.object.SubnetId] : [];
 };

--- a/src/utils/types/ec2Inventory.ts
+++ b/src/utils/types/ec2Inventory.ts
@@ -1,0 +1,30 @@
+// EC2 inventory types — defined locally because @forklift-ui/types
+// does not include EC2 inventory types yet.
+
+import type { PROVIDER_TYPES } from 'src/providers/utils/constants';
+
+// EC2 networks are AWS subnets, identified by SubnetId.
+export type Ec2Network = {
+  id: string;
+  name: string;
+  revision: number;
+  selfLink: string;
+  providerType: typeof PROVIDER_TYPES.ec2;
+};
+
+// EC2 storage items are static EBS volume types (gp2, gp3, io1, io2, st1, sc1, standard).
+export type Ec2Storage = {
+  id: string;
+  name: string;
+  revision: number;
+  selfLink: string;
+  providerType: typeof PROVIDER_TYPES.ec2;
+};
+
+// Shape of the EC2 VM `object` field relevant for network/storage extraction.
+// Full type: Ec2InstanceDetails in src/providers/details/tabs/VirtualMachines/utils/types/Ec2VM.ts
+export type Ec2VmObject = {
+  SubnetId?: string;
+  NetworkInterfaces?: { SubnetId?: string }[];
+  BlockDeviceMappings?: { Ebs?: { VolumeType?: string } }[];
+};


### PR DESCRIPTION
## Links

- [MTV-5248](https://redhat.atlassian.net/browse/MTV-5248)

## Description

MTV-5227 hid the network/storage mapping steps for EC2 providers, but the backend validates that EC2 plans have proper mappings. Plans created via the UI got empty `spec.map: []` and failed with `CannotStart` due to `VMNetworksNotMapped` and `VMStorageNotMapped` conditions.

This PR un-hides the mapping steps and wires EC2 inventory support so mappings are properly populated.

- Un-hide NetworkMap and StorageMap wizard steps for EC2
- Show mapping sections in the review step
- Add `ec2: 'storages'` to the storage inventory hook subPath map
- Define shared `Ec2Network`, `Ec2Storage`, and `Ec2VmObject` types (`src/utils/types/ec2Inventory.ts`)
- Extract subnet IDs from EC2 VMs for network mapping (via `NetworkInterfaces` or `SubnetId`)
- Treat all EBS volume types as "used" for storage mapping
- Use name-based source for EC2 storage mappings (backend `FindStorageClass` matches `Source.Name`)
- Add EC2 case to `getMapResourceLabel`
- Enhance `Ec2InstanceDetails` with `NetworkInterfaces` and `BlockDeviceMappings` fields

## Demo

Mappings steps shown:

<img width="1920" height="1080" alt="MTV-5248-2-network-map-step-subnets" src="https://github.com/user-attachments/assets/2a8bcd7f-96da-4164-b69c-17526be67091" />

<img width="1920" height="1080" alt="MTV-5248-3-storage-map-step-ebs-volumes" src="https://github.com/user-attachments/assets/bc6676fa-4ff2-4fe4-84fd-fc33f77b01b4" />

functional plan and mapping yamls:

<img width="1920" height="1080" alt="MTV-5248-verify-1-plan-status-ready" src="https://github.com/user-attachments/assets/a7235cc4-1e0f-42af-9404-5e14a7b2a87b" />
<img width="1920" height="1080" alt="MTV-5248-verify-2-plan-yaml-map-refs" src="https://github.com/user-attachments/assets/52c179b7-fb1b-433a-a3e9-f54ad84a3feb" />
<img width="1920" height="1080" alt="MTV-5248-verify-3-networkmap-yaml-populated" src="https://github.com/user-attachments/assets/f607f133-db18-407f-9b0d-22f9358a7b15" />
<img width="1920" height="1080" alt="MTV-5248-verify-4-storagemap-yaml-populated" src="https://github.com/user-attachments/assets/86efe2d6-6508-49cd-bdbf-c75d69281abb" />

## CC://


Made with [Cursor](https://cursor.com)

[MTV-5248]: https://redhat.atlassian.net/browse/MTV-5248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EC2 VMs now participate in network mapping (subnet-based detection) and storage mapping during plan creation.
  * Network and storage mapping sections are shown in the migration plan review for EC2 and all providers.
  * EC2 storage mappings are built from source storage names (no offload fallback), improving volume mapping accuracy.
  * EC2 network and storage types added to inventory and selection lists.

* **Tests**
  * Added unit tests covering EC2 subnet extraction and EC2 storage mapping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->