### PR TITLE
Fix EC2 provider settings keys for target-az and target-region

### DIFF
--- a/src/providers/create/utils/buildEc2ProviderResources.ts
+++ b/src/providers/create/utils/buildEc2ProviderResources.ts
@@ -41,8 +41,9 @@ export const buildEc2ProviderResources = (formData: Ec2FormData): ProviderResour
     provider.spec.settings = {
       ec2Region: ec2Region.trim(),
       ...(autoTargetCredentials && { autoTargetCredentials: 'true' }),
-      ...(!autoTargetCredentials && targetAz?.trim() && { targetAz: targetAz.trim() }),
-      ...(!autoTargetCredentials && targetRegion?.trim() && { targetRegion: targetRegion.trim() }),
+      ...(!autoTargetCredentials && targetAz?.trim() && { 'target-az': targetAz.trim() }),
+      ...(!autoTargetCredentials &&
+        targetRegion?.trim() && { 'target-region': targetRegion.trim() }),
     };
   }
 


### PR DESCRIPTION
## Links

- [MTV-5256](https://redhat.atlassian.net/browse/MTV-5256)

## Description

Fix EC2 provider creation to use the correct kebab-case settings keys expected by the backend.

- Change `targetAz` → `target-az` in `spec.settings`
- Change `targetRegion` → `target-region` in `spec.settings`

The backend Go constants define these as `target-az` and `target-region` ([provider.go](https://github.com/kubev2v/forklift/blob/main/pkg/apis/forklift/v1beta1/provider.go)), but the UI was sending camelCase variants which the controller doesn't recognize. This caused the migration to fail at the "create volume from snapshot" step with:

```
provider spec.settings.target-az is not configured, must specify target availability zone
```

## Demo

<img width="1920" height="1080" alt="MTV-5256-verify-1-provider-yaml-kebab-case-keys" src="https://github.com/user-attachments/assets/146b1ed9-1094-49e0-a1c8-f5587ca20fc8" />


## CC://

Made with [Cursor](https://cursor.com)

[MTV-5256]: https://redhat.atlassian.net/browse/MTV-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated EC2 provider configuration settings to use correct naming format for credential targeting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->