### PR TITLE
MTV-3988 | Replace hardcoded icon colors with PF6 Icon status prop

### DIFF
--- a/src/components/Concerns/ConcernsColumnPopover.tsx
+++ b/src/components/Concerns/ConcernsColumnPopover.tsx
@@ -22,8 +22,8 @@ const ConcernsColumnPopover: FC = () => {
       {/* Informational */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md">
-            <InfoCircleIcon color="var(--pf-t--global--color--status--info--default)" />
+          <Icon size="md" status="info">
+            <InfoCircleIcon />
           </Icon>
         </FlexItem>
 
@@ -37,8 +37,8 @@ const ConcernsColumnPopover: FC = () => {
       {/* Warning */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md">
-            <ExclamationTriangleIcon color="var(--pf-t--global--color--status--warning--default)" />
+          <Icon size="md" status="warning">
+            <ExclamationTriangleIcon />
           </Icon>
         </FlexItem>
 
@@ -53,8 +53,8 @@ const ConcernsColumnPopover: FC = () => {
       {/* Critical */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md">
-            <ExclamationCircleIcon color="var(--pf-t--global--color--status--danger--default)" />
+          <Icon size="md" status="danger">
+            <ExclamationCircleIcon />
           </Icon>
         </FlexItem>
 

--- a/src/components/Concerns/ConcernsColumnPopover.tsx
+++ b/src/components/Concerns/ConcernsColumnPopover.tsx
@@ -1,11 +1,7 @@
 import type { FC } from 'react';
 
-import { Flex, FlexItem, Icon } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
+import { STATUS_ICONS } from '@components/status/statusIcons';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
 
 const ConcernsColumnPopover: FC = () => {
@@ -19,13 +15,8 @@ const ConcernsColumnPopover: FC = () => {
         )}
       </p>
 
-      {/* Informational */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
-        <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md" status="info">
-            <InfoCircleIcon />
-          </Icon>
-        </FlexItem>
+        <FlexItem className="pf-v6-u-mr-sm">{STATUS_ICONS.info}</FlexItem>
 
         <FlexItem>
           <ForkliftTrans>
@@ -34,13 +25,8 @@ const ConcernsColumnPopover: FC = () => {
         </FlexItem>
       </Flex>
 
-      {/* Warning */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
-        <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md" status="warning">
-            <ExclamationTriangleIcon />
-          </Icon>
-        </FlexItem>
+        <FlexItem className="pf-v6-u-mr-sm">{STATUS_ICONS.warning}</FlexItem>
 
         <FlexItem>
           <ForkliftTrans>
@@ -50,13 +36,8 @@ const ConcernsColumnPopover: FC = () => {
         </FlexItem>
       </Flex>
 
-      {/* Critical */}
       <Flex flexWrap={{ default: 'nowrap' }} alignItems={{ default: 'alignItemsCenter' }}>
-        <FlexItem className="pf-v6-u-mr-sm">
-          <Icon size="md" status="danger">
-            <ExclamationCircleIcon />
-          </Icon>
-        </FlexItem>
+        <FlexItem className="pf-v6-u-mr-sm">{STATUS_ICONS.danger}</FlexItem>
 
         <FlexItem>
           <ForkliftTrans>

--- a/src/components/Concerns/utils/category.tsx
+++ b/src/components/Concerns/utils/category.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 import type { Concern, V1beta1PlanStatusConditions } from '@forklift-ui/types';
-import type { LabelProps } from '@patternfly/react-core';
+import { Icon, type LabelProps } from '@patternfly/react-core';
 import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
@@ -31,12 +31,36 @@ const CATEGORY_TITLES: Record<ConcernCategory, string> = {
 };
 
 const CATEGORY_ICONS: Record<ConcernCategory, ReactNode> = {
-  [ConcernCategoryOptions.Advisory]: <InfoCircleIcon color="#2B9AF3" />,
-  [ConcernCategoryOptions.Critical]: <ExclamationCircleIcon color="#C9190B" />,
-  [ConcernCategoryOptions.Error]: <ExclamationCircleIcon color="#C9190B" />,
-  [ConcernCategoryOptions.Information]: <InfoCircleIcon color="#2B9AF3" />,
-  [ConcernCategoryOptions.Warn]: <ExclamationTriangleIcon color="#F0AB00" />,
-  [ConcernCategoryOptions.Warning]: <ExclamationTriangleIcon color="#F0AB00" />,
+  [ConcernCategoryOptions.Advisory]: (
+    <Icon status="info">
+      <InfoCircleIcon />
+    </Icon>
+  ),
+  [ConcernCategoryOptions.Critical]: (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ),
+  [ConcernCategoryOptions.Error]: (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ),
+  [ConcernCategoryOptions.Information]: (
+    <Icon status="info">
+      <InfoCircleIcon />
+    </Icon>
+  ),
+  [ConcernCategoryOptions.Warn]: (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ),
+  [ConcernCategoryOptions.Warning]: (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ),
 };
 
 const CATEGORY_STATUS: Record<ConcernCategory, LabelProps['status'] | undefined> = {

--- a/src/components/Concerns/utils/category.tsx
+++ b/src/components/Concerns/utils/category.tsx
@@ -1,12 +1,8 @@
 import type { ReactNode } from 'react';
 
+import { STATUS_ICONS } from '@components/status/statusIcons';
 import type { Concern, V1beta1PlanStatusConditions } from '@forklift-ui/types';
-import { Icon, type LabelProps } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-  InfoCircleIcon,
-} from '@patternfly/react-icons';
+import type { LabelProps } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
 
@@ -31,36 +27,12 @@ const CATEGORY_TITLES: Record<ConcernCategory, string> = {
 };
 
 const CATEGORY_ICONS: Record<ConcernCategory, ReactNode> = {
-  [ConcernCategoryOptions.Advisory]: (
-    <Icon status="info">
-      <InfoCircleIcon />
-    </Icon>
-  ),
-  [ConcernCategoryOptions.Critical]: (
-    <Icon status="danger">
-      <ExclamationCircleIcon />
-    </Icon>
-  ),
-  [ConcernCategoryOptions.Error]: (
-    <Icon status="danger">
-      <ExclamationCircleIcon />
-    </Icon>
-  ),
-  [ConcernCategoryOptions.Information]: (
-    <Icon status="info">
-      <InfoCircleIcon />
-    </Icon>
-  ),
-  [ConcernCategoryOptions.Warn]: (
-    <Icon status="warning">
-      <ExclamationTriangleIcon />
-    </Icon>
-  ),
-  [ConcernCategoryOptions.Warning]: (
-    <Icon status="warning">
-      <ExclamationTriangleIcon />
-    </Icon>
-  ),
+  [ConcernCategoryOptions.Advisory]: STATUS_ICONS.info,
+  [ConcernCategoryOptions.Critical]: STATUS_ICONS.danger,
+  [ConcernCategoryOptions.Error]: STATUS_ICONS.danger,
+  [ConcernCategoryOptions.Information]: STATUS_ICONS.info,
+  [ConcernCategoryOptions.Warn]: STATUS_ICONS.warning,
+  [ConcernCategoryOptions.Warning]: STATUS_ICONS.warning,
 };
 
 const CATEGORY_STATUS: Record<ConcernCategory, LabelProps['status'] | undefined> = {

--- a/src/components/status/StatusIcon.tsx
+++ b/src/components/status/StatusIcon.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import { Spinner } from '@patternfly/react-core';
+import { Icon, Spinner } from '@patternfly/react-core';
 import {
   BanIcon,
   CheckCircleIcon,
@@ -56,7 +56,11 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
 
     case 'Warning':
     case 'RequiresApproval':
-      return <ExclamationTriangleIcon color="#F0AB00" />;
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon />
+        </Icon>
+      );
 
     case 'ContainerCannotRun':
     case 'CrashLoopBackOff':
@@ -70,7 +74,11 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
     case 'Lost':
     case 'Rejected':
     case 'UpgradeFailed':
-      return <ExclamationCircleIcon color="#C9190B" />;
+      return (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      );
 
     case 'Accepted':
     case 'Active':
@@ -87,10 +95,18 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
     case 'Preferred':
     case 'Connected':
     case 'Deployed':
-      return <CheckCircleIcon color="#3E8635" />;
+      return (
+        <Icon status="success">
+          <CheckCircleIcon />
+        </Icon>
+      );
 
     case 'Info':
-      return <InfoCircleIcon color="#2B9AF3" />;
+      return (
+        <Icon status="info">
+          <InfoCircleIcon />
+        </Icon>
+      );
 
     case 'Unknown':
       return <UnknownIcon />;

--- a/src/components/status/StatusIcon.tsx
+++ b/src/components/status/StatusIcon.tsx
@@ -1,21 +1,19 @@
 import type { FC } from 'react';
 
-import { Icon, Spinner } from '@patternfly/react-core';
+import { Spinner } from '@patternfly/react-core';
 import {
   BanIcon,
-  CheckCircleIcon,
   ClipboardListIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
   HourglassHalfIcon,
   HourglassStartIcon,
-  InfoCircleIcon,
   MinusCircleIcon,
   NotStartedIcon,
   PlusCircleIcon,
   SyncAltIcon,
   UnknownIcon,
 } from '@patternfly/react-icons';
+
+import { STATUS_ICONS } from './statusIcons';
 
 const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
   switch (phase) {
@@ -56,11 +54,7 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
 
     case 'Warning':
     case 'RequiresApproval':
-      return (
-        <Icon status="warning">
-          <ExclamationTriangleIcon />
-        </Icon>
-      );
+      return STATUS_ICONS.warning;
 
     case 'ContainerCannotRun':
     case 'CrashLoopBackOff':
@@ -74,11 +68,7 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
     case 'Lost':
     case 'Rejected':
     case 'UpgradeFailed':
-      return (
-        <Icon status="danger">
-          <ExclamationCircleIcon />
-        </Icon>
-      );
+      return STATUS_ICONS.danger;
 
     case 'Accepted':
     case 'Active':
@@ -95,18 +85,10 @@ const StatusIcon: FC<{ phase: string }> = ({ phase }) => {
     case 'Preferred':
     case 'Connected':
     case 'Deployed':
-      return (
-        <Icon status="success">
-          <CheckCircleIcon />
-        </Icon>
-      );
+      return STATUS_ICONS.success;
 
     case 'Info':
-      return (
-        <Icon status="info">
-          <InfoCircleIcon />
-        </Icon>
-      );
+      return STATUS_ICONS.info;
 
     case 'Unknown':
       return <UnknownIcon />;

--- a/src/components/status/statusIcons.tsx
+++ b/src/components/status/statusIcons.tsx
@@ -1,0 +1,30 @@
+import { Icon } from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+} from '@patternfly/react-icons';
+
+export const STATUS_ICONS = {
+  danger: (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ),
+  info: (
+    <Icon status="info">
+      <InfoCircleIcon />
+    </Icon>
+  ),
+  success: (
+    <Icon status="success">
+      <CheckCircleIcon />
+    </Icon>
+  ),
+  warning: (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ),
+};

--- a/src/components/table/utils/useStatusPhaseValues.tsx
+++ b/src/components/table/utils/useStatusPhaseValues.tsx
@@ -1,13 +1,21 @@
 import { type ReactNode, useMemo } from 'react';
 
-import { Spinner } from '@patternfly/react-core';
+import { Icon, Spinner } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { CATEGORY_TYPES } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
 
-const errorIcon = () => <ExclamationCircleIcon color="#C9190B" />;
+const errorIcon = () => (
+  <Icon status="danger">
+    <ExclamationCircleIcon />
+  </Icon>
+);
 const progressIcon = () => <Spinner size="sm" />;
-const readyIcon = () => <CheckCircleIcon color="#3E8635" />;
+const readyIcon = () => (
+  <Icon status="success">
+    <CheckCircleIcon />
+  </Icon>
+);
 
 export const useStatusPhaseValues = (
   phase?: string,

--- a/src/components/table/utils/useStatusPhaseValues.tsx
+++ b/src/components/table/utils/useStatusPhaseValues.tsx
@@ -1,21 +1,11 @@
 import { type ReactNode, useMemo } from 'react';
 
-import { Icon, Spinner } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { STATUS_ICONS } from '@components/status/statusIcons';
+import { Spinner } from '@patternfly/react-core';
 import { CATEGORY_TYPES } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
 
-const errorIcon = () => (
-  <Icon status="danger">
-    <ExclamationCircleIcon />
-  </Icon>
-);
 const progressIcon = () => <Spinner size="sm" />;
-const readyIcon = () => (
-  <Icon status="success">
-    <CheckCircleIcon />
-  </Icon>
-);
 
 export const useStatusPhaseValues = (
   phase?: string,
@@ -25,18 +15,18 @@ export const useStatusPhaseValues = (
   return useMemo(() => {
     switch (phase) {
       case CATEGORY_TYPES.CONNECTION_FAILED:
-        return { phaseIcon: errorIcon(), phaseLabel: t('Connection Failed') };
+        return { phaseIcon: STATUS_ICONS.danger, phaseLabel: t('Connection Failed') };
       case CATEGORY_TYPES.CRITICAL:
-        return { phaseIcon: errorIcon(), phaseLabel: t('Critical') };
+        return { phaseIcon: STATUS_ICONS.danger, phaseLabel: t('Critical') };
       case CATEGORY_TYPES.NOT_READY:
         return { phaseIcon: progressIcon(), phaseLabel: t('Not Ready') };
       case CATEGORY_TYPES.STAGING:
         return { phaseIcon: progressIcon(), phaseLabel: t('Staging') };
       case CATEGORY_TYPES.VALIDATION_FAILED:
-        return { phaseIcon: errorIcon(), phaseLabel: t('Validation Failed') };
+        return { phaseIcon: STATUS_ICONS.danger, phaseLabel: t('Validation Failed') };
       case CATEGORY_TYPES.READY:
       case undefined:
-        return { phaseIcon: readyIcon(), phaseLabel: t('Ready') };
+        return { phaseIcon: STATUS_ICONS.success, phaseLabel: t('Ready') };
       default:
         return { phaseIcon: null, phaseLabel: t('Undefined') };
     }

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/DiskLabel.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/DiskLabel.tsx
@@ -25,8 +25,8 @@ const DiskLabel: FC<DiskLabelProps> = ({ diskKey }) => {
               'Root filesystem format should start with "/dev/sd[X]", see documentation for more information.',
             )}
           >
-            <Icon className="pf-v6-u-mr-xs">
-              <ExclamationTriangleIcon color="#F0AB00" />
+            <Icon className="pf-v6-u-mr-xs" status="warning">
+              <ExclamationTriangleIcon />
             </Icon>
           </Tooltip>
         )

--- a/src/providers/details/tabs/Hosts/components/NetworkCellRenderer.tsx
+++ b/src/providers/details/tabs/Hosts/components/NetworkCellRenderer.tsx
@@ -4,7 +4,14 @@ import { calculateCidrNotation } from 'src/providers/details/tabs/Hosts/utils/he
 import { determineHostStatus } from 'src/providers/details/tabs/Hosts/utils/helpers/determineHostStatus';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { Button, ButtonVariant, HelperText, HelperTextItem, Popover } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  HelperText,
+  HelperTextItem,
+  Icon,
+  Popover,
+} from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -14,9 +21,21 @@ import {
 import type { HostCellProps } from './utils/types';
 
 const statusIcons: Record<string, ReactNode> = {
-  error: <ExclamationCircleIcon color="#C9190B" />,
-  ready: <CheckCircleIcon color="#3E8635" />,
-  running: <ExclamationTriangleIcon color="#F0AB00" />,
+  error: (
+    <Icon status="danger">
+      <ExclamationCircleIcon />
+    </Icon>
+  ),
+  ready: (
+    <Icon status="success">
+      <CheckCircleIcon />
+    </Icon>
+  ),
+  running: (
+    <Icon status="warning">
+      <ExclamationTriangleIcon />
+    </Icon>
+  ),
 };
 
 // Define cell renderer for 'network'

--- a/src/providers/details/tabs/Hosts/components/NetworkCellRenderer.tsx
+++ b/src/providers/details/tabs/Hosts/components/NetworkCellRenderer.tsx
@@ -1,41 +1,18 @@
 import type { FC, ReactNode } from 'react';
+import { STATUS_ICONS } from 'src/components/status/statusIcons';
 import { TableCell } from 'src/components/TableCell/TableCell';
 import { calculateCidrNotation } from 'src/providers/details/tabs/Hosts/utils/helpers/calculateCidrNotation';
 import { determineHostStatus } from 'src/providers/details/tabs/Hosts/utils/helpers/determineHostStatus';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import {
-  Button,
-  ButtonVariant,
-  HelperText,
-  HelperTextItem,
-  Icon,
-  Popover,
-} from '@patternfly/react-core';
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import { Button, ButtonVariant, HelperText, HelperTextItem, Popover } from '@patternfly/react-core';
 
 import type { HostCellProps } from './utils/types';
 
 const statusIcons: Record<string, ReactNode> = {
-  error: (
-    <Icon status="danger">
-      <ExclamationCircleIcon />
-    </Icon>
-  ),
-  ready: (
-    <Icon status="success">
-      <CheckCircleIcon />
-    </Icon>
-  ),
-  running: (
-    <Icon status="warning">
-      <ExclamationTriangleIcon />
-    </Icon>
-  ),
+  error: STATUS_ICONS.danger,
+  ready: STATUS_ICONS.success,
+  running: STATUS_ICONS.warning,
 };
 
 // Define cell renderer for 'network'


### PR DESCRIPTION
## Links

- [MTV-3988](https://redhat.atlassian.net/browse/MTV-3988)

## Description

Replaced all hardcoded PF5 hex colors and inline CSS tokens on status icons with PF6's `Icon` component `status` prop. This ensures icons use theme-driven colors — notably info icons now display PF6 purple instead of PF5 blue.

Additionally, extracted a shared `STATUS_ICONS` map (`src/components/status/statusIcons.tsx`) for reuse across components, per review feedback.

**Files changed:**
- `statusIcons.tsx` — **new** shared status icon constants (danger, warning, success, info)
- `category.tsx` — concern severity icons, now imports from `STATUS_ICONS`
- `ConcernsColumnPopover.tsx` — concerns column help popover icons, now uses `STATUS_ICONS`
- `StatusIcon.tsx` — provider/plan phase status icons, now imports from `STATUS_ICONS`
- `NetworkCellRenderer.tsx` — host network status icons, now imports from `STATUS_ICONS`
- `useStatusPhaseValues.tsx` — provider phase values, now imports from `STATUS_ICONS`
- `DiskLabel.tsx` — root disk warning icon

## Demo

Before:
<img width="487" height="219" alt="Screenshot (32)" src="https://github.com/user-attachments/assets/0c1afb33-bf87-4385-b595-b67923ec152d" />
<img width="619" height="263" alt="Screenshot (31)" src="https://github.com/user-attachments/assets/a247d460-5aa1-4e0a-aa87-7ecb23814163" />

After:
<img width="505" height="287" alt="Screenshot (33)" src="https://github.com/user-attachments/assets/d5cd6d31-dc31-450b-b1e9-6a042636fed2" />
<img width="462" height="272" alt="Screenshot (30)" src="https://github.com/user-attachments/assets/6454af00-13e3-4a66-826c-f8eb949ee45c" />


## CC://

Made with [Cursor](https://cursor.com)

[MTV-3988]: https://redhat.atlassian.net/browse/MTV-3988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated status icon styling and definitions for improved consistency across the application. Icons for informational, warning, danger, and success states now use unified styling, ensuring a more cohesive visual experience throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->