### PR TITLE
Fix throughput chart rendering and tick values

### DIFF
--- a/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
@@ -5,6 +5,7 @@ import {
   ChartAxis,
   ChartGroup,
   ChartLine,
+  ChartScatter,
   ChartThemeColor,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts/victory';
@@ -39,13 +40,81 @@ const SHORT_RANGES = new Set<ThroughputTimeRange>([
   ThroughputTimeRange.Last6H,
 ]);
 
-const TICK_COUNTS: Record<ThroughputTimeRange, number> = {
-  [ThroughputTimeRange.Last1H]: 6,
-  [ThroughputTimeRange.Last24H]: 5,
-  [ThroughputTimeRange.Last2D]: 4,
-  [ThroughputTimeRange.Last30Min]: 6,
-  [ThroughputTimeRange.Last6H]: 6,
-  [ThroughputTimeRange.Last7D]: 5,
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+const TIME_TICK_INTERVALS: Record<ThroughputTimeRange, number> = {
+  [ThroughputTimeRange.Last1H]: 10 * MS_PER_MINUTE,
+  [ThroughputTimeRange.Last24H]: 4 * MS_PER_HOUR,
+  [ThroughputTimeRange.Last2D]: 12 * MS_PER_HOUR,
+  [ThroughputTimeRange.Last30Min]: 5 * MS_PER_MINUTE,
+  [ThroughputTimeRange.Last6H]: MS_PER_HOUR,
+  [ThroughputTimeRange.Last7D]: 24 * MS_PER_HOUR,
+};
+
+const TARGET_TICK_COUNT = 5;
+const BYTES_DIVISOR = 1024;
+
+const computeTimeTicks = (domain: [number, number], timeRange: ThroughputTimeRange): number[] => {
+  const interval = TIME_TICK_INTERVALS[timeRange];
+  const start = Math.ceil(domain[0] / interval) * interval;
+  const ticks: number[] = [];
+
+  for (let ts = start; ts <= domain[1]; ts += interval) {
+    ticks.push(ts);
+  }
+
+  return ticks;
+};
+
+const computeNiceTicks = (data: ChartLineEntry[]): number[] => {
+  let max = 0;
+
+  for (const entry of data) {
+    for (const datum of entry.data) {
+      if (datum.y > max) {
+        max = datum.y;
+      }
+    }
+  }
+
+  if (max === 0) {
+    return [0];
+  }
+
+  let displayMax = max;
+  let unitMultiplier = 1;
+
+  while (displayMax >= BYTES_DIVISOR) {
+    displayMax /= BYTES_DIVISOR;
+    unitMultiplier *= BYTES_DIVISOR;
+  }
+
+  const rough = displayMax / TARGET_TICK_COUNT;
+  const magnitude = 10 ** Math.floor(Math.log10(rough));
+  const residual = rough / magnitude;
+
+  let step = 10 * magnitude;
+
+  if (residual <= 1) {
+    step = magnitude;
+  } else if (residual <= 2) {
+    step = 2 * magnitude;
+  } else if (residual <= 5) {
+    step = 5 * magnitude;
+  }
+
+  const ticks: number[] = [];
+
+  for (let val = 0; val <= displayMax; val += step) {
+    ticks.push(Math.round(val * unitMultiplier));
+  }
+
+  if (ticks[ticks.length - 1] < max) {
+    ticks.push(Math.round((ticks[ticks.length - 1] / unitMultiplier + step) * unitMultiplier));
+  }
+
+  return ticks;
 };
 
 const formatTimestamp = (ts: number, timeRange: ThroughputTimeRange): string => {
@@ -98,11 +167,20 @@ const ThroughputLineChart: FC<ThroughputLineChartProps> = ({
 
   const legendData = useMemo(() => chartData.map((cd) => ({ name: cd.name })), [chartData]);
 
+  /* eslint-disable react-hooks/exhaustive-deps -- series triggers recalculation of Date.now() */
   const xDomain = useMemo((): [number, number] => {
     const now = Date.now();
     const { timespan } = THROUGHPUT_TIME_RANGE_CONFIG[timeRange];
     return [now - timespan, now];
-  }, [timeRange]);
+  }, [timeRange, series]);
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  const timeTicks = useMemo(
+    (): number[] => computeTimeTicks(xDomain, timeRange),
+    [xDomain, timeRange],
+  );
+
+  const niceTicks = useMemo((): number[] => computeNiceTicks(chartData), [chartData]);
 
   if (isEmpty(visibleSeries)) {
     return (
@@ -131,21 +209,32 @@ const ThroughputLineChart: FC<ThroughputLineChartProps> = ({
         legendData={legendData}
         legendPosition="bottom"
         minDomain={{ y: 0 }}
-        padding={{ bottom: 75, left: 70, right: 20, top: 10 }}
+        padding={{ bottom: 75, left: 85, right: 20, top: 10 }}
         width={chartDimensions.width}
       >
         <ChartAxis
           fixLabelOverlap
           tickFormat={(ts: number) => formatTimestamp(ts, timeRange)}
-          tickCount={TICK_COUNTS[timeRange]}
+          tickValues={timeTicks}
           style={{ tickLabels: { padding: 0 } }}
         />
-        <ChartAxis dependentAxis tickFormat={(val: number) => formatThroughputTick(val)} />
+        <ChartAxis
+          dependentAxis
+          tickFormat={(val: number) => formatThroughputTick(val)}
+          tickValues={niceTicks}
+        />
         <ChartGroup>
-          {chartData.map((cd) => (
-            <ChartLine key={cd.planId} data={cd.data} name={cd.name} />
-          ))}
+          {chartData
+            .filter((cd) => cd.data.length > 1)
+            .map((cd) => (
+              <ChartLine key={cd.planId} data={cd.data} name={cd.name} />
+            ))}
         </ChartGroup>
+        {chartData
+          .filter((cd) => cd.data.length === 1)
+          .map((cd) => (
+            <ChartScatter key={cd.planId} data={cd.data} name={cd.name} />
+          ))}
       </Chart>
     </div>
   );

--- a/src/overview/tabs/Overview/hooks/useThroughputQuery.ts
+++ b/src/overview/tabs/Overview/hooks/useThroughputQuery.ts
@@ -45,18 +45,21 @@ export const parseThroughputResponse = (
   }));
 };
 
-const POLL_DELAY_MS = 30000;
+const POLL_DELAY_MS = 30_000;
+const MS_PER_SECOND = 1000;
 
 export const useThroughputQuery = (
   metricName: string,
   timeRange: ThroughputTimeRange,
 ): UseThroughputQueryResult => {
   const config = THROUGHPUT_TIME_RANGE_CONFIG[timeRange];
+  const stepSeconds = Math.round(config.timespan / (config.samples * MS_PER_SECOND));
+  const query = `max_over_time(${metricName}[${stepSeconds}s])`;
 
   const [response, loaded, error] = usePrometheusPoll({
     delay: POLL_DELAY_MS,
     endpoint: PrometheusEndpoint.QUERY_RANGE,
-    query: metricName,
+    query,
     samples: config.samples,
     timespan: config.timespan,
   });


### PR DESCRIPTION
## Summary

- **Fix invisible chart lines**: Added `series` to xDomain `useMemo` dependency array so the domain recalculates when Prometheus returns new data, keeping chart lines visible.
- **ChartScatter fallback**: VictoryLine cannot render single-point series; added `ChartScatter` dots for plans with only 1 data point.
- **Preserve peaks across time ranges**: Wrapped raw gauge query in `max_over_time(metric[step])` so peak throughput values are preserved at lower resolutions (longer time ranges).
- **Round tick values**: Replaced `tickCount` with computed `tickValues` using interval-aligned X-axis ticks and a 1-2-5 "nice numbers" algorithm for Y-axis ticks.

## Test plan

- [x] Open Overview page with active migrations
- [x] Verify Network and Storage throughput charts render visible lines
- [x] Switch between all time ranges (30m, 1h, 6h, 24h, 2d, 7d) and confirm data is consistent
- [x] Confirm X-axis tick labels align to round time boundaries
- [x] Confirm Y-axis tick labels use round values (0, 10, 20, 30, 40 instead of 0, 7.6, 15.2, ...)
- [x] Verify single-point series render as dots instead of being invisible
- [x] All unit tests pass (`npm test`)

## Demo


https://github.com/user-attachments/assets/e1d55972-de2a-4909-916a-5e25aa97545e



Resolves: MTV-4751

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Throughput chart x-axis now dynamically adjusts tick placement based on selected time range for improved readability
  * Single data point series now display with visual scatter overlay for better visibility

* **Improvements**
  * Enhanced throughput metric accuracy through improved data aggregation and y-axis tick calculations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2405)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->