### PR TITLE
Resolves: MTV-3930 | Add AAP hooks E2E coverage and fix hook UI test selectors

### DIFF
--- a/src/plans/create/steps/review/HooksReviewSection.tsx
+++ b/src/plans/create/steps/review/HooksReviewSection.tsx
@@ -58,14 +58,16 @@ const HooksReviewSection: FC = () => {
         <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXl' }}>
           <FlexItem>
             <LocalHookReview
-              hookLabel={t('Pre-migration hook')}
               hookFieldId={HooksFormFieldId.PreMigration}
+              hookLabel={t('Pre-migration hook')}
+              testIdPrefix="review-pre-migration-hook"
             />
           </FlexItem>
           <FlexItem>
             <LocalHookReview
-              hookLabel={t('Post-migration hook')}
               hookFieldId={HooksFormFieldId.PostMigration}
+              hookLabel={t('Post-migration hook')}
+              testIdPrefix="review-post-migration-hook"
             />
           </FlexItem>
         </Flex>

--- a/src/plans/create/steps/review/LocalHookReview.tsx
+++ b/src/plans/create/steps/review/LocalHookReview.tsx
@@ -20,9 +20,10 @@ import { hooksFormFieldLabels } from '../migration-hooks/utils';
 type LocalHookReviewProps = {
   hookFieldId: HooksFormFieldId;
   hookLabel: string;
+  testIdPrefix: string;
 };
 
-const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel }) => {
+const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel, testIdPrefix }) => {
   const { t } = useForkliftTranslation();
   const { control } = useCreatePlanFormContext();
 
@@ -36,14 +37,16 @@ const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel }) =
         <>
           <DescriptionListGroup>
             <DescriptionListTerm>{t('Enabled')}</DescriptionListTerm>
-            <DescriptionListDescription>{t('True')}</DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${testIdPrefix}-enabled`}>
+              {t('True')}
+            </DescriptionListDescription>
           </DescriptionListGroup>
 
           <DescriptionListGroup>
             <DescriptionListTerm>
               {hooksFormFieldLabels[MigrationHookFieldId.HookRunnerImage]}
             </DescriptionListTerm>
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${testIdPrefix}-runner-image`}>
               {hookData[MigrationHookFieldId.HookRunnerImage] ?? t('None')}
             </DescriptionListDescription>
           </DescriptionListGroup>
@@ -52,7 +55,7 @@ const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel }) =
             <DescriptionListTerm>
               {hooksFormFieldLabels[MigrationHookFieldId.ServiceAccount]}
             </DescriptionListTerm>
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${testIdPrefix}-service-account`}>
               {hookData[MigrationHookFieldId.ServiceAccount] ?? t('None')}
             </DescriptionListDescription>
           </DescriptionListGroup>
@@ -61,7 +64,7 @@ const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel }) =
             <DescriptionListTerm>
               {hooksFormFieldLabels[MigrationHookFieldId.AnsiblePlaybook]}
             </DescriptionListTerm>
-            <DescriptionListDescription>
+            <DescriptionListDescription data-testid={`${testIdPrefix}-ansible-playbook`}>
               {hookData[MigrationHookFieldId.AnsiblePlaybook] ? (
                 <CodeBlock>
                   <CodeBlockCode>
@@ -77,7 +80,9 @@ const LocalHookReview: FC<LocalHookReviewProps> = ({ hookFieldId, hookLabel }) =
       ) : (
         <DescriptionListGroup>
           <DescriptionListTerm>{t('Enabled')}</DescriptionListTerm>
-          <DescriptionListDescription>{t('False')}</DescriptionListDescription>
+          <DescriptionListDescription data-testid={`${testIdPrefix}-enabled`}>
+            {t('False')}
+          </DescriptionListDescription>
         </DescriptionListGroup>
       )}
     </DescriptionList>

--- a/testing/playwright/e2e/downstream/overview-page.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-page.spec.ts
@@ -10,8 +10,8 @@ import {
 import { OverviewPage } from '../../page-objects/OverviewPage';
 import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 import { ResourceManager } from '../../utils/resource-manager/ResourceManager';
-import { V2_11_0 } from '../../utils/version/constants';
-import { requireVersion } from '../../utils/version/version';
+import { V2_11_0, V2_12_0 } from '../../utils/version/constants';
+import { isVersionAtLeast, requireVersion } from '../../utils/version/version';
 
 test.describe(
   'Overview Page - Settings',
@@ -150,6 +150,28 @@ test.describe(
         await expect(overviewPage.settingsTab.settingsEditModal.saveButton).toBeEnabled();
         await overviewPage.settingsTab.settingsEditModal.save();
       });
+
+      if (isVersionAtLeast(V2_12_0)) {
+        await test.step('Verify AAP settings fields are visible in read-only view', async () => {
+          await expect(overviewPage.settingsTab.aapUrlField).toBeVisible();
+          await expect(overviewPage.settingsTab.aapTokenSecretField).toBeVisible();
+          await expect(overviewPage.settingsTab.aapTimeoutField).toBeVisible();
+        });
+
+        await test.step('Verify AAP fields are present in edit modal', async () => {
+          await overviewPage.settingsTab.openSettingsEditModal();
+          await overviewPage.settingsTab.settingsEditModal.verifyAapFieldsVisible();
+
+          const aapUrl = await overviewPage.settingsTab.settingsEditModal.getAapUrlValue();
+          expect(aapUrl).toBe('');
+
+          const aapTimeout = await overviewPage.settingsTab.settingsEditModal.getAapTimeoutValue();
+          expect(Number(aapTimeout)).toBe(0);
+
+          await expect(overviewPage.settingsTab.settingsEditModal.saveButton).toBeDisabled();
+          await overviewPage.settingsTab.settingsEditModal.cancel();
+        });
+      }
     });
   },
 );

--- a/testing/playwright/e2e/downstream/plans/plan-aap-hooks.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-aap-hooks.spec.ts
@@ -1,5 +1,6 @@
 import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
 import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
+import { HookSource } from '../../../types/enums';
 import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
 import { disableGuidedTour } from '../../../utils/utils';
 import { V2_12_0 } from '../../../utils/version/constants';
@@ -29,39 +30,52 @@ test.describe('Plan AAP Hooks', { tag: '@downstream' }, () => {
     });
 
     await test.step('Verify hook source radio is visible with three options', async () => {
+      await wizard.hooks.verifyStepVisible();
+
       const noHooksRadio = page.getByTestId('hook-source-none');
       const localRadio = page.getByTestId('hook-source-local');
       const aapRadio = page.getByTestId('hook-source-aap');
 
-      await noHooksRadio.waitFor({ state: 'visible' });
-      await localRadio.waitFor({ state: 'visible' });
-      await aapRadio.waitFor({ state: 'visible' });
+      await test.expect(noHooksRadio).toBeVisible();
+      await test.expect(localRadio).toBeVisible();
+      await test.expect(aapRadio).toBeVisible();
     });
 
     await test.step('Verify "No hooks" is selected by default', async () => {
-      const noHooksRadio = page.getByTestId('hook-source-none');
-      await test.expect(noHooksRadio).toBeChecked();
-
+      await test.expect(page.getByTestId('hook-source-none')).toBeChecked();
       await test.expect(page.getByTestId('preMigrationHook.enableHook-checkbox')).not.toBeVisible();
     });
 
     await test.step('Switch to "Local playbook" and verify local fields appear', async () => {
-      await page.getByTestId('hook-source-local').click();
+      await wizard.hooks.selectHookSource(HookSource.LOCAL);
 
       await test.expect(page.getByTestId('preMigrationHook.enableHook-checkbox')).toBeVisible();
       await test.expect(page.getByTestId('postMigrationHook.enableHook-checkbox')).toBeVisible();
     });
 
     await test.step('Switch to "AAP" and verify AAP section appears', async () => {
-      await page.getByTestId('hook-source-aap').click();
+      await wizard.hooks.selectHookSource(HookSource.AAP);
 
       await test.expect(page.getByTestId('preMigrationHook.enableHook-checkbox')).not.toBeVisible();
+      await test.expect(page.getByText('AAP is not configured')).toBeVisible();
+    });
+
+    await test.step('Verify Technology Preview badge on AAP option', async () => {
+      await test.expect(page.getByText('Technology Preview')).toBeVisible();
     });
 
     await test.step('Switch back to "No hooks" and verify fields are hidden', async () => {
-      await page.getByTestId('hook-source-none').click();
+      await wizard.hooks.selectHookSource(HookSource.NONE);
 
       await test.expect(page.getByTestId('preMigrationHook.enableHook-checkbox')).not.toBeVisible();
+      await test.expect(page.getByText('AAP is not configured')).not.toBeVisible();
+    });
+
+    await test.step('Verify review step shows AAP hook source', async () => {
+      await wizard.hooks.selectHookSource(HookSource.AAP);
+      await wizard.clickNext();
+      await wizard.review.verifyStepVisible();
+      await wizard.review.verifyHooksSection(HookSource.AAP);
     });
   });
 });

--- a/testing/playwright/e2e/downstream/plans/plan-hooks.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-hooks.spec.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
 import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { HookSource } from '../../../types/enums';
 import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
 import { disableGuidedTour } from '../../../utils/utils';
 import { V2_12_0 } from '../../../utils/version/constants';
@@ -55,7 +56,11 @@ test.describe('Plan Hooks', { tag: '@downstream' }, () => {
       await wizard.hooks.verifyStepVisible();
     });
 
-    await test.step('Verify hook checkboxes are disabled by default', async () => {
+    await test.step('Select Local playbook as hook source', async () => {
+      await wizard.hooks.selectHookSource(HookSource.LOCAL);
+    });
+
+    await test.step('Verify hook checkboxes are unchecked by default', async () => {
       await wizard.hooks.verifyPreMigrationHookDisabled();
       await wizard.hooks.verifyPostMigrationHookDisabled();
     });
@@ -96,7 +101,7 @@ test.describe('Plan Hooks', { tag: '@downstream' }, () => {
       await wizard.clickNext();
       await wizard.review.verifyStepVisible();
       await wizard.review.verifyHooksSection(
-        'local',
+        HookSource.LOCAL,
         {
           enabled: true,
           hookRunnerImage: HOOK_RUNNER_IMAGE,
@@ -155,6 +160,24 @@ test.describe('Plan Hooks', { tag: '@downstream' }, () => {
       });
       await planDetailsPage.hooksTab.verifyPreMigrationHookEnabled(true);
       await planDetailsPage.hooksTab.verifyHookRunnerImage('pre', HOOK_RUNNER_IMAGE);
+    });
+
+    await test.step('Verify edit modal shows AAP radio with three-way switching', async () => {
+      await planDetailsPage.hooksTab.openPreMigrationHookEditModal();
+
+      const { hookEditModal } = planDetailsPage.hooksTab;
+      await hookEditModal.verifyAapRadioVisible();
+      await hookEditModal.verifyHookIsEnabled();
+      await hookEditModal.verifyLocalFieldsVisible();
+
+      await hookEditModal.selectAap();
+      await hookEditModal.verifyLocalFieldsHidden();
+      await hookEditModal.verifyAapNotConfiguredAlert();
+
+      await hookEditModal.disableHook();
+      await hookEditModal.verifyLocalFieldsHidden();
+
+      await hookEditModal.cancel();
     });
   });
 });

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/HooksStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/HooksStep.ts
@@ -1,5 +1,7 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import { HookSource } from '../../../types/enums';
+
 export interface HookConfig {
   enabled: boolean;
   hookRunnerImage?: string;
@@ -101,7 +103,7 @@ export class HooksStep {
     await this.verifyStepVisible();
 
     if (preMigrationHook || postMigrationHook) {
-      await this.page.getByTestId('hook-source-local').click();
+      await this.selectHookSource(HookSource.LOCAL);
     }
 
     if (preMigrationHook) {
@@ -123,6 +125,10 @@ export class HooksStep {
       },
       { yamlContent: content, index: editorIndex },
     );
+  }
+
+  async selectHookSource(source: HookSource): Promise<void> {
+    await this.page.getByTestId(`hook-source-${source}`).click();
   }
 
   async verifyPostMigrationHookDisabled(): Promise<void> {

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import { HookSource } from '../../../types/enums';
 import type {
   CustomizationScriptsTestData,
   HookConfig,
@@ -144,7 +145,7 @@ export class ReviewStep {
   }
 
   async verifyHooksSection(
-    hookSource: 'none' | 'local' | 'aap' = 'none',
+    hookSource: HookSource = HookSource.NONE,
     preHook?: HookConfig,
     postHook?: HookConfig,
   ): Promise<void> {
@@ -152,12 +153,12 @@ export class ReviewStep {
 
     const hookSourceLocator = this.page.getByTestId('review-hook-source');
 
-    if (hookSource === 'none') {
+    if (hookSource === HookSource.NONE) {
       await expect(hookSourceLocator).toHaveText('No hooks configured');
       return;
     }
 
-    if (hookSource === 'aap') {
+    if (hookSource === HookSource.AAP) {
       await expect(hookSourceLocator).toHaveText('Ansible Automation Platform');
       return;
     }

--- a/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
+++ b/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 import { V2_12_0 } from '../../../utils/version/constants';
 import { isVersionAtLeast } from '../../../utils/version/version';
@@ -16,6 +16,9 @@ import { BaseModal } from '../../common/BaseModal';
  *   - role='option' for selecting dropdown values by display text
  */
 export class SettingsEditModal extends BaseModal {
+  readonly aapTimeoutInput: Locator;
+  readonly aapTokenSecretDropdown: Locator;
+  readonly aapUrlInput: Locator;
   readonly controllerCpuLimitDropdown: Locator;
   readonly controllerMemoryLimitDropdown: Locator;
   readonly controllerTransferNetworkDropdown: Locator;
@@ -51,6 +54,12 @@ export class SettingsEditModal extends BaseModal {
     this.controllerTransferNetworkDropdown = this.page.getByTestId(
       'controller-transfer-network-select',
     );
+
+    this.aapUrlInput = this.page.getByTestId('aap-url-settings-input');
+    this.aapTokenSecretDropdown = this.page.getByTestId('aap-token-secret-settings-select');
+    this.aapTimeoutInput = this.page
+      .getByTestId('settings-aap-timeout-input')
+      .getByRole('spinbutton');
   }
 
   private async selectOptionByTestIdOrText(
@@ -70,7 +79,18 @@ export class SettingsEditModal extends BaseModal {
   }
 
   async decrementMaxVmInFlight(): Promise<void> {
-    await this.modal.getByRole('button', { name: 'minus' }).click();
+    await this.page
+      .getByTestId('max-vm-inflight-input')
+      .getByRole('button', { name: 'minus' })
+      .click();
+  }
+
+  async getAapTimeoutValue(): Promise<string> {
+    return (await this.aapTimeoutInput.inputValue()) ?? '';
+  }
+
+  async getAapUrlValue(): Promise<string> {
+    return (await this.aapUrlInput.inputValue()) ?? '';
   }
 
   async getControllerCpuLimitValue(): Promise<string | null> {
@@ -102,7 +122,10 @@ export class SettingsEditModal extends BaseModal {
   }
 
   async incrementMaxVmInFlight(): Promise<void> {
-    await this.modal.getByRole('button', { name: 'plus' }).click();
+    await this.page
+      .getByTestId('max-vm-inflight-input')
+      .getByRole('button', { name: 'plus' })
+      .click();
   }
 
   async openTransferNetworkDropdown(): Promise<void> {
@@ -162,6 +185,15 @@ export class SettingsEditModal extends BaseModal {
     await this.page.getByTestId('controller-transfer-network-select-option-none').click();
   }
 
+  async setAapTimeout(value: number): Promise<void> {
+    await this.aapTimeoutInput.fill(String(value));
+  }
+
+  async setAapUrl(url: string): Promise<void> {
+    await this.aapUrlInput.clear();
+    await this.aapUrlInput.fill(url);
+  }
+
   async setMaxVmInFlight(value: number): Promise<void> {
     await this.maxVmInFlightInput.fill(String(value));
   }
@@ -177,5 +209,11 @@ export class SettingsEditModal extends BaseModal {
     } else {
       await this.selectFirstAvailableNetwork();
     }
+  }
+
+  async verifyAapFieldsVisible(): Promise<void> {
+    await expect(this.aapUrlInput).toBeVisible();
+    await expect(this.aapTokenSecretDropdown).toBeVisible();
+    await expect(this.aapTimeoutInput).toBeVisible();
   }
 }

--- a/testing/playwright/page-objects/OverviewPage/tabs/SettingsTab.ts
+++ b/testing/playwright/page-objects/OverviewPage/tabs/SettingsTab.ts
@@ -5,6 +5,9 @@ import { SettingsEditModal } from '../modals/SettingsEditModal';
 
 export class SettingsTab {
   private readonly navigation: NavigationHelper;
+  readonly aapTimeoutField: Locator;
+  readonly aapTokenSecretField: Locator;
+  readonly aapUrlField: Locator;
   readonly controllerTransferNetworkField: Locator;
   readonly maxVmInFlightField: Locator;
   protected readonly page: Page;
@@ -21,6 +24,9 @@ export class SettingsTab {
       'settings-controller-transfer-network',
     );
     this.maxVmInFlightField = this.page.locator('dd').first();
+    this.aapUrlField = this.page.getByTestId('settings-aap-url');
+    this.aapTokenSecretField = this.page.getByTestId('settings-aap-token-secret');
+    this.aapTimeoutField = this.page.getByTestId('settings-aap-timeout');
     this.settingsEditModal = new SettingsEditModal(page);
   }
 
@@ -31,7 +37,7 @@ export class SettingsTab {
   }
 
   async getTransferNetworkCurrentValue(): Promise<string | null> {
-    return this.controllerTransferNetworkField.textContent();
+    return await this.controllerTransferNetworkField.textContent();
   }
 
   async navigateToSettings(): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/HookEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/HookEditModal.ts
@@ -2,31 +2,35 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 import { BaseModal } from '../../common/BaseModal';
 
-/**
- * Page object for the Hook Edit Modal.
- * Extends BaseModal with hook-specific functionality for configuring
- * pre/post migration hooks with Ansible playbooks.
- */
 export class HookEditModal extends BaseModal {
-  readonly enableHookCheckbox: Locator;
   readonly hookRunnerImageInput: Locator;
   readonly serviceAccountInput: Locator;
+  readonly sourceAapRadio: Locator;
+  readonly sourceLocalRadio: Locator;
+  readonly sourceNoneRadio: Locator;
 
   constructor(page: Page) {
     super(page, page.getByRole('dialog'));
-    this.enableHookCheckbox = this.page.getByTestId('hook-enabled-checkbox');
+    this.sourceAapRadio = this.page.getByTestId('hook-edit-source-aap');
+    this.sourceNoneRadio = this.page.getByTestId('hook-edit-source-none');
+    this.sourceLocalRadio = this.page.getByTestId('hook-edit-source-local');
     this.hookRunnerImageInput = this.page.getByTestId('hook-runner-image-input');
     this.serviceAccountInput = this.page.getByTestId('hook-service-account-input');
   }
 
   async disableHook(): Promise<void> {
-    await this.enableHookCheckbox.uncheck();
-    await expect(this.enableHookCheckbox).not.toBeChecked();
+    await this.sourceNoneRadio.click();
+    await expect(this.sourceNoneRadio).toBeChecked();
   }
 
   async enableHook(): Promise<void> {
-    await this.enableHookCheckbox.check();
-    await expect(this.enableHookCheckbox).toBeChecked();
+    await this.sourceLocalRadio.click();
+    await expect(this.sourceLocalRadio).toBeChecked();
+  }
+
+  async selectAap(): Promise<void> {
+    await this.sourceAapRadio.click();
+    await expect(this.sourceAapRadio).toBeChecked();
   }
 
   async setAnsiblePlaybook(playbook: string): Promise<void> {
@@ -59,11 +63,29 @@ export class HookEditModal extends BaseModal {
     await this.serviceAccountInput.fill(serviceAccount);
   }
 
+  async verifyAapNotConfiguredAlert(): Promise<void> {
+    await expect(this.page.getByRole('dialog').getByText('AAP is not configured')).toBeVisible();
+  }
+
+  async verifyAapRadioVisible(): Promise<void> {
+    await expect(this.sourceAapRadio).toBeVisible();
+  }
+
   async verifyHookIsDisabled(): Promise<void> {
-    await expect(this.enableHookCheckbox).not.toBeChecked();
+    await expect(this.sourceNoneRadio).toBeChecked();
   }
 
   async verifyHookIsEnabled(): Promise<void> {
-    await expect(this.enableHookCheckbox).toBeChecked();
+    await expect(this.sourceLocalRadio).toBeChecked();
+  }
+
+  async verifyLocalFieldsHidden(): Promise<void> {
+    await expect(this.hookRunnerImageInput).not.toBeVisible();
+    await expect(this.serviceAccountInput).not.toBeVisible();
+  }
+
+  async verifyLocalFieldsVisible(): Promise<void> {
+    await expect(this.hookRunnerImageInput).toBeVisible();
+    await expect(this.serviceAccountInput).toBeVisible();
   }
 }

--- a/testing/playwright/types/enums.ts
+++ b/testing/playwright/types/enums.ts
@@ -5,6 +5,7 @@ export enum MigrationType {
 }
 
 export enum ProviderType {
+  EC2 = 'ec2',
   HYPERV = 'hyperv',
   OPENSTACK = 'openstack',
   OVA = 'ova',
@@ -15,4 +16,10 @@ export enum ProviderType {
 export enum EndpointType {
   VCENTER = 'vcenter',
   ESXI = 'esxi',
+}
+
+export enum HookSource {
+  AAP = 'aap',
+  LOCAL = 'local',
+  NONE = 'none',
 }


### PR DESCRIPTION
## 📝 Links

- [MTV-3930](https://redhat.atlassian.net/browse/MTV-3930)

## 📝 Description

Add E2E test coverage for the AAP job template hooks feature (MTV-3818) and fix hook-related UI test selectors.

- Add `data-testid` attributes to `LocalHookReview` so the plan wizard review step is testable
- Update `HookEditModal` page object for the three-way radio (None / Local / AAP) with AAP-specific assertions
- Extend `plan-aap-hooks.spec.ts` with AAP "not configured" alert, Technology Preview badge, and review step verification
- Extend `plan-hooks.spec.ts` with edit-modal AAP radio switching coverage
- Add AAP settings field locators and assertions to `SettingsEditModal`, `SettingsTab`, and `overview-page.spec.ts` (version-gated to v2.12.0)
- Fix ambiguous `plus`/`minus` button selectors in `SettingsEditModal.incrementMaxVmInFlight`

## 🎥 Demo

<!-- Test-only changes — no UI demo needed -->

## 📝 CC://

[MTV-3930]: https://redhat.atlassian.net/browse/MTV-3930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AAP-related settings are exposed in the Settings edit modal and read-only view; AAP fields (URL, token, timeout) are validated.
  * “Technology Preview” badge added to the AAP hooks option.

* **Tests**
  * Expanded end-to-end tests for hook-source flows (none/local/AAP), hooks review/edit behavior, and transfer-network + AAP field validation.
  * Improved test helpers and page-object coverage for hooks and settings interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2406)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->