### PR TITLE
Bump z-stream version to 2.9.8

### DIFF
--- a/build/release.conf
+++ b/build/release.conf
@@ -1,5 +1,5 @@
 # Global version specifying version for every component and for bundle, format "x.y.z"
-RVERSION=2.9.7
+RVERSION=2.9.8
 
 # Release version, format "vX.Y"
 RELEASE=v2.9


### PR DESCRIPTION
Automated z-stream version bump.

Updates `RVERSION` from `2.9.7` → `2.9.8` in `build/release.conf`.