### PR TITLE
Add backend expert knowledge base from forklift Go codebase analysis

### DIFF
--- a/.cursor/rules/agents/forklift-expert.mdc
+++ b/.cursor/rules/agents/forklift-expert.mdc
@@ -8,6 +8,8 @@ alwaysApply: false
 Invoke with: *"as forklift expert"*, *"as migration expert"*, *"domain review"*, *"migration review"*
 
 > **Canonical source:** For the list of CRDs and provider types, see `project-context.mdc`. This agent expands on that with implementation details, status handling, and common pitfalls.
+>
+> **Backend deep-dive:** Detailed Go backend knowledge is available in `.cursor/rules/backend/`. Use the routing table below to load the relevant file when answering backend questions.
 
 ## Your Role
 
@@ -219,7 +221,38 @@ Your approach:
 
 ---
 
-### 9. Kubernetes Fundamentals
+### 9. Conversions & Deep Inspection
+
+**V1beta1Conversion**
+- Represents a conversion or deep-inspection operation on a VM
+- Group: `forklift.konveyor.io`, Version: `v1beta1`, Kind: `Conversion`
+- Types defined locally in `src/utils/crds/conversion/` (pending upstream `@forklift-ui/types`)
+
+**Conversion Types**
+- `DeepInspection` - Pre-migration VM analysis (detects compatibility issues, OS info, filesystem details)
+- `Inspection` - Basic inspection
+- `InPlace` - In-place conversion
+- `Remote` - Remote conversion
+
+**Phases**: `Pending` → `Running` → `Succeeded` / `Failed` / `Canceled`
+
+**Deep Inspection Feature (vSphere only)**
+- Entry points: Provider Details header button, Plan Details header button, Plan VM list kebab action
+- Guard hooks: `useCanInspectProvider`, `useCanInspectPlan` — check provider type is vSphere and provider is Ready
+- Modal: `InspectVirtualMachinesModal` — select VMs, configure disk encryption, set XFS v4 compatibility
+- Results stored in `status.inspectionResult` with OS info, filesystems, mountpoints, and concerns
+- Status flow: `getInspectionStatus(phase, inspectionPassed)` maps phase + results to UI status labels
+
+**Key Patterns**
+- Backend returns `all_checks_passed` in snake_case — always use the `hasInspectionPassed` selector which handles both casings
+- Inspection concerns use the same `ConcernsTable` as inventory concerns but with different categories
+- Conversion CRs are label-filtered: `CONVERSION_LABELS.PLAN_NAME`, `CONVERSION_LABELS.VM_ID`, etc.
+- XFS v4 compatibility: plan-level setting with per-VM override (Inherit/Enable/Disable)
+- Concurrency limit: `CONCURRENCY_LIMIT = 10` parallel inspections
+
+---
+
+### 10. Kubernetes Fundamentals
 
 **Resource Model**
 - Group: `forklift.konveyor.io`, Version: `v1beta1`
@@ -245,7 +278,7 @@ Your approach:
 
 ---
 
-### 10. Console SDK Integration
+### 11. Console SDK Integration
 
 **useK8sWatchResource Hook**
 - Proper GVK configuration
@@ -261,7 +294,7 @@ Your approach:
 
 ---
 
-### 11. Common Patterns & Pitfalls
+### 12. Common Patterns & Pitfalls
 
 **Resource Fetching**
 - Always handle loading and error states
@@ -286,6 +319,39 @@ Your approach:
 - 403: Permission denied
 - 409: Conflict (resource modified)
 - 422: Validation error (invalid plan configuration)
+
+---
+
+## Backend Knowledge Routing Table
+
+When answering questions about backend behavior, read the relevant `.mdc` file from `.cursor/rules/backend/`:
+
+| Topic | Load file |
+|-------|-----------|
+| Architecture, entry points, deployment roles | `backend/architecture.mdc` |
+| CRD types, phase constants, conditions framework | `backend/api-types.mdc` |
+| Provider reconciliation, credentials, inventory lifecycle | `backend/providers/provider-controller.mdc` |
+| vSphere inventory, VDDK, ESXi, vCenter API | `backend/providers/vsphere.mdc` |
+| oVirt Engine API, storage domains | `backend/providers/ovirt.mdc` |
+| OpenStack Keystone/Nova/Glance/Neutron | `backend/providers/openstack.mdc` |
+| OVA file parsing, NFS, OVAProviderServer | `backend/providers/ova.mdc` |
+| Hyper-V SMB/PowerShell, HyperVProviderServer | `backend/providers/hyperv.mdc` |
+| EC2 AWS SDK, AMI, platform gating | `backend/providers/ec2.mdc` |
+| OpenShift target provider, namespaces, StorageClass | `backend/providers/ocp.mdc` |
+| Plan validation, conditions, lifecycle | `backend/plans/plan-controller.mdc` |
+| Provider adapters, Builder/Client interfaces | `backend/plans/plan-adapters.mdc` |
+| Migration phases, itineraries, disk transfer, KubeVirt | `backend/plans/migration-pipeline.mdc` |
+| VM scheduling, concurrency, MaxInFlight | `backend/plans/scheduler.mdc` |
+| NetworkMap validation, source/target mapping | `backend/mappings/network-map.mdc` |
+| StorageMap, offload plugins, vendor integrations | `backend/mappings/storage-map.mdc` |
+| Admission webhooks (validating + mutating) | `backend/infrastructure/webhooks.mdc` |
+| Inventory REST API endpoints, per-provider routes | `backend/infrastructure/rest-api.mdc` |
+| virt-v2v conversion, inspection, customization | `backend/infrastructure/virt-v2v.mdc` |
+| Condition framework, inventory containers, lib/ | `backend/infrastructure/shared-libraries.mdc` |
+| Prometheus metrics, monitoring | `backend/infrastructure/monitoring.mdc` |
+| ESXi host controller | `backend/infrastructure/host-controller.mdc` |
+| Pre/post migration hooks | `backend/infrastructure/hook-controller.mdc` |
+| Operator deployment, feature flags, images | `backend/operator/operator.mdc` |
 
 ---
 

--- a/.cursor/rules/backend/api-types.mdc
+++ b/.cursor/rules/backend/api-types.mdc
@@ -1,0 +1,399 @@
+---
+description: Forklift CRD type definitions - Plan, Provider, Migration, NetworkMap, StorageMap, Hook, Host, conditions, phases
+alwaysApply: false
+---
+
+# API Types (CRD Definitions)
+
+> Analyzed from commit: `a976d24b6` on `2026-05-04`
+> Source paths: `pkg/apis/forklift/v1beta1/`, `pkg/lib/condition/`
+
+## Package Purpose
+
+Package `v1beta1` (`forklift.konveyor.io/v1beta1`) defines all Forklift CRDs. The `SchemeGroupVersion` is `forklift.konveyor.io/v1beta1`. All CRD types embed `meta.TypeMeta` + `meta.ObjectMeta` and follow the standard Spec/Status pattern. Every Status struct embeds `libcnd.Conditions` for the shared condition framework.
+
+---
+
+## Key Types and Structs
+
+### Provider (`provider.go`)
+
+Represents a source or target infrastructure connection.
+
+```
+ProviderSpec {
+  Type           *ProviderType            // required, see ProviderType enum below
+  URL            string                   // empty for "host" (local) OpenShift provider
+  Secret         core.ObjectReference     // credentials secret
+  Settings       map[string]string        // VDDK, SDK endpoint, vCenter, ESXi, target-az, etc.
+}
+ProviderStatus {
+  Phase                 string             // free-form string (Ready, Staging, ValidationFailed, ConnectionFailed)
+  Conditions            libcnd.Conditions  // embedded
+  ObservedGeneration    int64
+  Fingerprint           string
+  Service               *core.ObjectReference
+  SecretResourceVersion string
+}
+```
+
+**ProviderType enum**: `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv`, `""` (Undefined)
+
+**Key methods on Provider**:
+- `Type() ProviderType` — returns the provider type (or `Undefined`)
+- `IsHost() bool` — OpenShift provider with empty URL (local cluster)
+- `IsRestrictedHost() bool` — host provider outside the main Forklift namespace
+- `RequiresConversion() bool` — true for `vsphere`, `ova`, `hyperv`, `ec2`
+- `SupportsPreserveStaticIps() bool` — true for `vsphere`, `hyperv`
+- `HasReconciled() bool` — generation == observedGeneration
+- `UseVddkAioOptimization() bool` — reads `settings["useVddkAioOptimization"]`
+
+**Provider settings constants**: `VDDK`, `SDK` (sdkEndpoint), `VCenter`, `ESXI`, `UseVddkAioOptimization`, `VddkConfig`, `ESXiCloneMethod` ("vib"|"ssh"), `TargetAZ` (target-az), `TargetRegion` (target-region)
+
+### Plan (`plan.go`)
+
+Defines a migration plan selecting VMs and their mappings.
+
+```
+PlanSpec {
+  Description                    string
+  TargetNamespace                string
+  ServiceAccount                 string
+  TargetLabels                   map[string]string
+  TargetNodeSelector             map[string]string
+  TargetAffinity                 *core.Affinity
+  ConvertorLabels                map[string]string
+  ConvertorNodeSelector          map[string]string
+  ConvertorAffinity              *core.Affinity
+  ConversionTempStorageClass     string
+  ConversionTempStorageSize      string
+  Provider                       provider.Pair          // Source + Destination ObjectReferences
+  Map                            plan.Map               // Network + Storage ObjectReferences
+  VMs                            []plan.VM              // list of VMs to migrate
+  Warm                           bool                   // deprecated, use Type
+  Type                           MigrationType          // "cold"|"warm"|"live"|"conversion"
+  TransferNetwork                *core.ObjectReference
+  Archived                       bool
+  PreserveClusterCPUModel        bool
+  PreserveStaticIPs              bool                   // default true
+  SkipZoneNodeSelector           bool                   // EC2 only
+  MigrateSharedDisks             bool                   // default true
+  RDMAsLun                       bool
+  DeleteGuestConversionPod       bool
+  DeleteVmOnFailMigration        bool                   // default true
+  SkipGuestConversion            bool                   // default false
+  UseCompatibilityMode           bool                   // default true (SATA/E1000E when skip guest conversion)
+  RunPreflightInspection         bool                   // default true
+  TargetPowerState               plan.TargetPowerState  // "on"|"off"|"auto"
+  InstallLegacyDrivers           *bool
+  EnableNestedVirtualization     *bool
+  XfsCompatibility               bool                   // default false
+  VirtV2vImage                   string
+  CustomizationScripts           *core.ObjectReference
+  PVCNameTemplate                string
+  PVCNameTemplateUseGenerateName bool                   // default true
+  VolumeNameTemplate             string
+  NetworkNameTemplate            string
+  DiskBus                        cnv.DiskBus            // deprecated
+}
+PlanStatus {
+  Conditions         libcnd.Conditions
+  ObservedGeneration int64
+  Migration          plan.MigrationStatus   // VMs statuses, history snapshots, timing
+}
+```
+
+**MigrationType enum**: `cold`, `warm`, `live`, `conversion`
+
+**TargetPowerState enum**: `on`, `off`, `auto`
+
+**Key methods on Plan**:
+- `IsWarm() bool` — `Spec.Warm || Spec.Type == "warm"`
+- `ShouldUseV2vForTransfer(vmRef) (bool, error)` — true when cold vSphere migration to host cluster, with shared disks, not skip-guest-conversion, not conversion-only
+- `ShouldRunPreflightInspection() bool` — vSphere + warm + !skipGuestConversion + runPreflightInspection
+- `IsUsingOffloadPlugin() bool` — any storage mapping has VSphereXcopyPluginConfig
+- `IsSourceProviderVSphere/Ovirt/OCP/Openstack() bool`
+- `DestinationHasUdnNetwork(client) bool` — checks for primary UDN in target namespace
+
+### plan.VM (`plan/vm.go`)
+
+Individual VM entry in a Plan. Embeds `ref.Ref` (ID, Name, Namespace, Type). Key fields: `Hooks []HookRef`, `LUKS` (secret ref), `NbdeClevis`, `RootDisk`, `InstanceType`, `TargetName`, `TargetPowerState`. Override fields: `PVCNameTemplate`, `VolumeNameTemplate`, `NetworkNameTemplate`, `DeleteVmOnFailMigration`, `MigrateSharedDisks *bool`, `EnableNestedVirtualization *bool`, `RDMAsLun *bool`.
+
+### plan.VMStatus (`plan/vm.go`)
+
+Per-VM migration status. Embeds `Timed` + `VM` + `libcnd.Conditions`. Key fields: `Pipeline []*Step`, `Phase string` (phase constant), `Error *Error` (phase + reasons), `Warm *Warm` (successes/failures/precopies tracking), `RestorePowerState` ("On"|"Off"|"Unknown"), `Firmware`, `OperatingSystem`, `DetectedBootDisk *int`, `NewName`.
+
+### Migration (`migration.go`)
+
+Active migration execution, created when a Plan runs.
+
+```
+MigrationSpec {
+  Plan    core.ObjectReference  // ref to Plan
+  Cancel  []ref.Ref             // VMs to cancel
+  Cutover *meta.Time            // warm migration cutover override
+}
+MigrationStatus {
+  Timed                          // Started, Completed
+  Conditions      libcnd.Conditions
+  ObservedGeneration int64
+  VMs             []*plan.VMStatus
+}
+```
+
+### NetworkMap (`mapping.go`)
+
+Maps source networks to target networks.
+
+```
+NetworkMapSpec {
+  Provider   provider.Pair   // Source + Destination
+  Map        []NetworkPair   // source ref → DestinationNetwork
+}
+DestinationNetwork { Type string ("pod"|"multus"|"ignored"), Namespace, Name }
+```
+
+### StorageMap (`mapping.go`)
+
+Maps source storage to target storage classes.
+
+```
+StorageMapSpec {
+  Provider   provider.Pair
+  Map        []StoragePair   // source ref → DestinationStorage + optional OffloadPlugin
+}
+DestinationStorage { StorageClass, VolumeMode ("Filesystem"|"Block"), AccessMode }
+OffloadPlugin { VSphereXcopyPluginConfig { SecretRef, StorageVendorProduct } }
+```
+
+**StorageVendorProduct enum**: `flashsystem`, `vantara`, `ontap`, `primera3par`, `pureFlashArray`, `powerflex`, `powermax`, `powerstore`, `infinibox`
+
+Both NetworkMap and StorageMap share `MapStatus { Conditions, Refs, ObservedGeneration }`.
+
+### Hook (`hook.go`)
+
+Pre/post migration scripts. Local hooks need `image`; AAP hooks need `aap` config.
+
+```
+HookSpec {
+  ServiceAccount string
+  Image          string     // container image (local hooks)
+  Playbook       string     // base64-encoded Ansible playbook
+  Deadline       int64      // seconds
+  AAP            *AAPConfig // Ansible Automation Platform remote execution
+}
+AAPConfig { URL, JobTemplateID int, TokenSecret core.ObjectReference, Timeout int64 }
+```
+
+`HookExecutionConfigValid(hook)` validates mutual exclusivity of local vs AAP config.
+
+### Host (`host.go`)
+
+ESXi host for direct disk transfer (vSphere only).
+
+```
+HostSpec {
+  ref.Ref               // inline
+  Provider   core.ObjectReference
+  IpAddress  string
+  Secret     core.ObjectReference
+}
+```
+
+**Printed columns**: READY, CONNECTED, AGE
+
+### OVAProviderServer / HyperVProviderServer
+
+Sidecar server pods for OVA/HyperV inventory. Both have: `Spec { Provider ObjectRef }`, `Status { Phase, Service *ObjectRef, Conditions }`.
+
+### Volume Populators
+
+Provider-specific CRDs for disk transfer:
+- **OvirtVolumePopulator** — `Spec { EngineURL, EngineSecretName, DiskID, TransferNetwork }`
+- **OpenstackVolumePopulator** — `Spec { IdentityURL, SecretName, ImageID, TransferNetwork }`
+- **VSphereXcopyVolumePopulator** — `Spec { VmId, VmdkPath, SecretName, StorageVendorProduct }`
+
+### ref.Ref (`ref/ref.go`)
+
+Universal source reference: `{ ID, Name, Namespace, Type }`. `ID` = managed object ID (e.g., vSphere MoRef). `Namespace` only relevant for OpenShift sources.
+
+### Referenced (`referenced.go`)
+
+Transient (non-serialized, `json:"-"`) struct holding resolved references during validation. Contains `Provider {Source, Destination}`, `Secret`, `Plan`, `Map {Network, Storage}`, `Hooks`.
+
+---
+
+## Phase Constants (`doc.go`)
+
+### Common VM Phases
+| Constant | Value |
+|---|---|
+| `PhaseStarted` | `"Started"` |
+| `PhasePreHook` | `"PreHook"` |
+| `PhasePostHook` | `"PostHook"` |
+| `PhaseCompleted` | `"Completed"` |
+
+### Warm and Cold Migration Phases
+| Constant | Value |
+|---|---|
+| `PhaseAddCheckpoint` | `"AddCheckpoint"` |
+| `PhaseAddFinalCheckpoint` | `"AddFinalCheckpoint"` |
+| `PhaseAllocateDisks` | `"AllocateDisks"` |
+| `PhaseConvertGuest` | `"ConvertGuest"` |
+| `PhaseConvertOpenstackSnapshot` | `"ConvertOpenstackSnapshot"` |
+| `PhaseCopyDisks` | `"CopyDisks"` |
+| `PhaseCopyDisksVirtV2V` | `"CopyDisksVirtV2V"` |
+| `PhaseCopyingPaused` | `"CopyingPaused"` |
+| `PhaseCreateDataVolumes` | `"CreateDataVolumes"` |
+| `PhaseCreateFinalSnapshot` | `"CreateFinalSnapshot"` |
+| `PhaseCreateGuestConversionPod` | `"CreateGuestConversionPod"` |
+| `PhaseCreateInitialSnapshot` | `"CreateInitialSnapshot"` |
+| `PhaseCreateSnapshot` | `"CreateSnapshot"` |
+| `PhaseCreateVM` | `"CreateVM"` |
+| `PhaseFinalize` | `"Finalize"` |
+| `PhasePreflightInspection` | `"PreflightInspection"` |
+| `PhasePowerOffSource` | `"PowerOffSource"` |
+| `PhaseRemoveFinalSnapshot` | `"RemoveFinalSnapshot"` |
+| `PhaseRemovePenultimateSnapshot` | `"RemovePenultimateSnapshot"` |
+| `PhaseRemovePreviousSnapshot` | `"RemovePreviousSnapshot"` |
+| `PhaseStoreInitialSnapshotDeltas` | `"StoreInitialSnapshotDeltas"` |
+| `PhaseStorePowerState` | `"StorePowerState"` |
+| `PhaseStoreSnapshotDeltas` | `"StoreSnapshotDeltas"` |
+| `PhaseWaitForFinalSnapshot` | `"WaitForFinalSnapshot"` |
+| `PhaseWaitForFinalSnapshotRemoval` | `"WaitForFinalSnapshotRemoval"` |
+| `PhaseWaitForInitialSnapshot` | `"WaitForInitialSnapshot"` |
+| `PhaseWaitForPenultimateSnapshotRemoval` | `"WaitForPenultimateSnapshotRemoval"` |
+| `PhaseWaitForPowerOff` | `"WaitForPowerOff"` |
+| `PhaseWaitForPreviousSnapshotRemoval` | `"WaitForPreviousSnapshotRemoval"` |
+| `PhaseWaitForSnapshot` | `"WaitForSnapshot"` |
+
+### Step/Task Phases
+`StepStarted`, `StepPending`, `StepRunning`, `StepCompleted`
+
+---
+
+## Condition Framework (`pkg/lib/condition/`)
+
+### Condition Struct
+
+Fields: `Type` (string), `Status` ("True"/"False"), `Reason`, `Category`, `Message`, `Suggestion` (proposed resolution), `LastTransitionTime`, `Durable` (bool, never removed during staging), `Items` ([]string, referenced in Message).
+
+### Categories
+| Category | Effect |
+|---|---|
+| `Critical` | Blocks reconcile AND the `Ready` condition |
+| `Error` | Blocks the `Ready` condition |
+| `Warn` | Warning; does NOT block `Ready` |
+| `Required` | Required for `Ready` |
+| `Advisory` | Informational only |
+| `ValidatingVDDK` | Special: triggers re-queue while pending |
+| `VMMissingGuestIPs` | Special: VM missing guest IPs |
+| `VMMissingChangedBlockTracking` | Special: triggers re-queue |
+| `SharedDisks` | Special: user needs to power off VMs with shared disks |
+
+### Conditions Collection
+
+Embedded in every CRD Status via `libcnd.Conditions`. Uses a **staging pattern**:
+
+```go
+status.BeginStagingConditions()  // mark all non-Durable conditions as un-staged
+status.SetCondition(c1)          // stage conditions
+status.SetCondition(c2)
+status.EndStagingConditions()    // delete un-staged conditions
+status.SetReady(!status.HasBlockerCondition(), "Ready message")
+```
+
+**Key collection methods**:
+- `HasCondition(types...) bool` — all specified conditions exist with Status=True
+- `HasAnyCondition(types...) bool` — any of specified conditions exist
+- `HasBlockerCondition() bool` — has Critical or Error category
+- `HasCriticalCondition() bool` — has Critical category
+- `IsReady() bool` — Ready condition with Status=True
+- `FindCondition(type) *Condition`
+- `HasReQCondition() bool` — has ValidatingVDDK or VMMissingChangedBlockTracking
+
+### CRD-level Condition Type Constants (`doc.go`)
+| Constant | Value | Used by |
+|---|---|---|
+| `ConditionExecuting` | `"Executing"` | Plan |
+| `ConditionRunning` | `"Running"` | Migration |
+| `ConditionPending` | `"Pending"` | Migration VMs |
+| `ConditionCanceled` | `"Canceled"` | Migration VMs |
+| `ConditionSucceeded` | `"Succeeded"` | Plan, Migration |
+| `ConditionFailed` | `"Failed"` | Plan, Migration |
+| `ConditionBlocked` | `"Blocked"` | Plan VMs |
+| `ConditionDeleted` | `"Deleted"` | Plan VMs |
+
+Built-in types from `lib/condition`: `Ready`, `ReconcileFailed`
+
+---
+
+## Status Conditions per CRD
+
+| CRD | Printed Columns (kubebuilder) | Key Conditions |
+|---|---|---|
+| **Provider** | READY, CONNECTED (`ConnectionTestSucceeded`), INVENTORY (`InventoryCreated`) | Ready, ConnectionTestSucceeded, InventoryCreated |
+| **Plan** | READY, EXECUTING, SUCCEEDED, FAILED | Ready, Executing, Succeeded, Failed |
+| **Migration** | READY, RUNNING, SUCCEEDED, FAILED | Ready, Running, Succeeded, Failed |
+| **NetworkMap** | READY | Ready |
+| **StorageMap** | READY | Ready |
+| **Hook** | Ready | Ready |
+| **Host** | READY, CONNECTED (`ConnectionTestSucceeded`) | Ready, ConnectionTestSucceeded |
+
+---
+
+## Important Methods
+
+### Plan Decision Helpers
+- **`ShouldUseV2vForTransfer(vmRef)`** — Uses virt-v2v direct transfer (vs CDI+v2v-in-place). True when: vSphere source AND cold AND destination is host AND migrateSharedDisks AND !skipGuestConversion AND type != conversion. For OVA/HyperV always true.
+- **`ShouldRunPreflightInspection()`** — True when: vSphere AND warm AND !skipGuestConversion AND runPreflightInspection enabled.
+- **`IsUsingOffloadPlugin()`** — Scans storage map for XCOPY offload configs.
+- **`IsWarm()`** — Checks both deprecated `Warm` bool and new `Type` field.
+
+### Provider Type Checks
+- `RequiresConversion()` — `vsphere | ova | hyperv | ec2`
+- `SupportsPreserveStaticIps()` — `vsphere | hyperv`
+
+### Timed (plan/timed.go)
+Base struct for Started/Completed timestamps, used by VMStatus, MigrationStatus, Step, Task.
+- `MarkStarted()`, `MarkCompleted()`, `MarkedStarted()`, `MarkedCompleted()`, `Running()`
+
+### Pipeline (plan/migration.go)
+- `Step { Task, Tasks []*Task }` — nested pipeline structure
+- `Task { Timed, Name, Description, Phase, Reason, Progress, Annotations, Error }`
+- `VMStatus.ReflectPipeline()` — aggregates step states into VM-level started/completed/errors
+
+---
+
+## Labels and Annotations
+
+| Key | Constant | Usage |
+|---|---|---|
+| `forklift.konveyor.io/disk-source` | `AnnDiskSource` | Annotation on PVCs identifying source disk |
+| `forklift.konveyor.io/source` | `AnnSource` | Annotation on PVCs identifying source type |
+| `k8s.ovn.org/primary-user-defined-network` | (internal) | Namespace label for UDN detection |
+| `k8s.ovn.org/user-defined-network` | (internal) | NAD label for UDN detection |
+
+System-managed labels on target VMs and convertor pods (noted in PlanSpec docs): `migration`, `plan`, `vmID`, `app`/`forklift.app`.
+
+---
+
+## Frontend Relevance
+
+The Go types map to TypeScript types in `@forklift-ui/types`:
+
+| Go Type | TS Usage | Notes |
+|---|---|---|
+| `ProviderType` | Provider `spec.type` field | UI adds `ApplianceManagementEnabled`, `Unknown` pseudo-phases |
+| `MigrationType` | Plan `spec.type` | "cold"/"warm"/"live"/"conversion" |
+| `TargetPowerState` | Plan `spec.targetPowerState` | "on"/"off"/"auto" |
+| `Provider.Status.Phase` | Provider phase column | Go has no enum; UI adds Unknown |
+| `Condition.Type/Status/Category` | `status.conditions[]` on all CRDs | UI reads conditions array directly |
+| Phase constants | `VMStatus.phase` | Displayed in migration progress pipeline |
+| `Step/Task` | Pipeline progress bars | `progress.completed` tracked per task |
+| `plan.VM.TargetName` | VM rename in wizard | Empty = auto DNS1123 normalization |
+| `StorageVendorProduct` | Offload plugin config in storage mapping | Used for XCOPY vendor selection |
+| `DestinationNetwork.Type` | Network mapping "pod"/"multus"/"ignored" | Drives network mapping UI |
+| `DestinationStorage` | Storage mapping target | storageClass + volumeMode + accessMode |
+
+The console plugin reads `status.conditions` arrays and uses `condition.type` + `condition.status` to derive UI states. The Plan UI maps backend conditions (Ready, Executing, Succeeded, Failed) to frontend statuses (Ready, Executing, Completed, Paused, Incomplete, CannotStart, Canceled, Archived, Unknown).

--- a/.cursor/rules/backend/architecture.mdc
+++ b/.cursor/rules/backend/architecture.mdc
@@ -1,0 +1,285 @@
+---
+description: Forklift backend architecture - entry points, deployment roles, controller-runtime framework
+alwaysApply: false
+---
+
+# Backend Architecture
+
+> Analyzed from commit: `a976d24b6` on `2026-05-04`
+> Source paths: `cmd/forklift-controller/`, `cmd/forklift-api/`, `pkg/controller/controller.go`, `pkg/controller/base/`, `pkg/settings/`
+
+## Package Purpose
+
+The Forklift backend is a Go application built on **controller-runtime** (the sigs.k8s.io operator framework). It consists of **two binaries** that run as separate Deployments inside OpenShift:
+
+| Binary | Entry Point | What It Does |
+|---|---|---|
+| `forklift-controller` | `cmd/forklift-controller/main.go` | Runs all CRD reconciliation controllers (split by role). Registers K8s API schemes, sets up the controller-runtime Manager, and starts a Prometheus metrics endpoint on `:2112`. |
+| `forklift-api` | `cmd/forklift-api/forklift-api.go` | Runs admission webhooks (`:8443`) and a REST service API (`:8444`). Operates independently of controller-runtime Manager — uses plain `net/http` servers with TLS. |
+
+Both binaries share the `pkg/` library packages but have completely separate lifecycles.
+
+## Key Types and Structs
+
+### `settings.ControllerSettings` (`pkg/settings/settings.go`)
+
+Global singleton at `settings.Settings`. Loaded from environment variables in `init()` before `main()` runs. Composes:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `Role` | `settings.Role` | Which controller sets to start (`main`, `inventory`, or both) |
+| `Metrics` | `settings.Metrics` | HTTPS metrics endpoint port (default `8080`, env `METRICS_PORT`). Separate from the plain HTTP `:2112` endpoint in `main()` |
+| `Inventory` | `settings.Inventory` | Inventory API host/port/TLS/CORS/auth/namespace |
+| `Migration` | `settings.Migration` | VM concurrency, retry limits, virt-v2v images, container resource defaults |
+| `PolicyAgent` | `settings.PolicyAgent` | Validation policy agent URL and TLS |
+| `Logging` | `settings.Logging` | Log level and development mode |
+| `Profiler` | `settings.Profiler` | CPU/memory profiling output |
+| `Features` | `settings.Features` | Feature gates (warm migration, copy offload, live migration, etc.) |
+| `Providers` | `settings.Providers` | OVA/HyperV server images and resource limits |
+| `OpenShift` | `bool` | Whether running on OpenShift (adds Route API scheme) |
+| `Development` | `bool` | Development mode flag |
+
+### `settings.Role` (`pkg/settings/role.go`)
+
+Loaded from `ROLE` environment variable. Comma-separated list of `main` and/or `inventory`. If unset, **both roles are enabled** (single-pod deployment). The `Has(name)` method checks membership.
+
+### `base.Reconciler` (`pkg/controller/base/controller.go`)
+
+Shared base struct embedded by every controller's reconciler:
+
+```go
+type Reconciler struct {
+    record.EventRecorder    // K8s event recording
+    client.Client           // K8s API client (cached)
+    Log logging.LevelLogger // Structured logger
+}
+```
+
+Provides:
+- `Started()` / `Ended(reQ, err)` — lifecycle logging with requeue duration calculation
+- `Record(object, conditions)` — translates condition changes to K8s Events
+- Requeue constants: `FastReQ` (500ms), `SlowReQ` (3s), `LongReQ` (30s)
+- On conflict errors: logs info-level and returns `SlowReQ`
+- On `ProviderNotReadyError`: logs at V(1) and returns `SlowReQ`
+
+### `base.GetInsecureSkipVerifyFlag` / `base.VerifyTLSConnection`
+
+Helpers for provider TLS certificate handling. `GetInsecureSkipVerifyFlag` reads the `insecureSkipVerify` key from a provider connection Secret. `VerifyTLSConnection` performs a full TLS handshake against a provider URL using the secret-provided certificate.
+
+## Reconciliation / Execution Flow
+
+### Startup Sequence (`forklift-controller`)
+
+```
+init()
+  └─ Settings.Load()          ← reads ALL env vars (role, features, migration, etc.)
+  └─ logging.Factory.New()    ← configures structured logger
+
+main()
+  ├─ profiler()               ← optional CPU/memory profiler
+  ├─ http ":2112/metrics"     ← Prometheus scrape endpoint (goroutine)
+  ├─ http "localhost:6060"    ← pprof debug endpoint (goroutine)
+  ├─ config.GetConfig()       ← kubeconfig / in-cluster config
+  ├─ manager.New(cfg, opts)   ← controller-runtime Manager
+  ├─ apis.AddToScheme()       ← Forklift CRDs
+  ├─ [external schemes]       ← storage, CNI, KubeVirt, CDI, export, instancetype, multicluster, Route, Template
+  ├─ controller.AddToManager(mgr)  ← register controllers by role
+  ├─ webhook.AddToManager(mgr)     ← register manager-level webhooks
+  └─ mgr.Start(signals)       ← blocks until termination
+```
+
+### Two Deployment Roles
+
+The `ROLE` env var splits controllers into two groups, enabling separate Deployment scaling:
+
+**Main role** (`settings.MainRole = "main"`):
+| Controller | CRD | Package |
+|---|---|---|
+| `migration` | `Migration` | `pkg/controller/migration/` |
+| `plan` | `Plan` | `pkg/controller/plan/` |
+| `network` | `NetworkMap` | `pkg/controller/map/network/` |
+| `storage` | `StorageMap` | `pkg/controller/map/storage/` |
+| `host` | `Host` | `pkg/controller/host/` |
+| `hook` | `Hook` | `pkg/controller/hook/` |
+
+**Inventory role** (`settings.InventoryRole = "inventory"`):
+| Controller | CRD | Package |
+|---|---|---|
+| `provider` | `Provider` | `pkg/controller/provider/` |
+| `ova` | `OVAProviderServer` | `pkg/controller/ova/` |
+| `hyperv` | `HyperVProviderServer` | `pkg/controller/hyperv/` |
+
+The inventory role is special — the **provider controller** also starts:
+- An **inventory web server** (`libweb.WebServer`) on the configured port (default `8080`), serving the REST inventory API with TLS and CORS
+- A **policy agent** for VM validation rules
+
+### Controller Registration Pattern
+
+Every controller follows the same `Add(mgr manager.Manager) error` pattern:
+
+```go
+func Add(mgr manager.Manager) error {
+    reconciler := &Reconciler{
+        Reconciler: base.Reconciler{
+            EventRecorder: mgr.GetEventRecorderFor(Name),
+            Client:        mgr.GetClient(),
+            Log:           log,
+        },
+    }
+    cnt, err := controller.New(Name, mgr, controller.Options{
+        Reconciler:              reconciler,
+        MaxConcurrentReconciles: Settings.MaxConcurrentReconciles,
+    })
+    // Watch primary CRD
+    cnt.Watch(source.Kind(mgr.GetCache(), &api.PrimaryCRD{}, ...))
+    // Watch referenced resources (Secrets, Providers, Maps, etc.)
+    cnt.Watch(source.Kind(mgr.GetCache(), &api.ReferencedCRD{},
+        libref.TypedHandler[*api.ReferencedCRD](&api.PrimaryCRD{}), ...))
+    return nil
+}
+```
+
+Key points:
+- `MaxConcurrentReconciles` defaults to **10** (from `MAX_CONCURRENT_RECONCILES` env var)
+- Controllers watch their primary CR plus any referenced resources using `libref.TypedHandler` to map owner references back to the primary CR
+- The Plan controller additionally uses a `channel` source to receive events when provider inventory changes
+
+### `controller.AddToManager` dispatcher (`pkg/controller/controller.go`)
+
+```go
+var MainControllers = []AddFunction{migration.Add, plan.Add, network.Add, storage.Add, host.Add, hook.Add}
+var InventoryControllers = []AddFunction{provider.Add, ova.Add, hyperv.Add}
+
+func AddToManager(m manager.Manager) error {
+    if Settings.Role.Has("inventory") { load(InventoryControllers) }
+    if Settings.Role.Has("main")      { load(MainControllers) }
+}
+```
+
+## Integration Points
+
+### `forklift-api` Binary — Webhooks & Services
+
+The `forklift-api` binary runs two independent HTTPS servers:
+
+**Webhook server (`:8443`)** — Kubernetes admission webhooks:
+| Path | Type | Resource |
+|---|---|---|
+| `/secret-validate` | Validating | Secret (provider credentials) |
+| `/secret-mutate` | Mutating | Secret |
+| `/plan-validate` | Validating | Plan |
+| `/plan-mutate` | Mutating | Plan (sets transfer network, populator labels) |
+| `/provider-validate` | Validating | Provider |
+| `/provider-mutate` | Mutating | Provider |
+| `/migration-validate` | Validating | Migration |
+
+**Services server (`:8444`)** — REST API:
+| Path | Purpose |
+|---|---|
+| `/tls-certificate?URL=...` | Fetches and returns the TLS certificate from a given URL (used by frontend for provider certificate discovery) |
+
+Both servers require TLS certificates via environment variables:
+- Webhooks: `API_TLS_CERTIFICATE`, `API_TLS_KEY`
+- Services: `SERVICES_TLS_CERTIFICATE`, `SERVICES_TLS_KEY`
+
+### Inventory REST API (inside `forklift-controller`, inventory role)
+
+The provider controller starts a `libweb.WebServer` serving the inventory REST API. This is the API the **frontend** consumes to browse VMs, networks, datastores from source providers. Configured via `Inventory` settings (port, TLS, CORS, auth).
+
+### Scheme Registration
+
+The controller binary registers these API groups at startup:
+- `forklift.konveyor.io/v1beta1` (Forklift CRDs)
+- `storage.k8s.io/v1` (StorageClass)
+- `k8s.cni.cncf.io/v1` (NetworkAttachmentDefinition)
+- `kubevirt.io/v1` (VirtualMachine, etc.)
+- `cdi.kubevirt.io/v1beta1` (DataVolume, etc.)
+- `export.kubevirt.io/v1alpha1` (VirtualMachineExport)
+- `instancetype.kubevirt.io/v1beta1` (VirtualMachineInstancetype)
+- `multicluster.x-k8s.io/v1alpha1` (ServiceImport)
+- `template.openshift.io/v1` (optional, OpenShift only)
+- `route.openshift.io/v1` (optional, OpenShift only)
+
+## Configuration
+
+### Critical Environment Variables
+
+**Deployment role:**
+| Env Var | Default | Description |
+|---|---|---|
+| `ROLE` | `main,inventory` | Comma-separated roles |
+| `OPENSHIFT` | `false` | Enable OpenShift-specific APIs |
+| `DEVELOPMENT` | `false` | Development mode |
+| `OPENSHIFT_VERSION` | (none) | Used for feature gate version checks |
+
+**Feature gates (all default `false` unless noted):**
+| Env Var | Default | Description |
+|---|---|---|
+| `FEATURE_OVIRT_WARM_MIGRATION` | `false` | oVirt warm migration |
+| `FEATURE_VSPHERE_INCREMENTAL_BACKUP` | `false` | vSphere changeID-based incremental backup |
+| `FEATURE_COPY_OFFLOAD` | `false` | Storage copy offload plugins |
+| `FEATURE_OCP_LIVE_MIGRATION` | `false` | Cross-cluster live migration |
+| `FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER` | `true` | VMware system serial number (requires OCP ≥ 4.20) |
+| `FEATURE_STATIC_UDN_IP_ADDRESSES` | `false` | Static IPs in User Defined Network (requires OCP ≥ 4.20) |
+| `FEATURE_OVF_APPLIANCE_MANAGEMENT` | `false` | OVA/HyperV appliance management endpoints |
+| `FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL` | `false` | VMware driver removal during Windows conversion |
+
+Some feature gates have **OCP version floor checks** — they are silently disabled if `OPENSHIFT_VERSION` is below the minimum.
+
+**Migration tuning:**
+| Env Var | Default | Description |
+|---|---|---|
+| `MAX_VM_INFLIGHT` | `20` | Max concurrent VM migrations |
+| `MAX_CONCURRENT_RECONCILES` | `10` | Controller-runtime reconciler concurrency |
+| `VIRT_V2V_IMAGE` | (required for main) | Guest conversion image |
+| `BLOCKER_GRACE_PERIOD_MINUTES` | `5` | How long blocker conditions must persist before failing |
+| `PRECOPY_INTERVAL` | `60` | Warm migration precopy interval (minutes) |
+
+**Inventory API:**
+| Env Var | Default | Description |
+|---|---|---|
+| `API_HOST` | `localhost` | Inventory API bind host |
+| `API_PORT` | `8080` | Inventory API port |
+| `INVENTORY_SERVICE_SCHEME` | `https` | HTTP or HTTPS |
+| `AUTH_REQUIRED` | `true` | Whether auth is required |
+| `POD_NAMESPACE` | (none) | Pod's namespace |
+
+## Frontend Relevance
+
+### What the frontend talks to
+
+1. **Inventory REST API** (via the provider controller's web server) — Browse source provider inventory (VMs, networks, datastores). The frontend calls this through a proxy or route. Port is `API_PORT` (default 8080).
+
+2. **TLS certificate service** (`:8444/tls-certificate`) — The frontend's "Fetch certificate" button in provider creation calls this endpoint to discover a provider's TLS certificate before the user saves it.
+
+3. **Kubernetes API** (via OpenShift Console SDK) — CRUD operations on Forklift CRDs (Provider, Plan, NetworkMap, StorageMap, Migration, Hook). The webhooks on `:8443` validate/mutate these transparently.
+
+### CRD status fields driven by controllers
+
+Frontend status displays map to conditions and phases set by these controllers:
+
+| Frontend Page | Controller | Key Status Fields |
+|---|---|---|
+| Providers list/details | `provider` | `status.phase` (Ready, Staging, ValidationFailed, ConnectionFailed), `status.conditions` |
+| Plans list/details | `plan` | `status.conditions` (Ready, Executing, Succeeded, Failed), `status.migration.vms[]` |
+| Migrations | `migration` | `status.vms[].phase` (Running, Succeeded, Failed, Canceled, etc.) |
+| Network Maps | `network` | `status.conditions` |
+| Storage Maps | `storage` | `status.conditions` |
+
+### Feature gates the frontend should mirror
+
+The ForkliftController CR's `spec.feature_*` fields map to the `FEATURE_*` env vars above. When the frontend needs to show/hide UI based on feature gates, it reads the ForkliftController CR and checks these fields. Key ones:
+
+- `feature_copy_offload` → shows storage vendor offload options
+- `feature_ocp_live_migration` → enables live migration type in plan creation
+- `feature_ovf_appliance_management` → shows appliance management UI for OVA/HyperV providers
+
+### Webhook side effects on frontend operations
+
+When the frontend creates or updates a Plan via the K8s API:
+- **Mutating webhook** (`/plan-mutate`) auto-sets the transfer network from the destination provider's default and adds `populatorLabels` annotation
+- **Validating webhook** (`/plan-validate`) rejects plans with invalid storage mappings (e.g., ReadWriteOnce with live migration on non-vSphere sources)
+
+When the frontend creates a Provider Secret:
+- **Mutating webhook** (`/secret-mutate`) may normalize the secret data
+- **Validating webhook** (`/secret-validate`) checks credential format

--- a/.cursor/rules/backend/infrastructure/hook-controller.mdc
+++ b/.cursor/rules/backend/infrastructure/hook-controller.mdc
@@ -1,0 +1,117 @@
+---
+description: Hook controller - validation, Job creation, AAP integration, playbook execution
+alwaysApply: false
+---
+
+# Hook Controller
+
+Source: `pkg/controller/hook/` (validation), `pkg/controller/plan/hook.go` (execution)
+
+## Two Concerns
+
+The Hook lifecycle is split across two controllers:
+
+1. **Hook controller** (`pkg/controller/hook/`) — validates the Hook CRD and sets Ready.
+2. **Plan controller** (`pkg/controller/plan/hook.go`) — executes hooks via `HookRunner` during migration phases `PreHook` and `PostHook`.
+
+## Hook CRD Validation
+
+### Reconciliation Flow
+
+```
+Fetch Hook CR
+  → BeginStagingConditions
+  → validate()
+    → If spec.aap is set:
+        → Reject if image or playbook also set (InvalidHookExecute)
+        → validateAAP() — url, jobTemplateId > 0, tokenSecret.name required
+    → If spec.aap is nil (local hook):
+        → HookExecutionConfigValid() — image is required, playbook optional
+        → validateImage() — Docker image reference regex (OCI-compliant)
+        → validatePlaybook() — must be valid base64 if provided
+  → Set Ready if no blockers
+  → EndStagingConditions, record events, update status
+```
+
+### Conditions
+
+| Condition | Category | When Set |
+|-----------|----------|----------|
+| `InvalidImage` | Critical | Image name fails OCI reference regex |
+| `InvalidPlaybook` | Critical | Playbook is not valid base64 |
+| `InvalidHookExecute` | Critical | Invalid combination: AAP + image/playbook, or missing image for local hook |
+| `Ready` | Required | No blocker conditions |
+
+### Image Validation
+
+The `regexp.go` file contains a full OCI/Docker image reference parser:
+- Validates `[domain/]name[:tag][@digest]` format.
+- Supports multi-level paths, port numbers, tags, and SHA digests.
+
+## Hook Execution (HookRunner)
+
+File: `pkg/controller/plan/hook.go`
+
+Invoked by the migration controller during `PhasePreHook` and `PhasePostHook`:
+
+```go
+runner := HookRunner{Context: r.Context}
+err = runner.Run(vm)
+```
+
+### Two Execution Modes
+
+#### 1. Local Hook (Kubernetes Job)
+
+When `spec.aap` is nil:
+
+1. **ConfigMap**: Created with `workload.yml` (VM inventory data), `playbook.yml` (decoded from base64), and `plan.yml` (plan spec as YAML).
+2. **Job**: Created in the plan's namespace with:
+   - Container image from `hook.Spec.Image`
+   - ConfigMap mounted at `/tmp/hook`
+   - If playbook provided: command is `/bin/entrypoint ansible-runner run /tmp/runner -p /tmp/hook/playbook.yml`
+   - `BackoffLimit: 1`
+   - Resource requests/limits from `Settings.Migration.HooksContainer{Requests,Limits}{Cpu,Memory}`
+   - `ActiveDeadlineSeconds` from `hook.Spec.Deadline` (if > 0)
+3. **Service account precedence**: Hook SA → Plan SA → Global controller SA → namespace default.
+4. **Owned by Plan**: Job has owner reference to the Plan CR.
+
+**Failure handling**:
+- Job condition "Failed" → step gets error message, marked completed.
+- `job.Status.Failed > Settings.Migration.HookRetry` → "Retry limit exceeded."
+- `job.Status.Succeeded > 0` → step progress set to 1, marked completed.
+
+#### 2. AAP Hook (Remote Job Template)
+
+When `spec.aap` is set:
+
+1. Reads AAP token from the referenced Secret (`tokenSecret`).
+2. Creates an `AAPClient` with the AAP URL and token.
+3. Launches the job template with extra vars: `vm_id`, `vm_name`, `plan_name`, `plan_namespace`, `migration_phase`, `vm_source_id`.
+4. Polls for completion with timeout:
+   - `spec.aap.timeout < 0`: unlimited
+   - `spec.aap.timeout > 0`: use that value (seconds)
+   - `spec.aap.timeout == 0`: use `spec.deadline`, else default **3600 seconds**
+
+**Failure handling**: any error → step gets error message, marked completed.
+
+### Resource Labels
+
+All hook-created resources (Jobs, ConfigMaps) are labeled:
+- `plan`: Plan UID
+- `migration`: Migration UID
+- `vmID`: VM ID
+- `step`: current phase (PreHook/PostHook)
+- `hook`: Hook UID
+- `resource`: "hook-config"
+
+## Predicate Logic
+
+`HookPredicate`: Reconciles on create/delete; on update only when `ObservedGeneration < Generation` (spec changed).
+
+## Frontend Relevance
+
+- Hooks are configured in Plan creation/edit — each VM can have pre/post hook references.
+- The Hook CRD conditions (`InvalidImage`, `InvalidPlaybook`, `InvalidHookExecute`) should be surfaced as validation errors.
+- Hook execution status is visible in the per-VM migration pipeline as `PreHook`/`PostHook` steps.
+- The default hook runner image is `quay.io/konveyor/hook-runner` (or `quay.io/kubev2v/hook-runner`).

--- a/.cursor/rules/backend/infrastructure/host-controller.mdc
+++ b/.cursor/rules/backend/infrastructure/host-controller.mdc
@@ -1,0 +1,93 @@
+---
+description: Host controller - ESXi host management, connection testing, inventory watches
+alwaysApply: false
+---
+
+# Host Controller
+
+Source: `pkg/controller/host/`
+
+## Purpose
+
+The Host CRD represents an ESXi host used for **direct disk transfer** during vSphere migrations. The controller validates the host configuration and tests connectivity to the ESXi SDK endpoint.
+
+**Only vSphere providers** are supported. All other provider types set a `TypeNotValid` blocker condition. Non-vSphere handler implementations (oVirt, OCP, OpenStack, OVA, HyperV) are no-ops.
+
+## Watched Resources
+
+| Resource | Watch Type | Purpose |
+|----------|-----------|---------|
+| `Host` | Primary | Reconcile on create/update/delete |
+| `Provider` | Reference | Re-reconcile hosts when their provider changes; sets up inventory watches |
+| `Secret` | Reference | Re-reconcile when host credentials change |
+| Channel | Generic events | Receives events from inventory watches (host changes in vSphere) |
+
+## Reconciliation Flow
+
+```
+Fetch Host CR
+  → BeginStagingConditions
+  → validate()
+    → validateProvider()   — provider exists, is reconciled, and is vSphere
+    → validateRef()        — host ref (ID/Name) resolves in provider inventory
+    → validateIp()         — ipAddress is set
+    → validateSecret()     — secret exists, has "user" + "password" keys, TLS validates
+    → Set Validated condition
+    → testConnection()     — connect to ESXi SDK, check maintenance/health
+  → Set Ready if no blockers AND ConnectionTestSucceeded
+  → EndStagingConditions
+  → Record events, update status
+  → If ConnectionTestFailed: requeue after 15 minutes
+```
+
+## Conditions
+
+| Condition | Category | When Set |
+|-----------|----------|----------|
+| `Validated` | Advisory | All validations pass |
+| `RefNotValid` | Critical | Host ref not set, not found in inventory, or ambiguous |
+| `SecretNotValid` | Critical | Secret missing, not found, missing keys, or TLS failure |
+| `TypeNotValid` | Critical | Provider is not vSphere |
+| `IpNotValid` | Critical | `ipAddress` field is empty |
+| `ConnectionTestSucceeded` | Required | ESXi SDK connection successful |
+| `ConnectionTestFailed` | Critical | Cannot connect to ESXi host |
+| `InMaintenance` | Critical | ESXi host is in maintenance mode |
+| `NotHealthy` | Critical | ESXi host status is not "green" |
+| `Ready` | Required | No blockers + connection test succeeded |
+
+## Connection Testing
+
+`testConnection()` only runs when there are no blocker conditions:
+
+1. Queries the inventory API for the host model to get `Thumbprint`, `InMaintenanceMode`, and `Status`.
+2. Sets `InMaintenance` / `NotHealthy` conditions if applicable.
+3. Injects the host thumbprint into the secret data.
+4. Constructs URL: `https://{ipAddress}/sdk`.
+5. Creates an `EsxHost` adapter (from `pkg/controller/plan/adapter/vsphere`) and calls `TestConnection()`.
+6. On failure: requeues with a **15-minute** backoff to avoid triggering ESXi DOS protection.
+
+## Inventory Watch (vSphere Handler)
+
+File: `handler/vsphere/handler.go`
+
+The vSphere handler watches for inventory changes to `vsphere.Host` objects:
+
+- **Created/Deleted**: Finds all Host CRs referencing the same provider and enqueues reconcile events.
+- **Updated**: Only triggers if `Path` or `InMaintenanceMode` changed.
+- Matching: compares `host.Spec.Ref.ID` against inventory ID or path suffix against ref name.
+
+## Predicate Logic
+
+- **HostPredicate**: Reconciles on create/delete; on update only when `ObservedGeneration < Generation`.
+- **ProviderPredicate**: Triggers on provider updates (when reconciled); ensures inventory watch is started for ready providers.
+
+## Secret Requirements (vSphere)
+
+The host secret must contain:
+- `user` — ESXi username
+- `password` — ESXi password
+- Optional `insecureSkipVerify` — skips TLS verification if set
+
+## Frontend Relevance
+
+The Host CRD is surfaced in the UI under provider details for vSphere providers. The connection status conditions (`ConnectionTestSucceeded`, `ConnectionTestFailed`, `InMaintenance`, `NotHealthy`) are displayed to users. Plan execution uses Host resources for direct ESXi disk transfers.

--- a/.cursor/rules/backend/infrastructure/monitoring.mdc
+++ b/.cursor/rules/backend/infrastructure/monitoring.mdc
@@ -1,0 +1,88 @@
+---
+description: Forklift monitoring - Prometheus metrics, collection loops, HTTPS endpoint
+alwaysApply: false
+---
+
+# Monitoring & Metrics
+
+Source: `pkg/monitoring/`, `pkg/metrics/`
+
+## Prometheus Endpoint
+
+`pkg/metrics/promethousutil.go` (sic — typo in upstream Go source) → `StartPrometheusEndpoint(certsDirectory)`
+
+- Generates a self-signed TLS cert/key pair at startup.
+- Serves `/metrics` over HTTPS on port **8443** using `promhttp.Handler()`.
+- All metrics auto-registered via `promauto` (no manual `prometheus.Register` calls).
+
+## Metrics Defined
+
+All metrics live in `pkg/monitoring/metrics/forklift-controller/metrics.go`.
+
+### Counters
+
+| Metric | Type | Labels | Purpose |
+|--------|------|--------|---------|
+| `mtv_migrations_status_total` | CounterVec | status, provider, mode, target | Total VM migrations by terminal status |
+| `mtv_workload_migrations_status_total` | CounterVec | status, provider, mode, target, plan | Same but correlated to a specific plan UID |
+
+### Gauges
+
+| Metric | Type | Labels | Purpose |
+|--------|------|--------|---------|
+| `mtv_plans_status` | GaugeVec | status, provider, mode, target | Current plan counts by status (reset each cycle) |
+| `mtv_plan_alert_status` | GaugeVec | status, provider, mode, target, plan, plan_name, phase | Per-plan alerting (1 = active, deleted when resolved) |
+| `mtv_migration_duration_seconds` | GaugeVec | provider, mode, target, plan | Duration of completed migrations |
+| `mtv_migration_data_transferred_bytes` | GaugeVec | provider, mode, target, plan | Total bytes transferred (updated during execution and on completion) |
+
+### Histograms
+
+| Metric | Type | Labels | Buckets |
+|--------|------|--------|---------|
+| `mtv_migrations_duration_seconds` | HistogramVec | provider, mode, target | 1h, 2h, 5h, 10h, 24h, 48h (in seconds) |
+
+## Label Value Constants
+
+```
+status:   Succeeded, Failed, Executing, Running, Pending, Canceled, Completed, Blocked, Ready, Deleted
+provider: oVirt, VSphere, Openstack, OVA, Openshift
+mode:     Cold, Warm
+target:   Local (dest URL empty), Remote (dest URL set)
+```
+
+## Collection Loops
+
+Both run as background goroutines, polling every **10 seconds**.
+
+### Plan Metrics — `RecordPlanMetrics(client)`
+
+File: `plan_metrics.go`
+
+1. Lists all `Plan` resources via the k8s client.
+2. For each plan, resolves source/destination `Provider` to determine provider type, mode, and target.
+3. Checks plan conditions (Succeeded, Failed, Executing, Running, Pending, Canceled, Blocked, Deleted).
+4. Aggregates counts into `mtv_plans_status` gauge (reset stale label combos to 0).
+5. Sets `mtv_plan_alert_status` = 1 for active plans; deletes label set when plan no longer active.
+6. During Executing: sums `DiskTransfer`/`DiskTransferV2v` task progress into `mtv_migration_data_transferred_bytes`.
+7. For Failed plans: collects per-VM error phases into the `phase` alert label.
+
+### Migration Metrics — `RecordMigrationMetrics(client)`
+
+File: `migration_metrics.go`
+
+1. Lists all `Migration` resources.
+2. For each migration, resolves the parent `Plan` and its providers.
+3. Tracks terminal states (Succeeded, Failed, Canceled) using in-memory maps to avoid double-counting.
+4. On first observation of a terminal migration:
+   - Increments `mtv_migrations_status_total` and `mtv_workload_migrations_status_total`.
+   - For Succeeded: computes duration from `Status.Started` → `Status.Completed`, records to gauge and histogram; sums data transferred.
+
+## Key Design Decisions
+
+- **Polling, not event-driven**: Metrics are recalculated on a fixed 10s interval, not via controller watches.
+- **In-memory deduplication**: Maps like `processedSucceededMigrations` prevent counter double-increments across restarts — but these reset on pod restart, so counters may re-increment after operator restarts.
+- **Stale label cleanup**: `planStatusGauge` zeros out label combos that no longer appear; `planAlertStatusGauge` deletes stale label sets entirely.
+
+## Frontend Relevance
+
+The UI does not directly query these metrics, but they power Prometheus alerts and Grafana dashboards. The plan alert gauge (`mtv_plan_alert_status`) can trigger OpenShift alerts for failed/stalled migrations.

--- a/.cursor/rules/backend/infrastructure/rest-api.mdc
+++ b/.cursor/rules/backend/infrastructure/rest-api.mdc
@@ -1,0 +1,395 @@
+---
+description: Forklift inventory REST API - endpoints, per-provider routes, authentication, pagination, and web server setup
+alwaysApply: false
+---
+
+# Forklift Inventory REST API
+
+The forklift-api process runs an inventory REST API over TLS on **port 8444**.
+It exposes provider inventory data (VMs, networks, storage, hosts, etc.) collected
+by the inventory controller. The frontend plugin queries these endpoints for
+provider details, VM selection in plans, and mapping configuration.
+
+Source: `pkg/controller/provider/web/` and `pkg/forklift-api/services/` in the
+[forklift](https://github.com/kubev2v/forklift) repo.
+
+---
+
+## Server Setup
+
+```
+pkg/forklift-api/api.go  →  ForkliftApi.Execute()
+  ├── goroutine: serveServices()   → :8444 (REST services + inventory)
+  └── serveWebhooks()              → :8443 (webhooks, see webhooks.mdc)
+```
+
+- **Port**: 8444
+- **TLS**: Certificates from env vars `SERVICES_TLS_CERTIFICATE` and `SERVICES_TLS_KEY`
+- **Framework**: `gin-gonic/gin` for inventory routes; plain `net/http.ServeMux` for service endpoints
+- **Router**: Inventory handlers register via `AddRoutes(*gin.Engine)`
+
+---
+
+## Service Endpoints (port 8444, ServeMux)
+
+| Path | Method | Handler | Purpose |
+|------|--------|---------|---------|
+| `/tls-certificate` | GET | `serveTlsCertificate` | Fetches TLS certificate from a remote URL |
+
+**TLS Certificate Service**: Accepts a `?URL=<url>` query parameter, connects to the URL with
+`insecureSkipVerify`, retrieves the server's TLS certificate, and returns it as PEM-encoded
+`text/plain`. Used by the UI to auto-discover CA certificates during provider creation.
+
+---
+
+## Inventory REST Endpoints (port 8444, gin)
+
+Inventory read endpoints are **GET-only**. The base path is `/providers`. Provider utility/operation endpoints (e.g., VDDK image upload) may use other HTTP verbs.
+
+### Cross-Provider Endpoints
+
+| Route | Description |
+|-------|-------------|
+| `GET /providers` | Lists all providers across all types, grouped by provider type |
+| `GET /providers/` | Same as above |
+
+The aggregated `/providers` endpoint queries each provider-type handler and returns:
+```json
+{
+  "openshift": [...],
+  "vsphere": [...],
+  "ovirt": [...],
+  "openstack": [...],
+  "ova": [...],
+  "hyperv": [...],
+  "ec2": [...]
+}
+```
+
+### Per-Provider Route Pattern
+
+All per-provider endpoints follow this pattern:
+```
+/providers/<type>                        # List providers of this type
+/providers/<type>/:provider              # Get a specific provider (by UID)
+/providers/<type>/:provider/<resource>   # List resources
+/providers/<type>/:provider/<resource>/:id  # Get a specific resource
+```
+
+The `:provider` parameter is always the **K8s UID** of the Provider CR.
+
+---
+
+## vSphere Endpoints (`/providers/vsphere`)
+
+| Route | Description |
+|-------|-------------|
+| `/providers/vsphere` | List vSphere providers |
+| `/providers/vsphere/:provider` | Get provider details |
+| `/providers/vsphere/:provider/datacenters` | List datacenters |
+| `/providers/vsphere/:provider/datacenters/:datacenter` | Get datacenter |
+| `/providers/vsphere/:provider/clusters` | List clusters |
+| `/providers/vsphere/:provider/clusters/:cluster` | Get cluster |
+| `/providers/vsphere/:provider/hosts` | List ESXi hosts |
+| `/providers/vsphere/:provider/hosts/:host` | Get host |
+| `/providers/vsphere/:provider/networks` | List networks |
+| `/providers/vsphere/:provider/networks/:network` | Get network |
+| `/providers/vsphere/:provider/datastores` | List datastores |
+| `/providers/vsphere/:provider/datastores/:datastore` | Get datastore |
+| `/providers/vsphere/:provider/folders` | List folders |
+| `/providers/vsphere/:provider/folders/:folder` | Get folder |
+| `/providers/vsphere/:provider/vms` | List VMs |
+| `/providers/vsphere/:provider/vms/:vm` | Get VM |
+| `/providers/vsphere/:provider/workloads/:vm` | Get VM workload (migration-ready view) |
+| `/providers/vsphere/:provider/tree/host` | Host-based inventory tree |
+| `/providers/vsphere/:provider/tree/vm` | VM-based inventory tree |
+
+**VDDK endpoints** (OpenShift only):
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/providers/vsphere/:provider/vddk/build-image` | POST | Upload VDDK tar and trigger BuildConfig |
+| `/providers/vsphere/:provider/vddk/image-url` | GET | Get VDDK container image URL |
+| `/providers/vsphere/:provider/vddk/download-tar` | GET | Download VDDK tar file |
+
+---
+
+## oVirt (RHV) Endpoints (`/providers/ovirt`)
+
+| Route | Description |
+|-------|-------------|
+| `/providers/ovirt` | List oVirt providers |
+| `/providers/ovirt/:provider` | Get provider details |
+| `/providers/ovirt/:provider/datacenters` | List datacenters |
+| `/providers/ovirt/:provider/datacenters/:datacenter` | Get datacenter |
+| `/providers/ovirt/:provider/clusters` | List clusters |
+| `/providers/ovirt/:provider/clusters/:cluster` | Get cluster |
+| `/providers/ovirt/:provider/hosts` | List hosts |
+| `/providers/ovirt/:provider/hosts/:host` | Get host |
+| `/providers/ovirt/:provider/vms` | List VMs |
+| `/providers/ovirt/:provider/vms/:vm` | Get VM |
+| `/providers/ovirt/:provider/networks` | List networks |
+| `/providers/ovirt/:provider/networks/:network` | Get network |
+| `/providers/ovirt/:provider/nicprofiles` | List NIC profiles |
+| `/providers/ovirt/:provider/nicprofiles/:profile` | Get NIC profile |
+| `/providers/ovirt/:provider/diskprofiles` | List disk profiles |
+| `/providers/ovirt/:provider/diskprofiles/:profile` | Get disk profile |
+| `/providers/ovirt/:provider/storagedomains` | List storage domains |
+| `/providers/ovirt/:provider/storagedomains/:storagedomain` | Get storage domain |
+| `/providers/ovirt/:provider/disks` | List disks |
+| `/providers/ovirt/:provider/disks/:disk` | Get disk |
+| `/providers/ovirt/:provider/servercpus` | List server CPU types |
+| `/providers/ovirt/:provider/servercpus/:servercpu` | Get server CPU |
+| `/providers/ovirt/:provider/tree/cluster` | Cluster-based inventory tree |
+| `/providers/ovirt/:provider/workloads/:vm` | Get VM workload |
+
+---
+
+## OpenStack Endpoints (`/providers/openstack`)
+
+| Route | Description |
+|-------|-------------|
+| `/providers/openstack` | List OpenStack providers |
+| `/providers/openstack/:provider` | Get provider details |
+| `/providers/openstack/:provider/regions` | List regions |
+| `/providers/openstack/:provider/regions/:region` | Get region |
+| `/providers/openstack/:provider/projects` | List projects |
+| `/providers/openstack/:provider/projects/:project` | Get project |
+| `/providers/openstack/:provider/flavors` | List flavors |
+| `/providers/openstack/:provider/flavors/:flavor` | Get flavor |
+| `/providers/openstack/:provider/images` | List images |
+| `/providers/openstack/:provider/images/:image` | Get image |
+| `/providers/openstack/:provider/vms` | List VMs |
+| `/providers/openstack/:provider/vms/:vm` | Get VM |
+| `/providers/openstack/:provider/volumes` | List volumes |
+| `/providers/openstack/:provider/volumes/:volume` | Get volume |
+| `/providers/openstack/:provider/volumetypes` | List volume types |
+| `/providers/openstack/:provider/volumetypes/:volumetype` | Get volume type |
+| `/providers/openstack/:provider/snapshots` | List snapshots |
+| `/providers/openstack/:provider/snapshots/:snapshot` | Get snapshot |
+| `/providers/openstack/:provider/networks` | List networks |
+| `/providers/openstack/:provider/networks/:network` | Get network |
+| `/providers/openstack/:provider/subnets` | List subnets |
+| `/providers/openstack/:provider/subnets/:subnet` | Get subnet |
+| `/providers/openstack/:provider/tree/project` | Project-based inventory tree |
+| `/providers/openstack/:provider/workloads/:vm` | Get VM workload |
+
+---
+
+## OpenShift (OCP) Endpoints (`/providers/openshift`)
+
+| Route | Description |
+|-------|-------------|
+| `/providers/openshift` | List OpenShift providers |
+| `/providers/openshift/:provider` | Get provider details |
+| `/providers/openshift/:provider/namespaces` | List namespaces |
+| `/providers/openshift/:provider/namespaces/:namespace` | Get namespace |
+| `/providers/openshift/:provider/storageclasses` | List storage classes |
+| `/providers/openshift/:provider/storageclasses/:sc` | Get storage class |
+| `/providers/openshift/:provider/networkattachmentdefinitions` | List NADs |
+| `/providers/openshift/:provider/networkattachmentdefinitions/:network` | Get NAD |
+| `/providers/openshift/:provider/instancetypes` | List instance types |
+| `/providers/openshift/:provider/instancetypes/:instancetype` | Get instance type |
+| `/providers/openshift/:provider/clusterinstancetypes` | List cluster instance types |
+| `/providers/openshift/:provider/clusterinstancetypes/:clusterinstancetype` | Get cluster instance type |
+| `/providers/openshift/:provider/vms` | List VMs (VirtualMachines) |
+| `/providers/openshift/:provider/vms/:vm` | Get VM |
+| `/providers/openshift/:provider/persistentvolumeclaims` | List PVCs |
+| `/providers/openshift/:provider/persistentvolumeclaims/:pvc` | Get PVC |
+| `/providers/openshift/:provider/datavolumes` | List DataVolumes |
+| `/providers/openshift/:provider/datavolumes/:datavolume` | Get DataVolume |
+| `/providers/openshift/:provider/kubevirts` | List KubeVirt CRs |
+| `/providers/openshift/:provider/kubevirts/:kubevirt` | Get KubeVirt CR |
+| `/providers/openshift/:provider/tree/namespace` | Namespace-based inventory tree |
+
+OCP endpoints use a **user-scoped client** for restricted host providers — the user's
+Bearer token from the HTTP request is used to query the K8s API directly, ensuring
+RBAC enforcement.
+
+---
+
+## OVA Endpoints (`/providers/ova`)
+
+OVA uses the shared `ovfbase` handler package.
+
+| Route | Description |
+|-------|-------------|
+| `/providers/ova` | List OVA providers |
+| `/providers/ova/:provider` | Get provider details |
+| `/providers/ova/:provider/vms` | List VMs |
+| `/providers/ova/:provider/vms/:vm` | Get VM |
+| `/providers/ova/:provider/networks` | List networks |
+| `/providers/ova/:provider/networks/:network` | Get network |
+| `/providers/ova/:provider/disks` | List disks |
+| `/providers/ova/:provider/disks/:disk` | Get disk |
+| `/providers/ova/:provider/storages` | List storages |
+| `/providers/ova/:provider/storages/:storage` | Get storage |
+| `/providers/ova/:provider/workloads/:vm` | Get VM workload |
+
+---
+
+## Hyper-V Endpoints (`/providers/hyperv`)
+
+| Route | Description |
+|-------|-------------|
+| `/providers/hyperv` | List Hyper-V providers |
+| `/providers/hyperv/:provider` | Get provider details |
+| `/providers/hyperv/:provider/vms` | List VMs |
+| `/providers/hyperv/:provider/vms/:vm` | Get VM |
+| `/providers/hyperv/:provider/networks` | List networks |
+| `/providers/hyperv/:provider/networks/:network` | Get network |
+| `/providers/hyperv/:provider/storages` | List storages |
+| `/providers/hyperv/:provider/storages/:storage` | Get storage |
+| `/providers/hyperv/:provider/disks` | List disks |
+| `/providers/hyperv/:provider/disks/:disk` | Get disk |
+| `/providers/hyperv/:provider/tree/vm` | VM-based inventory tree |
+| `/providers/hyperv/:provider/workloads/:vm` | Get VM workload |
+
+---
+
+## Authentication & Authorization
+
+### Bearer Token Authentication
+
+All inventory endpoints require a **Bearer token** in the `Authorization` header:
+```
+Authorization: Bearer <token>
+```
+
+Controlled by `Settings.AuthRequired` (enabled by default in production).
+
+### Authorization Flow
+
+1. **TokenReview**: Validates the Bearer token via the K8s TokenReview API
+2. **SubjectAccessReview**: Checks if the authenticated user can `get` (single provider)
+   or `list` (all providers) the `providers` resource in `forklift.konveyor.io`
+3. **Token caching**: Successful authorizations are cached for 10 seconds per
+   `(token, provider-namespace, provider-name)` tuple
+
+### OCP Provider User-Scoped Client
+
+For restricted host providers (non-operator-namespace OpenShift providers), the handler
+constructs a new K8s client using the requesting user's token. This ensures the user
+only sees resources they have RBAC access to.
+
+---
+
+## Query Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `detail` | Detail level (0 = summary, `all` = full) | `?detail=all` |
+| `name` | Filter by resource name | `?name=my-vm` |
+| `namespace` | Filter by namespace (OCP endpoints) | `?namespace=default` |
+
+### Pagination (via `libweb.Paged`)
+
+Pagination is handled by the base handler's `Paged` mixin. List endpoints support
+standard offset/limit pagination through query parameters.
+
+### WebSocket Watch
+
+List endpoints support real-time updates via WebSocket. Send a request with the
+`X-Watch` header to upgrade the connection:
+```
+GET /providers/vsphere/:provider/vms
+X-Watch: true
+```
+
+The server pushes inventory change events over the WebSocket connection.
+
+---
+
+## Response Format
+
+### Resource Object
+
+Every inventory resource includes:
+```json
+{
+  "id": "<provider-internal-id>",
+  "name": "<display-name>",
+  "selfLink": "/providers/<type>/<uid>/<collection>/<id>",
+  "revision": 12345,
+  "path": "<hierarchical/path>",
+  "variant": "<optional-subtype>"
+}
+```
+
+Additional fields depend on the resource type and detail level.
+
+### Error Responses
+
+| Status | Header | Meaning |
+|--------|--------|---------|
+| 401 | — | Missing or invalid Bearer token |
+| 403 | — | User lacks RBAC permission on the Provider resource |
+| 404 | `X-Reason: ProviderNotFound` | Provider UID not in inventory |
+| 404 | — | Resource not found within the provider |
+| 206 | — | Provider not fully reconciled (partial content) |
+| 500 | `forklift-error-message: <msg>` | Internal error with detail in header |
+
+---
+
+## Base Handler Architecture
+
+```
+base.Handler
+  ├── Parity    (libweb.Parity)    → ensures collector is up-to-date
+  ├── Watched   (libweb.Watched)   → WebSocket watch support
+  ├── Paged     (libweb.Paged)     → pagination
+  ├── Container                     → inventory container (all collectors)
+  ├── Provider                      → resolved Provider CR for this request
+  ├── Collector                     → collector for this provider
+  └── Detail                        → requested detail level
+```
+
+The `Prepare(ctx)` method on each request:
+1. Initializes pagination from query params
+2. Sets up WebSocket watch if requested
+3. Parses detail level
+4. Resolves the Provider from the `:provider` UID param
+5. Runs Bearer token authorization
+
+### Provider-Specific Handlers
+
+Each provider type has its own `Handler` struct embedding `base.Handler` with
+additional logic for list options, predicates (name filtering), and path building
+for hierarchical inventory (datacenter → cluster → host → VM).
+
+### Internal REST Client (`web.NewClient`)
+
+Controllers and plan adapters query the inventory programmatically via
+`web.NewClient(provider)` which returns a typed client with `Get`, `List`,
+`Watch`, `Find`, and `Finder()` methods.
+Supported types: `openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `ec2`, `hyperv`.
+
+---
+
+## Source File Map
+
+```
+pkg/forklift-api/
+├── api.go                              # Server setup, port 8443/8444
+└── services/
+    ├── services.go                     # /tls-certificate registration
+    └── tls-certificate.go              # TLS cert retrieval handler
+
+pkg/controller/provider/web/
+├── doc.go                              # All() handler aggregation
+├── provider.go                         # Aggregated /providers endpoint
+├── client.go                           # ProviderClient + NewClient factory
+├── base/
+│   ├── handler.go                      # Base handler (auth, pagination, detail)
+│   ├── auth.go                         # TokenReview + SubjectAccessReview
+│   ├── client.go                       # RestClient, Finder, Resolver interfaces
+│   ├── tree.go                         # Tree builder for hierarchical views
+│   └── utils.go                        # Error helpers
+├── vsphere/                            # vSphere inventory handlers
+├── ovirt/                              # oVirt inventory handlers
+├── openstack/                          # OpenStack inventory handlers
+├── ocp/                                # OpenShift inventory handlers
+├── ovfbase/                            # Shared OVF handlers (OVA base)
+├── ova/                                # OVA provider (delegates to ovfbase)
+└── hyperv/                             # Hyper-V inventory handlers
+```

--- a/.cursor/rules/backend/infrastructure/shared-libraries.mdc
+++ b/.cursor/rules/backend/infrastructure/shared-libraries.mdc
@@ -1,0 +1,399 @@
+---
+description: Shared libraries - condition framework, inventory containers, file-backed DB, itinerary, references
+alwaysApply: false
+---
+
+# Shared Libraries (pkg/lib)
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+All Forklift controllers share a common set of library packages under `pkg/lib/`. Understanding these is essential because they define the patterns every controller follows.
+
+---
+
+## 1. Condition Framework (`pkg/lib/condition`) — CRITICAL
+
+The condition framework is **the** core abstraction for resource status. Every CRD's `.status.conditions` field uses it.
+
+### 1.1 Condition Struct
+
+```go
+type Condition struct {
+    Type               string   // e.g. "Ready", "ReconcileFailed", "ConnectionTestFailed"
+    Status             string   // "True" or "False"
+    Category           string   // severity: Critical, Error, Warn, Required, Advisory
+    Reason             string   // machine-readable reason
+    Message            string   // human-readable description
+    Suggestion         string   // suggested resolution
+    LastTransitionTime Time     // when status last changed
+    Durable            bool     // if true, survives staging sweeps
+    Items              []string // referenced items in Message
+    staged             bool     // internal: was this set in current cycle?
+}
+```
+
+### 1.2 Categories (Severity Levels)
+
+| Category | Constant | Effect |
+|----------|----------|--------|
+| `Critical` | Blocks `Reconcile()` AND blocks `Ready` |
+| `Error` | Blocks `Ready` only |
+| `Warn` | Does NOT block `Ready` — advisory warning |
+| `Required` | Required for `Ready` to be true |
+| `Advisory` | Purely informational |
+
+Special categories for pending states: `ValidatingVDDK`, `VMMissingGuestIPs`, `VMMissingChangedBlockTracking`, `SharedDisks`.
+
+### 1.3 Conditions Collection — The Staging Pattern
+
+`Conditions` is a managed slice embedded in every resource's `Status`:
+
+```go
+type Conditions struct {
+    List    []Condition // serialized to JSON
+    staging bool        // internal staging state
+}
+```
+
+**The staging lifecycle** (used in every controller's `Reconcile`):
+
+```go
+// 1. Begin staging — marks all non-Durable conditions as un-staged
+resource.Status.BeginStagingConditions()
+
+// 2. Set conditions for current reconcile cycle
+//    Each SetCondition call marks that condition as staged
+resource.Status.SetCondition(Condition{
+    Type:     "SomeValidation",
+    Status:   True,
+    Category: Error,
+    Message:  "Something is wrong",
+})
+
+// 3. End staging — deletes any conditions NOT set/staged this cycle
+//    Durable conditions always survive
+resource.Status.EndStagingConditions()
+
+// 4. Derive the Ready condition from blocker status
+resource.Status.SetCondition(Condition{
+    Type:     Ready,
+    Status:   boolToStatus(!resource.Status.HasBlockerCondition()),
+    Category: Required,
+    Message:  "Resource is ready.",
+})
+```
+
+**Key behavior:**
+- `BeginStagingConditions()` — resets `staged=false` on all conditions (except `Durable`)
+- `SetCondition()` — adds or updates, always marks `staged=true`
+- `EndStagingConditions()` — removes any condition where `staged==false`
+- This ensures stale conditions are automatically cleaned up each reconcile cycle
+
+### 1.4 Query Methods
+
+| Method | Returns true when... |
+|--------|---------------------|
+| `HasCondition(types...)` | ALL specified types exist with Status=True |
+| `HasAnyCondition(types...)` | ANY specified type exists with Status=True |
+| `HasConditionCategory(cats...)` | Any condition exists in given category with Status=True |
+| `HasCriticalCondition()` | Any Critical category condition exists |
+| `HasErrorCondition()` | Any Error category condition exists |
+| `HasBlockerCondition()` | Any Critical OR Error condition exists |
+| `IsReady()` | Ready condition exists with Status=True |
+| `FindCondition(type)` | Returns pointer to condition (nil if not found / not staged) |
+
+### 1.5 The Explain Report
+
+`Conditions.Explain()` returns a diff of what changed in the current staging cycle:
+
+```go
+type Explain struct {
+    Added   map[string]Condition
+    Updated map[string]Condition
+    Deleted map[string]Condition
+}
+```
+
+Controllers use `explain.Empty()` to skip status updates when nothing changed.
+
+### 1.6 Frontend Mapping
+
+The UI reads `status.conditions` from the API and maps them to display states. When adding a new condition type in the backend, the UI may need a corresponding handler. The `Category` field drives whether the UI shows the resource as healthy, degraded, or blocked.
+
+---
+
+## 2. Itinerary Framework (`pkg/lib/itinerary`)
+
+Defines ordered phase lists that migration tasks step through. Used by the Plan and Migration controllers to drive multi-phase workflows.
+
+### 2.1 Core Types
+
+```go
+type Step struct {
+    Name string   // phase name, e.g. "Initialize", "DiskTransfer", "Finalize"
+    All  Flag     // bitmask: ALL these predicates must be true to include step
+    Any  Flag     // bitmask: ANY of these predicates must be true
+}
+
+type Pipeline []Step
+
+type Predicate interface {
+    Evaluate(Flag) (bool, error)  // returns true when step should be included
+    Count() int                   // number of predicate flags
+}
+
+type Itinerary struct {
+    Pipeline              // ordered list of steps
+    Predicate             // evaluates step inclusion
+    Name      string
+}
+```
+
+### 2.2 Navigation API
+
+| Method | Purpose |
+|--------|---------|
+| `First()` | Get the first step (filtered by predicates) |
+| `Next(name)` | Get the step after `name` (filtered) |
+| `Get(name)` | Get a step by exact name (unfiltered) |
+| `List()` | Get all steps that pass predicate filtering |
+| `Progress(step)` | Returns `{Completed, Total}` counts |
+
+### 2.3 Predicate Filtering
+
+Steps can be conditionally included/excluded based on bitmask flags:
+- `Step.All` — all matching predicate flags must evaluate true
+- `Step.Any` — at least one matching flag must evaluate true
+- Steps with no flags (All=0, Any=0) are always included
+
+This allows different migration types (cold, warm, live) to use different step sequences from the same pipeline definition.
+
+---
+
+## 3. Inventory Container Framework (`pkg/lib/inventory/container`)
+
+Manages per-provider inventory collectors that maintain an in-memory SQLite database of discovered resources.
+
+### 3.1 Container
+
+```go
+type Container struct {
+    content map[Key]Collector  // keyed by object kind + UID
+}
+```
+
+Methods: `Get(owner)`, `Add(collector)`, `Replace(collector)`, `Delete(owner)`, `List()`.
+
+### 3.2 Collector Interface
+
+Every provider type implements this interface:
+
+```go
+type Collector interface {
+    Name() string
+    Owner() meta.Object       // the Provider CR that owns this collector
+    Start() error             // start goroutine, return quickly
+    Shutdown()                // disconnect, cleanup
+    HasParity() bool          // true when initial sync complete
+    DB() model.DB             // the inventory database
+    Test() (int, error)       // test connection, return HTTP status code
+    Reset()
+    Follow(moRef, path, dst) error  // follow inventory links (vSphere)
+    Version() (string, string, string, string, error)  // system version (oVirt)
+}
+```
+
+### 3.3 Collection Reconciliation
+
+The `Collection` type reconciles stored vs. desired model sets:
+
+```go
+type Collection struct {
+    Stored   fb.Iterator   // current DB contents
+    Tx       *model.Tx     // DB transaction
+    Shepherd Shepherd      // comparison/update strategy
+}
+```
+
+`Reconcile(desired)` performs: delete stale → add new → update changed. The `Shepherd` interface controls equality comparison and update logic. `DefaultShepherd` uses reflection, skipping PK, auto-incremented, and `eq:"-"` tagged fields.
+
+---
+
+## 4. Inventory Model / DB (`pkg/lib/inventory/model`)
+
+A reflection-based SQLite ORM for inventory data.
+
+### 4.1 Model Interface
+
+```go
+type Model interface {
+    Pk() string  // primary key
+}
+
+type Base struct {
+    PK     string `sql:"pk"`     // primary key (SHA-1 digest)
+    Object string `sql:""`       // raw JSON-encoded k8s resource
+}
+```
+
+### 4.2 DB Interface
+
+```go
+type DB interface {
+    Open(delete bool) error
+    Close(delete bool) error
+    Get(Model) error
+    List(interface{}, ListOptions) error
+    Find(interface{}, ListOptions) (fb.Iterator, error)
+    Count(Model, Predicate) (int64, error)
+    Begin(...string) (*Tx, error)
+    With(func(*Tx) error, ...string) error
+    Insert(Model) error
+    Update(Model, ...Predicate) error
+    Delete(Model) error
+    Watch(Model, EventHandler) (*Watch, error)
+    EndWatch(*Watch)
+}
+```
+
+### 4.3 Table Tags
+
+Field tags define schema: `sql:"pk"` (primary key), `sql:"key"` (natural key, indexed), `sql:"fk:Table(field)"` (FK with cascade), `sql:"unique(group)"` (unique constraint), `sql:"const"` (immutable after insert), `sql:"incremented"` (auto-increment), `sql:"d0"` (detail level for list queries).
+
+### 4.4 Transaction Pattern
+
+`db.With(func(tx *model.Tx) error { tx.Insert(m); return nil }, "label")` provides auto commit/rollback. Transactions stage events reported to watchers on commit via the Journal system.
+
+---
+
+## 5. File-Backed Data Structures (`pkg/lib/filebacked`)
+
+Provides disk-backed collections to handle large inventory datasets without exhausting memory.
+
+### 5.1 Core Components
+
+- **`Writer`** — appends gob-encoded objects to a temp file in `/tmp/*.fb`
+- **`Reader`** — random-access reads via an in-memory offset index
+- **`List`** — append-only list backed by Writer, provides `Iter()` for reading
+- **`Catalog`** — singleton type registry for gob encoding/decoding
+
+### 5.2 Iterator Interface
+
+```go
+type Iterator interface {
+    Len() int
+    At(index int) interface{}       // random access
+    Next() (interface{}, bool)      // stateful forward iteration
+    NextWith(object interface{}) bool
+    Reverse()
+    Close()
+}
+```
+
+File format per entry: `| kind: uint16 | size: uint64 | gob-encoded object |`. `runtime.SetFinalizer` auto-cleans temp files. `EmptyIterator` serves as a null-object.
+
+### 5.3 Usage
+
+```go
+list := fb.NewList()
+list.Append(obj)
+itr := list.Iter()
+for i := 0; i < itr.Len(); i++ { item := itr.At(i) }
+```
+
+---
+
+## 6. Reference Utilities (`pkg/lib/ref`)
+
+Tracks cross-resource references (e.g., Plan → Provider, Plan → NetworkMap) for controller-runtime event mapping.
+
+### 6.1 RefMap — Global Reference Registry
+
+```go
+var Map *RefMap   // singleton, initialized at package init
+
+type Owner  v1.ObjectReference  // resource containing the reference
+type Target v1.ObjectReference  // resource being referenced
+
+type RefMap struct {
+    Content map[Target]map[Owner]bool  // target → set of owners
+}
+```
+
+Thread-safe via `sync.RWMutex`. Methods: `Add`, `Delete`, `DeleteOwner`, `Match`, `Find`, `Prune`.
+
+### 6.2 EventMapper — Automatic Reference Tracking
+
+Uses reflection to find `ObjectReference` fields tagged with `ref:"Kind"`:
+
+```go
+type Resource struct {
+    ProviderRef *v1.ObjectReference `json:"provider" ref:"Provider"`
+}
+```
+
+The `EventMapper` hooks into controller-runtime predicates to automatically maintain the RefMap on Create/Update/Delete events.
+
+### 6.3 Handler — Cross-Resource Reconciliation
+
+`ref.Handler(&api.Plan{})` creates an event handler that reconciles Plans when a referenced resource changes. Also available as `TypedHandler[T]` for typed watches.
+
+### 6.4 Utility Functions
+
+`RefSet(ref)` — non-nil with non-empty Namespace/Name. `Equals(a, b)` — Name+Namespace comparison. `ToKind(obj)` — extract kind via reflection.
+
+---
+
+## 7. Error Framework (`pkg/lib/error`)
+
+Wraps errors with stack traces and structured context:
+
+- `liberr.Wrap(err)` — captures call stack at wrap site
+- `liberr.Wrap(err, "key", value)` — adds context key-value pairs
+- `liberr.New("msg", "key", value)` — create + wrap in one call
+- `liberr.Unwrap(err)` — unwrap to root cause
+- `err.(*liberr.Error).Stack()` / `.Context()` — access captured data
+
+All controllers use `liberr.Wrap` consistently. The logging package auto-extracts stack traces and context from wrapped errors.
+
+---
+
+## 8. Logging (`pkg/lib/logging`)
+
+Zap-based structured logging. Usage: `var log = logging.WithName("name")`, then `log.V(3).Info("msg", "k", v)`.
+
+Env vars: `LOG_LEVEL` (verbosity threshold), `LOG_DEVELOPMENT` (human-readable output). Level conventions: V(0) normal, V(2-3) detailed, V(4) DB ops, V(5-6) file I/O. Implements `LevelLogger` interface with `Info`, `Error`, `V`, `WithValues`, `WithName`, `Trace`. Auto-extracts stack traces from `liberr.Error`.
+
+---
+
+## 9. Client Utilities (`pkg/lib/client`)
+
+- **OpenShift** (`client/openshift`): `ocp.RestCfg(provider, secret)` builds `*rest.Config`; `ocp.Client(provider, secret)` builds a `controller-runtime` client. Handles host vs remote, TLS, bearer token. QPS=100, Burst=1000.
+- **OpenStack** (`client/openstack`): Gophercloud-based client supporting password, token, and application credential auth. Typed CRUD for Regions, Projects, VMs, Flavors, Images, Volumes, Networks, Subnets.
+
+## 10. General Utilities (`pkg/lib/util`)
+
+TLS: `GetTlsCertificate`, `Fingerprint`, `InsecureProvider`, `GetCACert(secret)` (tries `ca.crt` then legacy `cacert`). SSH: `TestSSHConnectivity`, `GenerateSSHPrivateSecretName/PublicSecretName` for vSphere XCOPY offload.
+
+## Key Patterns Summary
+
+### Pattern 1: Condition Staging in Reconcile
+
+Every controller follows this exact sequence:
+1. `BeginStagingConditions()` → 2. Validate & `SetCondition()` → 3. `EndStagingConditions()` → 4. Derive `Ready`
+
+### Pattern 2: Inventory Collection
+
+Provider reconciler creates a `Collector` → adds to `Container` → Collector runs goroutine that syncs resources into SQLite DB via `model.DB` → REST API reads from DB.
+
+### Pattern 3: Phase-Driven Migration
+
+Migration controller uses `Itinerary.Next(currentPhase)` to advance through steps. Predicates conditionally include/skip steps based on migration type flags.
+
+### Pattern 4: Reference-Driven Reconciliation
+
+Resources declare `ref:"Kind"` tagged fields → `EventMapper` auto-tracks in `RefMap` → `ref.Handler` triggers owner reconcile when referenced resource changes.
+
+### Pattern 5: Error Wrapping
+
+Always `liberr.Wrap(err)` — never return raw errors. The logging system extracts stack traces and context automatically.

--- a/.cursor/rules/backend/infrastructure/virt-v2v.mdc
+++ b/.cursor/rules/backend/infrastructure/virt-v2v.mdc
@@ -1,0 +1,338 @@
+---
+description: virt-v2v integration - guest conversion, inspection, customization, provider-specific args
+alwaysApply: false
+---
+
+# virt-v2v Integration
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Overview
+
+virt-v2v is the core guest conversion engine in Forklift. It runs as a pod during migration and is responsible for:
+
+1. **Disk conversion** — converting guest disk images from source format (VMDK, QCOW2, etc.) to raw format suitable for KubeVirt
+2. **Guest OS inspection** — detecting the OS type, distro, architecture via `virt-v2v-inspector`
+3. **Driver injection** — installing VirtIO drivers and removing source-specific drivers (e.g., VMware Tools)
+4. **Guest customization** — running `virt-customize` scripts for network config, static IPs, and cleanup
+
+Source: `pkg/virt-v2v/` and `cmd/virt-v2v/entrypoint.go`
+
+---
+
+## Entrypoint Flow (`cmd/virt-v2v/entrypoint.go`)
+
+The virt-v2v pod entrypoint follows this sequence:
+
+```
+1. Load environment config (AppConfig)
+2. Link SSL certificates (vSphere only)
+3. Create output directory (/var/tmp/v2v)
+4. Branch based on mode:
+
+   A. Remote Inspection (IsRemoteInspection=true):
+      └─ RunRemoteV2vInspection() → exits
+
+   B. Conversion (IsRemoteInspection=false):
+      ├─ In-Place (IsInPlace=true):
+      │   ├─ With LibvirtUrl → GetDomainXML() → RunVirtV2vInPlace() (-i libvirtxml)
+      │   └─ Without LibvirtUrl → RunVirtV2vInPlaceDisk() (-i disk, e.g. EC2)
+      ├─ Cold (default):
+      │   └─ RunVirtV2v() → pipes stdout to virt-v2v-monitor
+      │
+      ├─ RunVirtV2VInspection() → local inspection on converted disks
+      ├─ RunCustomize() → virt-customize with OS-specific scripts
+      │   (failure is non-fatal → adds Warning)
+      └─ Start HTTP server on :8080 (local migrations only)
+```
+
+Key behavior: customization failure does NOT fail the migration — it logs a warning exposed via `/warnings`.
+
+---
+
+## Conversion Modes
+
+### Cold Migration (`RunVirtV2v`)
+
+Used for vSphere, OVA, and HyperV. Runs `virt-v2v` with `-o kubevirt` output mode, producing KubeVirt YAML + converted disk images in the workdir.
+
+Output is piped through `virt-v2v-monitor` which parses progress lines and exposes Prometheus metrics on `:2112/metrics`.
+
+### In-Place with Libvirt XML (`RunVirtV2vInPlace`)
+
+Used when disks are already populated (warm/live migration). Fetches domain XML from libvirt, updates disk paths to local mounts, writes to `/tmp/input.xml`, runs `virt-v2v-in-place -i libvirtxml`.
+
+### In-Place Disk Mode (`RunVirtV2vInPlaceDisk`)
+
+Used for EC2 and providers without libvirt. Runs `virt-v2v-in-place -i disk` directly on mounted block devices or files.
+
+### Local Inspection (`RunVirtV2VInspection`)
+
+Runs `virt-v2v-inspector -i disk` on already-converted local disks. Outputs XML to `/var/tmp/v2v/inspection.xml`. Always runs after conversion (not in remote-inspection mode).
+
+### Remote Inspection (`RunRemoteV2vInspection`)
+
+vSphere-only. Runs `virt-v2v-inspector` directly against the source VM via VDDK without downloading disks first. Uses `-io vddk-file=<disk>` args to specify which remote disks to inspect. Controlled by `V2V_remoteInspection=true` and `V2V_remoteInspectDisk_N` env vars.
+
+---
+
+## Environment Variables (`pkg/virt-v2v/config/variables.go`)
+
+### Core Variables
+
+| Variable | Field | Description |
+|---|---|---|
+| `V2V_source` | `Source` | Provider type: `vSphere`, `ova`, `hyperv`, `ec2` |
+| `V2V_vmName` | `VmName` | Original VM name |
+| `V2V_NewName` | `NewVmName` | Renamed VM in output |
+| `V2V_inPlace` | `IsInPlace` | Run in-place conversion (bool) |
+| `LOCAL_MIGRATION` | `IsLocalMigration` | Whether controller can reach the pod (enables HTTP server) |
+| `V2V_RootDisk` | `RootDisk` | Which disk to boot from (default: `first`) |
+
+### vSphere-Specific
+
+| Variable | Field | Description |
+|---|---|---|
+| `V2V_libvirtURL` | `LibvirtUrl` | Libvirt connection URI for vSphere |
+| `V2V_fingerprint` | `Fingerprint` | SSL thumbprint for VDDK |
+| `V2V_HOSTNAME` | `HostName` | ESXi host for direct transfer |
+| `V2V_vsphereVmwareDriverRemoval` | `VsphereVmwareDriverRemoval` | Run VMware driver cleanup on Windows |
+
+### Network & Encryption
+
+| Variable | Field | Description |
+|---|---|---|
+| `V2V_staticIPs` | `StaticIPs` | MAC-to-IP mappings, `_`-separated |
+| `V2V_multipleIPsPerNic` | `MultipleIpsPerNicName` | Enable multiple IPs per NIC |
+| `V2V_NBDE_CLEVIS` | `NbdeClevis` | Decrypt disks via Clevis/NBDE |
+
+### Remote Inspection
+
+| Variable | Field | Description |
+|---|---|---|
+| `V2V_remoteInspection` | `IsRemoteInspection` | Enable remote inspection mode |
+| `V2V_remoteInspectDisk_N` | `RemoteInspectionDisks` | Indexed disk list (N=0,1,2...) |
+
+### Tuning & Compatibility
+
+| Variable | Field | Description |
+|---|---|---|
+| `V2V_extra_args` | `ExtraArgs` | JSON array of extra args for virt-v2v / virt-v2v-in-place |
+| `V2V_inspector_extra_args` | `InspectorExtraArgs` | JSON array of extra args for virt-v2v-inspector |
+| `V2V_memSize` | `MemSize` | Memory (MB) for conversion appliance |
+| `V2V_smp` | `Smp` | Virtual CPUs for conversion appliance |
+| `V2V_xfsCompatibility` | `XfsCompatibility` | Omit `--no-fstrim` (el9 v2v lacks this flag) |
+| `VIRTIO_WIN` | `VirtIoWinLegacyDrivers` | Path to legacy VirtIO drivers ISO |
+| `V2V_diskPath` | `DiskPath` | Disk path for OVA/HyperV (comma-separated for HyperV) |
+| `V2V_secretKey` | `SecretKey` | Path to password file (default `/etc/secret/secretKey`) |
+
+### Important Paths (Constants)
+
+| Path | Purpose |
+|---|---|
+| `/var/tmp/v2v` | Workdir for conversion output |
+| `/var/tmp/v2v/inspection.xml` | Inspection XML output |
+| `/opt/vmware-vix-disklib-distrib` | VDDK library directory |
+| `/etc/luks` | LUKS key files directory |
+| `/mnt/vddk-conf/vddk-config-file` | VDDK configuration file |
+| `/mnt/dynamic_scripts` | Dynamic customization scripts mount |
+| `/mnt/disks/disk[0-9]*` | Filesystem-backed disk mounts |
+| `/dev/block[0-9]*` | Block device disk mounts |
+| `/etc/secret/accessKeyId` | Username secret mount |
+| `/etc/secret/secretKey` | Password secret mount |
+| `/tmp/input.xml` | Libvirt domain XML for in-place conversion |
+
+---
+
+## HTTP Server (`pkg/virt-v2v/server/server.go`)
+
+The virt-v2v pod exposes an HTTP server on **`:8080`** (local migrations only) so the plan controller can retrieve conversion results.
+
+### Endpoints
+
+| Endpoint | Method | Response | Purpose |
+|---|---|---|---|
+| `/vm` | GET | `text/yaml` (200) or 204 (in-place) | KubeVirt VM YAML generated by virt-v2v |
+| `/inspection` | GET | `application/xml` (200) | Inspection XML from virt-v2v-inspector |
+| `/warnings` | GET | `application/json` (200) or 204 | Non-fatal warnings (e.g., customization failure) |
+| `/shutdown` | POST/GET | 204 | Gracefully shut down the pod |
+
+The controller polls these endpoints during the `CreateVM` phase. After retrieving the data, it calls `/shutdown` to terminate the pod.
+
+### Warning Structure
+
+```go
+type Warning struct {
+    Reason  string `json:"reason"`  // e.g. "CustomizationFailed"
+    Message string `json:"message"` // Detailed error message
+}
+```
+
+---
+
+## Progress Monitoring (`cmd/virt-v2v-monitor/virt-v2v-monitor.go`)
+
+A sidecar process that reads virt-v2v stdout, parses progress lines, and exposes Prometheus metrics:
+
+- **Endpoint**: `:2112/metrics`
+- **Metric**: `v2v_disk_transfers` (counter vec, label: `disk_id`)
+- **Regex patterns**:
+  - `Copying disk N/M` → new disk started
+  - `N% [***---]` → progress percentage update
+  - `Finishing off` → mark all disks at 100%
+
+---
+
+## Inspection XML Format
+
+The virt-v2v-inspector produces XML parsed by both the virt-v2v pod and the plan controller.
+
+### XML Structure (v2v pod parsing — `pkg/virt-v2v/utils/xml-reader.go`)
+
+```xml
+<v2v>
+  <operatingsystem>
+    <name>linux</name>
+    <distro>rhel</distro>
+    <osinfo>rhel9.4</osinfo>
+    <arch>x86_64</arch>
+  </operatingsystem>
+</v2v>
+```
+
+### OS Detection
+
+`InspectionOS.IsWindows()` checks if `osinfo` contains `"win"` (case-insensitive).
+
+### Controller-Side Parsing (`pkg/controller/plan/adapter/vsphere/inspectionparser.go`)
+
+The controller parses the same XML to map `osinfo` values to VMware guest IDs via `osV2VMap`. This mapping handles:
+
+- **Linux**: rocky, opensuse, ubuntu, fedora, centos6-9, rhel7-10, sles10-16, debian4-13
+- **Windows Desktop**: win7, win8, win10, win11, win12
+- **Windows Server**: win2k8r2, win2k12, win2k12r2, win2k16, win2k19, win2k22, win2k25
+- **Fallback**: `genericLinuxGuest` for unknown Linux, `otherGuest64` for everything else
+
+Minor versions are stripped (e.g., `rhel9.5` → `rhel9`) before lookup.
+
+---
+
+## Guest Customization (`pkg/virt-v2v/customize/`)
+
+Runs `virt-customize` on converted disks to prepare the guest for KubeVirt. Customization is OS-specific and non-fatal (failures produce warnings).
+
+### Embedded Scripts (`customize/scripts/`)
+
+Scripts are embedded via Go's `//go:embed` directive and extracted to the workdir at runtime.
+
+#### Windows Scripts
+
+| Script | Purpose |
+|---|---|
+| `9999-run-mtv-ps-scripts.bat` | Main firstboot init (standard) |
+| `9999-run-mtv-ps-scripts-legacy.bat` | Main firstboot init (legacy VirtIO drivers) |
+| `9999-restore_config-legacy.ps1` | Legacy driver config restoration |
+| `9999-network-config.ps1.tmpl` | Static IP configuration template |
+| `9999-remove_duplicate_persistent_routes.ps1` | Clean up duplicate routes after IP migration |
+| `9999-preserve_complementry_ips_per_nic.ps1.tmpl` | Multiple IPs per NIC template |
+| `9101-9105_*.bat` | VMware driver/service removal sequence (vSphere only) |
+
+VMware driver removal scripts (`9101`–`9105`) are only injected when `VsphereVmwareDriverRemoval=true` AND source is vSphere. They disable services, remove drivers, clean registry entries.
+
+#### Linux Scripts
+
+Located in `scripts/rhel/run/` and `scripts/rhel/firstboot/`:
+
+- **Run scripts** (`--run`): executed during customization (network config utility)
+- **Firstboot scripts** (`--firstboot`): executed on first boot after migration
+- `network_config_util.sh`: handles ifcfg, NetworkManager, netplan, wicked, and systemd-networkd configurations
+
+### Dynamic Scripts
+
+User-supplied scripts mounted at `/mnt/dynamic_scripts`. Naming convention with regex matching:
+
+- **Windows**: `^([0-9]+_win_firstboot([\w\-]*.ps1))$` → uploaded to Firstboot directory
+- **Linux**: `^([0-9]+_linux_(run|firstboot)([\w\-]*.sh))$` → `run` or `firstboot` based on second group
+
+### Static IP Handling
+
+For **Linux**: MAC-to-IP mappings written to `/tmp/macToIP` inside the guest, consumed by `network_config_util.sh`.
+
+For **Windows**: Templates rendered with Go `text/template`, generating PowerShell scripts that configure NICs by MAC address. Supports primary IP, complementary IPs (multiple per NIC), and DNS.
+
+### LUKS Encryption Support
+
+Both virt-v2v and virt-customize accept `--key` args for encrypted disks:
+
+- `--key all:clevis` — use Clevis/NBDE for decryption
+- `--key all:file:/etc/luks/<keyfile>` — use key files from the mounted LUKS directory
+
+---
+
+## Provider-Specific Conversion
+
+### vSphere
+
+- Input mode: `-i libvirt -ic <libvirtUrl>`
+- Authentication: `-ip <secretKeyPath>` + `--hostname <esxi-host>`
+- VDDK transport: `-it vddk -io vddk-libdir=<path> -io vddk-thumbprint=<fp>`
+- Optional: `-io vddk-config=<config-file>`
+- SSL certificates: symlinked from `/etc/secret/cacert` or system CA bundle
+- VM specified as positional arg after `--` separator
+
+### OVA
+
+- Input mode: `-i ova <diskPath>`
+- Minimal args — no authentication needed
+
+### HyperV
+
+- Input mode: `-i disk <disk1> <disk2> ...`
+- Disk paths from `V2V_diskPath` (comma-separated)
+- VM name derived from `VmName` when `NewVmName` is empty
+
+### EC2
+
+- Uses in-place disk mode (`RunVirtV2vInPlaceDisk`)
+- No libvirt connection — disks already mounted as block devices
+- `virt-v2v-in-place -i disk /dev/block0 /dev/block1 ...`
+
+---
+
+## Disk Management (`pkg/virt-v2v/conversion/disk.go`)
+
+Disks are discovered via glob patterns:
+
+- Filesystem disks: `/mnt/disks/disk[0-9]*` → adds `/disk.img` suffix
+- Block devices: `/dev/block[0-9]*` → used as-is
+
+Each disk gets a symlink in the workdir: `<vmName>-sd<letter>` (e.g., `myvm-sda`, `myvm-sdb`). Letter generation handles >26 disks with multi-character names (`aa`, `ab`, etc.).
+
+---
+
+## Domain XML Handling
+
+For in-place conversion with libvirt, the pod:
+
+1. Connects to libvirt using credentials from `/etc/secret/`
+2. Fetches the domain XML via `LookupDomainByName`
+3. Updates disk source paths to point at local mounts
+4. Sets disk driver to `qemu/raw`
+5. Removes CD-ROM devices
+6. Writes modified XML to `/tmp/input.xml`
+
+---
+
+## Frontend Relevance
+
+The UI interacts with virt-v2v indirectly through:
+
+- **Plan creation**: sets env vars via the Plan spec (static IPs, root disk, extra args, etc.)
+- **Migration monitoring**: reads Prometheus metrics from the monitor sidecar for progress bars
+- **Inspection results**: controller fetches from `:8080/inspection` and stores in VM annotations
+- **Warnings**: controller fetches from `:8080/warnings`, surfaced in the UI as migration warnings
+- **OS detection**: `osinfo` from inspection drives the VM's guest OS icon and compatibility checks in the UI
+
+### CRD Types Used in UI (`src/utils/crds/conversion/`)
+
+The frontend has TypeScript types mirroring the inspection XML structure for displaying conversion results in the plan details view.

--- a/.cursor/rules/backend/infrastructure/webhooks.mdc
+++ b/.cursor/rules/backend/infrastructure/webhooks.mdc
@@ -1,0 +1,234 @@
+---
+description: Forklift API webhooks - validating and mutating admission webhooks, paths, authorization, and TLS setup
+alwaysApply: false
+---
+
+# Forklift API Webhooks
+
+The forklift-api process runs Kubernetes admission webhooks over TLS on **port 8443**.
+It validates and mutates Forklift CRDs (Plans, Migrations, Providers) and their
+associated Secrets before they are persisted to etcd.
+
+Source: `pkg/forklift-api/` in the [forklift](https://github.com/kubev2v/forklift) repo.
+
+---
+
+## Server Setup
+
+```
+pkg/forklift-api/api.go  →  ForkliftApi.Execute()
+  ├── goroutine: serveServices()   → :8444 (REST services, see rest-api.mdc)
+  └── serveWebhooks()              → :8443 (admission webhooks)
+```
+
+- **Port**: 8443
+- **TLS**: Certificates from env vars `API_TLS_CERTIFICATE` and `API_TLS_KEY`
+- **Framework**: Plain `net/http.ServeMux` (no gin for webhooks)
+- **API version**: `admission/v1beta1` (backwards-compatible with v1)
+
+---
+
+## Webhook Paths
+
+### Validating Webhooks
+
+| Path | Handler | Resource |
+|------|---------|----------|
+| `/secret-validate` | `SecretAdmitter` | `Secret` (labeled for Forklift) |
+| `/plan-validate` | `PlanAdmitter` | `Plan` |
+| `/provider-validate` | `ProviderAdmitter` | `Provider` |
+| `/migration-validate` | `MigrationAdmitter` | `Migration` |
+
+### Mutating Webhooks
+
+| Path | Handler | Resource |
+|------|---------|----------|
+| `/secret-mutate` | `SecretMutator` | `Secret` (labeled for Forklift) |
+| `/plan-mutate` | `PlanMutator` | `Plan` |
+| `/provider-mutate` | `ProviderMutator` | `Provider` |
+
+---
+
+## Validating Webhook Details
+
+### SecretAdmitter (`/secret-validate`)
+
+Dispatches by the `createdForResourceType` label on the Secret:
+
+**For `providers` secrets:**
+- Validates `insecure` field is a valid boolean
+- Rejects secrets that set both `insecure=true` and a CA certificate
+- Requires `createdForProviderType` label
+- On UPDATE of OVA provider secrets: rejects URL changes (OVA URLs are immutable)
+- For all other provider types: builds a provider collector and runs a **connection test**
+  - 401/400 → reject with "Invalid credentials"
+  - Other errors → log warning but allow (connection may be temporarily unreachable)
+
+**For `hosts` secrets:**
+- Requires `createdForResource` label (the host name)
+- Requires `user` field in secret data
+- Tests ESXi host connection via vSphere SDK
+  - Fetches host thumbprint from inventory
+  - Copies ESXi credentials from provider secret if user field is empty
+  - Test failure → reject; inability to test → allow with warning
+
+### PlanAdmitter (`/plan-validate`)
+
+1. **Unmarshal** the Plan from the admission request
+2. **Skip validation** if the Plan is archived
+3. **Fetch source and destination Providers**
+4. **Authorization checks** (via `SubjectAccessReview`):
+   - User must have `get` on the source Provider
+   - User must have `get` on the destination Provider
+   - If destination is the host cluster: user must have `create` on `virtualmachines` in the target namespace
+   - If source is the host cluster: user must have `get` on each VM listed in the Plan
+5. **Storage validation**: Rejects plans using `kubernetes.io/no-provisioner` storage classes (static provisioners) for cold migrations from non-vSphere sources to the host cluster
+6. **Warm migration validation**: Rejects warm migrations from OpenStack (not supported)
+7. **LUKS validation**: Only vSphere and OVA sources support encrypted (LUKS) disk migration
+
+### ProviderAdmitter (`/provider-validate`)
+
+- Validates vSphere SDK endpoint type: if `spec.settings["sdk"]` is set for a vSphere provider, it must be either `vcenter` or `esxi`
+
+### MigrationAdmitter (`/migration-validate`)
+
+1. **Unmarshal** the Migration and fetch its referenced Plan
+2. **Fetch destination Provider**
+3. **Authorization checks**:
+   - If destination is host cluster: user must have `create` on `virtualmachines` in target namespace
+   - If source is host cluster: user must have `get` on each VM in the Plan
+
+---
+
+## Mutating Webhook Details
+
+### SecretMutator (`/secret-mutate`)
+
+Dispatches by `createdForResourceType` label:
+
+**For `providers` secrets:**
+- Sets `insecureSkipVerify` to `"false"` if not present
+- For **oVirt** providers in secure mode:
+  - Requires a valid CA certificate in the secret
+  - Fetches the engine CA certificate from `https://<host>/ovirt-engine/services/pki-resource`
+  - Appends the engine CA to the secret's `ca.crt` field if not already present
+  - Migrates legacy `cacert` field to `ca.crt`
+  - Adds `ca-cert-updated` label
+- Returns a JSON Patch replacing `/data` and `/metadata/labels`
+
+**For `hosts` secrets:**
+- If user/password are empty and the provider is ESXi: copies credentials from the provider secret
+- Copies `insecureSkipVerify` from the provider secret if not already set on the host secret
+- Returns a JSON Patch replacing `/data` and `/metadata/labels`
+
+### PlanMutator (`/plan-mutate`)
+
+- **Transfer network**: If `spec.transferNetwork` is unset, checks the destination Provider's
+  `forklift.konveyor.io/defaultTransferNetwork` annotation. If a matching
+  `NetworkAttachmentDefinition` exists on the target cluster, sets it as the transfer network.
+- **Populator labels annotation**: On CREATE, adds `populatorLabels: "True"` annotation if not present
+- Returns a JSON Patch replacing `/spec` and/or `/metadata`
+
+### ProviderMutator (`/provider-mutate`)
+
+- **SDK endpoint default**: For vSphere providers without `spec.settings["sdk"]`, defaults to `vcenter`
+- **Finalizers**: On CREATE, adds cleanup finalizers:
+  - OVA providers → `OvaProviderFinalizer`
+  - HyperV providers → `HyperVProviderFinalizer`
+- Returns a JSON Patch replacing `/spec` and/or `/metadata`
+
+---
+
+## Authorization Pattern (SubjectAccessReview)
+
+Webhooks use `util.PermitUser()` to check permissions:
+
+```go
+func PermitUser(request *AdmissionRequest, client Client,
+    groupResource GroupResource, name, ns, verb string) error
+```
+
+- Extracts user info (username, UID, groups, extra) from the AdmissionRequest
+- Creates a `SubjectAccessReview` against the K8s API
+- Supported verbs: `get`, `create`, `list`
+- On denial: returns a descriptive error message including user, verb, resource, group, and namespace
+
+---
+
+## Webhook Utilities (`webhooks/util/`)
+
+| Function | Purpose |
+|----------|---------|
+| `GetAdmissionReview(r)` | Parses admission review from HTTP request body (requires `application/json`) |
+| `ToAdmissionResponseError(err)` | Returns an `Allowed: false` response with the error message |
+| `ToAdmissionResponseAllow()` | Returns an `Allowed: true` response |
+| `GeneratePatchPayload(patches...)` | Marshals `PatchOperation` structs to JSON patch bytes |
+| `PermitUser(...)` | SubjectAccessReview authorization check |
+
+### PatchOperation
+
+```go
+type PatchOperation struct {
+    Op    string      `json:"op"`
+    Path  string      `json:"path"`
+    Value interface{} `json:"value"`
+}
+```
+
+Used by mutating webhooks to produce RFC 6902 JSON Patches.
+
+---
+
+## Request/Response Flow
+
+```
+K8s API Server
+  │
+  ├─ CREATE/UPDATE Secret ──→ /secret-mutate  ──→ /secret-validate
+  ├─ CREATE/UPDATE Plan    ──→ /plan-mutate    ──→ /plan-validate
+  ├─ CREATE/UPDATE Provider──→ /provider-mutate──→ /provider-validate
+  └─ CREATE Migration      ──→                    /migration-validate
+```
+
+1. K8s sends an `AdmissionReview` (JSON, `application/json`)
+2. Webhook deserializes the embedded resource
+3. For mutating: returns `Allowed: true` with a JSON Patch, or `Allowed: false`
+4. For validating: returns `Allowed: true` or `Allowed: false` with `StatusCause` details
+5. Response preserves the request UID and clears Object/OldObject before replying
+
+---
+
+## Frontend Impact
+
+- **Plan creation errors**: The UI must handle 422 (Unprocessable Entity) responses from plan validation — storage class issues, warm migration restrictions, LUKS restrictions, and permission denials
+- **Provider credential errors**: Secret validation returns 403 for invalid credentials — the UI shows these during provider creation/edit
+- **OVA URL immutability**: The UI should disable URL editing for existing OVA providers
+- **Transfer network defaults**: Plans may have their transfer network auto-populated by the mutating webhook
+
+---
+
+## Source File Map
+
+```
+pkg/forklift-api/
+├── api.go                          # Server setup, port 8443/8444
+└── webhooks/
+    ├── webhooks.go                 # Path constants, registration
+    ├── validating-webhook.go       # Serve* functions for validating
+    ├── mutating-webhook.go         # Serve* functions for mutating
+    ├── validating-webhook/
+    │   ├── validating-webhook.go   # Admitter interface, Serve(), response builders
+    │   └── admitters/
+    │       ├── secret-admitter.go  # Provider/host secret validation + connection test
+    │       ├── plan-admitter.go    # Plan validation (authz, storage, warm, LUKS)
+    │       ├── provider-admitter.go# SDK endpoint validation
+    │       └── migration-admitter.go # Migration authz checks
+    ├── mutating-webhook/
+    │   ├── mutating-webhook.go     # Mutator interface, Serve()
+    │   └── mutators/
+    │       ├── secret-mutator.go   # CA cert enrichment, credential copying
+    │       ├── plan-mutator.go     # Transfer network default, populator labels
+    │       └── provider-mutator.go # SDK default, finalizers
+    └── util/
+        └── util.go                 # AdmissionReview parsing, authz, patch helpers
+```

--- a/.cursor/rules/backend/mappings/network-map.mdc
+++ b/.cursor/rules/backend/mappings/network-map.mdc
@@ -1,0 +1,181 @@
+---
+description: NetworkMap controller - validation, inventory-based checks, mapping structure
+alwaysApply: false
+---
+
+# NetworkMap Controller
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+Source: `pkg/controller/map/network/` in the [forklift](https://github.com/kubev2v/forklift) repo.
+
+---
+
+## Overview
+
+The NetworkMap controller reconciles `NetworkMap` CRs (`forklift.konveyor.io/v1beta1`). Each NetworkMap defines how source provider networks map to target OpenShift networks for VM migration.
+
+---
+
+## Mapping Structure
+
+```
+spec:
+  provider:
+    source:   { namespace, name }      # ref to source Provider CR
+    destination: { namespace, name }   # ref to destination Provider CR (must be OpenShift)
+  map:
+    - source:                          # ref.Ref — identifies source network
+        id: "<inventory-id>"           # match by ID
+        name: "<network-name>"         # OR match by name (path suffix)
+      destination:
+        type: "pod" | "multus" | "ignored"
+        namespace: "<ns>"              # required when type=multus
+        name: "<nad-name>"            # NAD name when type=multus
+```
+
+### Destination Types
+
+| Type | Meaning | Validation |
+|---|---|---|
+| `pod` | Kubernetes pod network (default CNI) | Skipped — always valid |
+| `multus` | Multus NetworkAttachmentDefinition (NAD) | Looked up via inventory; namespace required |
+| `ignored` | Network is excluded from mapping | Skipped — always valid |
+
+---
+
+## Reconciliation Flow
+
+```
+Reconcile()
+ ├─ Fetch NetworkMap CR (return if NotFound)
+ ├─ BeginStagingConditions()
+ ├─ validate(mp)
+ │   ├─ ProviderPair.Validate() — validate source + destination providers
+ │   │   └─ Short-circuit if any provider condition is set
+ │   ├─ validateSource(mp) — check source networks against inventory
+ │   └─ validateDestination(mp) — check destination networks against inventory
+ ├─ Set Ready condition (if no blocker conditions)
+ ├─ EndStagingConditions()
+ ├─ Record Kubernetes events
+ └─ Update status (ObservedGeneration = Generation)
+```
+
+---
+
+## Validation Detail
+
+### Provider Pair Validation (shared with StorageMap)
+
+Uses `validation.ProviderPair` from `pkg/controller/validation/provider.go`:
+
+1. **Source Provider**: Must exist, must have `Ready` condition
+2. **Destination Provider**: Must exist, must have `Ready` condition, must be type `OpenShift`
+
+Conditions set on failure:
+- `SourceProviderNotValid` (reason: `NotSet` | `NotFound`)
+- `SourceProviderNotReady`
+- `DestinationProviderNotValid` (reason: `NotSet` | `NotFound` | `TypeNotValid`)
+- `DestinationProviderNotReady`
+
+If any provider condition fires, source/destination validation is **skipped entirely**.
+
+### Source Network Validation (`validateSource`)
+
+For each entry in `spec.map`:
+1. If `source.ID` and `source.Name` are both empty → `SourceNetworkNotValid` (reason: `NotSet`, category: `Critical`)
+2. Look up via `inventory.Network(ref)` against the source provider's inventory API
+3. `NotFoundError` → collected into `notValid` list
+4. `RefNotUniqueError` → collected into `ambiguous` list
+5. Valid refs are added to `status.refs`
+
+Conditions:
+- `SourceNetworkNotValid` / `NotFound` / `Warn` — with `Items` listing invalid refs
+- `SourceNetworkNotValid` / `Ambiguous` / `Critical` — with `Items` listing ambiguous refs
+
+### Destination Network Validation (`validateDestination`)
+
+For each entry in `spec.map`:
+1. `type=pod` or `type=ignored` → **skip** (always valid)
+2. `type=multus` with empty `namespace` → `Ambiguous` (namespace is required)
+3. `type=multus` → look up NAD as `<namespace>/<name>` via destination inventory
+4. `NotFoundError` → collected into `notFound` list
+
+Conditions:
+- `DestinationNetworkNotValid` / `NotFound` / `Critical` — NAD not found in inventory
+- `DestinationNetworkNotValid` / `Ambiguous` / `Critical` — namespace required for Multus
+
+---
+
+## Conditions Summary
+
+| Condition | Category | Reason | Blocker? | Meaning |
+|---|---|---|---|---|
+| `Ready` | Required | — | No | Map is valid and usable |
+| `SourceProviderNotValid` | Critical | NotSet, NotFound | Yes | Source provider ref missing or not found |
+| `SourceProviderNotReady` | Critical | — | Yes | Source provider not reconciled |
+| `DestinationProviderNotValid` | Critical | NotSet, NotFound, TypeNotValid | Yes | Dest provider invalid or not OpenShift |
+| `DestinationProviderNotReady` | Critical | — | Yes | Dest provider not reconciled |
+| `SourceNetworkNotValid` | Critical/Warn | NotSet, NotFound, Ambiguous | Yes (Critical) | Source network ref issue |
+| `DestinationNetworkNotValid` | Critical | NotFound, Ambiguous | Yes | Dest NAD not found or missing namespace |
+
+---
+
+## Watch Triggers
+
+### 1. Primary Watch — NetworkMap CR
+
+- **Create**: Always reconcile; registers with `libref.Mapper`
+- **Update**: Only if `ObservedGeneration < Generation` (spec changed)
+- **Delete**: Always; cleans up `libref.Mapper`
+
+### 2. Provider Watch — Provider CR
+
+- **Create**: Reconcile only if provider is already reconciled (`ObservedGeneration == Generation`)
+- **Update**: If reconciled, ensures inventory watch is started via `ensureWatch()`; triggers reconcile
+- **Delete**: Cleans up watch via `WatchManager.Deleted()`
+
+### 3. Inventory Channel — Provider Inventory Changes
+
+A buffered channel (size 10) receives events from per-provider inventory watchers. When a source network changes in the provider inventory, the handler:
+
+1. Lists all NetworkMap CRs
+2. Filters to those referencing the changed provider
+3. Checks if any mapping entry references the changed network (by ID or name suffix)
+4. Enqueues a reconcile event for matching maps
+
+### Per-Provider Inventory Resources Watched
+
+| Provider | Inventory Resource | Match Logic |
+|---|---|---|
+| vSphere | `vsphere.Network` | `ref.ID == network.ID` or `HasSuffix(network.Path, ref.Name)` |
+| oVirt | `ovirt.Network` | Same as vSphere |
+| OpenStack | `openstack.Network` | Same as vSphere |
+| OVA | `ova.Network` | Same as vSphere |
+| Hyper-V | `hyperv.Network` | `ref.ID == network.ID` or `ref.Name == network.Name` |
+| OpenShift | `ocp.NetworkAttachmentDefinition` | Periodic polling (no inventory watch support) |
+| EC2 | (via `ec2handler.NewNetworkHandler`) | Separate EC2 provider package |
+
+**OCP special case**: OCP inventory doesn't support real-time watches. Instead, `EnsurePeriodicEvents()` fires at `DefaultEventInterval` and enqueues reconcile events for all NetworkMaps that reference the OCP provider.
+
+---
+
+## Key Code Locations
+
+| File | Purpose |
+|---|---|
+| `controller.go` | Controller setup, watches, `Reconcile()` method |
+| `validation.go` | Source/destination validation against inventory |
+| `predicate.go` | Event filtering for NetworkMap and Provider watches |
+| `handler/doc.go` | Handler factory — dispatches to provider-specific handler |
+| `handler/<provider>/handler.go` | Inventory watch setup and change detection per provider |
+
+---
+
+## Frontend Relevance
+
+- The UI must present source networks from inventory and let users pick destination type (`pod`/`multus`/`ignored`)
+- For `multus`, both namespace and NAD name are required
+- Conditions on the NetworkMap status drive the UI's validation indicators
+- `SourceNetworkNotValid` with reason `NotFound` uses `Warn` (not blocking) — the map can still be Ready if other mappings are valid
+- `SourceNetworkNotValid` with reason `Ambiguous` is `Critical` (blocking)

--- a/.cursor/rules/backend/mappings/storage-map.mdc
+++ b/.cursor/rules/backend/mappings/storage-map.mdc
@@ -1,0 +1,244 @@
+---
+description: StorageMap controller - validation, inventory-based checks, offload plugins, mapping structure
+alwaysApply: false
+---
+
+# StorageMap Controller
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+Source: `pkg/controller/map/storage/` in the [forklift](https://github.com/kubev2v/forklift) repo.
+
+---
+
+## Overview
+
+The StorageMap controller reconciles `StorageMap` CRs (`forklift.konveyor.io/v1beta1`). Each StorageMap defines how source provider storage maps to target OpenShift StorageClasses for VM disk migration.
+
+---
+
+## Mapping Structure
+
+```
+spec:
+  provider:
+    source:      { namespace, name }    # ref to source Provider CR
+    destination: { namespace, name }    # ref to destination Provider CR (must be OpenShift)
+  map:
+    - source:                           # ref.Ref — identifies source storage
+        id: "<inventory-id>"            # match by ID
+        name: "<storage-name>"          # OR match by name (path suffix)
+      destination:
+        storageClass: "<sc-name>"       # target StorageClass name
+        volumeMode: "Filesystem" | "Block"        # optional
+        accessMode: "ReadWriteOnce" | "ReadWriteMany" | "ReadOnlyMany"  # optional
+      offloadPlugin:                    # optional — per-pair offload config
+        vsphereXcopyConfig:
+          secretRef: "<secret-name>"
+          storageVendorProduct: "<vendor>"
+```
+
+### Destination Fields
+
+| Field | Required | Values | Purpose |
+|---|---|---|---|
+| `storageClass` | Yes | Any valid SC name | Target StorageClass on OpenShift |
+| `volumeMode` | No | `Filesystem`, `Block` | PVC volume mode |
+| `accessMode` | No | `ReadWriteOnce`, `ReadWriteMany`, `ReadOnlyMany` | PVC access mode |
+
+---
+
+## Reconciliation Flow
+
+```
+Reconcile()
+ ├─ Fetch StorageMap CR (return if NotFound)
+ ├─ BeginStagingConditions()
+ ├─ Record Kubernetes events
+ ├─ validate(mp)
+ │   ├─ ProviderPair.Validate() — validate source + destination providers
+ │   │   └─ Short-circuit if any provider condition is set
+ │   ├─ validateSource(mp) — check source storage against inventory
+ │   └─ validateDestination(mp) — check destination StorageClasses against inventory
+ ├─ Set Ready condition (if no blocker conditions)
+ ├─ EndStagingConditions()
+ └─ Update status (ObservedGeneration = Generation)
+```
+
+---
+
+## Validation Detail
+
+### Provider Pair Validation (shared with NetworkMap)
+
+Identical to NetworkMap — uses `validation.ProviderPair`. Destination must be OpenShift.
+
+Conditions on failure: `SourceProviderNotValid`, `SourceProviderNotReady`, `DestinationProviderNotValid`, `DestinationProviderNotReady`.
+
+### Source Storage Validation (`validateSource`)
+
+For each entry in `spec.map`:
+1. If `source.ID` and `source.Name` are both empty → `SourceStorageNotValid` (reason: `NotSet`, category: `Critical`)
+2. Look up via `inventory.Storage(ref)` against the source provider's inventory API
+3. `NotFoundError` → collected into `notValid` list
+4. `RefNotUniqueError` → collected into `ambiguous` list
+5. Valid refs added to `status.refs`
+
+Conditions:
+- `SourceStorageNotValid` / `NotFound` / `Warn` — with `Items` listing invalid refs
+- `SourceStorageNotValid` / `Ambiguous` / `Critical` — with `Items` listing ambiguous refs
+
+### Destination Storage Validation (`validateDestination`)
+
+For each entry in `spec.map`:
+1. Look up `destination.storageClass` by name via `inventory.Storage(&ref.Ref{Name: name})`
+2. `NotFoundError` → collected into `notValid` list
+
+Conditions:
+- `DestinationStorageNotValid` / `NotFound` / `Critical` — StorageClass not found in inventory
+
+**Note**: Unlike NetworkMap, there is no `Ambiguous` condition for destinations since StorageClasses are looked up by exact name.
+
+---
+
+## Conditions Summary
+
+| Condition | Category | Reason | Blocker? | Meaning |
+|---|---|---|---|---|
+| `Ready` | Required | — | No | Map is valid and usable |
+| `SourceProviderNotValid` | Critical | NotSet, NotFound | Yes | Source provider ref missing or not found |
+| `SourceProviderNotReady` | Critical | — | Yes | Source provider not reconciled |
+| `DestinationProviderNotValid` | Critical | NotSet, NotFound, TypeNotValid | Yes | Dest provider invalid or not OpenShift |
+| `DestinationProviderNotReady` | Critical | — | Yes | Dest provider not reconciled |
+| `SourceStorageNotValid` | Critical/Warn | NotSet, NotFound, Ambiguous | Yes (Critical) | Source storage ref issue |
+| `DestinationStorageNotValid` | Critical | NotFound | Yes | Target StorageClass not found |
+
+---
+
+## Watch Triggers
+
+### 1. Primary Watch — StorageMap CR
+
+- **Create**: Always reconcile; registers with `libref.Mapper`
+- **Update**: Only if `ObservedGeneration < Generation` (spec changed)
+- **Delete**: Always; cleans up `libref.Mapper`
+
+### 2. Provider Watch — Provider CR
+
+- **Create**: Reconcile only if provider is already reconciled
+- **Update**: If reconciled, ensures inventory watch via `ensureWatch()`; triggers reconcile
+- **Delete**: Cleans up watch via `WatchManager.Deleted()`
+
+### 3. Inventory Channel — Provider Inventory Changes
+
+Buffered channel (size 10) receives events from per-provider inventory watchers.
+
+### Per-Provider Inventory Resources Watched
+
+| Provider | Inventory Resource | Match Logic |
+|---|---|---|
+| vSphere | `vsphere.Datastore` | `ref.ID == ds.ID` or `HasSuffix(ds.Path, ref.Name)` |
+| oVirt | `ovirt.StorageDomain` | Same as vSphere |
+| OpenStack | `openstack.VolumeType` | Same as vSphere |
+| OVA | `ova.Disk` | Same as vSphere |
+| Hyper-V | *(no watch)* | Single SMB share — no separate storage entities |
+| OpenShift | `ocp.StorageClass` | Periodic polling (`DefaultEventInterval`) |
+| EC2 | (via `ec2handler.NewStorageHandler`) | Separate EC2 provider package |
+
+**OCP special case**: Uses `EnsurePeriodicEvents()` instead of real-time watches. Enqueues reconcile events for all StorageMaps referencing the OCP provider at regular intervals.
+
+**Hyper-V special case**: The handler is a no-op (`Watch()` returns nil). Hyper-V uses a single SMB share, so there are no distinct storage entities to watch.
+
+---
+
+## Storage Offload Plugin (XCOPY)
+
+Each `StoragePair` in the map can optionally specify an `offloadPlugin` for hardware-accelerated copy. Currently only vSphere XCOPY is supported.
+
+### OffloadPlugin Structure
+
+```go
+type OffloadPlugin struct {
+    VSphereXcopyPluginConfig *VSphereXcopyPluginConfig
+}
+
+type VSphereXcopyPluginConfig struct {
+    SecretRef            string               // secret with storage array credentials
+    StorageVendorProduct StorageVendorProduct  // identifies the storage array type
+}
+```
+
+The `VSphereXcopyVolumePopulator` CR works with the plugin to offload disk copy to vSphere + the storage array, bypassing standard CDI data transfer.
+
+### Supported Storage Vendors
+
+| Enum Value | Vendor / Product |
+|---|---|
+| `flashsystem` | IBM FlashSystem |
+| `vantara` | Hitachi Vantara |
+| `ontap` | NetApp ONTAP |
+| `primera3par` | HPE Primera / 3PAR |
+| `pureFlashArray` | Pure Storage FlashArray |
+| `powerflex` | Dell PowerFlex |
+| `powermax` | Dell PowerMax |
+| `powerstore` | Dell PowerStore |
+| `infinibox` | Infinidat InfiniBox |
+
+### How It Works
+
+1. User configures `offloadPlugin.vsphereXcopyConfig` on a storage pair
+2. `secretRef` points to a Secret with storage array credentials (must be in source provider's namespace)
+3. `storageVendorProduct` selects the correct storage driver
+4. During migration, the plan controller detects `IsUsingOffloadPlugin()` and creates `VSphereXcopyVolumePopulator` CRs instead of standard CDI DataVolumes
+5. The volume populator handles the XCOPY transfer at the storage array level
+
+### Feature Gate
+
+Copy offload requires `feature_copy_offload` to be enabled in the `ForkliftController` CR.
+
+---
+
+## Key Code Locations
+
+| File | Purpose |
+|---|---|
+| `controller.go` | Controller setup, watches, `Reconcile()` method |
+| `validation.go` | Source/destination validation against inventory |
+| `predicate.go` | Event filtering for StorageMap and Provider watches |
+| `handler/doc.go` | Handler factory — dispatches to provider-specific handler |
+| `handler/<provider>/handler.go` | Inventory watch setup and change detection per provider |
+
+### API Types (in `pkg/apis/forklift/v1beta1/mapping.go`)
+
+| Type | Purpose |
+|---|---|
+| `StoragePair` | Source ref + destination StorageClass + optional offload plugin |
+| `DestinationStorage` | StorageClass name, volumeMode, accessMode |
+| `OffloadPlugin` | Container for offload plugin configs |
+| `VSphereXcopyPluginConfig` | Secret ref + vendor product identifier |
+| `StorageVendorProduct` | Enum of supported storage vendors |
+
+---
+
+## Differences from NetworkMap
+
+| Aspect | NetworkMap | StorageMap |
+|---|---|---|
+| Destination type | `pod` / `multus` / `ignored` | StorageClass name |
+| Destination validation | Skips pod/ignored; checks NAD for multus | Always checks StorageClass exists |
+| Ambiguous destination | Yes (missing namespace for multus) | No (exact name lookup) |
+| Offload plugin | N/A | Per-pair XCOPY offload config |
+| Hyper-V watch | Watches `hyperv.Network` | No-op (single SMB share) |
+| Source inventory type | Network | Datastore (vSphere), StorageDomain (oVirt), VolumeType (OpenStack), Disk (OVA) |
+
+---
+
+## Frontend Relevance
+
+- The UI must present source storage from inventory and let users select target StorageClass
+- Optional `volumeMode` and `accessMode` fields let users override PVC defaults
+- The offload plugin section is shown only when the `feature_copy_offload` feature gate is enabled
+- The vendor dropdown should use the `StorageVendorProduct` enum values
+- Conditions on StorageMap status drive validation indicators in the UI
+- `SourceStorageNotValid` with reason `NotFound` uses `Warn` (non-blocking)
+- `SourceStorageNotValid` with reason `Ambiguous` is `Critical` (blocking)

--- a/.cursor/rules/backend/operator/operator.mdc
+++ b/.cursor/rules/backend/operator/operator.mdc
@@ -1,0 +1,226 @@
+---
+description: Forklift operator - Ansible-based deployment, feature flags, container images, ForkliftController CRD
+alwaysApply: false
+---
+
+# Forklift Operator
+
+> Analyzed from commit: `a976d24b6` on `2026-05-04`
+
+## Overview
+
+The Forklift operator is an **Ansible-based operator** (operator-sdk) that watches the `ForkliftController` CRD and reconciles all Forklift components into the target namespace. It uses a single Ansible role (`forkliftcontroller`) with Jinja2 templates.
+
+---
+
+## ForkliftController CRD
+
+- **Group**: `forklift.konveyor.io`, **Version**: `v1beta1`, **Kind**: `ForkliftController`
+- Single watched resource defined in `operator/watches.yaml`
+- Has a finalizer (`forklift.konveyor.io/finalizer`) for cleanup on deletion
+- The CR's `.spec` fields map to Ansible variables that override defaults in `roles/forkliftcontroller/defaults/main.yml`
+
+### Key Configurable Fields (CR spec → Ansible var)
+
+| CR field | Ansible variable | Default |
+|----------|-----------------|---------|
+| `feature_volume_populator` | `feature_volume_populator` | `true` |
+| `feature_copy_offload` | `feature_copy_offload` | `true` |
+| `feature_ocp_live_migration` | `feature_ocp_live_migration` | `true` |
+| `feature_vmware_system_serial_number` | `feature_vmware_system_serial_number` | `true` |
+| `feature_vsphere_vmware_driver_removal` | `feature_vsphere_vmware_driver_removal` | `false` |
+| `feature_ui_plugin` | `feature_ui_plugin` | `true` |
+| `feature_validation` | `feature_validation` | `true` |
+| `feature_cli_download` | `feature_cli_download` | `true` |
+| `feature_ova_appliance_management` | `feature_ova_appliance_management` | `true` |
+| `controller_max_vm_inflight` | `controller_max_vm_inflight` | `20` |
+| `controller_precopy_interval` | `controller_precopy_interval` | `60` |
+| `controller_log_level` | `controller_log_level` | `3` |
+
+---
+
+## Feature Flags
+
+Feature flags flow from the ForkliftController CR through Ansible into environment variables on the controller pod:
+
+```
+ForkliftController CR spec
+  → Ansible defaults/main.yml
+    → Jinja2 template (deployment-controller.yml.j2)
+      → Pod env vars (FEATURE_*)
+        → Go pkg/settings/features.go loads them
+```
+
+### Feature Flag Environment Variables
+
+| Env Var | Go constant | Description |
+|---------|-------------|-------------|
+| `FEATURE_COPY_OFFLOAD` | `FeatureCopyOffload` | vSphere XCOPY copy offload plugins |
+| `FEATURE_OCP_LIVE_MIGRATION` | `FeatureOCPLiveMigration` | Cross-cluster live migration |
+| `FEATURE_VSPHERE_INCREMENTAL_BACKUP` | `FeatureVsphereIncrementalBackup` | changeID-based incremental backup |
+| `FEATURE_OVIRT_WARM_MIGRATION` | `FeatureOvirtWarmMigration` | oVirt warm migration support |
+| `FEATURE_STATIC_UDN_IP_ADDRESSES` | `FeatureStaticUdnIpAddresses` | Static IPs in User Defined Networks |
+| `FEATURE_VMWARE_SYSTEM_SERIAL_NUMBER` | `FeatureVmwareSystemSerialNumber` | VMware serial number for VMs |
+| `FEATURE_OVF_APPLIANCE_MANAGEMENT` | `FeatureOVFApplianceManagement` | Appliance management for OVA/HyperV |
+| `FEATURE_VSPHERE_VMWARE_DRIVER_REMOVAL` | `FeatureVsphereVmwareDriverRemoval` | VMware driver removal in Windows |
+| `FEATURE_RETAIN_PRECOPY_IMPORTER_PODS` | `FeatureRetainPrecopyImporterPods` | Keep precopy importer pods |
+
+Some features are gated by OpenShift version (e.g., `VmwareSystemSerialNumber` requires OCP ≥ 4.20, `InsecureSkipVerify` requires OCP ≥ 4.21).
+
+---
+
+## Container Images
+
+Defined in `operator/related_images.yaml` (referenced via `RELATED_IMAGE_*` env vars):
+
+| Name | Variable | Purpose |
+|------|----------|---------|
+| `controller` | `CONTROLLER_IMAGE` | Main controller + inventory binary |
+| `api` | `API_IMAGE` | Webhook/validation API server |
+| `validation` | `VALIDATION_IMAGE` | OPA policy agent for VM validation |
+| `ui_plugin` | `UI_PLUGIN_IMAGE` | Console UI plugin (this project) |
+| `virt_v2v` | `VIRT_V2V_IMAGE` | Guest conversion (virt-v2v) |
+| `populator_controller` | `POPULATOR_CONTROLLER_IMAGE` | Volume populator controller |
+| `rhv_populator` | `OVIRT_POPULATOR_IMAGE` | oVirt/RHV disk populator |
+| `openstack_populator` | `OPENSTACK_POPULATOR_IMAGE` | OpenStack disk populator |
+| `vsphere_copy_offload_populator` | `VSPHERE_COPY_OFFLOAD_POPULATOR_IMAGE` | vSphere XCOPY offload |
+| `ova_provider_server` | `OVA_PROVIDER_SERVER_IMAGE` | OVA inventory server (per-provider pod) |
+| `hyperv_provider_server` | `HYPERV_PROVIDER_SERVER_IMAGE` | Hyper-V inventory server |
+| `ova_proxy` | `OVA_PROXY_IMAGE` | OVA inventory proxy |
+| `cli_download` | `CLI_DOWNLOAD_IMAGE` | kubectl-mtv CLI download server |
+| `must_gather` | `MUST_GATHER_IMAGE` | Must-gather diagnostics |
+
+---
+
+## Deployment Topology
+
+The operator creates these Deployments (all in the Forklift namespace):
+
+### forklift-controller (single pod, two containers)
+
+| Container | Role | Binary | Key Env |
+|-----------|------|--------|---------|
+| `main` | Migration reconciler | `forklift-controller` | `ROLE=main` |
+| `inventory` | Inventory API server | `forklift-controller` | `ROLE=inventory` |
+
+Both containers share the same image (`controller_image_fqin`) but run different roles based on the `ROLE` env var. The Go code (`pkg/settings/role.go`) loads `ROLE` to enable `main`, `inventory`, or both.
+
+### forklift-api
+Admission webhooks (validating + mutating) for Plans, Providers, Migrations, Secrets.
+
+### forklift-validation (optional, `feature_validation`)
+OPA-based policy agent that validates VMs before migration.
+
+### forklift-ui-plugin (optional, `feature_ui_plugin`, OCP only)
+This console plugin. Registers as a ConsolePlugin CR with OpenShift.
+
+### forklift-volume-populator-controller (optional, `feature_volume_populator`)
+Watches VolumePopulator CRs and spawns populator pods (oVirt, OpenStack, XCOPY).
+
+### forklift-ova-proxy
+Proxies inventory requests for OVA-based providers.
+
+### forklift-cli-download (optional, `feature_cli_download`, OCP only)
+Serves kubectl-mtv binary downloads. Registered via ConsoleCLIDownload CR.
+
+---
+
+## Ansible Role Structure
+
+```
+operator/roles/forkliftcontroller/
+├── defaults/main.yml      # All configurable defaults
+├── tasks/main.yml         # Reconciliation logic
+├── tasks/cleanup.yml      # Resource cleanup for disabled features
+├── tasks/webhooks.yml     # Webhook configuration
+├── meta/main.yml          # Role metadata
+└── templates/
+    ├── controller/        # Controller deployment, configmap, services, routes
+    ├── api/               # API deployment, webhooks, certificates
+    ├── validation/        # Validation deployment, configmap
+    ├── ui-plugin/         # UI plugin deployment, ConsolePlugin CR
+    ├── populator/         # Volume populator controller deployment
+    ├── ova-proxy/         # OVA proxy deployment, service, route
+    ├── cli-download/      # CLI download server
+    ├── monitor/           # ServiceMonitor, PrometheusRules, alerts
+    └── smb-csi/           # SMB CSI driver (HyperV)
+```
+
+### Reconciliation Flow (tasks/main.yml)
+
+1. Evaluate feature flags → set `*_state` facts (`present`/`absent`)
+2. Detect cluster type (OpenShift vs plain k8s via `route.openshift.io` API group)
+3. Deploy controller ConfigMap + Deployment (always)
+4. Deploy OVA proxy (always)
+5. Deploy monitoring resources (OCP only)
+6. Deploy volume populator controller (if enabled)
+7. Configure TLS certificates (k8s: cert-manager; OCP: service-serving-cert)
+8. Deploy API server + webhooks
+9. Create default host Provider (if KubeVirt present)
+10. Deploy validation (if enabled)
+11. Deploy UI plugin + register ConsolePlugin (if enabled, OCP only)
+12. Deploy CLI download (if enabled, OCP only)
+13. Cleanup disabled features
+
+---
+
+## Environment Variable Propagation
+
+The operator injects configuration into the controller pod via two mechanisms:
+
+1. **Direct env vars** in the Deployment template (feature flags, image refs, resource limits)
+2. **ConfigMap** (`forklift-controller-config`) mounted as `envFrom`
+
+The Go controller loads all settings at startup via `pkg/settings.Settings.Load()` which reads:
+- `pkg/settings/role.go` — `ROLE` (main, inventory)
+- `pkg/settings/features.go` — `FEATURE_*` flags
+- `pkg/settings/migration.go` — Migration tuning (MAX_VM_INFLIGHT, VIRT_V2V_IMAGE, etc.)
+- `pkg/settings/inventory.go` — API server config (port, TLS, auth)
+- `pkg/settings/policy.go` — Validation policy agent URL
+- `pkg/settings/metrics.go` — Metrics port
+- `pkg/settings/logging.go` — Log level
+- `pkg/settings/profiler.go` — CPU/memory profiling
+- `pkg/settings/providers.go` — Provider-specific image refs
+
+---
+
+## Streams (Upstream vs Downstream)
+
+| Property | Upstream (Forklift) | Downstream (MTV) |
+|----------|-------------------|-----------------|
+| CSV name | `forklift-operator` | `mtv-operator` |
+| Display name | Forklift Operator | Migration Toolkit for Virtualization Operator |
+| Namespace | `konveyor-forklift` | `openshift-mtv` |
+| Provider | Konveyor | Red Hat |
+| Certified | No | Yes |
+
+---
+
+## OCP vs K8s Differences
+
+The operator detects OpenShift by checking for `route.openshift.io` API group:
+
+| Capability | OpenShift | Plain K8s |
+|------------|-----------|-----------|
+| Routes | Yes | No (use Ingress) |
+| UI Plugin | Yes | No |
+| CLI download | Yes | No |
+| TLS certs | service-serving-cert annotation | cert-manager Issuer/Certificate |
+| SCC | Applied | Skipped |
+| Monitoring | ServiceMonitor + PrometheusRules | Skipped |
+| Catalog | OLM Subscription | OLM Subscription (different source) |
+
+---
+
+## Key Tuning Parameters
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `MAX_VM_INFLIGHT` | 20 | Concurrent VMs per migration |
+| `PRECOPY_INTERVAL` | 60 min | Warm migration precopy frequency |
+| `VDDK_JOB_ACTIVE_DEADLINE` | 300 sec | VDDK validation job timeout |
+| `MAX_CONCURRENT_RECONCILES` | 10 | Controller reconcile parallelism |
+| `FILESYSTEM_OVERHEAD` | 10% | Extra space for filesystem PVCs |
+| `TLS_CONNECTION_TIMEOUT` | 5 sec | TLS handshake timeout |
+| `SNAPSHOT_REMOVAL_TIMEOUT` | 120 min | vSphere snapshot removal timeout |
+| `LOG_LEVEL` | 3 | Controller log verbosity (0-9) |

--- a/.cursor/rules/backend/plans/migration-pipeline.mdc
+++ b/.cursor/rules/backend/plans/migration-pipeline.mdc
@@ -1,0 +1,308 @@
+---
+description: Migration pipeline - itineraries (cold/warm/conversion), VM phases, disk transfer, KubeVirt resources
+alwaysApply: false
+---
+
+# Migration Pipeline
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+Source: `pkg/controller/plan/migration.go`, `pkg/controller/plan/kubevirt.go`,
+`pkg/controller/plan/migrator/base/`, `pkg/controller/plan/migrator/ocp/`
+
+---
+
+## Migration.Run() — Top-Level Loop
+
+The plan controller creates a `Migration` struct and calls `Run()` on each reconcile.
+
+```
+Run()
+  ├── init()           Build adapter (Client, Builder, Ensurer), KubeVirt helper,
+  │                    Scheduler, and Migrator based on source provider type
+  ├── begin()          Mark migration started, ensure target namespace,
+  │                    build VM status list and pipelines, call migrator.Begin()
+  ├── resolveCanceledRefs()
+  ├── for each runningVMs()  →  execute(vm)      // Resume already-running VMs
+  ├── loop: scheduler.Next() →  execute(vm)      // Schedule new VMs
+  └── end()            Check all VMs completed → set Succeeded/Failed/Canceled
+```
+
+**Polling**: `Run()` returns `PollReQ = 3s` until all VMs complete, then `NoReQ = 0`.
+
+---
+
+## Migrator Factory
+
+`migrator.New(context)` in `pkg/controller/plan/migrator/doc.go`:
+
+| Provider Type | Migrator            | Notes                                        |
+|---------------|---------------------|----------------------------------------------|
+| `openshift`   | `ocp.LiveMigrator`  | Only for `Plan.Spec.Type == MigrationLive`   |
+| `openshift`   | `base.BaseMigrator` | For non-live OCP-to-OCP                      |
+| `ec2`         | `ec2migrator`       | AWS EC2 custom migrator                      |
+| All others    | `base.BaseMigrator` | vSphere, oVirt, OpenStack, OVA, HyperV      |
+
+---
+
+## Migrator Interface
+
+Defined in `pkg/controller/plan/migrator/base/doc.go`:
+
+```go
+type Migrator interface {
+    Init() error
+    Begin() error
+    Complete(*plan.VMStatus)
+    Status(plan.VM) *plan.VMStatus
+    Reset(*plan.VMStatus, []*plan.Step)
+    Itinerary(plan.VM) *libitr.Itinerary
+    Pipeline(plan.VM) ([]*plan.Step, error)
+    Step(*plan.VMStatus) string
+    ExecutePhase(*plan.VMStatus) (bool, error)   // true = handled, false = delegate to migration.go
+    Logger() logging.LevelLogger
+}
+```
+
+---
+
+## Itinerary System
+
+An itinerary is an ordered list of **phases** (state machine steps). Each phase can have a
+predicate **flag** — if the flag evaluates to `false`, the phase is skipped.
+
+### Predicate Flags (base)
+
+| Flag                    | Hex    | Condition                                      |
+|-------------------------|--------|------------------------------------------------|
+| `HasPreHook`            | `0x01` | VM has a pre-migration hook defined            |
+| `HasPostHook`           | `0x02` | VM has a post-migration hook defined           |
+| `RequiresConversion`    | `0x04` | Provider requires virt-v2v AND not skipped     |
+| `CDIDiskCopy`           | `0x08` | Uses CDI DataVolume transfer (not virt-v2v)    |
+| `VirtV2vDiskCopy`       | `0x10` | Uses virt-v2v for disk transfer                |
+| `OpenstackImageMigration`| `0x20`| Source is OpenStack                            |
+| `VSphere`               | `0x40` | Source is vSphere                              |
+| `RunInspection`         | `0x80` | Plan should run preflight inspection           |
+
+### Cold Itinerary (default)
+
+```
+Started → [PreHook] → StorePowerState → PowerOffSource → WaitForPowerOff
+→ CreateDataVolumes → CopyDisks(CDI) | AllocateDisks(v2v)
+→ [CreateGuestConversionPod → ConvertGuest → CopyDisksVirtV2V]
+→ [ConvertOpenstackSnapshot]
+→ CreateVM → [PostHook] → Completed
+```
+
+Phases gated by flags:
+- `PreHook` / `PostHook`: only if hooks defined
+- `CopyDisks`: `CDIDiskCopy` (not v2v)
+- `AllocateDisks`: `VirtV2vDiskCopy` (v2v path)
+- `CreateGuestConversionPod` / `ConvertGuest` / `CopyDisksVirtV2V`: `RequiresConversion`
+- `ConvertOpenstackSnapshot`: `OpenstackImageMigration`
+
+### Warm Itinerary
+
+```
+Started → [PreHook]
+→ CreateInitialSnapshot → WaitForInitialSnapshot → [StoreInitialSnapshotDeltas(vSphere)]
+→ [PreflightInspection] → CreateDataVolumes
+── Precopy loop: ──────────────────────────────────────────
+│ CopyDisks → CopyingPaused → [RemovePreviousSnapshot(vSphere)]
+│ → [WaitForPreviousSnapshotRemoval(vSphere)]
+│ → CreateSnapshot → WaitForSnapshot → [StoreSnapshotDeltas(vSphere)]
+│ → AddCheckpoint  (loops back to CopyDisks until cutover)
+── End precopy loop ───────────────────────────────────────
+→ StorePowerState → PowerOffSource → WaitForPowerOff
+→ [RemovePenultimateSnapshot(vSphere)] → [WaitForPenultimateSnapshotRemoval(vSphere)]
+→ CreateFinalSnapshot → WaitForFinalSnapshot → AddFinalCheckpoint
+→ Finalize → [RemoveFinalSnapshot(vSphere)] → [WaitForFinalSnapshotRemoval(vSphere)]
+→ [CreateGuestConversionPod → ConvertGuest]
+→ CreateVM → [PostHook] → Completed
+```
+
+**CopyingPaused**: waits for either `Migration.Spec.Cutover` time or `NextPrecopyAt`
+(based on `Settings.PrecopyInterval` minutes).
+
+### Conversion-Only Itinerary (`MigrationOnlyConversion`)
+
+```
+Started → [PreHook] → StorePowerState → PowerOffSource → WaitForPowerOff
+→ [CreateGuestConversionPod → ConvertGuest]
+→ CreateVM → [PostHook] → Completed
+```
+
+No disk transfer at all — assumes disks are already present (e.g., storage offload).
+
+### OCP Live Migration Itinerary
+
+Completely separate phase set for OpenShift-to-OpenShift live migration:
+
+```
+Started → [PreHook] → CreateSecrets → CreateConfigMaps
+→ EnsurePreference → EnsureInstanceType → EnsureDataVolumes
+→ EnsurePersistentVolumeClaims → CreateTarget → SetOwnerReferences
+→ [CreateServiceExports(Submariner+Intercluster)]
+→ WaitForTargetVMI → CreateVirtualMachineInstanceMigrations
+→ WaitForStateTransfer → [PostHook] → Completed
+```
+
+---
+
+## Pipeline Steps (What the UI Shows)
+
+The **pipeline** is a higher-level grouping of phases into named steps shown in the UI.
+Many phases map to the same pipeline step.
+
+| Pipeline Step             | Phases Included                                                    |
+|---------------------------|--------------------------------------------------------------------|
+| `Initialize`              | Started, CreateInitialSnapshot, WaitForInitialSnapshot, StoreInitialSnapshotDeltas, CreateDataVolumes*, StorePowerState**, PowerOffSource**, WaitForPowerOff** |
+| `PreHook`                 | PreHook                                                            |
+| `DiskTransfer`            | CopyDisks, CopyingPaused, RemovePreviousSnapshot, WaitForPreviousSnapshotRemoval, CreateSnapshot, WaitForSnapshot, StoreSnapshotDeltas, AddCheckpoint, ConvertOpenstackSnapshot, CreateDataVolumes*** |
+| `DiskAllocation`          | AllocateDisks                                                      |
+| `DiskTransferV2v`         | CopyDisksVirtV2V                                                   |
+| `Cutover`                 | RemovePenultimateSnapshot, WaitForPenultimateSnapshotRemoval, CreateFinalSnapshot, WaitForFinalSnapshot, AddFinalCheckpoint, Finalize, RemoveFinalSnapshot, WaitForFinalSnapshotRemoval, StorePowerState**(warm), PowerOffSource**(warm), WaitForPowerOff**(warm) |
+| `ImageConversion`         | CreateGuestConversionPod, ConvertGuest                             |
+| `VirtualMachineCreation`  | CreateVM                                                           |
+| `PreflightInspection`     | PreflightInspection                                                |
+| `PostHook`                | PostHook                                                           |
+
+\* CreateDataVolumes maps to Initialize unless preflight inspection is active.
+\*\* StorePowerState/PowerOff phases map to Initialize in cold, Cutover in warm.
+\*\*\* CreateDataVolumes maps to DiskTransfer when preflight inspection is active.
+
+**OCP Live Migration Steps**: `Initialize`, `PrepareTarget`, `Synchronization`
+
+---
+
+## Phase Execution — execute(vm)
+
+The `execute()` method in `migration.go` steps each VM through its itinerary:
+
+1. **Check cancellation**: if user canceled, set condition and jump to Completed
+2. **Delegate to migrator**: `migrator.ExecutePhase(vm)` — if returns `true`, the migrator handled it
+3. **Default phase switch**: handles all common phases (see below)
+4. **Reflect pipeline**: `vm.ReflectPipeline()` updates step progress
+5. **Terminal handling**: on Completed, set Succeeded/Failed condition
+
+### Key Phase Behaviors
+
+**Started**: Validate VM name (DNS1123), check target name uniqueness, validate CustomizationScripts ConfigMap, cleanup previous resources, then advance.
+
+**PreHook / PostHook**: Run `HookRunner` which creates/monitors a Kubernetes Job.
+
+**CreateDataVolumes**: Call `provider.PreTransferActions()`, create populator PVCs or CDI DataVolumes (with snapshot checkpoints for warm), then advance.
+
+**CopyDisks / AllocateDisks**: Monitor DataVolume or PVC progress. Track per-disk tasks. For warm migrations, record precopy success and set `NextPrecopyAt`.
+
+**CopyingPaused** (warm only): Wait for cutover time or next precopy interval.
+
+**Snapshot phases** (warm, vSphere-gated): Create/wait/remove snapshots via provider, store deltas.
+
+**CreateGuestConversionPod**: Create virt-v2v pod with VM volumes mounted. For OVA/HyperV, also wait for provider storage PVC readiness.
+
+**ConvertGuest / CopyDisksVirtV2V**: Monitor virt-v2v pod. Poll `http://<podIP>:2112/metrics` for disk transfer progress. Fetch VM config from `http://<podIP>:8080/vm` when pod completes.
+
+**PreflightInspection**: Create virt-v2v inspection pod, wait for pod success/failure.
+
+**CreateVM**: Call `kubevirt.EnsureVM()` to create `VirtualMachine` CR, set PVC owner references, delete consumed DataVolumes and importer pods.
+
+**Completed**: Mark VM completed, set Succeeded condition, optionally delete guest conversion pod, detach LUN disks from source.
+
+---
+
+## KubeVirt Helper — K8s Resources Created
+
+The `KubeVirt` struct in `kubevirt.go` manages all Kubernetes resources:
+
+| Resource              | Created By                    | Purpose                                          |
+|-----------------------|-------------------------------|--------------------------------------------------|
+| **Namespace**         | `EnsureNamespace()`           | Target namespace for migrated VMs                |
+| **Secret**            | `ensureSecret()`              | Provider credentials for CDI/populator/v2v       |
+| **ConfigMap**         | `ensureConfigMap()`           | VM configuration, VDDK settings                  |
+| **DataVolume**        | `EnsureDataVolumes()`         | CDI disk transfer from source                    |
+| **PVC** (populator)   | `EnsurePopulatorVolumes()`    | Volume populator path for storage offload        |
+| **virt-v2v Pod**      | `EnsureVirtV2vPod()`         | Guest conversion or inspection pod               |
+| **VirtualMachine**    | `EnsureVM()`                  | Target KubeVirt VM CR                            |
+| **PV / PVC** (NFS)    | `EnsurePVForNFS()`           | OVA provider storage                             |
+| **PV / PVC** (SMB)    | `EnsurePVForSMB()`           | HyperV provider storage                          |
+| **Hook Jobs**         | `HookRunner`                  | Pre/post migration hook execution                |
+
+### Disk Transfer Paths
+
+**CDI DataVolume path** (oVirt, OpenStack without v2v):
+1. Create DataVolume with source URL/credentials
+2. CDI creates importer pod that pulls disk data
+3. Monitor `DataVolume.Status.Phase` (Pending → ImportInProgress → Succeeded)
+4. Track `PercentComplete()` for progress
+
+**Volume Populator path** (storage offload — vSphere XCOPY, etc.):
+1. Create PVC with populator data source annotations
+2. CDI/populator creates populator pod (`populate-<pvcUID>`)
+3. Monitor PVC `ClaimBound` status and `PopulatorTransferredBytes()`
+
+**virt-v2v path** (vSphere, OVA, HyperV, EC2):
+1. Create DataVolumes with blank source (or allocate disks directly)
+2. Create virt-v2v conversion pod with all disk PVCs mounted
+3. virt-v2v copies and converts disks inside the pod
+4. Monitor via Prometheus metrics endpoint `:2112/metrics`
+5. Fetch converted VM config from `:8080/vm` endpoint
+
+### Warm Migration Specifics
+
+- **Snapshots**: Provider creates incremental snapshots; deltas tracked per precopy
+- **Checkpoints**: CDI DataVolume checkpoints enable incremental copy
+- **Precopy loop**: CopyDisks → pause → new snapshot → checkpoint → CopyDisks
+- **Cutover**: Triggered by `Migration.Spec.Cutover` timestamp
+- **Final copy**: Power off source → final snapshot → finalize transfer
+
+---
+
+## Handler Pattern (Watch/Reconcile)
+
+Handlers in `pkg/controller/plan/handler/` are **inventory watch event handlers**, not
+migration phase handlers. They watch provider inventory for VM changes and trigger
+plan reconciliation.
+
+```go
+type Handler interface {
+    Watch(m *handler.WatchManager) error
+}
+```
+
+Factory in `handler/doc.go` creates per-provider handler:
+- `vsphere.Handler` — watches vSphere VMs
+- `ovirt.Handler` — watches oVirt VMs
+- `openstack.Handler`, `ova.Handler`, `hyperv.Handler`, `ocp.Handler`, `ec2.Handler`
+
+When a VM changes in inventory, the handler finds Plans referencing that provider+VM
+and enqueues reconcile events.
+
+---
+
+## Error Handling & Cleanup
+
+- **Step errors**: `step.AddError(msg)` — sets error on pipeline step, VM continues to Completed with Failed condition
+- **Fatal errors**: Return `err` from `execute()` — stops the reconcile, retried on next poll
+- **Cleanup on cancel/fail**: `cleanup(vm)` deletes VM (if `DeleteVmOnFailMigration`), DataVolumes, importer pods, conversion pods, secrets, configmaps, hook jobs, populator resources
+- **Archive**: `Archive()` cleans up all retained resources when plan is archived
+
+---
+
+## Phase Constants Reference
+
+All defined in `pkg/apis/forklift/v1beta1/doc.go`:
+
+```
+Started, PreHook, PostHook, Completed,
+AddCheckpoint, AddFinalCheckpoint, AllocateDisks,
+ConvertGuest, ConvertOpenstackSnapshot, CopyDisks, CopyDisksVirtV2V,
+CopyingPaused, CreateDataVolumes, CreateFinalSnapshot,
+CreateGuestConversionPod, CreateInitialSnapshot, CreateSnapshot,
+CreateVM, Finalize, PreflightInspection, PowerOffSource,
+RemoveFinalSnapshot, RemovePenultimateSnapshot, RemovePreviousSnapshot,
+StoreInitialSnapshotDeltas, StorePowerState, StoreSnapshotDeltas,
+WaitForFinalSnapshot, WaitForFinalSnapshotRemoval,
+WaitForInitialSnapshot, WaitForPenultimateSnapshotRemoval,
+WaitForPowerOff, WaitForPreviousSnapshotRemoval, WaitForSnapshot
+```

--- a/.cursor/rules/backend/plans/plan-adapters.mdc
+++ b/.cursor/rules/backend/plans/plan-adapters.mdc
@@ -1,0 +1,286 @@
+---
+description: Plan adapters - provider-specific migration logic, Builder/Client/Validator interfaces
+alwaysApply: false
+---
+
+# Plan Adapters
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Overview
+
+The plan adapter pattern abstracts provider-specific migration logic behind a uniform interface. Each source provider (vSphere, oVirt, OpenStack, OVA, Hyper-V, EC2, OpenShift) implements the same set of interfaces so the plan controller can orchestrate migrations without provider-specific branching.
+
+**Source**: `pkg/controller/plan/adapter/`
+
+---
+
+## Factory Pattern
+
+`pkg/controller/plan/adapter/doc.go` contains the `New()` factory that returns the correct adapter based on `provider.Type()`:
+
+```go
+func New(provider *api.Provider) (adapter Adapter, err error) {
+    switch provider.Type() {
+    case api.VSphere:   adapter = &vsphere.Adapter{}
+    case api.OVirt:     adapter = &ovirt.Adapter{}
+    case api.OpenStack: adapter = &openstack.Adapter{}
+    case api.OpenShift: adapter = &ocp.Adapter{}
+    case api.Ova:       adapter = &ova.Adapter{}    // alias for ovfbase.Adapter
+    case api.EC2:       adapter = ec2adapter.New()   // separate package
+    case api.HyperV:    adapter = &hyperv.Adapter{}
+    }
+}
+```
+
+The package re-exports base types so consumers import from `adapter` directly:
+`Adapter`, `Builder`, `Ensurer`, `Client`, `Validator`, `DestinationClient`.
+
+---
+
+## Core Interfaces
+
+### Adapter (top-level factory)
+
+Each provider's `Adapter` struct implements this interface to construct the four sub-interfaces. All methods receive `*plancontext.Context` (the plan execution context with source/destination provider refs, secrets, inventory clients, and plan spec).
+
+```go
+type Adapter interface {
+    Builder(ctx *plancontext.Context) (Builder, error)
+    Client(ctx *plancontext.Context) (Client, error)
+    Validator(ctx *plancontext.Context) (Validator, error)
+    DestinationClient(ctx *plancontext.Context) (DestinationClient, error)
+    Ensurer(ctx *plancontext.Context) (Ensurer, error)
+}
+```
+
+### Builder — constructs migration K8s resources
+
+The Builder translates source VM inventory into destination Kubernetes objects (DataVolumes, PVCs, VirtualMachine specs, Secrets, ConfigMaps).
+
+| Method | Purpose |
+|--------|---------|
+| `Secret()` | Build credential secret for CDI import (user/password, CA cert) |
+| `ConfigMap()` | Build certificate/config ConfigMap for the import |
+| `DataVolumes()` | Create `cdi.DataVolume` specs per disk (VDDK source for vSphere, imageIO for oVirt, HTTP for OpenStack/OVA) |
+| `VirtualMachine()` | Build the `cnv.VirtualMachineSpec` — disks, NICs, firmware, CPU, memory, TPM |
+| `Tasks()` | Build migration progress tasks (one per disk, sized in MB) |
+| `TemplateLabels()` | OS-based template labels for the destination VM |
+| `PodEnvironment()` | Env vars for the virt-v2v conversion pod |
+| `LunPersistentVolumes/Claims()` | Direct LUN PVs/PVCs (oVirt FC/iSCSI LUNs) |
+| `SupportsVolumePopulators()` | Whether provider uses volume populators (vSphere XCOPY offload) |
+| `PopulatorVolumes()` | Build PVCs with DataSourceRef pointing to a volume populator CR |
+| `PopulatorTransferredBytes()` | Query transfer progress from the populator CR |
+| `PreferenceName()` | Resolve KubeVirt instance type preference |
+| `ConfigMaps()` / `Secrets()` | Additional ConfigMaps/Secrets to create for the VM |
+| `ConversionPodConfig()` | Provider-specific node selectors, labels, annotations for the conversion pod |
+
+### Client — source VM operations
+
+The Client performs runtime operations on the source VM during migration.
+
+| Method | Purpose |
+|--------|---------|
+| `PowerOn/Off()` | Control source VM power state |
+| `PowerState()` / `PoweredOff()` | Query source VM power state |
+| `CreateSnapshot()` | Create a warm-migration precopy snapshot (returns snapshot ID + task ID) |
+| `RemoveSnapshot()` | Remove a snapshot after transfer |
+| `CheckSnapshotReady/Remove()` | Poll snapshot creation/removal task status |
+| `SetCheckpoints()` | Set CDI DataVolume checkpoint annotations for incremental copies |
+| `GetSnapshotDeltas()` | Get per-disk change IDs from a snapshot (CBT for vSphere) |
+| `Finalize()` | Post-migration cleanup (e.g., delete VMExports for OCP) |
+| `DetachDisks()` | Detach LUN disks from the source VM (oVirt) |
+| `PreTransferActions()` | Provider-specific pre-transfer setup (OpenStack: create volumes from snapshots) |
+| `Close()` | Close API connections |
+
+### Validator — plan validation
+
+The Validator performs pre-flight checks before migration starts.
+
+| Method | Purpose |
+|--------|---------|
+| `StorageMapped()` | All VM disks have storage mapping entries |
+| `DirectStorage()` | LUN/FC disk details are complete (oVirt-specific) |
+| `NetworksMapped()` | All VM NICs have network mapping entries |
+| `MaintenanceMode()` | Host is not in maintenance mode |
+| `WarmMigration()` | Provider supports warm migration |
+| `MigrationType()` | Plan's migration type is valid for this provider |
+| `StaticIPs()` | Static IP info available for all NICs |
+| `UdnStaticIPs()` | UDN subnet matches VM IP addresses |
+| `SharedDisks()` | Shared disk validation (vSphere: running VMs, duplicate detection) |
+| `ChangeTrackingEnabled()` | CBT enabled for warm migration (vSphere) |
+| `HasSnapshot()` | No pre-existing snapshots that conflict with warm migration |
+| `PowerState()` | VM power state compatible with migration type |
+| `VMMigrationType()` | VM inherently compatible (OCP: live migration checks) |
+| `InvalidDiskSizes()` | All disks have valid sizes (> 0) |
+| `MacConflicts()` | Source MAC addresses don't conflict with destination VMs |
+| `PVCNameTemplate()` | PVC name template produces valid DNS1123 labels |
+| `GuestToolsInstalled()` | Guest tools status check (vSphere: VMware Tools) |
+
+### DestinationClient — destination cluster operations
+
+| Method | Purpose |
+|--------|---------|
+| `DeletePopulatorDataSource()` | Clean up volume populator CRs after migration |
+| `SetPopulatorCrOwnership()` | Set owner references on populator CRs |
+
+### Ensurer — resource creation on destination
+
+Shared across all providers (uses `ensurer.Ensurer` from `pkg/controller/plan/ensurer/`):
+
+| Method | Purpose |
+|--------|---------|
+| `SharedConfigMaps()` | Ensure ConfigMaps exist in destination namespace |
+| `SharedSecrets()` | Ensure Secrets exist in destination namespace |
+
+The Ensurer also has `VirtualMachine()`, `DataVolumes()`, and `PersistentVolumeClaims()` methods on the concrete struct (not on the interface) that create resources idempotently using label-based lookups.
+
+---
+
+## Per-Provider Key Differences
+
+### vSphere (`vsphere/`)
+
+- **Transfer method**: VDDK (VMware Virtual Disk Development Kit) via CDI, or virt-v2v for disk copying
+- **Warm migration**: Supported via Changed Block Tracking (CBT) snapshots
+- **Volume populators**: Supported via vSphere XCOPY offload (`VSphereXcopyVolumePopulator` CR) when `feature_copy_offload` is enabled and StorageMap has `OffloadPlugin.VSphereXcopyPluginConfig`
+- **Host CRs**: Loads `api.Host` resources to determine ESXi direct transfer vs vCenter transfer
+- **Builder.Load()**: Pre-loads host map on construction (unique to vSphere)
+- **Connection**: govmomi SOAP client; supports per-ESXi-host client caching
+- **Shared disks**: Full support — detects shared VMDK, validates running VMs, finds existing PVCs
+- **RDM disks**: Maps as LUN devices when `RDMAsLun` is set
+- **OS mapping**: Large `osMap` translating VMware guest IDs → osinfo IDs
+- **PVC name templates**: Full template support with `VSpherePVCNameTemplateData` (VmName, PlanName, DiskIndex, FileName, WinDriveLetter, etc.)
+- **Legacy Windows**: Detects legacy OS (XP, 2003, Vista, 2008) for VirtIO driver selection
+- **Secret**: Maps `user`→`accessKeyId`, `password`→`secretKey`; adds CA cert
+- **Conversion pod config**: No special requirements (empty result)
+- **Libvirt URL**: Constructs `vpx://` (vCenter), `esx://` (ESXi direct) URLs for virt-v2v
+
+### oVirt (`ovirt/`)
+
+- **Transfer method**: imageIO (oVirt image transfer API) via CDI
+- **Warm migration**: Supported via oVirt snapshot API (event-based polling for snapshot completion)
+- **LUN disks**: Full support for FC/iSCSI LUNs — builds `LunPersistentVolumes()` and `LunPersistentVolumeClaims()` with iSCSI target details
+- **Connection**: `go-ovirt` SDK (`ovirtsdk.Connection`)
+- **DirectStorage()**: Validates LUN disk details (logical unit size, storage type)
+- **Finalize**: Removes migration snapshots and deletes transferred disks from source
+- **DetachDisks**: Detaches LUN disks from source VM
+- **OS mapping**: Maps oVirt guest IDs → osinfo IDs
+- **Secret**: Includes CA certificate from provider in PEM format
+- **ConfigMap**: Writes CA certificate for imageIO connections
+- **Conversion pod config**: Adds `V2V_source=ovirt`, libvirt URI, password from secret
+
+### OpenStack (`openstack/`)
+
+- **Transfer method**: Glance image download via HTTP(S) or Cinder volume snapshots
+- **Warm migration**: Not supported
+- **Connection**: Custom OpenStack client (`libclient.Client`) with Keystone auth
+- **Snapshot flow**: Creates Cinder volume snapshots → temporary volumes → Glance images for transfer
+- **PreTransferActions**: Complex multi-step: snapshot → volume → image pipeline, with polling for each status transition
+- **Finalize**: Deletes temporary volumes and images created during migration
+- **Image-based VMs**: Special handling for Glance-sourced VMs (maps `__glance` storage domain)
+- **Secret**: OpenStack credentials (username, password, domain, project, region)
+- **ConfigMap**: Writes CA certificate for Glance/Cinder connections
+- **Volume populators**: Not supported
+- **Conversion pod config**: Adds `V2V_source=openstack`, Keystone auth env vars
+
+### OVA (`ova/`) — alias for ovfbase
+
+- **Implementation**: Pure type alias to `ovfbase` package — `Adapter = ovfbase.Adapter`, etc.
+- **Transfer method**: HTTP download from OVA server appliance (NFS-backed)
+- **Warm migration**: Not supported
+- **OVF parsing**: Shared `ovfparser.go` parses OVF XML for VM metadata (firmware, OS, disks)
+- **DataVolumes**: Uses `cdi.DataVolumeSourceHTTP` pointing to the OVA server URL
+- **Secret**: No-op (no per-VM credentials needed)
+- **ConfigMap**: No-op
+- **Conversion pod config**: Adds `V2V_source=ova`, source disk paths
+- **Volume populators**: Not supported
+- **DestinationClient**: All methods are no-ops
+
+### Hyper-V (`hyperv/`)
+
+- **Implementation**: Separate adapter, not based on ovfbase despite initial similarity
+- **Transfer method**: SMB share with CSI driver (`-i disk` mode for virt-v2v)
+- **Warm migration**: Not supported
+- **Connection**: HyperV driver (`driver.HyperVDriver`) via WinRM/PowerShell
+- **Storage validation**: Checks `disk.SMBPath` presence (single SMB share model)
+- **Secret**: No-op (SMB credentials handled by CSI driver at pod mount time)
+- **ConfigMap**: No-op
+- **OS mapping**: Uses `ovfbase.OsMapToOsinfoId()` from shared OVF logic
+- **Conversion pod config**: Adds node selector for `hyperv-host` label, sets SMB-related labels/annotations
+- **Volume populators**: Not supported
+- **Builder**: Simpler disk mapping (no snapshot suffixes, no shared disk logic)
+
+### OpenShift (`ocp/`)
+
+- **Transfer method**: VirtualMachineExport API → HTTPS download of VM volumes
+- **Migration types**: Cold, Live (via `DecentralizedLiveMigration` feature gate), and Conversion
+- **Warm migration**: Not supported
+- **Connection**: `k8sclient.Client` to source OpenShift cluster (via kubeconfig from provider secret, or local for `IsHost`)
+- **ConfigMap**: Fetches TLS certificate from `VirtualMachineExport.Status.Links.External.Cert`
+- **DataVolumes**: Uses `cdi.DataVolumeSourceHTTP` with export URL; special handling for ContainerDisk (blank DV with prePopulated annotation)
+- **VirtualMachine**: Copies spec from source VM, remaps networks, handles ContainerDisk volumes
+- **PreTransferActions**: Creates `VirtualMachineExport` CR on source cluster, waits for it to become ready
+- **Finalize**: Deletes `VirtualMachineExport` CRs from source cluster
+- **Live migration**: Validates `LiveMigratable` and `StorageLiveMigratable` conditions on source VMI
+- **Secret**: Exports source cluster token as `accessKeyId`
+- **Volume populators**: Not supported
+
+---
+
+## Shared Utilities
+
+### `base/` package
+
+- **Annotations**: Constants for CDI/Forklift annotations (`AnnDiskSource`, `AnnBindImmediate`, `AnnRequiresConversion`, etc.)
+- **`ConversionPodConfigResult`**: Struct for provider-specific conversion pod config (NodeSelector, Labels, Annotations)
+- **`VolumePopulatorNotSupportedError`**: Sentinel error for providers that don't support volume populators
+- **`ValidatePVCNameTemplate()`**: Shared utility to validate PVC name templates produce valid DNS1123 labels
+- **MAC conflict detection**: `CheckMacConflicts()`, `FindSourceVM()`, `GetDestinationVMsFromInventory()` helpers
+
+### `ovfbase/` package
+
+Shared logic for OVF-format providers (OVA and partially Hyper-V):
+- **`ovfparser.go`**: Parses OVF XML for firmware type, OS info, disk metadata
+- **`OsMapToOsinfoId()`**: Maps OVF OS type strings to osinfo IDs
+- **`ParseCapacity()`**: Converts OVF capacity strings (with units) to bytes
+
+### `ensurer/` package
+
+Provider-agnostic resource creation on the destination cluster:
+- Creates VirtualMachines, DataVolumes, PVCs by label (idempotent)
+- Creates shared ConfigMaps and Secrets by name (allows pre-existing resources)
+
+---
+
+## How Adapters Connect Inventory to Execution
+
+```
+plancontext.Context
+├── Source.Provider     → API provider CR
+├── Source.Secret       → Provider credentials
+├── Source.Inventory    → Inventory client (Find/Get/List VMs, networks, datastores)
+├── Destination.Client  → K8s client for target cluster
+├── Plan               → Plan CR (spec.vms, mappings, settings)
+├── Migration          → Active Migration CR
+└── Map.Network/Storage → Resolved NetworkMap/StorageMap CRs
+
+Adapter.Builder(ctx) → reads inventory → builds K8s objects
+Adapter.Client(ctx)  → connects to source API → manages VM lifecycle
+Adapter.Validator(ctx) → reads inventory → validates plan feasibility
+```
+
+Each sub-interface embeds `*plancontext.Context` and uses `r.Source.Inventory.Find(vm, vmRef)` to load VM details from the provider inventory cache, then applies provider-specific transformations to produce Kubernetes resources.
+
+---
+
+## Migration Type Support Matrix
+
+| Provider | Cold | Warm | Live | Conversion |
+|----------|------|------|------|------------|
+| vSphere | Yes | Yes (CBT) | No | Yes |
+| oVirt | Yes | Yes (snapshots) | No | Yes |
+| OpenStack | Yes | No | No | No |
+| OVA | Yes | No | No | No |
+| Hyper-V | Yes | No | No | No |
+| OpenShift | Yes | No | Yes | Yes |

--- a/.cursor/rules/backend/plans/plan-controller.mdc
+++ b/.cursor/rules/backend/plans/plan-controller.mdc
@@ -1,0 +1,283 @@
+---
+description: Plan controller - reconciliation, validation conditions, lifecycle, Migration CR relationship
+alwaysApply: false
+---
+
+# Plan Controller
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Overview
+
+The Plan controller (`pkg/controller/plan/controller.go`) is the central reconciler for migration plans. It watches Plan CRs plus related resources (Provider, NetworkMap, StorageMap, Hook, Migration) and drives the full lifecycle from validation through execution.
+
+The Migration controller (`pkg/controller/migration/controller.go`) is intentionally thin — it sets owner references, validates the plan reference, and reflects plan snapshot status back onto the Migration CR.
+
+---
+
+## Reconcile Flow
+
+```
+Reconcile(plan)
+│
+├─ 1. Fetch Plan (abort if deleted → cleanup orphaned resources)
+├─ 2. Skip if Archived (spec.archived + status has Archived condition)
+├─ 3. Skip if Succeeded (unless needs archiving)
+├─ 4. Postpone if dependencies not yet reconciled
+│     (Provider, NetworkMap, StorageMap, Host, Hook ObservedGeneration < Generation)
+├─ 5. BeginStagingConditions()
+├─ 6. validate(plan) — sets conditions on plan.Status
+│     └─ If validation returns error for dangling archived plan → archive + return
+├─ 7. Set PopulatorDataSource labels (one-time, post-Succeeded/Failed/Canceled)
+├─ 8. Archive if spec.archived
+├─ 9. Set Ready condition (if no blockers, not archived, not validating VDDK)
+├─ 10. EndStagingConditions()
+└─ 11. execute(plan) — find/run migration, update status
+```
+
+### Execute Flow
+
+```
+execute(plan)
+│
+├─ If blocker/archived/reQ-condition → fail executing migration if grace period exceeded → return
+├─ Build plancontext.Context
+├─ Find active migration (from snapshot)
+│   ├─ If found → SetMigration, matchSnapshot (cancel if mutated)
+│   └─ If snapshot marked Canceled → propagate to all non-terminal VMs
+├─ runner.Cancel() — cancel VMs marked for cancellation
+├─ Find pending migrations (sorted by creationTimestamp)
+├─ If no active + pending exists → select first pending, create new snapshot
+├─ If no migration at all → delete Executing condition, slow requeue
+├─ runner.Run() — execute the migration
+└─ Reflect snapshot conditions (Executing/Succeeded/Failed/Canceled) onto plan.Status
+```
+
+---
+
+## Validation Conditions
+
+All conditions set during `validate()`. The UI reads these from `plan.status.conditions[]`.
+
+### Critical (Blockers — prevent execution)
+
+| Condition Type | When Set |
+|---|---|
+| `SourceProviderNotReady` | Source provider missing or not Ready |
+| `DestinationProviderNotReady` | Destination provider missing or not Ready |
+| `NamespaceNotValid` | Target namespace empty or invalid DNS1123 |
+| `NetworkMapRefNotValid` | Network map ref not set or not found |
+| `NetworkMapNotReady` | Referenced NetworkMap lacks Ready condition |
+| `StorageRefNotValid` | Storage map ref not set or not found |
+| `StorageMapNotReady` | Referenced StorageMap lacks Ready condition |
+| `VMRefNotValid` | VM ref has neither ID nor Name |
+| `VMNotFound` | VM not found in source inventory |
+| `VMAlreadyExists` | Target VM already exists in destination |
+| `DuplicateVM` | Duplicate source VM ID or duplicate targetName |
+| `VMNetworksNotMapped` | VM has networks not covered by NetworkMap |
+| `VMStorageNotMapped` | VM has storage not covered by StorageMap |
+| `VMStorageNotSupported` | Unsupported storage (e.g., Direct LUN/FC < oVirt 4.5.2.1) |
+| `VMMultiplePodNetworkMappings` | Multiple NICs mapped to pod network |
+| `VMDuplicateNADMappings` | Multiple NICs use same Multus NAD |
+| `VMMissingChangedBlockTracking` | Warm migration: CBT not enabled |
+| `VMHasSnapshots` | Warm migration: pre-existing snapshots |
+| `VMPowerStateUnsupported` | VM power state incompatible with migration type |
+| `VMMigrationTypeUnsupported` | VM incompatible with selected migration type |
+| `GuestToolsIssue` | VMware Tools not properly installed/running |
+| `InvalidDiskSizes` | VM has disks with invalid sizes |
+| `MacConflicts` | MAC address conflicts with existing destination VMs |
+| `MissingPvcForOnlyConversion` | Conversion-only mode: missing vendor PVCs |
+| `WarmMigrationNotReady` | Warm migration not supported from source provider |
+| `MigrationTypeNotValid` | Selected migration type not supported |
+| `TransferNetworkNotValid` | Transfer network NAD not found or invalid |
+| `HookNotValid` | Hook ref not set, not found, or not executable |
+| `HookNotReady` | Referenced Hook lacks Ready condition |
+| `HookStepNotValid` | Hook step not PreHook or PostHook |
+| `HookServiceAccountNotValid` | Hook ServiceAccount not found |
+| `ServiceAccountNotValid` | Plan ServiceAccount not found in target namespace |
+| `VDDKInvalid` | VDDK validation job failed |
+| `VDDKInitImageUnavailable` | VDDK image not set (required for warm/raw-copy) or pull exceeded deadline |
+| `UnsupportedVersion` | OCP-to-OCP: source version < 1.26 |
+| `UnsupportedUserDefinedNetwork` | UDN Layer3 in destination namespace |
+| `SharedDisks` | VMs with shared disks (critical category) |
+| `VDDKAndOffloadMixedUsage` | Mixed VDDK and copy-offload in same plan |
+| `VMCriticalConcerns` | VMs have critical-category inventory concerns |
+| `NetMapDestinationNADNotValid` | NAD in wrong namespace |
+| `TargetNameNotValid` | Manually-assigned target name is invalid |
+
+### Warning (Non-blocking)
+
+| Condition Type | When Set |
+|---|---|
+| `TargetNameNotValid` | Source VM name not DNS1123-compliant (auto-renamed; warning only) |
+| `HostNotReady` | VM host in maintenance mode |
+| `VMMissingGuestIPs` | Cannot preserve static IPs (no guest info) |
+| `VMIpNotMatchingUdnSubnet` | VM IP outside primary UDN subnet |
+| `NetMapPreservingIPsOnPodNetwork` | Preserving IPs with Pod networking (unsupported combo) |
+| `TransferNetworkMissingDefaultRoute` | Transfer network NAD missing route annotation |
+| `SharedWarnDisks` | VMs with shared disks (warning category) |
+| `LuksAndClevisIncompatibility` | LUKS + Clevis configured together |
+| `UnsupportedOVFExportSource` | OVA VM from unsupported OVF source |
+| `ConversionHasWarnings` | Conversion produced warnings |
+| `RestrictedPodSecurity` | Controller namespace has restricted pod security |
+
+### Advisory (Informational)
+
+| Condition Type | When Set |
+|---|---|
+| `ValidatingVDDK` | VDDK image validation in progress |
+| `VDDKInitImageNotReady` | VDDK image pull still in progress (within deadline) |
+| `Archived` | Plan has been archived |
+
+### Lifecycle Conditions (set during execution)
+
+| Condition Type | Meaning |
+|---|---|
+| `Executing` | Migration is actively running |
+| `Succeeded` | Migration completed successfully |
+| `Failed` | Migration failed |
+| `Canceled` | Migration was canceled (user request or snapshot mutation) |
+
+---
+
+## Condition Categories
+
+```go
+Required  = "Required"   // blocks Ready condition
+Advisory  = "Advisory"   // informational
+Critical  = "Critical"   // blocker — prevents execution
+Error     = "Error"      // blocker — prevents execution  
+Warn      = "Warn"       // non-blocking warning
+```
+
+The plan is **Ready** when: no blocker conditions + not Archived + not ValidatingVDDK.
+
+---
+
+## Blocker Grace Period
+
+When blocker conditions (Critical/Error) appear during active execution, the controller waits a configurable grace period (default 5 minutes, controlled by `BLOCKER_GRACE_PERIOD_MINUTES`) before failing the migration. This prevents transient issues from immediately killing migrations.
+
+---
+
+## Plan ↔ Migration Relationship
+
+```
+Plan (1) ──references──> (N) Migration CRs
+Plan.Status.Migration.History[] ──contains──> Snapshot[] (one per Migration)
+```
+
+1. **User creates a Migration CR** referencing a Plan
+2. **Migration controller** sets ownerReference (Plan owns Migration → auto-delete on plan deletion)
+3. **Plan controller** discovers pending migrations, sorted by creationTimestamp
+4. Plan creates a **Snapshot** capturing the current state of Plan + Provider + Maps
+5. Plan runs the migration via `Migration.Run()`
+6. Snapshot conditions are reflected back to `plan.status.conditions`
+7. **Migration controller** reflects snapshot state → migration.status (Running, Succeeded, Failed, Canceled)
+
+### Snapshot Mutation Detection
+
+If the Plan, providers, or maps change while a migration is active, `matchSnapshot()` detects the mismatch and marks the active snapshot as **Canceled**. This ensures migrations run against consistent configuration.
+
+---
+
+## Plan Context (`pkg/controller/plan/context`)
+
+The `Context` struct aggregates all data needed for migration execution:
+
+| Field | Source |
+|---|---|
+| `Plan` | The Plan CR with Referenced data populated |
+| `Migration` | The active Migration CR |
+| `Map.Network` | Referenced NetworkMap |
+| `Map.Storage` | Referenced StorageMap |
+| `Source.Provider` | Source provider + secret + inventory client |
+| `Destination.Provider` | Destination provider + remote k8s client + inventory |
+| `Hooks` | Referenced Hook CRs |
+| `Labeler` | Generates consistent labels (plan UID, migration UID, VM ID) |
+
+Context creation fails with `NotEnoughDataError` if required referenced data is missing.
+
+---
+
+## Ensurer (`pkg/controller/plan/ensurer`)
+
+The `Ensurer` creates resources on the destination cluster during migration:
+
+| Method | Creates | Matching Strategy |
+|---|---|---|
+| `VirtualMachine()` | Target VM | By label (vmID) |
+| `DataVolumes()` | CDI DataVolumes | By label + disk-source annotation |
+| `PersistentVolumeClaims()` | PVCs | By label + disk-source annotation |
+| `SharedConfigMaps()` | ConfigMaps | By name (shared across VMs) |
+| `SharedSecrets()` | Secrets | By name (shared across VMs) |
+
+Resources are labeled with: `plan=<planUID>`, `migration=<migrationUID>`, `vmID=<vmRefID>`
+
+---
+
+## Utilities (`pkg/controller/plan/util`)
+
+- `ChangeVmName(name)` — Converts VM names to DNS1123-compliant format
+- `CalculateSpaceWithOverhead(size, volumeMode)` — Adds filesystem/block overhead to disk sizes
+- `GetDeviceNumber(deviceString)` — Parses `/dev/sdX` for boot order
+- `VirtualMachineKind = "VirtualMachine"` — Used in owner reference checks
+
+---
+
+## Archived / Succeeded Plans
+
+- **Archived**: `plan.spec.archived=true` triggers `archive()` which cleans up lingering resources and sets the `Archived` condition. Once archived, reconciliation is skipped entirely.
+- **Succeeded**: Once a plan has `Succeeded` condition and is not being archived, reconciliation is skipped.
+- **Dangling archived plan**: If validation fails and the plan is archived with no source provider, it's force-archived.
+
+---
+
+## Orphaned Resource Cleanup
+
+When a Plan is deleted, `cleanupOrphanedResources` removes resources by plan-name/namespace labels:
+- PVCs, DataVolumes (preserving those owned by VirtualMachine)
+- Pods, Secrets, ConfigMaps, PersistentVolumes
+
+---
+
+## Migration Controller (Thin Layer)
+
+The Migration controller's responsibilities are minimal:
+
+1. **setOwnerReference** — Plan owns Migration (auto-cleanup)
+2. **validate** — Checks plan ref is set/found/Ready; validates Cancel[] VM refs
+3. **reflectPlan** — Copies snapshot conditions to migration.status:
+   - Snapshot `Executing` → Migration gets `Running` condition + `MarkStarted()`
+   - Snapshot `Succeeded` → Migration gets `Succeeded` + `MarkCompleted()`
+   - Snapshot `Failed` → Migration gets `Failed` + `MarkCompleted()`
+   - Snapshot `Canceled` → Migration gets `Canceled` + `MarkCompleted()`
+4. Sets `Ready` if no blocker conditions
+
+### Migration Validation Conditions
+
+| Condition | When Set |
+|---|---|
+| `PlanNotValid` | Plan ref not set or not found |
+| `PlanNotReady` | Referenced Plan lacks Ready condition |
+| `VMNotFound` | VM in Cancel[] not found in inventory |
+| `VMNotUnique` | VM in Cancel[] reference is ambiguous |
+
+---
+
+## Key Constants for UI Mapping
+
+The UI should map these backend condition types to user-visible plan statuses:
+
+```
+Backend Condition  →  UI Status
+─────────────────────────────────
+Ready (no blockers) →  Ready
+Executing           →  Executing
+Succeeded           →  Completed
+Failed              →  Failed
+Canceled            →  Canceled
+Archived            →  Archived
+Any Critical/Error  →  CannotStart (when not executing)
+ValidatingVDDK      →  Validating (not yet ready)
+```

--- a/.cursor/rules/backend/plans/scheduler.mdc
+++ b/.cursor/rules/backend/plans/scheduler.mdc
@@ -1,0 +1,216 @@
+---
+description: Plan scheduler - VM scheduling logic, concurrency limits, per-provider batching
+alwaysApply: false
+---
+
+# Plan Scheduler
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Overview
+
+The scheduler determines **which VM to migrate next** from a Plan's VM list. It enforces concurrency limits to prevent overloading source infrastructure. Each provider type has its own scheduler implementation, but all share the same interface and factory.
+
+**Source**: `pkg/controller/plan/scheduler/`
+
+---
+
+## Scheduler Interface
+
+```go
+// pkg/controller/plan/scheduler/doc.go
+type Scheduler interface {
+    Next() (vm *plan.VMStatus, hasNext bool, err error)
+}
+```
+
+`Next()` returns:
+- `vm` — the next `VMStatus` eligible to start migration
+- `hasNext` — `true` if a VM was found, `false` if all are busy/done or concurrency limit reached
+- `err` — any error during scheduling
+
+### Factory
+
+`scheduler.New(ctx *plancontext.Context)` creates the correct scheduler based on `ctx.Source.Provider.Type()`. All schedulers receive `settings.Settings.MaxInFlight` as their concurrency limit.
+
+---
+
+## MaxInFlight Setting
+
+| Setting | Env Var | Default | Scope |
+|---------|---------|---------|-------|
+| `MaxInFlight` | `MAX_VM_INFLIGHT` | **20** | Per source provider (all plans sharing the same provider) |
+
+Defined in `pkg/settings/migration.go`. Must be a positive integer.
+
+---
+
+## Two Scheduling Models
+
+### 1. Simple Model (oVirt, OpenStack, OCP, OVA, Hyper-V, EC2)
+
+These providers use a **flat VM-count** concurrency model:
+
+```
+inFlight (running VMs across all plans for same provider) < MaxInFlight → schedule next VM
+```
+
+**Algorithm** (`Next()`):
+1. Acquire package-level mutex
+2. List all Plans in the cluster
+3. Count running VMs across all Plans sharing the same source provider (skip archived, non-executing plans)
+4. If `inFlight >= MaxInFlight` → return no VM
+5. Iterate this Plan's VMs in order; return the first VM that is not canceled, not started, and not completed
+
+**Concurrency unit**: 1 VM = 1 slot. Simple counter across the provider.
+
+### 2. Host-Aware Model (vSphere only)
+
+vSphere uses a **per-ESXi-host disk-count** concurrency model. The limit is per host, not globally flat:
+
+```
+inFlight[host] (disk slots in use on that host) + cost(vm) <= MaxInFlight → schedulable
+```
+
+**Concurrency unit**: number of actively-transferring **disks** on each ESXi host. Each host gets up to `MaxInFlight` disk slots independently.
+
+---
+
+## vSphere Scheduler — Deep Dive
+
+### Data Structures
+
+```go
+type Scheduler struct {
+    *plancontext.Context
+    MaxInFlight int
+    inFlight    map[string]int          // host ID → occupied disk slots
+    pending     map[string][]*pendingVM  // host ID → VMs waiting to start
+}
+
+type pendingVM struct {
+    status *plan.VMStatus
+    cost   int  // number of disk slots this VM would consume
+}
+```
+
+### Cost Calculation
+
+The "cost" of a VM depends on the transfer method:
+
+**V2V transfer** (`ShouldUseV2vForTransfer` returns true):
+- Active transfer phases → cost = **1** (single transfer stream)
+- Post-transfer phases (`CreateVM`, `PostHook`, `Completed`) → cost = **0** (frees the slot)
+
+**CDI transfer** (default):
+- Active transfer phases → cost = `len(vm.Disks) - finishedDisks` (each disk is a parallel transfer pod)
+- Phases where disks are already transferred (`CopyingPaused`, `ConvertGuest`, `CreateGuestConversionPod`, `CreateVM`, `PostHook`, `Completed`) → cost = **0**
+
+The `finishedDisks()` helper counts disk-transfer tasks in the `Completed` phase, so slots free up as individual disks finish — a VM with 1 large + 5 small disks won't block the host after the small disks complete.
+
+### Build Schedule
+
+`buildSchedule()` runs two passes:
+
+1. **`buildInFlight()`** — counts occupied disk slots per host:
+   - From the current Plan's running VMs
+   - From **all other executing Plans** sharing the same source provider (cross-plan awareness)
+   - Skips archived plans, non-executing plans, canceled VMs
+   - Tolerates `NotFoundError` / `RefNotUniqueError` from inventory for other plans' VMs
+
+2. **`buildPending()`** — groups this Plan's unstarted VMs by host, computing each VM's cost
+
+### Schedulable Logic
+
+```go
+func (r *Scheduler) schedulable() map[string][]*pendingVM {
+    for host, vms := range r.pending {
+        if r.inFlight[host] >= r.MaxInFlight {
+            continue  // host at capacity
+        }
+        for _, vm := range vms {
+            if vm.cost + r.inFlight[host] <= r.MaxInFlight {
+                // VM fits within remaining capacity
+            }
+            if vm.cost > r.MaxInFlight && r.inFlight[host] == 0 {
+                // VM has more disks than MaxInFlight, but host is idle — allow it
+            }
+        }
+    }
+}
+```
+
+**Key rule**: A VM with more disks than `MaxInFlight` is still allowed if the host is completely idle (no other migrations running). This prevents large VMs from being permanently blocked.
+
+### Next() for vSphere
+
+After building the schedule, `Next()` iterates the schedulable map and returns the **first VM** from any host that has capacity. Only one VM is returned per call.
+
+---
+
+## Thread Safety
+
+Every provider's `Next()` acquires a **package-level `sync.Mutex`** before doing any work. Each provider package has its own independent mutex. This prevents concurrent reconcile loops from double-scheduling VMs into the same slots.
+
+Note: the mutexes are per-package, not per-instance, so concurrent schedulers for different plans using the same provider type are serialized.
+
+---
+
+## Cross-Plan Awareness
+
+All schedulers count in-flight VMs **across all Plans in the cluster** that share the same source provider. This means:
+- Two Plans migrating from the same vCenter share the per-host disk limits
+- Two Plans migrating from the same oVirt engine share the flat VM limit
+- Plans using different source providers are independent
+
+Plans are filtered by:
+1. Same `Spec.Provider.Source` reference
+2. Not archived (`Spec.Archived == false`) — vSphere only explicitly checks this
+3. Active snapshot has `Executing` condition
+
+---
+
+## Provider Comparison Matrix
+
+| Provider | Concurrency Unit | Scope | Cost Model | Cross-Plan | Special Rules |
+|----------|-----------------|-------|------------|------------|---------------|
+| **vSphere** | Disk slots per ESXi host | Per host | Disk count minus finished | Yes | Large VMs allowed on idle host; V2V vs CDI cost |
+| **oVirt** | VM count | Per provider | 1 per running VM | Yes | — |
+| **OpenStack** | VM count | Per provider | 1 per running VM | Yes | — |
+| **OCP** | VM count | Per provider | 1 per running VM | Yes | — |
+| **OVA** | VM count | Per provider | 1 per running VM | Yes | — |
+| **Hyper-V** | VM count | Per provider | 1 per running VM | Yes | — |
+| **EC2** | VM count | Per provider | 1 per running VM | Yes | Lives in `pkg/provider/ec2/controller/scheduler/` |
+
+---
+
+## Key Takeaways for the UI
+
+1. **MaxInFlight is global per provider** — the UI cannot show a per-plan concurrency limit; it's shared across all plans using the same source provider.
+
+2. **vSphere is host-aware** — the scheduler considers per-host capacity, so VMs on different ESXi hosts can migrate in parallel even if one host is at capacity.
+
+3. **Disk-level granularity (vSphere)** — as individual disks finish transferring, their slots free up immediately, allowing new VMs to start sooner.
+
+4. **VM ordering** — VMs are scheduled in the order they appear in `Plan.Status.Migration.VMs`. The scheduler returns the **first eligible** VM, not the optimal one.
+
+5. **No priority or preemption** — the scheduler is first-come-first-served with no priority mechanism.
+
+6. **Default 20 concurrent** — with default settings, up to 20 VMs (or 20 disk slots per host for vSphere) can migrate simultaneously per provider.
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `scheduler/doc.go` | Interface definition, factory function |
+| `scheduler/vsphere/scheduler.go` | Host-aware disk-slot scheduler |
+| `scheduler/vsphere/scheduler_test.go` | Unit tests for schedulable() logic |
+| `scheduler/ovirt/scheduler.go` | Flat VM-count scheduler |
+| `scheduler/openstack/scheduler.go` | Flat VM-count scheduler |
+| `scheduler/ocp/scheduler.go` | Flat VM-count scheduler |
+| `scheduler/ova/scheduler.go` | Flat VM-count scheduler |
+| `scheduler/hyperv/scheduler.go` | Flat VM-count scheduler |
+| `provider/ec2/controller/scheduler/scheduler.go` | Flat VM-count scheduler (separate package) |
+| `settings/migration.go` | `MaxInFlight` setting (env: `MAX_VM_INFLIGHT`, default: 20) |

--- a/.cursor/rules/backend/providers/ec2.mdc
+++ b/.cursor/rules/backend/providers/ec2.mdc
@@ -1,0 +1,294 @@
+---
+description: EC2 provider - AWS SDK inventory, adapter, migrator, platform-gated availability
+alwaysApply: false
+---
+
+# EC2 Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Architecture Overview
+
+EC2 lives in `pkg/provider/ec2/` — **separate from other providers** which are under `pkg/controller/provider/`. It has its own self-contained packages for adapter, migrator, inventory, web API, builder, validator, ensurer, scheduler, and client.
+
+```
+pkg/provider/ec2/
+├── controller/          # Plan controller integration
+│   ├── adapter/         # base.Adapter implementation (factory)
+│   ├── builder/         # VirtualMachine + PV/PVC spec generation
+│   ├── client/          # AWS SDK client for migration operations
+│   ├── ensurer/         # K8s resource creation (PV, PVC)
+│   ├── handler/         # Plan reconciliation event handler
+│   ├── inventory/       # Inventory lookup helpers (instances, volumes)
+│   ├── mapping/         # Network/storage mapping utilities
+│   ├── migrator/        # Migration state machine and phase executor
+│   ├── scheduler/       # VM scheduling with MaxInFlight limit
+│   └── validator/       # Pre-migration validation
+├── inventory/           # Inventory collection and REST API
+│   ├── client/          # AWS SDK client for inventory polling
+│   ├── collector/       # Periodic AWS API poller
+│   ├── model/           # Database models (Instance, Volume, Network, Storage)
+│   └── web/             # REST API handlers (gin)
+├── testutil/            # Fake EC2/STS API implementations
+└── docs/                # Feature comparison, guest conversion, tagging docs
+```
+
+---
+
+## Platform Gating
+
+EC2 is **only available on AWS-platform OpenShift clusters**. The frontend gates visibility using `useClusterIsAwsPlatform` hook. The backend requires AWS credentials in the Provider secret.
+
+---
+
+## Inventory Collection
+
+### AWS SDK v2
+
+Uses `github.com/aws/aws-sdk-go-v2` with paginated API calls.
+
+**Inventory client interface** (`inventory/client/ec2api.go`):
+- `DescribeInstances` — paginated, all instances in region
+- `DescribeVolumes` — paginated, all EBS volumes
+- `DescribeVpcs` — non-paginated
+- `DescribeSubnets` — paginated
+- `DescribeSecurityGroups` — paginated
+
+### Collector Loop
+
+`inventory/collector/collector.go` — polls AWS at `RefreshInterval` (default 10s, configurable via `EC2_INVENTORY_INTERVAL_SECONDS` env var).
+
+Collection tasks run sequentially with partial-success semantics:
+1. `collectInstances` — EC2 instances → `model.Instance`
+2. `collectVolumes` — EBS volumes → `model.Volume`
+3. `collectNetworks` — VPCs + Subnets → `model.Network`
+4. `collectStorageTypes` — static EBS type definitions → `model.Storage`
+
+Each task uses change detection (`HasChanged()`) to avoid unnecessary DB writes. Records track `Revision` (incremented on update) for efficient watch/polling.
+
+### Database Models (`inventory/model/`)
+
+| Model | AWS Resource | PK (UID) | Indexed Fields | Labels Source |
+|-------|-------------|----------|----------------|---------------|
+| `Instance` | EC2 Instance | Instance ID | instanceType, state, platform | AWS Tags |
+| `Volume` | EBS Volume | Volume ID | volumeType, state, size | AWS Tags |
+| `Network` | VPC or Subnet | VPC/Subnet ID | networkType, cidr | AWS Tags (subnet only) |
+| `Storage` | EBS volume type | Type code (gp2, gp3, …) | volumeType | None (static) |
+
+All models embed `Base` struct with `UID`, `Name`, `Kind`, `Provider`, `Revision`. Models store the complete AWS SDK object for full-fidelity API responses.
+
+### Static Storage Types
+
+Storage types are a hardcoded list of EBS volume types (not fetched from AWS):
+
+| Type | Description | Max IOPS | Max Throughput (MB/s) |
+|------|-------------|----------|----------------------|
+| gp2 | General Purpose SSD | 16,000 | 250 |
+| gp3 | General Purpose SSD | 16,000 | 1,000 |
+| io1 | Provisioned IOPS SSD | 64,000 | 1,000 |
+| io2 | Provisioned IOPS SSD | 64,000 | 1,000 |
+| st1 | Throughput Optimized HDD | 500 | 500 |
+| sc1 | Cold HDD | 250 | 250 |
+| standard | Magnetic | 0 | 0 |
+
+---
+
+## REST API Endpoints (`inventory/web/`)
+
+Base: `/providers/ec2/:provider`
+
+| Endpoint | Handler | Model | Label Filtering | Watch |
+|----------|---------|-------|-----------------|-------|
+| `GET /vms` | VMHandler | Instance | Yes (`label.*`) | Yes |
+| `GET /vms/:vm` | VMHandler | Instance | — | — |
+| `GET /networks` | NetworkHandler | Network | Yes (`label.*`) | Yes |
+| `GET /networks/:id` | NetworkHandler | Network | — | — |
+| `GET /volumes` | VolumeHandler | Volume | Yes (`label.*`) | Yes |
+| `GET /volumes/:id` | VolumeHandler | Volume | — | — |
+| `GET /storages` | StorageHandler | Storage | No (static) | Yes |
+| `GET /storages/:id` | StorageHandler | Storage | — | — |
+
+Query parameters: `?name=...` for name filter, `?label.key=value` for AWS tag filtering. WebSocket watch via `X-Watch` header.
+
+---
+
+## AWS Credentials
+
+### Provider Secret Fields
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `region` | Yes | AWS region (e.g., us-east-1) |
+| `accessKeyId` | Optional* | IAM access key |
+| `secretAccessKey` | Optional* | IAM secret key |
+| `targetAccessKeyId` | Optional | Cross-account target key |
+| `targetSecretAccessKey` | Optional | Cross-account target secret |
+
+*If access keys are omitted, falls back to default AWS credential chain (IAM role, EKS pod identity, env vars).
+
+### Cross-Account Mode
+
+When `targetAccessKeyId` and `targetSecretAccessKey` are present, the client operates in **cross-account mode**:
+- **Source client**: snapshots, power operations (source account)
+- **Target client**: volume creation, volume checks (target account)
+- **STS client**: `GetCallerIdentity` to retrieve target account ID for snapshot sharing
+
+---
+
+## Adapter (`controller/adapter/`)
+
+`Adapter` implements `base.Adapter` — the factory interface the plan controller calls to get provider-specific components:
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `Builder()` | `*builder.Builder` | VM spec, PV/PVC generation |
+| `Validator()` | `*validator.Validator` | Pre-migration checks |
+| `Ensurer()` | `*ensurer.Ensurer` | K8s resource creation |
+| `Client()` | `*client.Client` | AWS operations (power, snapshots, volumes) |
+| `DestinationClient()` | `*DestinationClient` | No-op (no volume populators) |
+
+`DestinationClient` methods (`DeletePopulatorDataSource`, `SetPopulatorCrOwnership`) are no-ops because EC2 uses **direct volume creation** instead of volume populators.
+
+---
+
+## Migrator (`controller/migrator/`)
+
+### Migration Type
+
+EC2 **only supports cold migration** (`api.MigrationCold`). Warm/live migration is not supported because EC2 requires instance shutdown for consistent EBS snapshots.
+
+### Phase Itinerary
+
+```
+Started → [PreHook] → PowerOffSource → WaitForPowerOff →
+CreateSnapshots → WaitForSnapshots → [ShareSnapshots] →
+CreateVolumes → WaitForVolumes → CreatePVsAndPVCs →
+[CreateGuestConversionPod → ConvertGuest] →
+Finalize → CreateVM → RemoveSnapshots → [PostHook] → Completed
+```
+
+Conditional phases (controlled by predicate flags):
+- **PreHook/PostHook** — included if VM has hook configuration
+- **ShareSnapshots** — included if cross-account mode is enabled
+- **CreateGuestConversionPod/ConvertGuest** — included if provider `RequiresConversion()` and `SkipGuestConversion` is false
+
+### EC2-Specific Phases
+
+| Phase | What It Does |
+|-------|-------------|
+| `CreateSnapshots` | Creates EBS snapshots for all attached volumes, tags with `forklift.konveyor.io/vmID` |
+| `WaitForSnapshots` | Polls `DescribeSnapshots` until all reach `completed` state |
+| `ShareSnapshots` | Cross-account: `ModifySnapshotAttribute` to grant `createVolumePermission` to target account |
+| `CreateVolumes` | Creates EBS volumes from snapshots in target AZ, tags with `forklift.konveyor.io/original-volume` |
+| `WaitForVolumes` | Polls `DescribeVolumes` until all reach `available` state |
+| `CreatePVsAndPVCs` | Creates PVs with CSI source (`ebs.csi.aws.com`) pre-bound to PVCs via ClaimRef |
+| `RemoveSnapshots` | Deletes snapshots; on failure also cleans up created volumes |
+
+### UI Pipeline Steps
+
+| Step Name | Mapped Phases |
+|-----------|--------------|
+| Initialize | PhaseStarted |
+| PrepareSource | PhasePowerOffSource, PhaseWaitForPowerOff |
+| CreateSnapshots | PhaseCreateSnapshots, PhaseWaitForSnapshots |
+| ShareSnapshots | PhaseShareSnapshots |
+| DiskTransfer | PhaseCreateVolumes, PhaseWaitForVolumes, PhaseCreatePVsAndPVCs |
+| ImageConversion | PhaseCreateGuestConversionPod, PhaseConvertGuest |
+| CreateVM | PhaseFinalize, PhaseCreateVM |
+| Cleanup | PhaseRemoveSnapshots |
+
+---
+
+## Builder (`controller/builder/`)
+
+### VM Spec Generation
+
+`VirtualMachine()` converts an EC2 instance to a KubeVirt `VirtualMachineSpec`:
+
+- **CPU**: Maps EC2 instance size suffix (nano→32xlarge) to vCPU/memory. Defaults: 2 vCPU / 4096 MiB. Bare metal instances (`.metal` suffix) get nested virt features (vmx/svm).
+- **Firmware**: Maps EC2 `BootMode` → BIOS or UEFI. Uses instance ID as serial number.
+- **Disks**: Attaches PVCs as virtio disks (or SATA in compatibility mode). First disk gets boot order 1.
+- **Networks**: Maps subnets via NetworkMap to pod/Multus/UDN networking. Preserves MAC addresses. Compatibility mode uses E1000e instead of VirtIO NIC.
+- **Node Selector**: Sets `topology.kubernetes.io/zone` to target AZ for co-location with EBS volumes (skippable via `SkipZoneNodeSelector`).
+- **OS Detection**: Reads `Platform` and `PlatformDetails` to set template labels (RHEL, Ubuntu, Windows variants).
+- **Compatibility Mode**: Active when both `SkipGuestConversion` and `UseCompatibilityMode` are true. Uses SATA disks, E1000e NICs, USB input.
+
+### PV/PVC Creation
+
+PVs use **CSI volume source** with `ebs.csi.aws.com` driver, `VolumeHandle` = EBS volume ID. PVCs are created in block mode with pre-binding via PV's `ClaimRef`. Storage class comes from StorageMap (EBS volume type → K8s StorageClass).
+
+EC2 **does not use volume populators** — `SupportsVolumePopulators()` returns `false`. All populator-related builder methods are no-ops.
+
+---
+
+## Validator (`controller/validator/`)
+
+Four validation checks run before migration starts:
+
+1. **Storage** (`validateStorage`): Ensures VM has at least one EBS volume. Instance store volumes are detected and warned but don't fail validation.
+2. **Network Mapping** (`NetworksMapped`): Verifies all subnet IDs have entries in the NetworkMap.
+3. **Storage Mapping** (`StorageMapped`): Verifies all EBS volume types have entries in the StorageMap.
+4. **Migration Type** (`MigrationType`): Only cold migration (or empty/default) is accepted.
+
+---
+
+## Scheduler (`controller/scheduler/`)
+
+Controls concurrent VM migration with `MaxInFlight` limit. Counts in-flight VMs across all plans sharing the same source provider. Uses package-level mutex for thread safety. Skips canceled VMs.
+
+---
+
+## Resource Tagging Convention
+
+All AWS resources created during migration are tagged with `forklift.konveyor.io/*` tags:
+
+| Tag Key | Applied To | Purpose |
+|---------|-----------|---------|
+| `forklift.konveyor.io/vmID` | Snapshots, Volumes | VM instance ID for filtering |
+| `forklift.konveyor.io/vm-name` | Snapshots, Volumes | Human-readable VM name |
+| `forklift.konveyor.io/volume` | Snapshots | Source volume ID |
+| `forklift.konveyor.io/original-volume` | Volumes | Maps new volume → original |
+| `forklift.konveyor.io/snapshot` | Volumes | Snapshot used to create volume |
+
+These tags enable idempotent operations — each phase checks for existing tagged resources before creating new ones.
+
+---
+
+## Provider Settings
+
+EC2 providers use `spec.settings` on the Provider CR:
+
+| Setting | Required | Purpose |
+|---------|----------|---------|
+| `target-az` | Yes | Availability zone for volume creation and VM scheduling |
+
+---
+
+## Key Differences from Other Providers
+
+| Aspect | Other Providers | EC2 |
+|--------|----------------|-----|
+| Code location | `pkg/controller/provider/` | `pkg/provider/ec2/` |
+| Migration type | Cold, Warm, Live | **Cold only** |
+| Disk transfer | CDI DataVolumes / Volume Populators | **Direct EBS snapshot → volume → PV/PVC** |
+| Volume source | Disk image transfer | CSI (`ebs.csi.aws.com`) VolumeHandle |
+| Cross-account | N/A | Supported via separate source/target credentials |
+| Platform gating | None | **AWS-platform clusters only** |
+| DestinationClient | Active (populator management) | **No-op** |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EC2_INVENTORY_INTERVAL_SECONDS` | 10 | Inventory collector AWS polling interval |
+| `EC2_CONTROLLER_INTERVAL_SECONDS` | 15 | Plan handler reconciliation interval |
+
+---
+
+## Test Utilities (`testutil/`)
+
+- `fake_ec2api.go` — Mock `EC2API` interface for unit tests
+- `fake_stsapi.go` — Mock `STSAPI` interface for unit tests
+- `fixtures.go` — Test data fixtures (instances, volumes, subnets, VPCs)

--- a/.cursor/rules/backend/providers/hyperv.mdc
+++ b/.cursor/rules/backend/providers/hyperv.mdc
@@ -1,0 +1,375 @@
+---
+description: Hyper-V provider - WinRM inventory, PowerShell scripts, SMB storage, driver library, REST API, HyperVProviderServer CRD
+alwaysApply: false
+---
+
+# Hyper-V Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Architecture Overview
+
+The Hyper-V provider collects VM inventory directly from a Windows Hyper-V host via **WinRM** (PowerShell remoting over HTTPS). Disk files are accessed through an **SMB share** mounted in a sidecar pod via the SMB CSI driver.
+
+```
+┌──────────────────────┐
+│  Hyper-V Host        │
+│  (Windows Server)    │
+│  - WinRM :5986       │
+│  - SMB share         │
+└──────────┬───────────┘
+           │ WinRM/HTTPS (PowerShell commands)
+           ▼
+┌─────────────────────────┐
+│  Inventory Collector    │  (runs inside forklift-controller)
+│  - WinRM driver         │
+│  - Stores in libmodel DB│
+│  - Validates VMs (OPA)  │
+└────────────┬────────────┘
+             │ HTTP (validate-disks)
+             ▼
+┌─────────────────────────┐
+│  HyperV Provider Server │  (Deployment + SMB CSI mount)
+│  - Mounts SMB share     │
+│  - /validate-disks      │
+│  - /healthz             │
+└─────────────────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│  Inventory REST API     │  (gin handlers in forklift-controller)
+│  /providers/hyperv/…    │
+└─────────────────────────┘
+```
+
+---
+
+## Key Source Locations
+
+| Component | Path (under `pkg/`) |
+|-----------|---------------------|
+| Collector | `controller/provider/container/hyperv/` |
+| Data model | `controller/provider/model/hyperv/` |
+| Types (wire format) | `controller/provider/model/hyperv/types/` |
+| REST API handlers | `controller/provider/web/hyperv/` |
+| HyperVProviderServer controller | `controller/hyperv/` |
+| Driver interface & WinRM impl | `lib/hyperv/driver/` |
+| PowerShell scripts | `lib/hyperv/powershell/scripts.go` |
+
+---
+
+## HyperVProviderServer CRD
+
+**Kind**: `HyperVProviderServer` (group `forklift.konveyor.io/v1beta1`)
+**Finalizer**: `api.HyperVProviderFinalizer`
+**Controller name**: `hyperv-server`
+
+### Lifecycle
+
+1. Provider controller creates a `HyperVProviderServer` CR for each Hyper-V provider.
+2. The controller ensures:
+   - **PersistentVolume** — SMB CSI driver (`smb.csi.k8s.io`), `ReadOnlyMany`, source from `smbUrl` in Secret.
+   - **PersistentVolumeClaim** — Binds to static PV.
+   - **Deployment** — Runs provider server image (`Settings.Providers.HyperV.ContainerImage`), mounts SMB at `/hyperv`.
+   - **Service** — ClusterIP on port `8080`.
+3. On deletion: Service → Deployment → PVC → PV cleanup.
+
+### Builder Constants
+
+```go
+SMBVolumeMountPath = "/hyperv"
+SMBCSIDriver       = "smb.csi.k8s.io"
+QEMUGroup          = 107
+PVSize             = "1Gi"
+```
+
+---
+
+## Secret Format
+
+The provider Secret contains:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `username` | Yes | Hyper-V host admin username |
+| `password` | Yes | Hyper-V host password |
+| `smbUrl` | Yes | SMB share URL (e.g., `//192.168.1.100/VMShare`) |
+| `smbUser` | No | Dedicated SMB username (falls back to `username`) |
+| `smbPassword` | No | Dedicated SMB password (falls back to `password`) |
+
+### Provider Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `winrmPort` | `5986` | WinRM HTTPS port on the host |
+
+---
+
+## WinRM Driver (`pkg/lib/hyperv/driver`)
+
+### Interface: `HyperVDriver`
+
+```go
+type HyperVDriver interface {
+    Connect() error
+    Close() error
+    IsAlive() (bool, error)
+    ListAllDomains() ([]Domain, error)
+    LookupDomainByName(name string) (Domain, error)
+    LookupDomainByUUIDString(uuid string) (Domain, error)
+    ListAllNetworks() ([]Network, error)
+    LookupNetworkByUUIDString(uuid string) (Network, error)
+    ExecuteCommand(command string) (string, error)
+}
+```
+
+### WinRM Implementation
+
+- Uses `github.com/masterzen/winrm` library
+- Connects via HTTPS (port 5986 by default, `insecureSkipVerify=true`)
+- Commands wrapped in `powershell -EncodedCommand <base64>` for complex scripts
+- Default command timeout: 60 seconds
+- Thread-safe (mutex-protected)
+
+### Domain Interface
+
+Represents a VM with methods for:
+- `GetName()`, `GetUUIDString()`, `GetState()`, `GetInfo()`
+- `GetGeneration()` — Gen1 (BIOS) vs Gen2 (UEFI)
+- `GetDisks()` — returns disk paths with controller info
+- `GetNICs()` — returns MAC + switch name
+- `Shutdown()` — force-stops the VM
+
+### Network Interface
+
+Represents a virtual switch:
+- `GetName()`, `GetUUIDString()`, `GetSwitchType()`
+- Switch types: External (0), Internal (1), Private (2)
+
+---
+
+## PowerShell Scripts (`pkg/lib/hyperv/powershell`)
+
+All scripts return JSON via `ConvertTo-Json`. Key scripts:
+
+| Constant | Purpose | Parameters |
+|----------|---------|-----------|
+| `ListAllVMs` | Get all VMs (Id, Name, State, CPU, Memory, Gen) | — |
+| `GetVMByName` | Single VM by name | vmName |
+| `GetVMByID` | Single VM by GUID | vmId |
+| `StopVM` | Force-stop a VM | vmName |
+| `ListAllSwitches` | Get all virtual switches | — |
+| `GetVMDisks` | VM hard disk drives | vmName |
+| `GetDiskCapacity` | VHD/VHDX file size | windowsPath |
+| `GetDiskRCTEnabled` | Resilient Change Tracking status | windowsPath |
+| `GetVMNICs` | VM network adapters | vmName |
+| `GetSMBSharePath` | Windows path for an SMB share | shareName |
+| `GetStorageCapacity` | Volume capacity & free space | windowsPath |
+| `GetGuestOS` | Guest OS name via KVP Exchange | vmName |
+| `GetGuestNetworkConfig` | Guest IP config via KVP Exchange | vmName |
+| `GetVMSecurityInfo` | TPM + SecureBoot (Gen2 only) | vmName×3 |
+| `GetVMHasCheckpoint` | Check for existing snapshots | vmName |
+
+### Argument Sanitization
+
+```go
+func BuildCommand(template string, args ...string) string {
+    // Escapes single quotes by doubling them
+    sanitized[i] = strings.ReplaceAll(arg, "'", "''")
+    return fmt.Sprintf(template, sanitized...)
+}
+```
+
+---
+
+## Inventory Collector
+
+### Connection
+
+Connects directly to the Hyper-V host via WinRM using credentials from the Secret:
+```go
+drv := driver.NewWinRMDriver(host, port, username, password, true, nil)
+```
+
+The host is extracted from `Provider.Spec.URL` (supports `host`, `host:port`, or `[ipv6]`).
+
+### Refresh Settings
+
+```go
+DefaultRefreshInterval   = 10 * time.Second   // env: HYPERV_REFRESH_INTERVAL
+DefaultValidationTimeout = 30 * time.Second   // env: HYPERV_VALIDATION_TIMEOUT
+```
+
+### Collection Flow
+
+1. **Connect** — Establish WinRM session
+2. **Load** — Full inventory via adapters (Network → Storage → Disk → VM)
+3. **Parity** — Set parity=true, start DB watches
+4. **Refresh loop** — Re-poll every 10s, apply deletes then upserts
+
+### Adapters
+
+| Adapter | Source | Collects |
+|---------|--------|----------|
+| `NetworkAdapter` | `ListNetworks()` via WinRM | Virtual switches |
+| `StorageAdapter` | `ListStorages()` from SMB config | Single SMB storage record |
+| `DiskAdapter` | `ListDisks()` via WinRM | All VM disks |
+| `VMAdapter` | `ListVMs()` via WinRM | Full VM details |
+
+### VM Collection Details
+
+For each VM, the collector gathers:
+- Basic info: UUID, name, power state, CPU, memory
+- Generation → firmware (Gen1=bios, Gen2=uefi)
+- Security info (Gen2 only): TPM, SecureBoot
+- Checkpoint existence
+- Disks: Windows path → SMB path mapping, capacity, format (vhd/vhdx), RCT status
+- NICs: MAC, switch name → resolved to network UUID
+- Guest OS (running VMs only, via KVP Exchange)
+- Guest network config (running VMs only, via KVP Exchange)
+
+### SMB Path Mapping
+
+Windows paths are mapped to the SMB mount:
+```
+Windows: C:\Hyper-V\VMs\disk.vhdx
+SMB prefix: C:\Hyper-V  (discovered via Get-SmbShare)
+Mount path: /hyperv
+Result: /hyperv/VMs/disk.vhdx
+```
+
+### SMB Disk Validation
+
+After collecting VMs, the collector POSTs to the provider-server sidecar:
+```
+POST http://<service>.svc.cluster.local:8080/validate-disks
+Body: {"paths": ["/hyperv/VMs/disk1.vhdx", ...]}
+Response: {"missing": ["/hyperv/VMs/disk1.vhdx"]}
+```
+
+Missing disks generate a `DiskNotFoundOnSMB` concern on the VM.
+
+### Guest Network Preservation
+
+When a VM transitions from Running to Off, existing `GuestNetworks` and `GuestOS` data is preserved from the previous poll (KVP Exchange only works while VM is running).
+
+---
+
+## Data Model (`model/hyperv`)
+
+### Entities
+
+| Model | PK | Key Fields |
+|-------|-----|-----------|
+| `VM` | UUID | PowerState, CpuCount, MemoryMB, Firmware, GuestOS, TpmEnabled, SecureBoot, HasCheckpoint, Disks[], NICs[], GuestNetworks[], Concerns[] |
+| `Network` | UUID | SwitchName, SwitchType (External/Internal/Private) |
+| `Storage` | ID (`storage-0`) | Type (SMB), Path, Capacity, Free |
+| `Disk` | `<vmUUID>-disk-<index>` | WindowsPath, SMBPath, Capacity, Format, RCTEnabled, Datastore ref |
+
+### VM Power States
+
+`On`, `Off`, `Paused`, `ShuttingDown`, `Crashed`, `Suspended`, `Unknown`
+
+### NIC Model
+
+```go
+type NIC struct {
+    Name        string
+    MAC         string
+    DeviceIndex int
+    Network     Ref    // {Kind: "Network", ID: uuid}
+    NetworkName string
+}
+```
+
+NICs are sorted by `GuestNetwork.DeviceIndex` order for stable ordering.
+
+### GuestNetwork
+
+```go
+type GuestNetwork struct {
+    MAC          string
+    IP           string
+    DeviceIndex  int
+    Origin       string   // "Manual" or "Dhcp"
+    PrefixLength int32
+    DNS          []string
+    Gateway      string
+}
+```
+
+### VM Validation
+
+Similar to OVA, VMs are validated against OPA policy:
+```
+/v1/data/io/konveyor/forklift/hyperv/validate
+```
+
+---
+
+## REST API Endpoints
+
+Base path: `/providers/hyperv`
+
+| Method | Path | Handler | Description |
+|--------|------|---------|-------------|
+| GET | `/providers/hyperv` | ProviderHandler.List | List Hyper-V providers |
+| GET | `/providers/hyperv/:provider` | ProviderHandler.Get | Get provider details |
+| GET | `/providers/hyperv/:provider/vms` | VMHandler.List | List VMs (supports watch) |
+| GET | `/providers/hyperv/:provider/vms/:vm` | VMHandler.Get | Get VM details |
+| GET | `/providers/hyperv/:provider/networks` | NetworkHandler.List | List networks |
+| GET | `/providers/hyperv/:provider/networks/:network` | NetworkHandler.Get | Get network |
+| GET | `/providers/hyperv/:provider/storages` | StorageHandler.List | List storages |
+| GET | `/providers/hyperv/:provider/storages/:storage` | StorageHandler.Get | Get storage |
+| GET | `/providers/hyperv/:provider/disks` | DiskHandler.List | List disks |
+| GET | `/providers/hyperv/:provider/disks/:disk` | DiskHandler.Get | Get disk |
+| GET | `/providers/hyperv/:provider/tree` | TreeHandler | Tree view |
+| GET | `/providers/hyperv/:provider/workloads` | WorkloadHandler.List | List workloads |
+| GET | `/providers/hyperv/:provider/workloads/:vm` | WorkloadHandler.Get | Get workload |
+
+### Handler Behavior
+
+- Returns `404` if provider type is not `hyperv`
+- Returns `503 Service Unavailable` if collector hasn't reached parity
+- Supports `X-Watch` header for websocket upgrade on VM list
+
+### Finder/Resolver
+
+Used by plan validation to look up resources by ref (ID or Name):
+```go
+finder := hyperv.NewFinder()
+finder.ByRef(&network, ref)  // by ID or Name
+finder.VM(&ref)
+finder.Network(&ref)
+finder.Storage(&ref)
+finder.Workload(&ref)
+```
+
+---
+
+## Labels & Selectors
+
+```yaml
+app: forklift
+subapp: hyperv-server
+provider: <provider-UID>
+hyperv-server: <server-UID>
+```
+
+---
+
+## Frontend Implications
+
+- **Provider URL**: Host address (IP or FQDN, optionally with port). Not a full URL scheme.
+- **Secret fields**: `username`, `password`, `smbUrl` required; `smbUser`/`smbPassword` optional
+- **Provider Settings**: `winrmPort` (default 5986)
+- **Single storage**: Always one storage record (`storage-0`) representing the SMB share
+- **Disk.SMBPath**: The accessible path for migration; empty if path mapping fails
+- **Disk.RCTEnabled**: Required for warm migration support
+- **VM.HasCheckpoint**: Blocks migration if snapshots exist
+- **VM.GuestOS**: Only populated when VM is running (KVP Exchange)
+- **VM.GuestNetworks**: IP config from running VMs; preserved when VM stops
+- **Network.SwitchType**: External, Internal, or Private
+- **VM.TpmEnabled / SecureBoot**: Gen2 VMs only
+- **Concerns**: Include `DiskNotFoundOnSMB` when disk files are missing from the SMB mount
+- **Power states**: On, Off, Paused, ShuttingDown, Crashed, Suspended, Unknown

--- a/.cursor/rules/backend/providers/ocp.mdc
+++ b/.cursor/rules/backend/providers/ocp.mdc
@@ -1,0 +1,371 @@
+---
+description: OpenShift provider - target/source provider, namespace inventory, StorageClass, NetworkAttachmentDefinition
+alwaysApply: false
+---
+
+# OpenShift (OCP) Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Overview
+
+The OpenShift provider is unique among Forklift providers: it serves as the **migration target** in every migration, and can also act as a **source** for OCP-to-OCP (live) migrations. Unlike source-only providers (vSphere, oVirt, OpenStack), it watches native Kubernetes/KubeVirt resources rather than connecting to a vendor-specific API.
+
+### Dual Role
+
+| Role | When | Resources used |
+|------|------|----------------|
+| **Target** | Every migration | StorageClasses, NetworkAttachmentDefinitions, Namespaces |
+| **Source** | OCP live migration | VirtualMachines, VirtualMachineInstances |
+
+### Host vs Remote Provider
+
+- **Host provider** (`Spec.URL == ""`): represents the local cluster where Forklift is installed. Uses the controller's in-cluster ServiceAccount. Determined by `Provider.IsHost()`.
+- **Remote OCP provider**: connects to a different OCP cluster via `Spec.URL` + Secret containing a bearer token.
+- **Restricted host provider**: a host-type provider created outside the operator namespace (`POD_NAMESPACE`). Scoped to its own namespace only; API requests use the requesting user's token for RBAC. Determined by `Provider.IsRestrictedHost()`.
+
+---
+
+## Source Files
+
+```
+pkg/controller/provider/
+├── container/ocp/    # Inventory collector (K8s watches)
+│   ├── collector.go  # Collector factory, Version() stub
+│   └── collection.go # Collection types wrapping K8s objects
+├── model/ocp/        # Data model (SQLite-backed)
+│   ├── model.go      # Base, Namespace, StorageClass, NAD, VM, etc.
+│   ├── tree.go       # Tree kinds (VmKind, NamespaceKind)
+│   └── doc.go        # All() returns registered model types
+└── web/ocp/          # REST API handlers (gin)
+    ├── doc.go         # Handler registration, Root path
+    ├── base.go        # Base handler, UserClient, list helpers
+    ├── provider.go    # GET /providers/openshift[/:uid]
+    ├── namespace.go   # .../namespaces[/:uid]
+    ├── storageclass.go          # .../storageclasses[/:uid]
+    ├── netattachdefinition.go   # .../networkattachmentdefinitions[/:uid]
+    ├── vm.go                    # .../vms[/:uid]
+    ├── instancetype.go          # .../instancetypes[/:uid]
+    ├── clusterinstancetype.go   # .../clusterinstancetypes[/:uid]
+    ├── persistentvolumeclaim.go # .../persistentvolumeclaims[/:uid]
+    ├── datavolume.go            # .../datavolumes[/:uid]
+    ├── kubevirt.go              # .../kubevirts[/:uid]
+    ├── tree.go        # .../tree/namespace (VM-by-namespace tree)
+    ├── resource.go    # Base REST resource struct
+    └── client.go      # Finder + Resolver for ref-based lookups
+```
+
+---
+
+## Inventory Collection
+
+### Watched Kubernetes Resources
+
+The collector watches **9 resource types** using `controller-runtime` watches:
+
+| # | Collection Type | K8s Object | Scope |
+|---|----------------|------------|-------|
+| 1 | `Namespace` | `core/v1.Namespace` | Cluster |
+| 2 | `NetworkAttachmentDefinition` | `k8s.cni.cncf.io/v1.NetworkAttachmentDefinition` | Namespaced |
+| 3 | `StorageClass` | `storage/v1.StorageClass` | Cluster |
+| 4 | `InstanceType` | `instancetype.kubevirt.io/v1beta1.VirtualMachineInstancetype` | Namespaced |
+| 5 | `ClusterInstanceType` | `instancetype.kubevirt.io/v1beta1.VirtualMachineClusterInstancetype` | Cluster |
+| 6 | `VM` | `kubevirt.io/v1.VirtualMachine` | Namespaced |
+| 7 | `PersistentVolumeClaim` | `core/v1.PersistentVolumeClaim` | Namespaced |
+| 8 | `DataVolume` | `cdi.kubevirt.io/v1beta1.DataVolume` | Namespaced |
+| 9 | `KubeVirt` | `kubevirt.io/v1.KubeVirt` | Namespaced |
+
+Each collection embeds `libocp.BaseCollection` and returns its K8s object type via `Object()`.
+
+### Collection Architecture
+
+```
+ocp.Collector
+  └── libocp.Collector  (pkg/lib/inventory/container/ocp)
+       ├── cluster   Cluster   (the Provider CR)
+       ├── secret    *core.Secret
+       ├── client    controller-runtime client.Client
+       └── collections []Collection  (the 9 types above)
+```
+
+The base `libocp.Collector` calls `buildClient()` which uses `ocp.RestCfg()` to produce a `rest.Config`:
+- **Host provider**: uses in-cluster config (ServiceAccount token)
+- **Remote provider**: uses `Spec.URL` as host + `Secret.Data["token"]` as BearerToken
+
+### Version
+
+`Version()` is a **no-op** for OCP (returns empty strings). OCP providers don't expose a product version the way vSphere/oVirt do.
+
+---
+
+## Data Model
+
+All models share a common `Base` struct stored in SQLite:
+
+```go
+type Base struct {
+    UID       string  `sql:"pk"`     // K8s UID
+    Version   string  `sql:"d0"`     // resourceVersion
+    Namespace string  `sql:"key"`
+    Name      string  `sql:"key"`
+    labels    libmodel.Labels
+}
+```
+
+### Model Types
+
+| Model | Embedded K8s Object | Notes |
+|-------|-------------------|-------|
+| `Provider` | `api.Provider` | Also stores `Type` string |
+| `Namespace` | `core.Namespace` | Full namespace object |
+| `StorageClass` | `storage.StorageClass` | Cluster-scoped |
+| `NetworkAttachmentDefinition` | `net.NetworkAttachmentDefinition` | Contains `NetworkConfig` for UDN filtering |
+| `VM` | `cnv.VirtualMachine` + `*cnv.VirtualMachineInstance` | VMI attached separately via `WithVMI()` |
+| `InstanceType` | `instancetype.VirtualMachineInstancetype` | Namespaced |
+| `ClusterInstanceType` | `instancetype.VirtualMachineClusterInstancetype` | Cluster-scoped |
+| `PersistentVolumeClaim` | `core.PersistentVolumeClaim` | |
+| `DataVolume` | `cdi.DataVolume` | CDI data volumes |
+| `KubeVirt` | `cnv.KubeVirt` | KubeVirt operator CR |
+
+### NetworkConfig and UDN Filtering
+
+NADs are parsed for OVN-Kubernetes UDN (User Defined Network) configuration:
+
+```go
+type NetworkConfig struct {
+    AllowPersistentIPs bool
+    CNIVersion         string
+    Name               string
+    Role               RoleType      // "primary" | "secondary"
+    Topology           TopologyType  // "layer2" | "layer3"
+    Type               NadType       // "ovn-k8s-cni-overlay"
+}
+```
+
+**Unsupported UDN NADs are filtered out** during listing. A NAD is excluded if:
+- `Type == "ovn-k8s-cni-overlay"` AND (`Role == "primary"` OR `Topology == "layer3"`)
+
+This prevents users from selecting incompatible network configurations as migration targets.
+
+### Registered Models
+
+`doc.go` → `All()` returns models for SQLite table creation (note: `KubeVirt` is **not** in this list, only tracked at runtime):
+
+```
+Provider, NetworkAttachmentDefinition, StorageClass, Namespace,
+InstanceType, ClusterInstanceType, VM, PersistentVolumeClaim, DataVolume
+```
+
+---
+
+## REST API
+
+### Base Path
+
+```
+/providers/openshift/:provider
+```
+
+All endpoints are GET-only (inventory is read-only).
+
+### Endpoints
+
+| Endpoint | Handler | Description |
+|----------|---------|-------------|
+| `GET /providers/openshift` | `ProviderHandler.List` | List all OCP providers |
+| `GET /providers/openshift/:provider` | `ProviderHandler.Get` | Single provider with counts |
+| `GET .../namespaces` | `NamespaceHandler.List` | All namespaces |
+| `GET .../namespaces/:namespace` | `NamespaceHandler.Get` | Single namespace by UID |
+| `GET .../storageclasses` | `StorageClassHandler.List` | All storage classes |
+| `GET .../storageclasses/:sc` | `StorageClassHandler.Get` | Single SC by UID |
+| `GET .../networkattachmentdefinitions` | `NadHandler.List` | NADs (UDN-filtered) |
+| `GET .../networkattachmentdefinitions/:network` | `NadHandler.Get` | Single NAD by UID |
+| `GET .../vms` | `VMHandler.List` | VMs with VMI data |
+| `GET .../vms/:vm` | `VMHandler.Get` | Single VM by UID |
+| `GET .../instancetypes` | `InstanceHandler.List` | Namespaced instance types |
+| `GET .../instancetypes/:instancetype` | `InstanceHandler.Get` | Single instance type |
+| `GET .../clusterinstancetypes` | `ClusterInstanceHandler.List` | Cluster-scoped instance types |
+| `GET .../clusterinstancetypes/:clusterinstancetype` | `ClusterInstanceHandler.Get` | Single cluster instance type |
+| `GET .../persistentvolumeclaims` | `PersistentVolumeClaimHandler.List` | PVCs |
+| `GET .../persistentvolumeclaims/:pvc` | `PersistentVolumeClaimHandler.Get` | Single PVC |
+| `GET .../datavolumes` | `DataVolumeHandler.List` | CDI DataVolumes |
+| `GET .../datavolumes/:dv` | `DataVolumeHandler.Get` | Single DataVolume |
+| `GET .../kubevirts` | `KubeVirtHandler.List` | KubeVirt CRs |
+| `GET .../kubevirts/:kubevirt` | `KubeVirtHandler.Get` | Single KubeVirt CR |
+| `GET .../tree/namespace` | `TreeHandler.Tree` | Namespace → VM hierarchy |
+
+### Query Parameters
+
+| Param | Key | Description |
+|-------|-----|-------------|
+| Namespace | `namespace` | Filter namespaced resources |
+| Name | `name` | Filter by name |
+| Detail | `detail` | Detail level (`0` = summary, `1+` = full object) |
+
+### Provider Detail Response
+
+When `detail > 0`, the provider response includes inventory counts:
+
+```json
+{
+  "uid": "...",
+  "type": "openshift",
+  "object": { /* full Provider CR */ },
+  "vmCount": 42,
+  "networkCount": 5,
+  "storageClassCount": 3
+}
+```
+
+`networkCount` = NAD count **+ 1** (accounts for the default pod network).
+
+### REST Resource Shape
+
+Every resource shares this base shape:
+
+```json
+{
+  "uid": "k8s-uid",
+  "version": "resourceVersion",
+  "namespace": "ns",
+  "name": "resource-name",
+  "selfLink": "/providers/openshift/<provider-uid>/...",
+  "id": "k8s-uid",
+  "object": { /* full K8s object */ }
+}
+```
+
+The `id` field duplicates `uid` for compatibility with providers that use a separate ID system.
+
+---
+
+## Authentication & Authorization
+
+### UserClient Pattern
+
+The OCP handler has a unique `UserClient()` method not found in other providers. Instead of querying a cached inventory DB, it makes **live K8s API calls** using the appropriate client:
+
+1. **Restricted host provider** → builds a new `client.Client` using the **requesting user's bearer token** from the HTTP request. This enforces RBAC so users only see resources they have access to.
+2. **Non-restricted provider** → uses the collector's cached client (SA or secret-based).
+
+### Credentials
+
+| Provider Type | Auth Method | Source |
+|--------------|-------------|--------|
+| Host (operator namespace) | ServiceAccount | In-cluster config |
+| Host (other namespace) | User's bearer token | HTTP `Authorization` header |
+| Remote OCP | Bearer token | `Secret.Data["token"]` |
+| Remote OCP | CA cert | `Secret.Data["cacert"]` (optional) |
+| Remote OCP | Insecure flag | `Secret.Data["insecure"]` |
+
+---
+
+## Restricted Host Provider Scoping
+
+When `provider.IsRestrictedHost() == true`, resources are scoped:
+
+| Resource | Scope |
+|----------|-------|
+| Namespaces | Only the provider's own namespace |
+| VMs | Only in provider's namespace |
+| NADs | Provider's namespace + `default` namespace |
+| InstanceTypes | Only in provider's namespace |
+| PVCs | Only in provider's namespace |
+| DataVolumes | Only in provider's namespace |
+| KubeVirts | Only in provider's namespace |
+| StorageClasses | All (cluster-scoped, readable by any user) |
+| ClusterInstanceTypes | All (cluster-scoped, readable by any user) |
+
+---
+
+## Storage Mapping (Target)
+
+StorageClasses are listed via the `/storageclasses` endpoint. The frontend uses this list to build StorageMap entries:
+
+```
+Source datastore/domain → Target StorageClass
+```
+
+StorageClasses are **cluster-scoped** and accessible to all authenticated users, so no namespace restriction is applied even for restricted providers.
+
+---
+
+## Network Mapping (Target)
+
+NetworkAttachmentDefinitions are listed via `/networkattachmentdefinitions`. The frontend uses this plus the implicit Pod network to build NetworkMap entries:
+
+```
+Source network → Target NAD (or Pod network)
+```
+
+NADs that represent unsupported UDN configurations (OVN overlay with primary role or layer3 topology) are **automatically excluded** from the API response.
+
+For restricted providers, NAD queries are limited to:
+- The provider's own namespace
+- The `default` namespace
+
+---
+
+## Tree API
+
+The namespace tree endpoint (`/tree/namespace`) builds a hierarchy:
+
+```
+Root
+├── Namespace A
+│   ├── VM 1
+│   └── VM 2
+└── Namespace B
+    └── VM 3
+```
+
+Only namespaces **containing at least one VM** are included. The tree is built by:
+1. Fetching all VMs → extracting unique namespaces
+2. Fetching all namespaces → filtering to those with VMs
+3. For each namespace, listing VMs as children
+
+---
+
+## Finder / Resolver
+
+The `Finder` resolves resource references (`Ref`) used in Plans and Mappings:
+
+| Method | Resolves To |
+|--------|-------------|
+| `VM(ref)` | VirtualMachine |
+| `Workload(ref)` | VirtualMachine (alias) |
+| `Network(ref)` | NetworkAttachmentDefinition |
+| `Storage(ref)` | StorageClass |
+| `Host(ref)` | Always returns NotFound (OCP has no host concept) |
+| `InstanceType(ref)` | VirtualMachineInstancetype |
+| `ClusterInstanceType(ref)` | VirtualMachineClusterInstancetype |
+| `PersistentVolumeClaim(ref)` | PersistentVolumeClaim |
+| `DataVolume(ref)` | DataVolume |
+| `KubeVirt(ref)` | KubeVirt |
+
+Refs can be resolved by:
+- `ref.ID` (UID) → direct GET
+- `ref.Namespace` + `ref.Name` → filtered list
+- `ref.Name` containing `namespace/name` → parsed and split
+
+---
+
+## Frontend Integration Points
+
+The frontend plugin consumes these endpoints for:
+
+1. **Plan creation** (target provider):
+   - `/storageclasses` → populate StorageMap target dropdown
+   - `/networkattachmentdefinitions` → populate NetworkMap target dropdown
+   - `/namespaces` → select target namespace for migrated VMs
+
+2. **Plan creation** (source, OCP-to-OCP):
+   - `/vms` → select VMs to migrate
+   - `/tree/namespace` → browse VMs by namespace
+
+3. **Provider details page**:
+   - Provider GET with detail → vmCount, networkCount, storageClassCount
+   - `/namespaces`, `/vms` → inventory tables
+
+4. **Instance type selection**:
+   - `/instancetypes` + `/clusterinstancetypes` → select instance types for target VMs

--- a/.cursor/rules/backend/providers/openstack.mdc
+++ b/.cursor/rules/backend/providers/openstack.mdc
@@ -1,0 +1,325 @@
+---
+description: OpenStack provider - Keystone/Nova/Glance/Neutron inventory, data model, REST API
+alwaysApply: false
+---
+
+# OpenStack Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Architecture Overview
+
+The OpenStack provider uses **gophercloud** to talk to five OpenStack services, collects inventory into an in-process SQLite DB, and exposes it via a REST API.
+
+```
+Keystone (Identity v3)   ──► Region, Project
+Nova    (Compute v2)     ──► VM (servers.Server), Flavor
+Glance  (Image v2)       ──► Image
+Cinder  (Block Storage v3) ► Volume, VolumeType, Snapshot
+Neutron (Network v2)     ──► Network, Subnet
+```
+
+Source: `pkg/lib/client/openstack/client.go`
+
+---
+
+## Credentials (Secret Keys)
+
+All values are read from the Provider's referenced `Secret.data` map.
+
+| Secret key | Purpose |
+|---|---|
+| `authType` | `password` (default), `token`, or `applicationcredential` |
+| `username` | Keystone username (password & app-credential auth) |
+| `userID` | Alternative to username |
+| `password` | Keystone password |
+| `applicationCredentialID` | App credential ID |
+| `applicationCredentialName` | App credential name |
+| `applicationCredentialSecret` | App credential secret |
+| `token` | Pre-existing token (token auth) |
+| `projectName` / `projectID` | Scoped project |
+| `domainName` / `domainID` | Keystone domain |
+| `userDomainName` / `userDomainID` | User's domain |
+| `projectDomainName` / `projectDomainID` | Project's domain |
+| `defaultDomain` | Fallback domain |
+| `regionName` | OpenStack region to use |
+| `insecureSkipVerify` | Skip TLS verification (`"true"`) |
+| `cacert` | PEM-encoded CA certificate |
+| `availability` | Endpoint availability: `public` (default), `internal`, `admin` |
+
+Provider `spec.url` is the **Keystone auth URL** (e.g. `https://openstack.example.com:5000/v3`).
+
+---
+
+## Inventory Collection
+
+### Collector Lifecycle
+
+`pkg/controller/provider/container/openstack/collector.go`
+
+Phases: **Started → Load → Loaded → Parity → Refresh (loop)**
+
+| Phase | Action |
+|---|---|
+| Started | `Client.Connect()` — authenticate with Keystone, verify user projects |
+| Load | Full list of all resources via adapters, bulk insert into DB |
+| Loaded | First refresh pass (detect deletes + updates) |
+| Parity | Start DB watches (VMEventHandler), mark `parity = true` |
+| Refresh | Every **10 seconds**: delete missing resources, upsert changed ones |
+
+On error in any phase, retry after **5 seconds**.
+
+### Adapter Order
+
+Adapters are executed sequentially in this order:
+
+```
+Region → Project → Image → Flavor → VM → Snapshot → Volume → VolumeType → Network → Subnet
+```
+
+Each adapter implements the `Adapter` interface:
+
+```go
+type Adapter interface {
+    List(ctx *Context) (itr fb.Iterator, err error)
+    GetUpdates(ctx *Context) (updates []Updater, err error)
+    DeleteUnexisting(ctx *Context) (updates []Updater, err error)
+}
+```
+
+### Change Detection Strategies
+
+| Resource | Update detection | Delete detection |
+|---|---|---|
+| Image | `UpdatedAt` filter (`SetUpdateAtQueryFilterGT`) | Status `deleted` / `pending_delete`, or GET returns 404 |
+| Flavor | `ChangesSince` query param | GET returns 404 |
+| VM | `ChangesSince` query param | Status `DELETED` / `SOFT_DELETED`, or GET returns 404 |
+| Volume | Full re-list (gophercloud lacks `UpdatedAt` filter) | Status `deleting`, or GET returns 404 |
+| Snapshot | Full re-list, compare `UpdatedAt` | GET returns 404 |
+| Network | Full re-list, compare `UpdatedAt` | GET returns 404 |
+| Subnet | Full re-list, field equality check | GET returns 404 |
+| Region/Project | Full re-list, field equality check | GET returns 404 |
+| VolumeType | Full re-list, field equality check | GET returns 404 |
+
+### Volume → VM Cascading Revalidation
+
+When a volume changes, the adapter finds all VMs attached to that volume (via `volume.Attachments[].ServerID`) and resets their `RevisionValidated = 0`, triggering revalidation.
+
+---
+
+## Data Model
+
+`pkg/controller/provider/model/openstack/model.go`
+
+### Base
+
+All models share a `Base` with `ID` (PK), `Name` (indexed), and `Revision` (auto-incremented).
+
+### VM
+
+```go
+type VM struct {
+    Base
+    RevisionValidated int64                    // tracks validation state
+    PolicyVersion     int                      // OPA policy version
+    TenantID          string                   // FK → Project
+    UserID            string
+    Updated, Created  time.Time
+    HostID            string
+    Status            string                   // ACTIVE, SHUTOFF, ERROR, etc.
+    Progress          int
+    AccessIPv4/v6     string
+    ImageID           string                   // FK → Image
+    FlavorID          string                   // FK → Flavor
+    Addresses         map[string]interface{}   // network name → address list
+    Metadata          map[string]string
+    KeyName           string
+    AdminPass         string
+    SecurityGroups    []map[string]interface{}
+    AttachedVolumes   []AttachedVolume         // list of {ID}
+    Fault             Fault                    // {Code, Created, Details, Message}
+    Tags              *[]string
+    ServerGroups      *[]string
+    Concerns          []Concern                // populated by OPA validation
+}
+```
+
+Foreign keys: `TenantID → Project (+cascade)`, `ImageID → Image (+cascade)`, `FlavorID → Flavor (+cascade)`.
+
+### Image (Glance)
+
+Key fields: `Status`, `ContainerFormat`, `DiskFormat`, `MinDiskGigabytes`, `MinRAMMegabytes`, `SizeBytes`, `VirtualSize`, `Checksum`, `Properties` (map), `Visibility`.
+
+### Flavor (Nova)
+
+Key fields: `Disk`, `RAM`, `VCPUs`, `Swap`, `Ephemeral`, `RxTxFactor`, `IsPublic`, `ExtraSpecs` (map).
+
+### Volume (Cinder)
+
+Key fields: `Status`, `Size`, `AvailabilityZone`, `VolumeType` (name string), `Bootable` (string "true"/"false"), `Encrypted`, `Multiattach`, `Attachments` (list of `Attachment`), `VolumeImageMetadata` (map — contains `image_id` for boot volumes), `SnapshotID`, `SourceVolID`.
+
+### VolumeType (Cinder)
+
+Key fields: `ExtraSpecs`, `IsPublic`, `QosSpecID`, `PublicAccess`.
+
+### Snapshot (Cinder)
+
+Key fields: `VolumeID`, `Status`, `Size`, `Metadata`.
+
+### Network (Neutron)
+
+Key fields: `AdminStateUp`, `Status`, `Subnets` (list of subnet IDs), `TenantID`, `ProjectID`, `Shared`, `AvailabilityZoneHints`, `RevisionNumber`.
+
+FK: `TenantID → Project (+cascade)`, `ProjectID → Project (+cascade)`.
+
+### Subnet (Neutron)
+
+Key fields: `NetworkID` (FK → Network +cascade), `IPVersion`, `CIDR`, `GatewayIP`, `DNSNameservers`, `AllocationPools` [{Start, End}], `HostRoutes` [{DestinationCIDR, NextHop}], `EnableDHCP`, `IPv6AddressMode`, `IPv6RAMode`, `SubnetPoolID`.
+
+### Region / Project (Keystone)
+
+Region: `Description`, `ParentRegionID`.
+Project: `Description`, `DomainID`, `ParentID`, `Enabled`, `IsDomain`.
+
+### Tree Kinds
+
+```go
+RegionKind, ProjectKind, ImageKind, FlavorKind, VMKind,
+SnapshotKind, VolumeKind, VolumeTypeKind, NetworkKind, SubnetKind
+```
+
+---
+
+## VM Concern Validation (OPA Policy Agent)
+
+`pkg/controller/provider/container/openstack/watch.go`
+
+### How It Works
+
+1. **VMEventHandler** watches the VM model table for create/update events.
+2. VMs with `Revision != RevisionValidated` are submitted to the **OPA policy agent**.
+3. The policy endpoint: `/v1/data/io/konveyor/forklift/openstack/validate`
+4. The workload payload is built by `Workload.Expand()` which joins VM + Image + Flavor + Networks + Subnets + Volumes + VolumeTypes + Snapshots.
+5. Results (concerns list) are written back: `VM.Concerns = task.Concerns`.
+6. A periodic search also finds unvalidated VMs (batch up to 1024).
+7. Updates are applied in batches to reduce DB transactions.
+
+### Workload Expansion
+
+The `XVM` struct sent to the policy agent includes all related resources:
+
+```go
+type XVM struct {
+    VM
+    Image       Image
+    Flavor      Flavor
+    Networks    []Network
+    Subnets     []Subnet
+    Volumes     []Volume
+    VolumeTypes []VolumeType
+    Snapshots   []Snapshot
+}
+```
+
+Image resolution: uses `VM.ImageID` first; if empty, checks attached bootable volumes for `VolumeImageMetadata["image_id"]`.
+
+---
+
+## REST API Endpoints
+
+Base path: `/providers/openstack`
+
+All collection endpoints support `GET` (list) and `GET /:id` (get).
+Most support **WebSocket watch** via `X-Watch` header.
+Query params: `name` (filter by name/path), `detail` (detail level).
+
+| Endpoint | Collection | Handler |
+|---|---|---|
+| `GET .../` | Providers | `ProviderHandler` |
+| `GET .../:provider/regions` | Regions | `RegionHandler` |
+| `GET .../:provider/projects` | Projects | `ProjectHandler` |
+| `GET .../:provider/images` | Images | `ImageHandler` |
+| `GET .../:provider/flavors` | Flavors | `FlavorHandler` |
+| `GET .../:provider/vms` | Virtual Machines | `VMHandler` |
+| `GET .../:provider/snapshots` | Snapshots | `SnapshotHandler` |
+| `GET .../:provider/volumes` | Volumes | `VolumeHandler` |
+| `GET .../:provider/volumetypes` | Volume Types | `VolumeTypeHandler` |
+| `GET .../:provider/networks` | Networks | `NetworkHandler` |
+| `GET .../:provider/subnets` | Subnets | `SubnetHandler` |
+| `GET .../:provider/workloads/:vm` | Workload (expanded VM) | `WorkloadHandler` |
+| `GET .../:provider/tree/project` | Project tree | `TreeHandler` |
+
+### Detail Levels
+
+VM uses three detail tiers:
+
+- **detail=0** (`VM0`/`Resource`): `id`, `revision`, `name`, `path`, `selfLink`
+- **detail=1** (`VM1`): adds `tenantID`, `status`, `hostID`, `revisionValidated`, `imageID`, `flavorID`, `addresses`, `attachedVolumes`, `concerns`
+- **detail=2** (`VM`): adds `userID`, `updated`, `created`, `progress`, `accessIPv4/v6`, `metadata`, `keyName`, `adminPass`, `securityGroups`, `fault`, `tags`, `serverGroups`
+
+Other resources use two tiers (0 = base resource, full = all fields).
+
+### Provider Summary (with detail)
+
+The provider GET response includes derived counts: `regionCount`, `projectCount`, `vmCount`, `imageCount`, `volumeCount`, `volumeTypeCount`, `networkCount`.
+
+### Workload Endpoint
+
+`GET .../:provider/workloads/:vmID` returns a fully expanded VM with nested image, flavor, networks, subnets, volumes, volume types, and snapshots. This is the payload used for policy validation.
+
+### Finder / Resolver
+
+The `Finder` struct supports lookup by ref (ID or Name) for: VM, Workload, Network, VolumeType, Snapshot, Volume, Image.
+
+Storage mapping uses `VolumeType` as the storage unit. The special name `api.GlanceSource` is handled to indicate image-based (non-volume) storage.
+
+### Tree Endpoint
+
+`GET .../:provider/tree/project` returns a hierarchical tree: `Project → [VM, VM, ...]`. The `BranchNavigator` lists VMs for each project using `TenantID` predicate.
+
+---
+
+## Key Patterns for Frontend
+
+### OpenStack IDs
+
+All OpenStack resources use **UUID strings** as their primary key (`ID` field), not numeric IDs.
+
+### VM Status Values
+
+From `pkg/lib/client/openstack/model.go`:
+`ACTIVE`, `BUILD`, `DELETED`, `ERROR`, `HARD_REBOOT`, `MIGRATING`, `PASSWORD`, `PAUSED`, `REBOOT`, `REBUILD`, `RESCUE`, `RESIZE`, `REVERT_RESIZE`, `SHELVED`, `SHELVED_OFFLOADED`, `SHUTOFF`, `SOFT_DELETED`, `SUSPENDED`, `UNKNOWN`, `VERIFY_RESIZE`.
+
+### Network Status Values
+
+`null`, `ACTIVE`, `DOWN`.
+
+### Image Status Values
+
+`queued`, `saving`, `active`, `killed`, `deleted`, `pending_delete`, `deactivated`, `uploading`, `importing`.
+
+### Volume Status Values
+
+`creating`, `available`, `reserved`, `attaching`, `detaching`, `in-use`, `maintenance`, `deleting`, `awaiting-transfer`, `error`, `error_deleting`, `backing-up`, `restoring-backup`, `error_backing-up`, `error_restoring`, `error_extending`, `downloading`, `uploading`, `retyping`, `extending`.
+
+### Boot Volume Detection
+
+A volume is a boot volume when `Bootable == "true"`. The original image ID can be found in `VolumeImageMetadata["image_id"]`.
+
+### Addresses Structure
+
+`VM.Addresses` is `map[string]interface{}` where keys are **network names** and values are arrays of address objects. The workload expansion resolves networks by matching these names.
+
+### Auth Types
+
+Three supported: `password` (default), `token`, `applicationcredential`.
+
+### Migration Operations (Client Methods)
+
+The client exposes methods used during migration execution:
+- `VMStatus(vmID)` — get VM power state
+- `VMStart(vmID)` / `VMStop(vmID)` — power on/off source VM
+- `VMCreateSnapshotImage(vmID, opts)` — create snapshot image
+- `UploadImage(name, volumeID)` — convert volume to image (raw format)
+- `DownloadImage(imageID)` — stream image data
+- `VMRemoveSnapshotImage(imageID)` — clean up snapshot

--- a/.cursor/rules/backend/providers/ova.mdc
+++ b/.cursor/rules/backend/providers/ova.mdc
@@ -1,0 +1,255 @@
+---
+description: OVA provider - inventory collection, OVF parsing, NFS storage, REST API, OVAProviderServer CRD
+alwaysApply: false
+---
+
+# OVA Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Architecture Overview
+
+The OVA provider imports VMs from OVF/OVA files stored on an NFS share. It uses a **sidecar server** pattern: a dedicated pod (OVA provider server) mounts the NFS share, parses OVF descriptors, and exposes a REST API. The main inventory controller then polls this sidecar to build its in-memory DB.
+
+```
+NFS Share (OVA/OVF files)
+    │
+    ▼
+┌─────────────────────────┐
+│  OVA Provider Server    │  (Deployment + Service in Forklift namespace)
+│  - Mounts NFS via PV    │
+│  - Parses OVF files     │
+│  - Exposes REST :8080   │
+└────────────┬────────────┘
+             │ HTTP (cluster-internal)
+             ▼
+┌─────────────────────────┐
+│  Inventory Collector    │  (runs inside forklift-controller)
+│  - Polls sidecar API    │
+│  - Stores in libmodel DB│
+│  - Validates VMs (OPA)  │
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│  Inventory REST API     │  (gin handlers in forklift-controller)
+│  /providers/ova/:uid/…  │
+└─────────────────────────┘
+```
+
+---
+
+## Key Source Locations
+
+| Component | Path (under `pkg/`) |
+|-----------|---------------------|
+| Collector (thin wrapper) | `controller/provider/container/ova/collector.go` |
+| Shared OVF collector logic | `controller/provider/container/ovfbase/` |
+| OVF data model | `controller/provider/model/ovf/` |
+| REST API handlers | `controller/provider/web/ova/` + `web/ovfbase/` |
+| OVAProviderServer controller | `controller/ova/` |
+
+---
+
+## OVAProviderServer CRD
+
+**Kind**: `OVAProviderServer` (group `forklift.konveyor.io/v1beta1`)
+**Finalizer**: `api.OvaProviderFinalizer`
+**Controller name**: `ova-server`
+
+### Lifecycle
+
+1. Provider controller creates an `OVAProviderServer` CR when an OVA-type Provider is reconciled.
+2. The OVA server controller watches `OVAProviderServer` and ensures these resources:
+   - **PersistentVolume** — NFS volume, `ReadOnlyMany`, source parsed from `Provider.Spec.URL` (`server:path` format).
+   - **PersistentVolumeClaim** — Binds to the PV, owned by the OVAProviderServer.
+   - **Deployment** — Runs the sidecar image (`Settings.Providers.OVA.ContainerImage`), mounts NFS at `/ova`.
+   - **Service** — ClusterIP on port `8080`, named `api-http`.
+3. On deletion, the controller tears down Service → Deployment → PVC → PV.
+
+### Builder Constants
+
+```go
+NFSVolumeMountPath = "/ova"
+QEMUGroup          = 107   // container runs as this GID
+PVSize             = "1Gi" // minimal; NFS doesn't enforce
+```
+
+### Provider URL Format
+
+```
+<nfs-server>:<nfs-path>
+```
+
+Split on `:` → `segments[0]` = NFS server, `segments[1]` = NFS export path.
+
+### Appliance Management Feature
+
+Controlled by two gates:
+- Global: `Settings.Features.OVFApplianceManagement`
+- Per-provider: `Provider.Spec.Settings["applianceManagement"]`
+
+When both enabled, the deployment sets `APPLIANCE_ENDPOINTS=true` and the controller adds an `ApplianceManagementEnabled` condition to the CRD status.
+
+---
+
+## Inventory Collector
+
+### Initialization
+
+```go
+// OVA-specific: just delegates to the shared OVF collector
+func New(db, provider, secret) *ovfbase.Collector {
+    return ovfbase.New(db, provider, secret, "ova")
+}
+```
+
+### Connection
+
+The collector connects to the sidecar via:
+```
+http://<service-name>.<namespace>.svc.cluster.local:8080/test_connection
+```
+The service reference comes from `Provider.Status.Service`.
+
+### Phases
+
+| Phase | Description |
+|-------|-------------|
+| `Started` | Connect to sidecar |
+| `Load` | Initial full inventory load |
+| `Loaded` | Post-load refresh |
+| `Parity` | Begin DB watches, set parity=true |
+| `Refresh` | Periodic re-sync (every 60s) |
+
+### Adapters
+
+Four adapters handle different resource types:
+
+1. **NetworkAdapter** — fetches `GET /networks`
+2. **DiskAdapter** — fetches `GET /disks`
+3. **VMAdapter** — fetches `GET /vms`
+4. **StorageAdapter** — derives storage from disks
+
+Each adapter implements:
+- `List()` — initial population
+- `GetUpdates()` — upsert changes
+- `DeleteUnexisting()` — remove stale records
+
+### Refresh Strategy
+
+Two-phased approach:
+1. Fetch data from sidecar API (no DB lock held)
+2. Apply changeSet in a single transaction
+
+VM updates are triggered when `OvfPath` or `ExportSource` changes.
+
+---
+
+## Data Model (`model/ovf`)
+
+### Entities
+
+| Model | PK | Key Fields |
+|-------|-----|-----------|
+| `VM` | UUID | OvfPath, ExportSource, OsType, Firmware, SecureBoot, CpuCount, MemoryMB, Disks[], NICs[], Concerns[] |
+| `Network` | ID | Name, Description |
+| `Disk` | DiskId | FilePath, Capacity, Format, PopulatedSize |
+| `Storage` | ID | Name (derived from Disks) |
+
+### VM Validation
+
+VMs are validated against OPA policy at:
+```
+/v1/data/io/konveyor/forklift/ova/validate
+```
+
+The `VMEventHandler` watch:
+- Triggers on VM create/update events
+- Periodically searches for `Revision != RevisionValidated`
+- Submits validation tasks to the policy agent
+- Harvests results in batches (max 1024) and updates `Concerns`
+
+---
+
+## REST API Endpoints
+
+Base path: `/providers/ova`
+
+| Method | Path | Handler | Description |
+|--------|------|---------|-------------|
+| GET | `/providers/ova` | ProviderHandler.List | List OVA providers |
+| GET | `/providers/ova/:provider` | ProviderHandler.Get | Get provider details (includes counts) |
+| GET | `/providers/ova/:provider/vms` | VMHandler.List | List VMs (supports websocket watch) |
+| GET | `/providers/ova/:provider/vms/:vm` | VMHandler.Get | Get VM details |
+| GET | `/providers/ova/:provider/networks` | NetworkHandler.List | List networks |
+| GET | `/providers/ova/:provider/networks/:network` | NetworkHandler.Get | Get network |
+| GET | `/providers/ova/:provider/disks` | DiskHandler.List | List disks |
+| GET | `/providers/ova/:provider/disks/:disk` | DiskHandler.Get | Get disk |
+| GET | `/providers/ova/:provider/storages` | StorageHandler.List | List storages |
+| GET | `/providers/ova/:provider/storages/:storage` | StorageHandler.Get | Get storage |
+| GET | `/providers/ova/:provider/workloads` | WorkloadHandler.List | List workloads (validation payloads) |
+| GET | `/providers/ova/:provider/workloads/:vm` | WorkloadHandler.Get | Get workload |
+| GET | `/providers/ova/:provider/tree` | TreeHandler | Tree view |
+| GET | `/providers/ova/:provider/tree/vm` | TreeHandler | VM tree |
+
+### Detail Levels
+
+- `detail=0` — minimal (ID, Name, Revision, SelfLink)
+- `detail=1` — includes Disks, Networks, Concerns, RevisionValidated
+- `detail=2` (full) — all fields including firmware, CPU, memory, NICs, devices
+
+### Query Parameters
+
+- `name` — filter by name (supports path-based filtering)
+- `X-Watch` header — upgrades to websocket for real-time events
+
+### Provider Response (detail > 0)
+
+Includes derived counts:
+```json
+{
+  "vmCount": 42,
+  "networkCount": 3,
+  "diskCount": 84,
+  "storageCount": 84
+}
+```
+
+---
+
+## Sidecar REST Endpoints
+
+The OVA provider server pod exposes (consumed by the collector):
+
+| Path | Description |
+|------|-------------|
+| `GET /test_connection` | Health/readiness check |
+| `GET /vms` | List all VMs parsed from OVF |
+| `GET /networks` | List all networks |
+| `GET /disks` | List all virtual disks |
+
+---
+
+## Labels & Selectors
+
+Resources created by the OVA controller use these labels:
+
+```yaml
+app: forklift
+subapp: ova-server
+provider: <provider-UID>
+ova-server: <server-UID>
+```
+
+---
+
+## Frontend Implications
+
+- **Provider URL**: Must be `<nfs-server>:<path>` format (split on first colon)
+- **Provider.Status.Service**: Populated when sidecar is ready — indicates provider is operational
+- **ApplianceManagementEnabled condition**: Drives UI feature flag for appliance management
+- **VM.ExportSource**: Indicates origin system (vSphere, etc.) for OVA exports
+- **VM.OvfPath**: Path to the OVF descriptor file within the NFS share
+- **Disk.Format**: `vmdk`, `raw`, etc. from the OVF descriptor
+- **Storage**: One storage record per disk (synthetic, derived from disk list)

--- a/.cursor/rules/backend/providers/ovirt.mdc
+++ b/.cursor/rules/backend/providers/ovirt.mdc
@@ -1,0 +1,316 @@
+---
+description: oVirt provider - Engine API inventory, data model, REST API, storage domains, networks
+alwaysApply: false
+---
+
+# oVirt Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Authentication & Connection
+
+The collector authenticates against the oVirt Engine SSO endpoint:
+
+- **Token URL**: `{engine-url}/ovirt-engine/sso/oauth/token`
+- **Grant type**: `password` with scope `ovirt-app-api`
+- **Secret fields**: `user`, `password`, `cacert` (PEM CA certificate)
+- **InsecureSkipVerify**: controlled by `insecureSkipVerify` flag in the Secret
+- **API version header**: `Version: 4` (oVirt API v4)
+- **Token management**: Bearer token with automatic refresh on expiry
+- **Client timeout**: default 30 minutes, overridable via `spec.settings.ovirtClientTimeout`
+
+Source: `pkg/controller/provider/container/ovirt/client.go`
+
+---
+
+## Inventory Collector
+
+### Lifecycle Phases
+
+The collector runs a state machine loop:
+
+| Phase     | Action                                                              |
+|-----------|---------------------------------------------------------------------|
+| `Started` | Note the last oVirt event ID (GET `events?max=1`)                   |
+| `Load`    | Full inventory load — list every resource type from Engine API       |
+| `Loaded`  | First incremental refresh via Engine events                         |
+| `Parity`  | Start DB watches; mark `parity = true`                              |
+| `Refresh` | Poll Engine events every **10 s**, apply changesets to local DB     |
+
+On any error the collector retries after **5 s**.
+
+### oVirt Engine API Endpoints Queried
+
+Resources are loaded in this adapter order (important for FK resolution):
+
+| # | Adapter              | Engine API path            | `follow` params                                                      |
+|---|----------------------|----------------------------|----------------------------------------------------------------------|
+| 1 | DataCenterAdapter    | `datacenters`              | —                                                                    |
+| 2 | StorageDomainAdapter | `storagedomains`           | —                                                                    |
+| 3 | NICProfileAdapter    | `vnicprofiles`             | —                                                                    |
+| 4 | DiskProfileAdapter   | `diskprofiles`             | —                                                                    |
+| 5 | NetworkAdapter       | `networks`                 | `vnic_profiles`                                                      |
+| 6 | DiskAdapter          | `disks`                    | — (LUN disks re-fetched individually for logical unit details)       |
+| 7 | ClusterAdapter       | `clusters`                 | —                                                                    |
+| 8 | ServerCPUAdapter     | `options/ServerCPUList`    | —                                                                    |
+| 9 | HostAdapter          | `hosts`                    | `network_attachments`, `nics`                                        |
+|10 | VMAdapter            | `vms`                      | `disk_attachments`, `host_devices`, `snapshots`, `watchdogs`, `cdroms`, `nics` |
+
+Source: `pkg/controller/provider/container/ovirt/model.go`
+
+### Event-Driven Refresh
+
+After initial load, the collector polls oVirt Engine events (integer event codes). Key event codes:
+
+**DataCenter** (950/952/954), **Network** (942/1114/944), **StorageDomain** (956/958/960/981/964),
+**vNIC Profile** (1122/1124/1126), **DiskProfile** (10120/10124/10122),
+**Cluster** (809/811/813), **Host** (42/43/44/600/620/10453/13),
+**VM** (34/53/35/253/113/1130/172/1720/1152 + disk/NIC/snapshot/host-device/power events),
+**Disk** (2021/2014/2042 + VM-related events)
+
+Source: `pkg/controller/provider/container/ovirt/model.go` (event code constants)
+
+---
+
+## Data Model
+
+All models are in `pkg/controller/provider/model/ovirt/model.go`.
+
+### Base Fields (all resources)
+
+```
+ID          string    (primary key — oVirt UUID)
+Name        string    (indexed)
+Description string
+Revision    int64     (auto-incremented, indexed)
+```
+
+### VM Model — Key Fields
+
+| Field                        | Type               | Notes                                       |
+|------------------------------|--------------------|---------------------------------------------|
+| Cluster                      | string (FK)        | Cluster ID, cascading delete                 |
+| Host                         | string             | Current host ID (indexed)                    |
+| Status                       | string             | `up`, `down`, `suspended`, etc.              |
+| GuestName                    | string             | `distribution + " " + version`               |
+| CpuSockets / CpuCores / CpuThreads | int16       | CPU topology                                 |
+| CpuAffinity                  | []CpuPinning       | vCPU pinning set                             |
+| CpuPinningPolicy             | string             | `none`, `manual`, `resize_and_pin_numa`, `dedicated`, `isolate_threads` |
+| Memory                       | int64              | Bytes                                        |
+| BalloonedMemory              | bool               | Memory ballooning enabled                    |
+| BIOS                         | string             | BIOS type (e.g. `q35_sea_bios`)             |
+| Display                      | string             | Display type (e.g. `spice`, `vnc`)           |
+| IOThreads                    | int16              | I/O thread count                             |
+| HaEnabled                    | bool               | High availability                            |
+| UsbEnabled                   | bool               |                                              |
+| BootMenuEnabled              | bool               |                                              |
+| HasIllegalImages             | bool               | VM has disks in illegal state                |
+| LeaseStorageDomain           | string             | Storage domain for VM lease                  |
+| StorageErrorResumeBehaviour  | string             |                                              |
+| Stateless                    | string             |                                              |
+| SerialNumber                 | string             |                                              |
+| Timezone                     | string             |                                              |
+| OSType                       | string             | e.g. `rhel_8x64`                             |
+| CustomCpuModel               | string             |                                              |
+| Guest                        | Guest              | `{distribution, fullVersion}`                |
+| DiskAttachments              | []DiskAttachment   | See below                                    |
+| NICs                         | []NIC              | See below                                    |
+| HostDevices                  | []HostDevice       | Passthrough devices                          |
+| CDROMs                       | []CDROM            |                                              |
+| WatchDogs                    | []WatchDog         |                                              |
+| Properties                   | []Property         | Custom properties `{name, value}`            |
+| Snapshots                    | []Snapshot         | `{id, description, type, persistMemory}`     |
+| Concerns                     | []Concern          | Populated by policy validation               |
+| RevisionValidated            | int64              | Last validated revision                      |
+| PolicyVersion                | int                | OPA policy version                           |
+
+### DiskAttachment
+
+```go
+type DiskAttachment struct {
+    ID              string   // attachment ID
+    Interface       string   // "virtio", "virtio_scsi", "ide", "sata"
+    SCSIReservation bool
+    Disk            string   // Disk ID (FK to Disk)
+    Bootable        bool
+}
+```
+
+### NIC
+
+```go
+type NIC struct {
+    ID        string
+    Name      string
+    Interface string       // "virtio", "e1000", "rtl8139"
+    Plugged   bool
+    IpAddress []IpAddress  // {address, version}
+    Profile   string       // vNIC Profile ID (FK to NICProfile)
+    MAC       string
+}
+```
+
+### Disk
+
+| Field           | Type   | Notes                                           |
+|-----------------|--------|-------------------------------------------------|
+| Shared          | bool   |                                                 |
+| Profile         | string | DiskProfile ID                                  |
+| StorageDomain   | string | StorageDomain ID (FK)                           |
+| Status          | string | `ok`, `locked`, `illegal`                       |
+| ActualSize      | int64  | Bytes                                           |
+| ProvisionedSize | int64  | Bytes                                           |
+| Backup          | string |                                                 |
+| StorageType     | string | `image` or `lun`                                |
+| Lun             | Lun    | Only populated for `lun` type disks             |
+
+### StorageDomain
+
+| Field      | Type   | Notes                                                |
+|------------|--------|------------------------------------------------------|
+| DataCenter | string | DataCenter ID                                         |
+| Type       | string | `data`, `iso`, `export`                               |
+| Storage    | struct | `.Type` = `nfs`, `iscsi`, `fcp`, `glusterfs`, `posixfs`, `localfs` |
+| Available  | int64  | Bytes                                                 |
+| Used       | int64  | Bytes                                                 |
+
+### Network & NICProfile
+
+**Network**: `{DataCenter, VLan, Usages[]string, Profiles[]string}`
+- Usages: `"vm"`, `"display"`, `"migration"`, `"management"`, `"default_route"`
+
+**NICProfile** (vNIC Profile): `{Network, PortMirroring, NetworkFilter, QoS, Properties[], PassThrough}`
+- PassThrough mode maps to SR-IOV
+
+### Other Models
+
+- **Cluster**: `{DataCenter, HaReservation, KsmEnabled, BiosType, CPU{Architecture,Type}, Version{Major,Minor}}`
+- **Host**: `{Cluster, Status, ProductName, ProductVersion, InMaintenance, CpuSockets, CpuCores, NetworkAttachments[], NICs[]}`
+- **ServerCpu**: `{DataCenter, SystemOptionValue{Value, Version}}` — keyed by cluster compatibility version
+
+---
+
+## REST API Endpoints
+
+Base path: `/providers/ovirt/:provider`
+
+| Collection       | List                        | Get                           | Watch | Notes                              |
+|------------------|-----------------------------|-------------------------------|-------|------------------------------------|
+| providers        | `GET /providers/ovirt`      | `GET /providers/ovirt/:uid`   | No    | Includes resource counts           |
+| datacenters      | `GET .../datacenters`       | `GET .../datacenters/:id`     | Yes   |                                    |
+| clusters         | `GET .../clusters`          | `GET .../clusters/:id`        | Yes   |                                    |
+| hosts            | `GET .../hosts`             | `GET .../hosts/:id`           | Yes   |                                    |
+| networks         | `GET .../networks`          | `GET .../networks/:id`        | Yes   |                                    |
+| nicprofiles      | `GET .../nicprofiles`       | `GET .../nicprofiles/:id`     | Yes   | vNIC profiles                      |
+| diskprofiles     | `GET .../diskprofiles`      | `GET .../diskprofiles/:id`    | Yes   |                                    |
+| storagedomains   | `GET .../storagedomains`    | `GET .../storagedomains/:id`  | Yes   |                                    |
+| disks            | `GET .../disks`             | `GET .../disks/:id`           | Yes   |                                    |
+| vms              | `GET .../vms`               | `GET .../vms/:id`             | Yes   | Detail levels 0/1/2                |
+| servercpus       | `GET .../servercpus`        | `GET .../servercpus/:id`      | Yes   |                                    |
+| workloads        | —                           | `GET .../workloads/:vm-id`    | No    | Expanded VM with all refs resolved |
+| tree/cluster     | `GET .../tree/cluster`      | —                             | No    | Hierarchical DC→Cluster→Host/VM   |
+
+### Query Parameters
+
+- `?detail=0` — minimal (id, name, revision, selfLink); `?detail=1` — summary; omit / `?detail=all` — full
+- `?name=<path>` — filter by hierarchical path (e.g. `datacenter/cluster/vm-name`)
+- Watch via `X-Watch` header (upgrades to WebSocket)
+
+### VM Detail Levels
+
+| Level | JSON fields included                                                    |
+|-------|-------------------------------------------------------------------------|
+| 0     | `id`, `revision`, `path`, `name`, `description`, `selfLink`            |
+| 1     | + `cluster`, `status`, `host`, `revisionValidated`, `nics`, `diskAttachments`, `concerns` |
+| 2     | + all remaining fields (cpu, memory, bios, display, snapshots, etc.)    |
+
+### Workload Endpoint (Expanded VM)
+
+`GET .../workloads/:vm-id` returns a fully expanded VM with:
+- **DiskAttachments** → each disk resolved with its DiskProfile
+- **NICs** → each NIC resolved with its NICProfile
+- **Host** object (if VM is running)
+- **Cluster** object
+- **DataCenter** object
+- **ServerCpu** object (keyed by cluster version)
+
+This is the payload sent to the OPA policy agent for validation.
+
+Source: `pkg/controller/provider/web/ovirt/workload.go`
+
+---
+
+## VM Concerns (Validation)
+
+Concerns are populated by an OPA (Open Policy Agent) policy engine.
+
+### How It Works
+
+1. **VMEventHandler** watches for VM create/update events
+2. Unvalidated VMs (where `Revision != RevisionValidated`) are submitted to the policy agent
+3. The policy agent evaluates rules at `/v1/data/io/konveyor/forklift/ovirt/validate`
+4. The workload payload (expanded VM) is sent as input
+5. Returned concerns are stored on `VM.Concerns`
+6. `RevisionValidated` is set to current `Revision`
+
+### Cascade Revalidation
+
+Changes to related resources trigger revalidation of affected VMs:
+- **Cluster update** → all VMs in that cluster's hosts get `RevisionValidated = 0`
+- **Host update** → all VMs on that host get `RevisionValidated = 0`
+- **NICProfile update** → all VMs referencing that profile get `RevisionValidated = 0`
+- **DiskProfile update** → all VMs with disks referencing that profile get `RevisionValidated = 0`
+
+Source: `pkg/controller/provider/container/ovirt/watch.go`
+
+---
+
+## Provider Summary JSON
+
+`GET /providers/ovirt/:uid` (detail > 0) returns:
+
+```json
+{
+  "uid": "...",
+  "type": "ovirt",
+  "object": { /* full Provider CR */ },
+  "datacenterCount": 2,
+  "clusterCount": 4,
+  "hostCount": 8,
+  "vmCount": 150,
+  "networkCount": 6,
+  "storageDomainCount": 3
+}
+```
+
+---
+
+## Frontend-Relevant JSON Field Names
+
+These are the `json` tags the frontend reads from the inventory REST API:
+
+### VM (detail=2)
+`id`, `revision`, `path`, `name`, `description`, `selfLink`, `cluster`, `status`, `host`,
+`revisionValidated`, `policyVersion`, `guestName`, `cpuSockets`, `cpuCores`, `cpuThreads`,
+`cpuShares`, `cpuAffinity`, `cpuPinningPolicy`, `memory`, `balloonedMemory`, `ioThreads`,
+`bios`, `display`, `hasIllegalImages`, `numaNodeAffinity`, `leaseStorageDomain`,
+`storageErrorResumeBehaviour`, `haEnabled`, `usbEnabled`, `bootMenuEnabled`,
+`placementPolicyAffinity`, `timezone`, `stateless`, `serialNumber`,
+`hostDevices[]`, `cdroms[]`, `watchDogs[]`, `properties[]`, `snapshots[]`,
+`guest{distribution,fullVersion}`, `osType`, `customCpuModel`,
+`nics[]{id,name,interface,plugged,ipAddress[],profile,mac}`,
+`diskAttachments[]{id,interface,scsiReservation,disk,bootable}`,
+`concerns[]{category,label,assessment}`
+
+### Disk
+`id`, `name`, `shared`, `storageDomain`, `profile`, `provisionedSize`, `actualSize`,
+`storageType` (`image`|`lun`), `status`, `lunStorage`
+
+### StorageDomain
+`id`, `name`, `dataCenter`, `type`, `capacity`, `free`, `storage{type}`
+
+### Network
+`id`, `name`, `dataCenter`, `vlan`, `usages[]`, `nicProfiles[]`
+
+### NICProfile
+`id`, `name`, `network`, `networkFilter`, `portMirroring`, `qos`, `properties[]`, `passThrough`

--- a/.cursor/rules/backend/providers/provider-controller.mdc
+++ b/.cursor/rules/backend/providers/provider-controller.mdc
@@ -1,0 +1,250 @@
+---
+description: Provider controller - common reconciliation loop, inventory lifecycle, credentials, status phases
+alwaysApply: false
+---
+
+# Provider Controller (Common)
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+Source: `pkg/controller/provider/` in the [forklift](https://github.com/kubev2v/forklift) backend.
+
+---
+
+## Reconciliation Loop
+
+The Provider controller watches `Provider`, `Secret`, `OVAProviderServer`, and `HyperVProviderServer` resources. On each reconcile cycle it runs the following steps in order:
+
+```
+Reconcile(request)
+│
+├─ 1. Fetch Provider CR (delete container if NotFound)
+├─ 2. Set phase = Staging, begin staging conditions
+├─ 3. Provider-server lifecycle (OVA / HyperV only)
+│     ├─ If deletion → cleanupProviderServer (remove server + finalizer)
+│     └─ If alive → ensureProviderServer (create/redeploy)
+├─ 4. Validate
+│     ├─ validateType
+│     ├─ validateURL
+│     ├─ validateSecret (provider-type-specific key checks)
+│     ├─ testConnection (builds ephemeral collector, calls Test())
+│     ├─ inventoryCreated (checks collector parity)
+│     ├─ validateSSHReadiness (vSphere + SSH method only)
+│     └─ validateSMBCSI (HyperV only)
+├─ 5. Ensure SSH keys (vSphere only)
+├─ 6. Update container (build/replace inventory collector)
+├─ 7. Ready check
+│     └─ If no blocker AND ConnectionTestSucceeded + InventoryCreated → phase = Ready
+├─ 8. Update DB (sync provider into collector owner)
+├─ 9. Requeue
+│     ├─ SlowReQ  if not yet ConnectionTestSucceeded + InventoryCreated
+│     └─ LongReQ  for periodic re-testing
+│
+└─ deferred: EndStagingConditions → updateProviderStatus
+             Stop reconciliation entirely on ConnectionAuthFailed
+```
+
+### Key behaviors
+
+- **Generation tracking**: `HasReconciled()` compares `ObservedGeneration` with `Generation`. When the provider spec changes, the old collector is shut down and its DB closed before a new one is created.
+- **Secret change detection**: `SecretResourceVersion` in status tracks the last reconciled secret version. When it changes the collector is replaced even if the provider spec hasn't changed.
+- **Auth failure stops reconciliation**: If `ConnectionAuthFailed` is set, `RequeueAfter` is zeroed and no further reconciles happen until the secret/spec changes (prevents account lockout).
+
+---
+
+## Status Phases
+
+| Phase              | Constant           | Set When                                                    |
+|--------------------|--------------------|------------------------------------------------------------|
+| `Staging`          | `Staging`          | Beginning of every reconcile                               |
+| `Ready`            | `Ready`            | No blocker + `ConnectionTestSucceeded` + `InventoryCreated`|
+| `ValidationFailed` | `ValidationFailed` | Type/URL/Secret validation fails, SMB CSI missing, pod errors |
+| `ConnectionFailed` | `ConnectionFailed` | Connection test fails or TLS certificate error             |
+
+---
+
+## Condition Types
+
+### Blocker / Critical conditions
+
+| Condition               | Category   | Trigger                                                      |
+|-------------------------|------------|--------------------------------------------------------------|
+| `ProviderTypeNotSupported` | Critical | `provider.Type()` not in `api.ProviderTypes`                |
+| `UrlNotValid`           | Critical   | URL empty, malformed, or invalid NFS/HyperV format          |
+| `SecretNotValid`        | Critical   | Secret ref missing, secret not found, or required keys absent|
+| `ConnectionAuthFailed`  | Critical   | HTTP 401/400 from connection test (stops reconciliation)     |
+| `ConnectionTestFailed`  | Critical   | Any other connection test failure or TLS error               |
+| `SMBCSIDriverNotReady`  | Critical   | HyperV: `smb.csi.k8s.io` CSIDriver not found               |
+| `SMBMountFailed`        | Critical   | HyperV: provider-server pod stuck pending with mount error   |
+
+### Required conditions (must be present for Ready)
+
+| Condition                 | Category | Trigger                                       |
+|---------------------------|----------|-----------------------------------------------|
+| `ConnectionTestSucceeded` | Required | Connection test passes                        |
+| `InventoryCreated`        | Required | Collector has reached parity (`HasParity()`)  |
+
+### Advisory / Warning conditions
+
+| Condition            | Category | Trigger                                                |
+|----------------------|----------|--------------------------------------------------------|
+| `Validated`          | Advisory | All validations pass with no blockers                  |
+| `LoadInventory`      | Advisory | Collector exists but hasn't reached parity yet         |
+| `WaitingForService`  | Advisory | OVA/HyperV provider-server pod not yet ready           |
+| `ConnectionInsecure` | Warn     | `insecureSkipVerify` flag set in secret                |
+| `SSHReady`           | Advisory | vSphere SSH: some/all ESXi hosts pass SSH test         |
+| `SSHNotReady`        | Warn     | vSphere SSH: keys missing or hosts fail SSH test       |
+
+---
+
+## Secret / Credentials Handling
+
+Each provider type requires specific keys in the referenced `Secret`:
+
+| Provider    | Required Secret Keys                              | Optional            |
+|-------------|---------------------------------------------------|---------------------|
+| `openshift` | `token`                                           |                     |
+| `vsphere`   | `user`, `password`                                | `ca.crt` (required unless `insecureSkipVerify`) |
+| `ovirt`     | `user`, `password`                                | `ca.crt` (required unless `insecureSkipVerify`) |
+| `openstack` | *(validated by collector)*                        |                     |
+| `ova`       | `url` (NFS path of OVA server service)            |                     |
+| `hyperv`    | `username`, `password`, `smbUrl`                  | `ca.crt` (required unless `insecureSkipVerify`) |
+| `ec2`       | *(validated by collector)*                        |                     |
+
+The `insecureSkipVerify` flag is read from `secret.Data` via `base.GetInsecureSkipVerifyFlag()`. When set, TLS certificate validation is skipped and a `ConnectionInsecure` warning condition is added.
+
+For vSphere, the controller also computes a TLS fingerprint (`provider.Status.Fingerprint`) from the server certificate.
+
+---
+
+## SSH Key Management (vSphere)
+
+When `provider.Spec.Settings["esxiCloneMethod"] == "ssh"`:
+
+1. **Key generation** (`ensureSSHKeys`): Generates a 2048-bit RSA key pair and stores them in two secrets:
+   - `{sanitized-provider-name}-ssh-private` with key `private-key`
+   - `{sanitized-provider-name}-ssh-public` with key `public-key`
+   - Both secrets have `ownerReferences` pointing to the Provider (garbage-collected on deletion).
+
+2. **SSH validation** (`validateSSHReadiness`): Runs only after inventory is ready. Tests SSH connectivity to every ESXi host:
+   - **vCenter**: Lists hosts from inventory DB, checks `Host` CRD `IpAddress` (migration network override) then falls back to `ManagementIPs`.
+   - **Direct ESXi**: Extracts host IP from `provider.Spec.URL`.
+   - Sets `SSHReady` (with per-host items) and/or `SSHNotReady` (with setup instructions in `Suggestion` field).
+
+---
+
+## Inventory Container Lifecycle
+
+### Building collectors (`container.Build`)
+
+`container.Build(db, provider, secret)` dispatches by `provider.Type()`:
+
+| Type        | Collector Package                                     |
+|-------------|-------------------------------------------------------|
+| `openshift` | `pkg/controller/provider/container/ocp`               |
+| `vsphere`   | `pkg/controller/provider/container/vsphere`            |
+| `ovirt`     | `pkg/controller/provider/container/ovirt`              |
+| `openstack` | `pkg/controller/provider/container/openstack`          |
+| `ova`       | `pkg/controller/provider/container/ova`                |
+| `ec2`       | `pkg/provider/ec2/inventory/collector`                 |
+| `hyperv`    | `pkg/controller/provider/container/hyperv`             |
+
+Each collector implements `libcontainer.Collector` with `Test()`, `Start()`, `Shutdown()`, `HasParity()`, `DB()`, and `Owner()`.
+
+### Container update flow
+
+```
+updateContainer(provider)
+│
+├─ getSecret → check SecretResourceVersion changed?
+├─ If secret unchanged AND already reconciled → skip
+├─ If secret unchanged AND blocker or no ConnectionTestSucceeded → skip
+├─ Open/create SQLite DB at: {WorkingDir}/{namespace}/{name}/{uid}.db
+├─ container.Build(db, provider, secret) → new collector
+├─ container.Replace(collector) → old collector DB closed
+└─ Update provider.Status.SecretResourceVersion
+```
+
+### Connection testing
+
+`testConnection` builds an **ephemeral** collector (with `db=nil`) and calls `Test()`. This returns an HTTP status code and error. Status 401/400 triggers `ConnectionAuthFailed`; other errors trigger `ConnectionTestFailed`.
+
+For OVA and HyperV, connection testing is gated on the provider-server pod being ready (`checkOVAServiceReady` / `checkHyperVServiceReady`).
+
+---
+
+## Provider-Server Lifecycle (OVA / HyperV)
+
+OVA and HyperV providers require a sidecar server deployment managed via CRDs:
+
+| Provider | CR Type              | Finalizer                      |
+|----------|----------------------|--------------------------------|
+| OVA      | `OVAProviderServer`  | `api.OvaProviderFinalizer`     |
+| HyperV   | `HyperVProviderServer` | `api.HyperVProviderFinalizer`|
+
+### Lifecycle steps
+
+1. **Ensure** (`ensureProviderServer`): Creates the provider-server CR if it doesn't exist. If the provider spec changed (`!HasReconciled()`), the old server is deleted first to force a redeploy.
+
+2. **Readiness checks**: Before connection testing:
+   - **OVA**: Checks Deployment has `ReadyReplicas > 0`. Inspects pod `ContainerStatuses` for image pull errors, crash loops, and pending timeout (configurable via `Settings.Providers.ProviderPendingTimeoutSeconds`).
+   - **HyperV**: Checks pod readiness and detects stuck SMB mounts (pods pending on a node beyond timeout).
+
+3. **Cleanup on deletion** (`cleanupProviderServer`):
+   - OVA: Legacy PV cleanup (labels `subapp=ova-server`, `app=forklift`, `provider={name}`).
+   - Deletes the provider-server CR.
+   - Removes the finalizer from the Provider.
+
+---
+
+## Web API Handlers
+
+The inventory REST API is served by `libweb.WebServer` on `Settings.Inventory.Port` (with optional TLS).
+
+### Handler registration (`web.All`)
+
+`web.All(container)` returns all request handlers:
+
+1. `SchemaHandler` — OpenAPI schema
+2. `ProviderHandler` — `/providers` endpoint (aggregates all provider types)
+3. Per-type handlers registered via `{type}.Handlers(container)`:
+   - `ocp.Handlers` — OpenShift resources (namespaces, VMs, etc.)
+   - `vsphere.Handlers` — vSphere resources (datacenters, clusters, hosts, VMs, networks, datastores)
+   - `ovirt.Handlers` — oVirt resources (datacenters, clusters, hosts, VMs, networks, storage domains)
+   - `openstack.Handlers` — OpenStack resources (projects, VMs, volumes, networks)
+   - `ova.Handlers` — OVA resources (VMs, networks, disks)
+   - `ec2web.Handlers` — EC2 resources (instances, volumes, VPCs)
+   - `hyperv.Handlers` — HyperV resources (VMs, networks, disks)
+
+### Provider list endpoint
+
+`GET /providers` aggregates inventory from all provider types into a single JSON response keyed by provider type string (`openshift`, `vsphere`, `ovirt`, `openstack`, `ova`, `hyperv`, `ec2`).
+
+---
+
+## Base Model Types
+
+`pkg/controller/provider/model/base/model.go` defines shared types:
+
+- **`Ref`**: `{ Kind string, ID string }` — generic object reference used in inventory models.
+- **`Concern`**: `{ Id, Label, Category, Assessment string }` — VM migration concern (displayed in UI's concerns table).
+- **`ConcernHolder`** interface: `GetConcerns() []Concern` — implemented by all provider-specific VM models.
+- **`InvalidRefError`** / **`InvalidKindError`**: Error types for model lookups.
+
+---
+
+## DB Storage
+
+Each provider gets its own SQLite database:
+
+```
+{Settings.Inventory.WorkingDir}/{namespace}/{name}/{uid}.db
+```
+
+The DB schema is defined by `model.Models(provider)` which returns provider-type-specific model slices. The `libmodel.DB` handle is passed to the collector via `container.Build`.
+
+---
+
+## Catalog
+
+The `Catalog` is a thread-safe in-memory map (`sync.Mutex` + `map[reconcile.Request]*api.Provider`) that tracks the last-known Provider for each reconcile request. Used during deletion to retrieve the provider reference after the CR is gone (needed to shut down the correct collector).

--- a/.cursor/rules/backend/providers/vsphere.mdc
+++ b/.cursor/rules/backend/providers/vsphere.mdc
@@ -1,0 +1,260 @@
+---
+description: vSphere provider - inventory collection, data model, REST API, credentials, VDDK
+alwaysApply: false
+---
+
+# vSphere Provider
+
+> Analyzed from commit: `412c71822` on `2026-05-04`
+
+## Inventory Collection
+
+### Connection & Authentication
+
+The collector uses the `govmomi` library to connect to vCenter or standalone ESXi hosts.
+
+**Credentials** come from a Kubernetes Secret with these keys:
+- `user` — vCenter/ESXi username
+- `password` — vCenter/ESXi password
+
+**TLS thumbprint** comes from `provider.Status.Fingerprint`. If `insecureSkipVerify` is not set in the secret, TLS is verified and the thumbprint is computed from the server certificate.
+
+**SDK endpoint validation**: The provider's `spec.settings["sdkEndpoint"]` value (`vCenter` or `ESXI`) is checked against the actual server type. Mismatches fail the connection.
+
+### Collection Mechanism
+
+The collector uses vSphere's **PropertyCollector** with `WaitForUpdatesEx` — a long-polling mechanism that blocks until the server reports changes.
+
+```
+Connect → Create PropertyCollector → Create Filter → WaitForUpdatesEx loop
+```
+
+**Key constants:**
+- `RetryDelay`: 5 seconds between reconnection attempts
+- `MaxObjectUpdates`: 10,000 objects per update batch
+- `ConnectionTimeout`: 30 seconds
+
+**Tracked vSphere object types:**
+| vSphere Type | Model Type | Notes |
+|---|---|---|
+| `Folder` | `Folder` | Hierarchy container |
+| `Datacenter` | `Datacenter` | Top-level organizational unit |
+| `ClusterComputeResource` | `Cluster` | Also handles standalone `ComputeResource` (variant) |
+| `HostSystem` | `Host` | ESXi host |
+| `Network` | `Network` | Standard network (variant=`Standard`) |
+| `OpaqueNetwork` | `Network` | NSX-T network (variant=`OpaqueNetwork`) |
+| `DistributedVirtualPortgroup` | `Network` | DVS port group (variant=`DvPortGroup`) |
+| `VmwareDistributedVirtualSwitch` | `Network` | DVS switch (variant=`DvSwitch`) |
+| `Datastore` | `Datastore` | Storage |
+| `VirtualMachine` | `VM` | VMs — templates are excluded from API responses |
+
+**Parity**: After the first complete `WaitForUpdatesEx` response (not truncated), `parity=true` is set and model watches begin.
+
+### Adapters
+
+Each vSphere object type has an adapter that translates `ObjectUpdate` changesets into model structs. For VMs, adapter logic handles:
+- Disk extraction from multiple backing types (FlatVer1, FlatVer2, RDM)
+- Controller mapping (IDE, SCSI, SATA, NVME, USB)
+- NIC extraction from various ethernet card types (E1000, E1000e, Vmxnet, Vmxnet2, Vmxnet3, PCNet32)
+- Guest network info, guest disk mount points, guest IP stacks
+- Changed Block Tracking (CBT) per disk via `ExtraConfig` keys
+- NUMA affinity from `ExtraConfig`
+- TPM detection (only for vSphere API >= 6.7)
+
+## Data Model
+
+### VM Fields (Complete)
+
+```
+ID, Name, Parent, Variant, Revision
+Folder, Host, UUID, Firmware, PowerState, ConnectionState
+CpuAffinity, CpuHotAddEnabled, CpuHotRemoveEnabled, MemoryHotAddEnabled
+FaultToleranceEnabled, CpuCount, CoresPerSocket, MemoryMB
+GuestName, GuestNameFromVmwareTools, HostName, GuestID
+BalloonedMemory, IpAddress, NumaNodeAffinity, StorageUsed
+Snapshot, IsTemplate, ChangeTrackingEnabled, TpmEnabled
+SecureBoot, NestedHVEnabled, DiskEnableUuid
+ToolsStatus, ToolsRunningStatus, ToolsVersionStatus
+RevisionValidated, PolicyVersion
+Devices[]        — {kind}
+NICs[]           — {network, mac, order, deviceKey}
+Disks[]          — {key, unitNumber, controllerKey, file, datastore, capacity,
+                    shared, rdm, bus, mode, serial, winDriveLetter,
+                    changeTrackingEnabled, parent}
+Controllers[]    — {key, bus, disks[]}
+Networks[]       — Ref[]
+Concerns[]       — {category, label, assessment}
+GuestNetworks[]  — {device, deviceConfigId, mac, ip, origin, prefix, dns[], network}
+GuestDisks[]     — {key, diskPath, capacity, freeSpace, filesystemType}
+GuestIpStacks[]  — {device, gateway, network, prefix, dns[]}
+```
+
+### Disk Bus Types
+
+```
+SCSI = "scsi"   IDE = "ide"   SATA = "sata"   NVME = "nvme"   USB = "usb"
+```
+
+### Network Variants
+
+```
+Standard      — standard vSwitch port group
+DvPortGroup   — distributed virtual port group
+OpaqueNetwork — NSX-T opaque network
+DvSwitch      — distributed virtual switch (hosts/PNICs, not selectable as VM network)
+```
+
+### Concern Structure
+
+```json
+{ "category": "Warning|Critical|Information|Advisory",
+  "label": "Human-readable short label",
+  "assessment": "Detailed explanation" }
+```
+
+## REST API
+
+### Base Path
+
+```
+/providers/vsphere/:provider
+```
+
+Where `:provider` is the Provider CR's UID.
+
+### Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/providers/vsphere` | List all vSphere providers |
+| `GET` | `/providers/vsphere/:provider` | Get provider details (with inventory counts) |
+| `GET` | `…/folders` | List folders |
+| `GET` | `…/folders/:folder` | Get folder |
+| `GET` | `…/datacenters` | List datacenters |
+| `GET` | `…/datacenters/:datacenter` | Get datacenter |
+| `GET` | `…/clusters` | List clusters (excludes standalone ComputeResource) |
+| `GET` | `…/clusters/:cluster` | Get cluster |
+| `GET` | `…/hosts` | List hosts |
+| `GET` | `…/hosts/:host` | Get host (supports `?advancedOption=key`) |
+| `GET` | `…/networks` | List networks |
+| `GET` | `…/networks/:network` | Get network |
+| `GET` | `…/datastores` | List datastores |
+| `GET` | `…/datastores/:datastore` | Get datastore |
+| `GET` | `…/vms` | List VMs (templates excluded) |
+| `GET` | `…/vms/:vm` | Get VM |
+| `GET` | `…/workloads/:vm` | Get workload (VM + host + cluster + datacenter) |
+| `GET` | `…/tree/host` | Datacenter → Cluster → Host → VM tree |
+| `GET` | `…/tree/vm` | Datacenter → Folder → VM tree |
+| `POST` | `/vddk/build-image` | Upload VDDK tar, trigger OpenShift build |
+| `GET` | `/vddk/image-url` | Get VDDK image URL (supports WebSocket watch) |
+| `GET` | `/vddk/download-tar` | Download previously uploaded VDDK tar |
+
+### Query Parameters
+
+- `?detail=` — Controls response depth: `0` = minimal (id, name, path, selfLink), `1` = summary, `2+` or `all` = full detail
+- `?name=` — Filter by name; supports path-based matching (`/DC/folder/name`)
+- `?advancedOption=key` — On host GET: fetch a specific vSphere advanced option value
+
+### WebSocket Watch
+
+Any list endpoint supports WebSocket upgrade via the `X-Watch` header. The server pushes `{action, updated}` events as inventory changes.
+
+### Detail Levels — VM Response
+
+**detail=0** (Resource):
+```json
+{ "id": "vm-123", "variant": "", "parent": {"kind":"Folder","id":"group-v4"},
+  "path": "/DC/vm/MyVM", "revision": 5, "name": "MyVM", "selfLink": "..." }
+```
+
+**detail=1** (VM1): Adds `revisionValidated`, `isTemplate`, `powerState`, `host`, `networks[]`, `disks[]`, `concerns[]`
+
+**detail=2+** (VM full): Adds all remaining fields: `uuid`, `firmware`, `connectionState`, `snapshot`, `changeTrackingEnabled`, `cpuAffinity[]`, `cpuHotAddEnabled`, `cpuHotRemoveEnabled`, `memoryHotAddEnabled`, `faultToleranceEnabled`, `cpuCount`, `coresPerSocket`, `memoryMB`, `guestName`, `guestNameFromVmwareTools`, `hostName`, `guestId`, `balloonedMemory`, `ipAddress`, `storageUsed`, `tpmEnabled`, `numaNodeAffinity[]`, `devices[]`, `nics[]`, `guestNetworks[]`, `guestDisks[]`, `guestIpStacks[]`, `secureBoot`, `toolsStatus`, `toolsRunningStatus`, `toolsVersionStatus2`, `diskEnableUuid`, `nestedHVEnabled`, `policyVersion`
+
+### Provider Response (detail>0)
+
+Includes inventory counts: `datacenterCount`, `clusterCount`, `hostCount`, `vmCount`, `networkCount`, `datastoreCount`, plus `apiVersion`, `product`, `instanceUuid`.
+
+### Workload Response
+
+Enriched VM that embeds host and cluster data:
+```json
+{
+  "selfLink": "...",
+  "<all VM fields>": "...",
+  "host": {
+    "<all Host fields>": "...",
+    "cluster": {
+      "<all Cluster fields>": "...",
+      "datacenter": { "<Datacenter fields>" }
+    }
+  }
+}
+```
+
+Used for policy validation workloads sent to the OPA policy agent.
+
+## Policy Validation (Concerns)
+
+### Architecture
+
+Validation is **asynchronous and non-blocking**:
+1. VM create/update events trigger validation via the `VMEventHandler`
+2. A periodic search finds VMs where `revision != revisionValidated`
+3. Each VM is sent to the OPA **policy agent** at `/v1/data/io/konveyor/forklift/vmware/validate`
+4. Results (concerns) are batched and written back to the VM model
+
+### Validation Triggers
+
+- **VM events**: Created or Updated VMs are queued for validation
+- **Host events**: All VMs on the host get `revisionValidated=0` → revalidated
+- **Cluster events**: All hosts in the cluster → all VMs on those hosts revalidated
+- **Shared disk changes**: When a VM is deleted or validated, VMs sharing its disk files are revalidated
+
+### Shared Disk Detection
+
+A `diskFileMap` (disk file path → VM count) is rebuilt each validation cycle. Disks are marked `shared=true` when multiple VMs reference the same file path. The concern ID is `vmware.disk.shared.detected`.
+
+### Policy Version
+
+The policy agent exposes a version at `/v1/data/io/konveyor/forklift/vmware/rules_version`. If the version changes, all VMs are revalidated.
+
+## VDDK (Virtual Disk Development Kit)
+
+VDDK is VMware's SDK for reading virtual disks. The backend provides endpoints to:
+
+1. **Upload** a VDDK tar.gz file (`POST /vddk/build-image`)
+2. **Build** an OCI image via an OpenShift `BuildConfig` named `vddk`
+3. **Watch** build progress via WebSocket (`GET /vddk/image-url` with `X-Watch` + `?build-name=`)
+4. **Query** the final image URL from the `vddk:latest` ImageStreamTag
+
+VDDK endpoints are only registered when running on OpenShift (`settings.Settings.OpenShift`).
+
+## ESXi Host Handling
+
+- Hosts track: `cluster`, `status`, `inMaintenanceMode`, `managementServerIp`, `managementIPs[]`, `thumbprint`, `timezone`, CPU/memory specs, `productName`, `productVersion`
+- Host networking is modeled in detail: `PNICs[]`, `VNICs[]`, `PortGroups[]`, `Switches[]`
+- The REST API builds `networkAdapters[]` by correlating VNICs with port groups and switches
+- SCSI disk info (`hostScsiDisks[]`), HBA info (`hbaDiskInfo[]`), and SCSI topology are tracked for storage offload features
+- `advancedOptions` can be queried on demand via the `?advancedOption=key` query parameter (lazy-loaded from vCenter)
+
+## Disk Sorting for Migration
+
+Disks are sorted to match the order that `virt-v2v` (via libvirt) expects:
+- **Libvirt order**: SCSI → SATA → IDE → NVME
+- **VMware order**: SATA → IDE → SCSI → NVME
+
+Within each bus type, disks are sorted by `key`. This ensures PVCs are populated with the correct disk content during migration.
+
+## Key Frontend Implications
+
+1. **Templates are filtered out** of VM list responses — the backend skips `isTemplate=true`
+2. **Concerns** drive migration readiness warnings in the UI; they come from OPA policy validation
+3. **Network variant** determines how a network is displayed and which additional fields are present (`dvSwitch`, `key`, `tag`, `vlanId`)
+4. **detail=1** is typically used for table/list views (has power state, disks, concerns); **detail=2+** for detail panels
+5. **Tree endpoints** provide pre-built hierarchies for folder pickers
+6. **Workload endpoint** is used internally for policy validation, not typically called by the frontend directly
+7. **Shared disks** (`disk.shared=true`) need special handling — they can be excluded or flagged in the UI
+8. **CBT per disk** (`disk.changeTrackingEnabled`) is important for warm migration eligibility
+9. **Guest tools status** fields: `toolsStatus`, `toolsRunningStatus`, `toolsVersionStatus2` — note the `2` suffix on version
+10. **`guestNameFromVmwareTools`** may differ from `guestName` (which comes from config summary); prefer the tools version when available

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -54,6 +54,17 @@ Maps source storage to target storage. Referenced by Plans.
 - Supports offload plugins (e.g., vSphere XCOPY)
 - Integrates with storage vendors (IBM FlashSystem, NetApp ONTAP, Dell PowerFlex/PowerMax/PowerStore, HPE Primera/3PAR, Pure Storage, Hitachi, Infinidat)
 
+### Conversion
+Represents a conversion or deep-inspection operation on a VM.
+
+- **Conversion types**: `DeepInspection` (pre-migration analysis), `Inspection`, `InPlace`, `Remote`
+- **Phases**: Pending, Running, Succeeded, Failed, Canceled
+- **Stages**: CreatingPod, CreatingSnapshot, WaitingForSnapshot, PodRunning, FetchingResults, RemovingSnapshot, WaitingForSnapshotRemoval, Finished
+- Stores inspection results (`status.inspectionResult`) with OS info, filesystem details, and compatibility concerns
+- Types defined locally in `src/utils/crds/conversion/` (pending upstream `@forklift-ui/types` export)
+- Constants and selectors: `CONVERSION_PHASE`, `CONVERSION_TYPE`, `getInspectionStatus`, `hasInspectionPassed`
+- **Note**: Backend returns `all_checks_passed` in snake_case — use the `hasInspectionPassed` selector to handle both casings
+
 ### Hook
 Pre/post migration scripts executed as containers (`quay.io/konveyor/hook-runner`). Referenced in Plan VM specifications.
 

--- a/.cursor/skills/backend-analyzer/SKILL.md
+++ b/.cursor/skills/backend-analyzer/SKILL.md
@@ -1,0 +1,158 @@
+# Backend Analyzer Skill
+
+Invoke with: *"analyze backend"*, *"refresh backend knowledge"*, *"update backend expert"*, *"scrape forklift backend"*
+
+## Purpose
+
+Systematically analyze the Forklift Go backend codebase (`kubev2v/forklift`) and generate structured knowledge files as `.mdc` Cursor rules under `.cursor/rules/backend/`.
+
+## Configuration
+
+- **Forklift repo path**: Set by `state.json` field `forkliftRepoPath` (default: `../forklift` relative to this repo)
+- **Target branch**: `upstream/main`
+- **Output directory**: `.cursor/rules/backend/`
+- **State file**: `.cursor/skills/backend-analyzer/state.json`
+
+## Modes
+
+### Full Analysis (first run or forced refresh)
+
+Run all 6 phases sequentially. Within each phase, launch parallel subagents.
+
+### Incremental Refresh
+
+1. Read `state.json` for `lastAnalyzedCommit`
+2. Run `git fetch upstream` in the forklift repo
+3. Run `git diff --name-only <lastCommit>..upstream/main` to find changed files
+4. Map changed files to domain areas using the domain-to-path mapping below
+5. Re-run analysis only for affected domains
+6. Update `state.json`
+
+## Domain-to-Path Mapping
+
+| Domain file | Source paths in forklift repo |
+|-------------|-------------------------------|
+| `architecture.mdc` | `cmd/forklift-controller/`, `pkg/controller/controller.go`, `pkg/controller/base/`, `cmd/forklift-api/` |
+| `api-types.mdc` | `pkg/apis/forklift/v1beta1/` |
+| `providers/provider-controller.mdc` | `pkg/controller/provider/controller.go`, `pkg/controller/provider/validation.go`, `pkg/controller/provider/container/doc.go`, `pkg/controller/provider/web/doc.go`, `pkg/controller/provider/web/provider.go` |
+| `providers/vsphere.mdc` | `pkg/controller/provider/container/vsphere/`, `pkg/controller/provider/model/vsphere/`, `pkg/controller/provider/web/vsphere/` |
+| `providers/ovirt.mdc` | `pkg/controller/provider/container/ovirt/`, `pkg/controller/provider/model/ovirt/`, `pkg/controller/provider/web/ovirt/` |
+| `providers/openstack.mdc` | `pkg/controller/provider/container/openstack/`, `pkg/controller/provider/model/openstack/`, `pkg/controller/provider/web/openstack/` |
+| `providers/ova.mdc` | `pkg/controller/provider/container/ova/`, `pkg/controller/provider/model/ovf/`, `pkg/controller/provider/web/ova/`, `pkg/controller/ova/` |
+| `providers/hyperv.mdc` | `pkg/controller/provider/container/hyperv/`, `pkg/controller/provider/model/hyperv/`, `pkg/controller/provider/web/hyperv/`, `pkg/controller/hyperv/` |
+| `providers/ec2.mdc` | `pkg/provider/ec2/` |
+| `providers/ocp.mdc` | `pkg/controller/provider/container/ocp/`, `pkg/controller/provider/model/ocp/`, `pkg/controller/provider/web/ocp/` |
+| `plans/plan-controller.mdc` | `pkg/controller/plan/controller.go`, `pkg/controller/plan/validation.go`, `pkg/controller/plan/context/`, `pkg/controller/plan/ensurer/`, `pkg/controller/plan/util/`, `pkg/controller/migration/` |
+| `plans/plan-adapters.mdc` | `pkg/controller/plan/adapter/` |
+| `plans/migration-pipeline.mdc` | `pkg/controller/plan/migration.go`, `pkg/controller/plan/kubevirt.go`, `pkg/controller/plan/handler/`, `pkg/controller/plan/migrator/` |
+| `plans/scheduler.mdc` | `pkg/controller/plan/scheduler/` |
+| `mappings/network-map.mdc` | `pkg/controller/map/network/` |
+| `mappings/storage-map.mdc` | `pkg/controller/map/storage/` |
+| `infrastructure/webhooks.mdc` | `pkg/forklift-api/webhooks/` |
+| `infrastructure/rest-api.mdc` | `pkg/forklift-api/services/`, `pkg/controller/provider/web/` |
+| `infrastructure/virt-v2v.mdc` | `pkg/virt-v2v/` |
+| `infrastructure/shared-libraries.mdc` | `pkg/lib/` |
+| `infrastructure/monitoring.mdc` | `pkg/monitoring/`, `pkg/metrics/` |
+| `infrastructure/host-controller.mdc` | `pkg/controller/host/` |
+| `infrastructure/hook-controller.mdc` | `pkg/controller/hook/` |
+| `operator/operator.mdc` | `operator/` |
+
+## Analysis Template
+
+Each subagent MUST follow this template when producing a `.mdc` file:
+
+```markdown
+---
+description: <one-line description for Cursor rule matching>
+alwaysApply: false
+---
+
+# <Domain Title>
+
+> Analyzed from commit: `<SHA>` on `<date>`
+> Source paths: `<list of paths>`
+
+## Package Purpose
+
+<One paragraph explaining what this code does and its role in the system>
+
+## Key Types and Structs
+
+<Important Go types with significant fields. Use code blocks for struct definitions.>
+
+## Interfaces and Implementations
+
+<How the code is extensible. List interfaces and their concrete implementations.>
+
+## Reconciliation / Execution Flow
+
+<Step-by-step flow for controllers. Use numbered lists or mermaid diagrams.>
+
+## Status Conditions
+
+<What conditions are set, when, and what they mean. Table format preferred.>
+
+## REST API Endpoints
+
+<If applicable: routes, methods, request/response shapes.>
+
+## Integration Points
+
+<What other packages this calls and what calls it. Dependency direction.>
+
+## Configuration
+
+<Env vars, settings, feature flags. Table format.>
+
+## Error Patterns
+
+<How errors are handled, common failure modes, retry behavior.>
+
+## Frontend Relevance
+
+<What status fields, API responses, or behaviors the console-plugin UI depends on.
+Map Go fields to the TypeScript types the frontend uses.>
+```
+
+## Execution Phases
+
+### Phase 1: Architecture + API Types (2 parallel agents)
+
+**Agent A** -> `architecture.mdc`:
+- Read: `cmd/forklift-controller/`, `cmd/forklift-api/`, `pkg/controller/controller.go`, `pkg/controller/base/`
+- Focus: Entry points, deployment roles (Main vs Inventory), controller-runtime setup, how controllers are registered
+
+**Agent B** -> `api-types.mdc`:
+- Read: All files in `pkg/apis/forklift/v1beta1/`
+- Focus: CRD type definitions, phase constants (from `doc.go`), condition types, validation defaults, important methods on types
+
+### Phase 2: Providers (8 parallel agents)
+
+One agent per provider type plus one for the common controller. Each provider agent reads the container/, model/, and web/ subdirectories for that provider type.
+
+### Phase 3: Plans + Migration (4 parallel agents)
+
+- Agent A: Plan controller + validation + context + migration CR controller
+- Agent B: Adapter pattern (base + per-provider adapters)
+- Agent C: Migration execution pipeline (migration.go, kubevirt.go, handler/, migrator/)
+- Agent D: Scheduler (per-provider scheduling logic)
+
+### Phase 4: Mappings (2 parallel agents)
+
+- Agent A: NetworkMap controller
+- Agent B: StorageMap controller
+
+### Phase 5: Infrastructure (6 parallel agents)
+
+- Webhooks, REST API, virt-v2v, shared libraries, monitoring, host+hook controllers
+
+### Phase 6: Operator (1 agent)
+
+- Ansible operator configuration
+
+## Post-Analysis
+
+After all phases complete:
+1. Update `state.json` with new commit SHA and date
+2. Run a cross-reference validation to check integration point consistency
+3. Update `.cursor/rules/agents/forklift-expert.mdc` routing table

--- a/.cursor/skills/backend-analyzer/state.json
+++ b/.cursor/skills/backend-analyzer/state.json
@@ -1,0 +1,152 @@
+{
+  "lastAnalyzedCommit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+  "lastRunDate": "2026-05-04",
+  "forkliftRepoPath": "/Users/aturgema/Workspace/forklift",
+  "targetBranch": "upstream/main",
+  "analyzedDomains": {
+    "architecture": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "cmd/forklift-controller/",
+        "cmd/forklift-api/",
+        "pkg/controller/controller.go",
+        "pkg/controller/base/",
+        "pkg/settings/"
+      ]
+    },
+    "api-types": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/apis/forklift/v1beta1/", "pkg/lib/condition/"]
+    },
+    "providers/provider-controller": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/controller.go",
+        "pkg/controller/provider/validation.go",
+        "pkg/controller/provider/container/doc.go",
+        "pkg/controller/provider/web/doc.go"
+      ]
+    },
+    "providers/vsphere": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/vsphere/",
+        "pkg/controller/provider/model/vsphere/",
+        "pkg/controller/provider/web/vsphere/"
+      ]
+    },
+    "providers/ovirt": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/ovirt/",
+        "pkg/controller/provider/model/ovirt/",
+        "pkg/controller/provider/web/ovirt/"
+      ]
+    },
+    "providers/openstack": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/openstack/",
+        "pkg/controller/provider/model/openstack/",
+        "pkg/controller/provider/web/openstack/"
+      ]
+    },
+    "providers/ova": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/ova/",
+        "pkg/controller/provider/model/ovf/",
+        "pkg/controller/provider/web/ova/",
+        "pkg/controller/ova/"
+      ]
+    },
+    "providers/hyperv": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/hyperv/",
+        "pkg/controller/provider/model/hyperv/",
+        "pkg/controller/provider/web/hyperv/",
+        "pkg/controller/hyperv/"
+      ]
+    },
+    "providers/ec2": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/provider/ec2/"]
+    },
+    "providers/ocp": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/provider/container/ocp/",
+        "pkg/controller/provider/model/ocp/",
+        "pkg/controller/provider/web/ocp/"
+      ]
+    },
+    "plans/plan-controller": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/plan/controller.go",
+        "pkg/controller/plan/validation.go",
+        "pkg/controller/plan/context/",
+        "pkg/controller/plan/ensurer/",
+        "pkg/controller/migration/"
+      ]
+    },
+    "plans/plan-adapters": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/plan/adapter/"]
+    },
+    "plans/migration-pipeline": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": [
+        "pkg/controller/plan/migration.go",
+        "pkg/controller/plan/kubevirt.go",
+        "pkg/controller/plan/handler/",
+        "pkg/controller/plan/migrator/"
+      ]
+    },
+    "plans/scheduler": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/plan/scheduler/"]
+    },
+    "mappings/network-map": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/map/network/"]
+    },
+    "mappings/storage-map": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/map/storage/"]
+    },
+    "infrastructure/webhooks": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/forklift-api/webhooks/"]
+    },
+    "infrastructure/rest-api": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/forklift-api/services/", "pkg/controller/provider/web/"]
+    },
+    "infrastructure/virt-v2v": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/virt-v2v/"]
+    },
+    "infrastructure/shared-libraries": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/lib/"]
+    },
+    "infrastructure/monitoring": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/monitoring/", "pkg/metrics/"]
+    },
+    "infrastructure/host-controller": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/host/"]
+    },
+    "infrastructure/hook-controller": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["pkg/controller/hook/"]
+    },
+    "operator/operator": {
+      "commit": "412c71822cacbdc0961f6926fae1c5184d1c4296",
+      "paths": ["operator/"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -639,6 +639,25 @@ import { useForm, FormProvider } from 'react-hook-form';
 const { control, handleSubmit } = useForm<FormValues>();
 ```
 
+**Validation with cross-field dependencies:** In `validate` closures, use `getValues()` instead of `useWatch` to read sibling field values -- `useWatch` captures stale React state inside validation functions. Use the `deps` option to trigger cross-field re-validation when related fields change:
+
+```typescript
+const { control, getValues } = useForm<FormValues>();
+
+<Controller
+  name="scriptName"
+  control={control}
+  rules={{
+    validate: (value) => {
+      const allNames = getValues('scripts').map((s) => s.name);
+      const duplicates = allNames.filter((n) => n === value);
+      return duplicates.length <= 1 || 'Duplicate script name';
+    },
+    deps: ['scripts'],
+  }}
+/>
+```
+
 ### Kubernetes Resources
 Use hooks from `@openshift-console/dynamic-plugin-sdk`:
 ```typescript


### PR DESCRIPTION
## Summary

- Analyzed the entire `kubev2v/forklift` backend codebase (~126K lines of Go, ~592 files in `pkg/`) and produced **24 structured `.mdc` knowledge files** under `.cursor/rules/backend/`, covering:
  - **Architecture** (entry points, deployment roles, controller-runtime framework)
  - **API types** (all CRD definitions, phase constants, condition framework)
  - **Providers** (vSphere, oVirt, OpenStack, OVA, Hyper-V, EC2, OpenShift -- inventory models, REST APIs, credentials)
  - **Plans** (controller, adapters, migration pipeline/itineraries, scheduler)
  - **Mappings** (NetworkMap, StorageMap -- validation, offload plugins)
  - **Infrastructure** (webhooks, REST API, virt-v2v, shared libraries, monitoring, host/hook controllers)
  - **Operator** (Ansible roles, feature flags, deployment topology)
- Added a **routing table** to `forklift-expert.mdc` so the agent loads the right backend knowledge file per topic
- Added a reusable **backend-analyzer skill** (`.cursor/skills/backend-analyzer/`) for refreshing the knowledge when the upstream backend changes

## Test plan

- [x] Verify `.mdc` files load correctly in Cursor when invoking "as forklift expert"
- [x] Test a backend question (e.g. "how does vSphere inventory collection work?") and confirm the agent loads the right knowledge file
- [x] Run "refresh backend knowledge" skill to verify the incremental refresh flow

Resolves: None

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded backend knowledge covering architecture, REST inventory endpoints, monitoring metrics, provider capabilities (vSphere, EC2, OpenStack, OVA, Hyper‑V, oVirt, OCP), migration pipeline, scheduler concurrency, and shared libraries.
  * Added Conversion & Deep Inspection guidance (inspection modal, UI status mapping, vSphere deep‑inspection workflow).
  * Documented Hook and Host behaviors, NetworkMap/StorageMap semantics, and how backend conditions map to UI statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->