### PR TITLE
chore: update Playwright to 1.60

### DIFF
--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.59.0-noble
+FROM mcr.microsoft.com/playwright:v1.60.0-noble
 
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -12,9 +12,9 @@
         "@forklift-ui/types": "1.0.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.0",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20.0.0",
-        "playwright": "^1.59.1",
+        "playwright": "^1.60.0",
         "typescript": "^5.8.2"
       }
     },
@@ -26,13 +26,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -65,13 +65,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/testing/package.json
+++ b/testing/package.json
@@ -15,9 +15,9 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.59.0",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20.0.0",
-    "playwright": "^1.59.1",
+    "playwright": "^1.60.0",
     "typescript": "^5.8.2"
   },
   "dependencies": {

--- a/testing/playwright.config.ts
+++ b/testing/playwright.config.ts
@@ -39,8 +39,13 @@ export default defineConfig({
         headless: true,
         viewport: { width: 1920, height: 1080 },
         screenshot: 'only-on-failure',
-        video: 'retain-on-failure',
-        trace: 'retain-on-failure',
+        video: {
+          mode: 'retain-on-failure',
+          show: {
+            actions: { position: 'top-right' },
+          },
+        },
+        trace: 'retain-on-failure-and-retries',
         // Use data-testid to match actual rendered HTML
         testIdAttribute: 'data-testid',
         ignoreHTTPSErrors: true,

--- a/testing/run-e2e-docker.sh
+++ b/testing/run-e2e-docker.sh
@@ -17,5 +17,5 @@ docker run --rm -it \
   --env LC_ALL=en_US.UTF-8 \
   --env LANG=en_US.UTF-8 \
   --env LANGUAGE=en_US.UTF-8 \
-  mcr.microsoft.com/playwright:v1.59.0-noble \
+  mcr.microsoft.com/playwright:v1.60.0-noble \
   bash -c "npm install && npx playwright test --grep @downstream"


### PR DESCRIPTION
Bump Playwright from 1.59 to 1.60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Playwright tooling and container image to the latest v1.60.x release for E2E testing.
  * Updated E2E execution to use the new runtime image tag.
  * Enhanced test recording: retain video on failure and display action overlays; retain traces on failure and retries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->