### PR TITLE
Bump ocp-plugin-i18n-scripts to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "lint-staged": "^15.4.3",
         "mini-svg-data-uri": "^1.4.4",
         "monaco-editor": "^0.52.2",
-        "ocp-plugin-i18n-scripts": "^1.0.0",
+        "ocp-plugin-i18n-scripts": "^1.0.2",
         "prettier": "^3.5.3",
         "sass": "^1.86.0",
         "sass-loader": "^16.0.5",
@@ -16083,9 +16083,9 @@
       "license": "MIT"
     },
     "node_modules/ocp-plugin-i18n-scripts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ocp-plugin-i18n-scripts/-/ocp-plugin-i18n-scripts-1.0.1.tgz",
-      "integrity": "sha512-PVxRTgIkeat1NDLC7kW0LMRlPITgecaxYricnST8l172mphFqVx0W+M7APrg22mseUVaTnTtM6GOu4mh8H2cZA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ocp-plugin-i18n-scripts/-/ocp-plugin-i18n-scripts-1.0.2.tgz",
+      "integrity": "sha512-/EYALwxnfE0HpkzY2PaC6Tes1YlOCpqVR0SZwtzeRY5GKnfkwlCrOue+CNSDCw1uIVzmFmvbJDq9TOqpzQJhOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "lint-staged": "^15.4.3",
     "mini-svg-data-uri": "^1.4.4",
     "monaco-editor": "^0.52.2",
-    "ocp-plugin-i18n-scripts": "^1.0.0",
+    "ocp-plugin-i18n-scripts": "^1.0.2",
     "prettier": "^3.5.3",
     "sass": "^1.86.0",
     "sass-loader": "^16.0.5",


### PR DESCRIPTION
## Summary
- Bumps `ocp-plugin-i18n-scripts` from `1.0.0` to `1.0.2`
- Fixes language alias resolution during PO export (e.g. `zh-cn` -> `zh` locale directory), which previously caused all existing Chinese translations to be dropped on every Memsource upload
- Fixes `sed` delimiter in the upload script so branch names with `/` (e.g. `bug/MTV-1234`) no longer break the project title substitution

## Test plan
- [x] Run `npm run export-pos` and verify `po-files/zh-cn/` PO file contains translated `msgstr` values (not all empty)
- [x] Verify the upload script's sed substitution handles `/` in branch names:
  ```bash
  # Dry run: just test the sed substitution, no actual upload
  BRANCH="bug/MTV-1234"
  TEMPLATE='[Forklift $VERSION] UI Localization - Sprint $SPRINT/Branch $BRANCH'
  echo "$TEMPLATE" | sed -e "s|\\\$VERSION|2.12|g" -e "s|\\\$SPRINT|2|g" -e "s|\\\$BRANCH|$BRANCH|g"
  # Expected: [Forklift 2.12] UI Localization - Sprint 2/Branch bug/MTV-1234
  ```

Resolves: None