### PR TITLE
Update i18n-memsource skill for ocp-plugin-i18n-scripts 1.0.2

### DIFF
--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -15,12 +15,15 @@ Read `.cursor/skills/i18n-memsource/state.json` for current sprint, version, and
 
 ### Memsource CLI
 
-The `memsource` CLI is a Python package (`memsource-cli`) installed via pip3. The
-executable lives at `/Users/aturgema/Library/Python/3.9/bin/memsource` and is **not**
-on the default PATH. Always prepend it:
+The `memsource` CLI is a Python package (`memsource-cli`) installed via pip3. It
+may not be on the default PATH. Locate and export it:
 
 ```bash
-export PATH="/Users/aturgema/Library/Python/3.9/bin:$PATH"
+MEMSOURCE_BIN=$(python3 -c "import shutil; print(shutil.which('memsource') or '')")
+if [ -z "$MEMSOURCE_BIN" ]; then
+  MEMSOURCE_BIN=$(find "$HOME/Library/Python" -name memsource -type f 2>/dev/null | head -1)
+fi
+export PATH="$(dirname "$MEMSOURCE_BIN"):$PATH"
 ```
 
 ### Authentication
@@ -35,13 +38,17 @@ work inside npm scripts, you must capture the token and export it as
 `MEMSOURCE_TOKEN`:
 
 ```bash
-export PATH="/Users/aturgema/Library/Python/3.9/bin:$PATH"
 source ~/.memsourcerc
 export MEMSOURCE_TOKEN=$(memsource auth login \
   --user-name "$MEMSOURCE_USERNAME" \
   --password "$MEMSOURCE_PASSWORD" \
-  -f json 2>/dev/null \
+  -f json \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+if [ -z "$MEMSOURCE_TOKEN" ]; then
+  echo "ERROR: Memsource authentication failed. Check ~/.memsourcerc credentials."
+  return 1
+fi
 ```
 
 Run this **once** at the start of every action. All subsequent `memsource` and
@@ -308,7 +315,7 @@ Trigger: user says "translation status", "memsource status", "check translations
 
 ## Important Notes
 
-- **CLI path:** The `memsource` binary is at `/Users/aturgema/Library/Python/3.9/bin/memsource`. Always export this to PATH before use.
+- **CLI path:** The `memsource` binary is installed via pip3 and may not be on PATH. Use the discovery snippet from Prerequisites to locate it.
 - **Auth token:** Use `MEMSOURCE_TOKEN` env var (captured from `memsource auth login`) so child processes (npm scripts) inherit auth. Do not rely on `memsource auth login` alone -- the token is not persisted to disk.
 - **Language aliases and branch names:** Both are handled automatically since `ocp-plugin-i18n-scripts@1.0.2`. No symlinks or branch switching needed.
 - The `npm run memsource-upload` and `npm run memsource-download` scripts use the `ocp-plugin-i18n-scripts` npm package CLI commands under the hood.

--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -13,15 +13,45 @@ Read `.cursor/skills/i18n-memsource/state.json` for current sprint, version, and
 
 ## Prerequisites
 
-Before running any Memsource commands, always authenticate first:
+### Memsource CLI
+
+The `memsource` CLI is a Python package (`memsource-cli`) installed via pip3. The
+executable lives at `/Users/aturgema/Library/Python/3.9/bin/memsource` and is **not**
+on the default PATH. Always prepend it:
 
 ```bash
-source ~/.memsourcerc
+export PATH="/Users/aturgema/Library/Python/3.9/bin:$PATH"
 ```
 
-Run this in the Shell tool at the start of every action. Do not ask the user to do it.
+### Authentication
 
-Also read `i18n-scripts.config.json` from the project root for plugin config (languages, plugin name, etc).
+Credentials are stored in `~/.memsourcerc` (exports `MEMSOURCE_USERNAME` and
+`MEMSOURCE_PASSWORD`). The CLI also accepts a token via the `MEMSOURCE_TOKEN`
+environment variable.
+
+**Important:** The `memsource auth login` command returns a token but does not
+persist it for child processes (like those spawned by `npm run`). To make auth
+work inside npm scripts, you must capture the token and export it as
+`MEMSOURCE_TOKEN`:
+
+```bash
+export PATH="/Users/aturgema/Library/Python/3.9/bin:$PATH"
+source ~/.memsourcerc
+export MEMSOURCE_TOKEN=$(memsource auth login \
+  --user-name "$MEMSOURCE_USERNAME" \
+  --password "$MEMSOURCE_PASSWORD" \
+  -f json 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+```
+
+Run this **once** at the start of every action. All subsequent `memsource` and
+`npm run memsource-*` commands in the same shell session will inherit the token.
+Do not ask the user to authenticate manually.
+
+### Config
+
+Read `i18n-scripts.config.json` from the project root for plugin config
+(languages, plugin name, language aliases, etc).
 
 ---
 
@@ -58,11 +88,9 @@ Read these files:
 
 ### Step 3: Authenticate
 
-```bash
-source ~/.memsourcerc
-```
+Run the full authentication sequence from Prerequisites (export PATH, source
+credentials, capture MEMSOURCE_TOKEN). Verify with:
 
-Verify authentication works:
 ```bash
 memsource auth whoami
 ```
@@ -83,6 +111,9 @@ Verify it exits with code 0 and writes locale files.
 rm -rf po-files
 npm run export-pos
 ```
+
+The script resolves `languageAliases` from `i18n-scripts.config.json` automatically
+(e.g. `zh-cn` maps to locale directory `zh/`). Fixed in `ocp-plugin-i18n-scripts@1.0.2`.
 
 ### Step 6: Validate PO files
 
@@ -122,11 +153,17 @@ Ask for explicit approval before proceeding. Use the AskQuestion tool:
 
 ### Step 8: Upload to Memsource
 
+Run the upload (MEMSOURCE_TOKEN must be exported from Step 3):
+
 ```bash
 npm run memsource-upload -- -v VERSION -s SPRINT
 ```
 
-Capture the output. The script prints the PROJECT_ID. Extract it from the `memsource project create` output line.
+The script handles branch names with `/` and resolves language aliases
+automatically (fixed in `ocp-plugin-i18n-scripts@1.0.2`).
+
+Capture the output. The script prints the PROJECT_ID in JSON. Extract the `uid`
+field from the `memsource project create` output.
 
 If the upload fails (auth error, network error), report the error and suggest fixes.
 
@@ -185,9 +222,8 @@ Read `.cursor/skills/i18n-memsource/state.json` for `lastProjectId`. Show it to 
 
 ### Step 2: Authenticate
 
-```bash
-source ~/.memsourcerc
-```
+Run the full authentication sequence from Prerequisites (export PATH, source
+credentials, capture MEMSOURCE_TOKEN).
 
 ### Step 3: Check translation status
 
@@ -249,10 +285,8 @@ Trigger: user says "translation status", "memsource status", "check translations
 
 1. Read `.cursor/skills/i18n-memsource/state.json` for `lastProjectId`
 2. Ask user to confirm or provide a different PROJECT_ID
-3. Authenticate:
-   ```bash
-   source ~/.memsourcerc
-   ```
+3. Authenticate using the full sequence from Prerequisites (export PATH, source
+   credentials, capture MEMSOURCE_TOKEN).
 4. For each language in `i18n-scripts.config.json`, query:
    ```bash
    memsource job list --project-id PROJECT_ID --target-lang LANG -f json -c uid,status,targetLang
@@ -274,7 +308,9 @@ Trigger: user says "translation status", "memsource status", "check translations
 
 ## Important Notes
 
-- Always run `source ~/.memsourcerc` before any `memsource` CLI command. Do this silently.
+- **CLI path:** The `memsource` binary is at `/Users/aturgema/Library/Python/3.9/bin/memsource`. Always export this to PATH before use.
+- **Auth token:** Use `MEMSOURCE_TOKEN` env var (captured from `memsource auth login`) so child processes (npm scripts) inherit auth. Do not rely on `memsource auth login` alone -- the token is not persisted to disk.
+- **Language aliases and branch names:** Both are handled automatically since `ocp-plugin-i18n-scripts@1.0.2`. No symlinks or branch switching needed.
 - The `npm run memsource-upload` and `npm run memsource-download` scripts use the `ocp-plugin-i18n-scripts` npm package CLI commands under the hood.
 - PO files are temporary artifacts in `po-files/` -- they're cleaned up after upload.
 - The `memsource-download` script auto-commits. The PR creation is a separate step.

--- a/.cursor/skills/i18n-memsource/state.json
+++ b/.cursor/skills/i18n-memsource/state.json
@@ -1,9 +1,10 @@
 {
   "version": "2.12",
-  "sprint": 1,
-  "lastProjectId": "28wosG55nMVH8VwafbqC13",
-  "memsourceProjectUrl": "https://cloud.memsource.com/web/project2/show/28wosG55nMVH8VwafbqC13",
+  "sprint": 2,
+  "lastProjectId": "xNCkdYqlrFbPdd3B1ruWB5",
+  "memsourceProjectUrl": "https://cloud.memsource.com/web/project2/show/xNCkdYqlrFbPdd3B1ruWB5",
   "history": [
-    { "sprint": 1, "version": "2.12", "projectId": "28wosG55nMVH8VwafbqC13", "date": "2026-03-05" }
+    { "sprint": 1, "version": "2.12", "projectId": "28wosG55nMVH8VwafbqC13", "date": "2026-03-05" },
+    { "sprint": 2, "version": "2.12", "projectId": "xNCkdYqlrFbPdd3B1ruWB5", "date": "2026-05-17" }
   ]
 }


### PR DESCRIPTION
## Summary
- Documents the memsource CLI path and `MEMSOURCE_TOKEN` auth flow needed for npm subprocess compatibility
- Removes language alias symlink workarounds (fixed in ocp-plugin-i18n-scripts 1.0.2)
- Removes branch name `/` workaround (fixed in ocp-plugin-i18n-scripts 1.0.2)
- Updates state.json with Sprint 2 upload from May 17

## Test plan
- [x] Cursor skill files only -- no runtime impact

Resolves: None

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated i18n Memsource workflow guides with streamlined authentication setup instructions
  * Clarified upload, download, and status operation procedures
  * Improved guidance on automatic language alias and branch name handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->