### PR TITLE
Add Technology Preview labels for TP features in 2.12

### DIFF
--- a/src/plans/details/tabs/Automation/components/ScriptsSection/ScriptsSection.tsx
+++ b/src/plans/details/tabs/Automation/components/ScriptsSection/ScriptsSection.tsx
@@ -4,13 +4,14 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 
 import { DetailsItem } from '@components/DetailItems/DetailItem';
 import SectionHeadingWithEdit from '@components/headers/SectionHeadingWithEdit';
+import TechPreviewLabel from '@components/PreviewLabels/TechPreviewLabel';
 import type { IoK8sApiCoreV1ConfigMap, V1beta1Plan } from '@forklift-ui/types';
 import {
   getGroupVersionKindForModel,
   ResourceLink,
   useOverlay,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { Content, DescriptionList, Flex } from '@patternfly/react-core';
+import { Content, DescriptionList, Flex, FlexItem } from '@patternfly/react-core';
 import { ConfigMapModel } from '@utils/constants';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -37,15 +38,22 @@ const ScriptsSection: FC<ScriptsSectionProps> = ({ configMap, plan, scripts }) =
 
   return (
     <Flex direction={{ default: 'column' }}>
-      <SectionHeadingWithEdit
-        editable={planEditable}
-        title={t('Customization scripts')}
-        onClick={() => {
-          launchOverlay(ScriptEdit, { configMap, plan, scripts });
-        }}
-        data-testid="scripts-section-edit-button"
-        headingLevel="h3"
-      />
+      <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>
+          <SectionHeadingWithEdit
+            editable={planEditable}
+            title={t('Customization scripts')}
+            onClick={() => {
+              launchOverlay(ScriptEdit, { configMap, plan, scripts });
+            }}
+            data-testid="scripts-section-edit-button"
+            headingLevel="h3"
+          />
+        </FlexItem>
+        <FlexItem>
+          <TechPreviewLabel />
+        </FlexItem>
+      </Flex>
       {hasScripts && configMap ? (
         <>
           <DescriptionList>

--- a/src/plans/details/tabs/Hooks/components/HookSection/AapHookDetails.tsx
+++ b/src/plans/details/tabs/Hooks/components/HookSection/AapHookDetails.tsx
@@ -1,7 +1,9 @@
 import type { FC } from 'react';
 
 import { DetailsItem } from '@components/DetailItems/DetailItem';
+import TechPreviewLabel from '@components/PreviewLabels/TechPreviewLabel';
 import type { V1beta1Hook, V1beta1HookSpecAap } from '@forklift-ui/types';
+import { Flex, FlexItem } from '@patternfly/react-core';
 import { getAnnotation } from '@utils/crds/common/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
 import { ANNOTATION_AAP_JOB_TEMPLATE_NAME } from '@utils/types/aap';
@@ -20,7 +22,17 @@ const AapHookDetails: FC<AapHookDetailsProps> = ({ aap, hook }) => {
       <DetailsItem
         testId="hook-type-detail-item"
         title={t('Hook type')}
-        content={t('Ansible Automation Platform')}
+        content={
+          <Flex
+            spaceItems={{ default: 'spaceItemsSm' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <FlexItem>{t('Ansible Automation Platform')}</FlexItem>
+            <FlexItem>
+              <TechPreviewLabel />
+            </FlexItem>
+          </Flex>
+        }
       />
       <DetailsItem
         testId="aap-job-template-id-detail-item"

--- a/src/providers/create/fields/ProviderTypeField.tsx
+++ b/src/providers/create/fields/ProviderTypeField.tsx
@@ -3,7 +3,8 @@ import { useController } from 'react-hook-form';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import Select from '@components/common/Select';
-import { SelectList, SelectOption } from '@patternfly/react-core';
+import TechPreviewLabel from '@components/PreviewLabels/TechPreviewLabel';
+import { Flex, FlexItem, SelectList, SelectOption } from '@patternfly/react-core';
 import { getInputValidated } from '@utils/form';
 import { useClusterIsAwsPlatform } from '@utils/hooks/useClusterIsAwsPlatform';
 import { useIsDarkTheme } from '@utils/hooks/useIsDarkTheme';
@@ -67,7 +68,19 @@ const ProviderTypeField: FC = () => {
               icon={option.icon}
               data-testid={`provider-type-option-${option.value}`}
             >
-              {option.label}
+              {option.techPreview ? (
+                <Flex
+                  spaceItems={{ default: 'spaceItemsSm' }}
+                  alignItems={{ default: 'alignItemsCenter' }}
+                >
+                  <FlexItem>{option.label}</FlexItem>
+                  <FlexItem>
+                    <TechPreviewLabel />
+                  </FlexItem>
+                </Flex>
+              ) : (
+                option.label
+              )}
             </SelectOption>
           ))}
         </SelectList>

--- a/src/providers/create/utils/getProviderTypeOptions.tsx
+++ b/src/providers/create/utils/getProviderTypeOptions.tsx
@@ -16,6 +16,7 @@ type ProviderTypeOption = {
   description: string;
   icon: ReactElement;
   label: string;
+  techPreview?: boolean;
   value: string;
 };
 
@@ -29,6 +30,7 @@ export const getProviderTypeOptions = (
           description: t('Migrate Amazon EC2 instances to OpenShift Virtualization'),
           icon: ec2Logo,
           label: t('Amazon EC2'),
+          techPreview: true,
           value: PROVIDER_TYPES.ec2,
         },
       ]
@@ -57,6 +59,7 @@ export const getProviderTypeOptions = (
     description: t('Microsoft Hyper-V virtualization platform. Supports migration via SMB share.'),
     icon: hypervLogo,
     label: t('Microsoft Hyper-V'),
+    techPreview: true,
     value: PROVIDER_TYPES.hyperv,
   },
   {

--- a/src/providers/details/tabs/Details/components/DetailsSection/UploadFilesSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/UploadFilesSection.tsx
@@ -3,8 +3,7 @@ import { PROVIDER_TYPES } from 'src/providers/utils/constants';
 
 import SectionHeading from '@components/headers/SectionHeading';
 import OvaFileUploader from '@components/OvaFileUploader/OvaFileUploader';
-import TechPreviewLabel from '@components/PreviewLabels/TechPreviewLabel';
-import { Flex, PageSection } from '@patternfly/react-core';
+import { PageSection } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -24,19 +23,7 @@ const UploadFilesSection: FC<DetailsSectionProps> = ({ data }) => {
 
   return (
     <PageSection hasBodyWrapper={false} className="forklift-page-section--details">
-      <SectionHeading
-        text={
-          <Flex
-            alignItems={{ default: 'alignItemsCenter' }}
-            direction={{ default: 'row' }}
-            gap={{ default: 'gapSm' }}
-          >
-            {t('Upload local OVA file')}
-            <TechPreviewLabel />
-          </Flex>
-        }
-        testId="ova-upload-section-heading"
-      />
+      <SectionHeading text={t('Upload local OVA file')} testId="ova-upload-section-heading" />
       <OvaFileUploader provider={provider} />
     </PageSection>
   );

--- a/src/providers/list/components/TypeCell.tsx
+++ b/src/providers/list/components/TypeCell.tsx
@@ -1,25 +1,22 @@
 import type { FC } from 'react';
 import { getResourceFieldValue } from 'src/components/common/FilterGroup/matchers';
+import TechPreviewLabel from 'src/components/PreviewLabels/TechPreviewLabel';
 import { TableLabelCell } from 'src/components/TableCell/TableLabelCell';
 import type { CellProps } from 'src/providers/list/components/CellProps';
-import type { PROVIDER_TYPES } from 'src/providers/utils/constants';
+import { isTechPreviewProvider, type PROVIDER_TYPES } from 'src/providers/utils/constants';
 import { getIsOnlySource } from 'src/providers/utils/helpers/getIsTarget';
 import { PROVIDERS } from 'src/utils/enums';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { SOURCE_LABEL_COLOR, SOURCE_LABEL_TEXT } from './utils/constants';
 
-/**
- * TypeCell component, used for displaying the type of a resource.
- * @param {CellProps} props - The props for the component.
- * @returns {JSX.Element} - The rendered component.
- */
 export const TypeCell: FC<CellProps> = ({ data, fields }) => {
   const { t } = useForkliftTranslation();
 
   const { provider } = data;
   const type = getResourceFieldValue(data, 'type', fields);
   const isSource = getIsOnlySource(provider);
+  const isTechPreview = isTechPreviewProvider(type as string);
 
   return (
     <TableLabelCell
@@ -28,6 +25,7 @@ export const TypeCell: FC<CellProps> = ({ data, fields }) => {
       labelColor={SOURCE_LABEL_COLOR}
     >
       {PROVIDERS?.[type as keyof typeof PROVIDER_TYPES] ?? ''}
+      {isTechPreview && <TechPreviewLabel />}
     </TableLabelCell>
   );
 };

--- a/src/providers/utils/constants.ts
+++ b/src/providers/utils/constants.ts
@@ -36,6 +36,14 @@ export const PROVIDER_TYPES = {
 
 export type ProviderTypes = (typeof PROVIDER_TYPES)[keyof typeof PROVIDER_TYPES];
 
+const TECH_PREVIEW_PROVIDER_TYPES: readonly ProviderTypes[] = [
+  PROVIDER_TYPES.ec2,
+  PROVIDER_TYPES.hyperv,
+] as const;
+
+export const isTechPreviewProvider = (type: string): boolean =>
+  TECH_PREVIEW_PROVIDER_TYPES.includes(type as ProviderTypes);
+
 export enum VSphereEndpointType {
   ESXi = 'esxi',
   vCenter = 'vcenter',


### PR DESCRIPTION
## 📝 Links

- [MTV-5531](https://redhat.atlassian.net/browse/MTV-5531)
- [MTV-4377](https://redhat.atlassian.net/browse/MTV-4377) - HyperV provider TP
- [MTV-2997](https://redhat.atlassian.net/browse/MTV-2997) - EC2 provider TP
- [MTV-3818](https://redhat.atlassian.net/browse/MTV-3818) - AAP hooks TP
- [MTV-3641](https://redhat.atlassian.net/browse/MTV-3641) - Customization scripts TP

## 📝 Description

Add missing Technology Preview labels for features marked as TP in 2.12, and remove a stale one from OVA upload.

- Add `TechPreviewLabel` to HyperV and EC2 provider types in the create provider form dropdown and the provider list Type column
- Add `TechPreviewLabel` next to "Ansible Automation Platform" in the plan details Hooks tab (AapHookDetails)
- Add `TechPreviewLabel` next to "Customization scripts" heading in the plan details Automation tab
- Remove `TechPreviewLabel` from OVA upload section (no longer Tech Preview)
- Add `isTechPreviewProvider()` utility and `TECH_PREVIEW_PROVIDER_TYPES` constant for reuse

## 🎥 Demo

### Create provider form - HyperV with TP label
![create-provider-dropdown](https://github.com/user-attachments/assets/placeholder-1)

### Plan details - Automation tab with TP label
![automation-tab](https://github.com/user-attachments/assets/placeholder-2)

### Plan details - Hook edit modal with AAP TP label
![hook-edit-modal](https://github.com/user-attachments/assets/placeholder-3)


Made with [Cursor](https://cursor.com)

[MTV-5531]: https://redhat.atlassian.net/browse/MTV-5531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-4377]: https://redhat.atlassian.net/browse/MTV-4377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-2997]: https://redhat.atlassian.net/browse/MTV-2997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-3818]: https://redhat.atlassian.net/browse/MTV-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-3641]: https://redhat.atlassian.net/browse/MTV-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Tech Preview visual indicators across the UI to highlight early-stage features.
  * Tech Preview labels now appear on automation scripts, Ansible Automation Platform hooks, provider type options, and provider list entries.
  * Amazon EC2 and Microsoft Hyper‑V providers are marked as Tech Preview in creation and list views.

* **Changes**
  * Removed the Tech Preview label from the "Upload local OVA file" section heading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->