### PR TITLE
Resolves: MTV-5354 | Show plan Validating status during VDDK validation

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -1489,6 +1489,7 @@
   "Username is required": "Username is required",
   "Username is required. The username usually includes @ character, for example: name@internal": "Username is required. The username usually includes @ character, for example: name@internal",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.",
+  "Validating": "Validating",
   "Validation Failed": "Validation Failed",
   "Value": "Value",
   "Values": "Values",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -1497,6 +1497,7 @@
   "Username is required": "El nombre de usuario es obligatorio",
   "Username is required. The username usually includes @ character, for example: name@internal": "Se requiere un nombre de usuario. Por lo general, el nombre de usuario incluye el carácter @, por ejemplo: name@internal",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "Utiliza un recurso compartido SMB para acceder a los discos de la máquina virtual. Requiere una URL de recurso compartido SMB y, opcionalmente, credenciales SMB independientes.",
+  "Validating": "Validating",
   "Validation Failed": "Validación fallida",
   "Value": "Valor",
   "Values": "Valores",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -1497,6 +1497,7 @@
   "Username is required": "Un nom d'utilisateur est requis.",
   "Username is required. The username usually includes @ character, for example: name@internal": "Un nom d'utilisateur est requis. Le nom d'utilisateur comprend généralement le caractère @, par exemple\u00a0: nom@interne",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "Utilise un partage SMB pour accéder aux disques des machines virtuelles. Nécessite une URL de partage SMB et, éventuellement, des informations d'identification SMB distinctes.",
+  "Validating": "Validating",
   "Validation Failed": "Échec de la validation",
   "Value": "Valeur",
   "Values": "Valeurs",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -1488,6 +1488,7 @@
   "Username is required": "ユーザー名は必須です",
   "Username is required. The username usually includes @ character, for example: name@internal": "ユーザー名は必須です。ユーザー名には通常 @ 記号が含まれます。例: name@internal",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "仮想マシンディスクへのアクセスに SMB 共有を使用します。SMB 共有の URL が必須であり、必要に応じて別の SMB 認証情報を指定できます。",
+  "Validating": "Validating",
   "Validation Failed": "検証に失敗しました",
   "Value": "値",
   "Values": "値",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -1488,6 +1488,7 @@
   "Username is required": "사용자 이름은 필수입니다",
   "Username is required. The username usually includes @ character, for example: name@internal": "사용자 이름은 필수 입력 사항입니다. 사용자 이름에는 일반적으로 '@' 문자가 포함됩니다. 예: name@internal",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "SMB 공유를 사용하여 VM 디스크에 액세스합니다. SMB 공유 URL과 선택적으로 별도의 SMB 자격 증명이 필요합니다.",
+  "Validating": "Validating",
   "Validation Failed": "검증 실패",
   "Value": "값",
   "Values": "값",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -1488,6 +1488,7 @@
   "Username is required": "名称是必需的",
   "Username is required. The username usually includes @ character, for example: name@internal": "用户名是必需的。用户名通常包含 @ 字符，例如： name@internal",
   "Uses an SMB share to access VM disks. Requires an SMB share URL and optionally separate SMB credentials.": "使用 SMB 共享访问虚拟机磁盘。需要 SMB 共享 URL 以及可选的单独的 SMB 凭证。",
+  "Validating": "Validating",
   "Validation Failed": "验证失败",
   "Value": "值",
   "Values": "值",

--- a/src/plans/details/components/PlanStatus/utils/constants.ts
+++ b/src/plans/details/components/PlanStatus/utils/constants.ts
@@ -1,1 +1,4 @@
 export const STATUS_POPOVER_VMS_COUNT_THRESHOLD = 5;
+
+export const PLAN_CONDITION_VALIDATING_VDDK = 'ValidatingVDDK';
+export const PLAN_CONDITION_VDDK_INIT_IMAGE_NOT_READY = 'VDDKInitImageNotReady';

--- a/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
@@ -97,4 +97,9 @@ export const planStatusLabelMapper: Record<PlanStatuses, ReactNode> = {
       {t('Unknown')}
     </Label>
   ),
+  [PlanStatuses.Validating]: (
+    <Label status="info" isCompact variant="filled" data-testid="plan-status-label">
+      {t('Validating')}
+    </Label>
+  ),
 };

--- a/src/plans/details/components/PlanStatus/utils/types.ts
+++ b/src/plans/details/components/PlanStatus/utils/types.ts
@@ -46,6 +46,7 @@ export enum PlanStatuses {
   Pending = 'Pending',
   Executing = 'Executing',
   Ready = 'Ready',
+  Validating = 'Validating',
 }
 
 export const planMigrationVirtualMachineStatuses = {

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -12,7 +12,11 @@ import { deepCopy } from '@utils/deepCopy';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
 
-import { STATUS_POPOVER_VMS_COUNT_THRESHOLD } from './constants';
+import {
+  PLAN_CONDITION_VALIDATING_VDDK,
+  PLAN_CONDITION_VDDK_INIT_IMAGE_NOT_READY,
+  STATUS_POPOVER_VMS_COUNT_THRESHOLD,
+} from './constants';
 import {
   type MigrationVirtualMachinesStatusCountObjectVM,
   type MigrationVirtualMachinesStatusesCounts,
@@ -206,7 +210,10 @@ export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
     return PlanStatuses.Ready;
   }
 
-  if (conditions.includes('ValidatingVDDK') || conditions.includes('VDDKInitImageNotReady')) {
+  if (
+    conditions.includes(PLAN_CONDITION_VALIDATING_VDDK) ||
+    conditions.includes(PLAN_CONDITION_VDDK_INIT_IMAGE_NOT_READY)
+  ) {
     return PlanStatuses.Validating;
   }
 

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -206,6 +206,10 @@ export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
     return PlanStatuses.Ready;
   }
 
+  if (conditions.includes('ValidatingVDDK') || conditions.includes('VDDKInitImageNotReady')) {
+    return PlanStatuses.Validating;
+  }
+
   return PlanStatuses.Unknown;
 };
 

--- a/src/plans/list/utils/planFields.ts
+++ b/src/plans/list/utils/planFields.ts
@@ -25,6 +25,7 @@ const planPhases: { id: PlanStatuses; label: string }[] = [
   { id: PlanStatuses.Paused, label: t('Paused') },
   { id: PlanStatuses.Pending, label: t('Pending') },
   { id: PlanStatuses.Ready, label: t('Ready to start') },
+  { id: PlanStatuses.Validating, label: t('Validating') },
 ];
 
 const migrationTypes: { id: MigrationTypeValue; label: string }[] = [


### PR DESCRIPTION
## Links

- [MTV-5354](https://redhat.atlassian.net/browse/MTV-5354)

## Description

When the VDDK/v2v image is being pulled after an MTV upgrade, plans showed "Unknown" status because the backend's `ValidatingVDDK` advisory condition was not mapped in the frontend's `getPlanStatus()`.

- Added `Validating` to the `PlanStatuses` enum
- Added condition check for `ValidatingVDDK` and `VDDKInitImageNotReady` in `getPlanStatus()` before the final `Unknown` fallback
- Added "Validating" label with `info` status in the plan status mapper
- Added `Validating` to the plan list phase filter

## Demo

<!-- Screenshots to be added after visual verification on a cluster -->



[MTV-5354]: https://redhat.atlassian.net/browse/MTV-5354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Validating" status for migration plans. Plans now show an info-level indicator for the validation phase in list views, plan details, and filters/groupings. The status is included in available status options and is localized for English, Spanish, French, Japanese, Korean, and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->