### PR TITLE
Add typeahead filtering to instance type selectors

### DIFF
--- a/src/plans/create/steps/other-settings/InstanceTypeField.tsx
+++ b/src/plans/create/steps/other-settings/InstanceTypeField.tsx
@@ -3,7 +3,7 @@ import { useWatch } from 'react-hook-form';
 import { NO_INSTANCE_TYPE } from 'src/plans/constants';
 import { useInstanceTypeOptions } from 'src/plans/hooks/useInstanceTypeOptions';
 
-import Select from '@components/common/Select';
+import TypeaheadSelect from '@components/common/TypeaheadSelect/TypeaheadSelect';
 import {
   Flex,
   FlexItem,
@@ -42,11 +42,11 @@ const InstanceTypeField: FC = () => {
   const vmEntries = useMemo(() => Object.entries(vms ?? {}), [vms]);
 
   const handleInstanceTypeChange = useCallback(
-    (vmId: string, selectedValue: string | undefined): void => {
+    (vmId: string, selectedValue: string | number | undefined): void => {
       const updated = { ...currentInstanceTypes };
 
-      if (selectedValue) {
-        updated[vmId] = selectedValue;
+      if (selectedValue && selectedValue !== NO_INSTANCE_TYPE) {
+        updated[vmId] = String(selectedValue);
       } else {
         delete updated[vmId];
       }
@@ -80,19 +80,17 @@ const InstanceTypeField: FC = () => {
                 >
                   <FlexItem className="instance-type-field__vm-name">{vm.name}</FlexItem>
                   <FlexItem grow={{ default: 'grow' }}>
-                    <Select
+                    <TypeaheadSelect
                       id={`instance-type-${vmId}`}
                       testId={`instance-type-select-${vmId}`}
                       value={selectedValue ?? NO_INSTANCE_TYPE}
                       options={options}
-                      isDisabled={!loaded}
-                      onSelect={(_event, val) => {
-                        handleInstanceTypeChange(
-                          vmId,
-                          val === NO_INSTANCE_TYPE ? undefined : String(val),
-                        );
+                      onChange={(val) => {
+                        handleInstanceTypeChange(vmId, val);
                       }}
+                      allowClear
                       placeholder={t('Select instance type')}
+                      isDisabled={!loaded}
                     />
                   </FlexItem>
                 </Flex>

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { NO_INSTANCE_TYPE } from 'src/plans/constants';
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useInstanceTypeOptions } from 'src/plans/hooks/useInstanceTypeOptions';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
-import Select from '@components/common/Select';
+import TypeaheadSelect from '@components/common/TypeaheadSelect/TypeaheadSelect';
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, Stack } from '@patternfly/react-core';
@@ -28,6 +28,10 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
   const [value, setValue] = useState<string | undefined>(vm?.instanceType);
   const { loaded, options } = useInstanceTypeOptions();
 
+  const handleChange = useCallback((selected: string | number | undefined): void => {
+    setValue(selected === NO_INSTANCE_TYPE ? undefined : String(selected ?? ''));
+  }, []);
+
   return (
     <ModalForm
       title={t('Edit instance type')}
@@ -45,14 +49,13 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
         )}
         <Form>
           <FormGroupWithHelpText label={t('Instance type')} isRequired={false}>
-            <Select
+            <TypeaheadSelect
               id="instanceType"
               testId="instance-type-select"
               value={value ?? NO_INSTANCE_TYPE}
               options={options}
-              onSelect={(_event, val) => {
-                setValue(val === NO_INSTANCE_TYPE ? undefined : String(val));
-              }}
+              onChange={handleChange}
+              allowClear
               placeholder={t('Select instance type')}
               isDisabled={!loaded}
             />

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
@@ -29,7 +29,9 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
   const { loaded, options } = useInstanceTypeOptions();
 
   const handleChange = useCallback((selected: string | number | undefined): void => {
-    setValue(selected === NO_INSTANCE_TYPE ? undefined : String(selected ?? ''));
+    setValue(
+      selected === undefined || selected === NO_INSTANCE_TYPE ? undefined : String(selected),
+    );
   }, []);
 
   return (

--- a/src/plans/hooks/useInstanceTypeOptions.ts
+++ b/src/plans/hooks/useInstanceTypeOptions.ts
@@ -1,19 +1,14 @@
 import { useMemo } from 'react';
 import { NO_INSTANCE_TYPE } from 'src/plans/constants';
 
+import type { TypeaheadSelectOption } from '@components/common/TypeaheadSelect/utils/types';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import { useClusterInstanceTypes } from './useClusterInstanceTypes';
 
-type SelectOption = {
-  description: string;
-  label: string;
-  value: string;
-};
-
 type UseInstanceTypeOptionsResult = {
-  options: SelectOption[];
   loaded: boolean;
+  options: TypeaheadSelectOption[];
 };
 
 export const useInstanceTypeOptions = (): UseInstanceTypeOptionsResult => {
@@ -21,15 +16,15 @@ export const useInstanceTypeOptions = (): UseInstanceTypeOptionsResult => {
   const { instanceTypes, loaded } = useClusterInstanceTypes();
 
   const options = useMemo(
-    (): SelectOption[] => [
+    (): TypeaheadSelectOption[] => [
       {
-        description: t("Keep the VM's original CPU and memory"),
-        label: t('None'),
+        content: t('None'),
+        optionProps: { description: t("Keep the VM's original CPU and memory") },
         value: NO_INSTANCE_TYPE,
       },
       ...instanceTypes.map((instanceType) => ({
-        description: instanceType.description,
-        label: instanceType.name,
+        content: instanceType.name,
+        optionProps: { description: instanceType.description },
         value: instanceType.name,
       })),
     ],

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
@@ -44,7 +44,7 @@ export class AdditionalSettingsStep {
     return this.page
       .locator('.instance-type-field__vm-name', { hasText: vmName })
       .locator('..')
-      .getByRole('button', { name: 'Select menu toggle' });
+      .locator('[data-testid^="instance-type-select-"]');
   }
 
   get instanceTypesSection(): Locator {


### PR DESCRIPTION
## Links

- [MTV-5535](https://redhat.atlassian.net/browse/MTV-5535)

## Description

When choosing an instance type for VMs, the dropdown shows a large unfiltered list of all cluster instance types. Users cannot type to search/filter by name.

This PR replaces the basic `Select` component with the existing `TypeaheadSelect` component in both locations where instance types are selected:

- **Plan creation wizard** (`InstanceTypeField.tsx`) — the "Other settings" step
- **Plan details edit modal** (`EditVmInstanceType.tsx`) — the per-VM kebab menu action

Changes:
- Updated `useInstanceTypeOptions` to return `TypeaheadSelectOption[]` format
- Replaced `Select` with `TypeaheadSelect` in both instance type selectors
- Updated E2E page object selector in `AdditionalSettingsSteps.ts` for compatibility with the typeahead toggle

## Demo

**Before:** Plain dropdown with no filtering — users must scroll through dozens of instance types.

![before](https://github.com/kubev2v/forklift-console-plugin/releases/download/_gh-attach-assets/MTV-5535-before-1-instance-type-dropdown-no-filter.png)

**After:** TypeaheadSelect with type-to-filter — typing "cx1" instantly narrows the list to matching options.

![after](https://github.com/kubev2v/forklift-console-plugin/releases/download/_gh-attach-assets/MTV-5535-after-1-instance-type-typeahead-filter.png)

Resolves: MTV-5535

[MTV-5535]: https://redhat.atlassian.net/browse/MTV-5535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instance type selection fields throughout the plan creation and virtual machine editing interfaces now feature integrated search and filtering capabilities, enabling users to quickly locate and select the most appropriate instance types from the complete list of available options.

* **Tests**
  * Updated test automation to properly support the enhanced instance type selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->