### PR TITLE
Resolves: MTV-5454 | Fix misleading 'No source networks' warning on EC2 network mapping

### DIFF
--- a/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
+++ b/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
@@ -65,7 +65,7 @@ const NewNetworkMapFields: FC = () => {
     <Stack hasGutter className="pf-v6-u-ml-lg">
       {error?.root && <Alert variant={AlertVariant.danger} isInline title={error.root.message} />}
 
-      {isEmpty(usedSourceNetworks) && !sourceNetworksLoading && (
+      {isEmpty(availableSourceNetworks) && !sourceNetworksLoading && (
         <Alert
           variant={AlertVariant.warning}
           isInline

--- a/src/plans/create/steps/network-map/__tests__/getSourceNetworkValues.test.ts
+++ b/src/plans/create/steps/network-map/__tests__/getSourceNetworkValues.test.ts
@@ -1,0 +1,85 @@
+import { PROVIDER_TYPES } from 'src/providers/utils/constants';
+
+import type { ProviderVirtualMachine } from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+
+import type { ProviderNetwork } from '../../../types';
+import { getSourceNetworkValues } from '../utils';
+
+const makeEc2Network = (id: string, name: string): ProviderNetwork =>
+  ({
+    id,
+    name,
+    providerType: PROVIDER_TYPES.ec2,
+    revision: 1,
+    selfLink: `/providers/ec2/uid/networks/${id}`,
+  }) as ProviderNetwork;
+
+const makeEc2Vm = (
+  subnetId: string | undefined,
+  networkInterfaces?: { SubnetId?: string }[],
+): ProviderVirtualMachine =>
+  ({
+    id: 'i-test',
+    name: 'test-instance',
+    object: {
+      NetworkInterfaces: networkInterfaces,
+      SubnetId: subnetId,
+    },
+    providerType: PROVIDER_TYPES.ec2,
+  }) as unknown as ProviderVirtualMachine;
+
+describe('getSourceNetworkValues - EC2', () => {
+  const subnets: ProviderNetwork[] = [
+    makeEc2Network('subnet-aaa', 'subnet-a'),
+    makeEc2Network('subnet-bbb', 'subnet-b'),
+  ];
+
+  it('categorizes matching EC2 subnets as used', () => {
+    const vm = makeEc2Vm('subnet-aaa', [{ SubnetId: 'subnet-aaa' }]);
+    const { other, used } = getSourceNetworkValues(subnets, [vm], []);
+
+    expect(used).toHaveLength(1);
+    expect(used[0].id).toBe('subnet-aaa');
+    expect(other).toHaveLength(1);
+    expect(other[0].id).toBe('subnet-bbb');
+  });
+
+  it('returns all subnets as other when EC2 VM has no subnet data', () => {
+    const vm = makeEc2Vm(undefined, undefined);
+    const { other, used } = getSourceNetworkValues(subnets, [vm], []);
+
+    expect(used).toHaveLength(0);
+    expect(other).toHaveLength(2);
+  });
+
+  it('returns empty used and other when no source networks exist', () => {
+    const vm = makeEc2Vm('subnet-aaa');
+    const { other, used } = getSourceNetworkValues([], [vm], []);
+
+    expect(used).toHaveLength(0);
+    expect(other).toHaveLength(0);
+  });
+
+  it('matches via SubnetId fallback when NetworkInterfaces is empty', () => {
+    const vm = makeEc2Vm('subnet-bbb', []);
+    const { used } = getSourceNetworkValues(subnets, [vm], []);
+
+    expect(used).toHaveLength(1);
+    expect(used[0].id).toBe('subnet-bbb');
+  });
+
+  it('categorizes VPC entries as other (VMs reference subnets, not VPCs)', () => {
+    const networks: ProviderNetwork[] = [
+      makeEc2Network('vpc-111', 'my-vpc'),
+      makeEc2Network('subnet-aaa', 'subnet-a'),
+    ];
+    const vm = makeEc2Vm('subnet-aaa', [{ SubnetId: 'subnet-aaa' }]);
+    const { other, used } = getSourceNetworkValues(networks, [vm], []);
+
+    expect(used).toHaveLength(1);
+    expect(used[0].id).toBe('subnet-aaa');
+    expect(other).toHaveLength(1);
+    expect(other[0].id).toBe('vpc-111');
+  });
+});

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
@@ -72,7 +72,6 @@ const PlanNetworkMapEdit: ModalComponent<PlanNetworkMapEditProps> = ({
                 variant={AlertVariant.warning}
                 isInline
                 title={t('No source networks are available for the selected VMs.')}
-                className="pf-v"
               />
             )}
 

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
@@ -65,14 +65,16 @@ const PlanNetworkMapEdit: ModalComponent<PlanNetworkMapEditProps> = ({
             <Alert variant={AlertVariant.danger} isInline title={error.root.message} />
           )}
 
-          {isEmpty(usedSourceNetworks) && !sourceNetworksLoading && (
-            <Alert
-              variant={AlertVariant.warning}
-              isInline
-              title={t('No source networks are available for the selected VMs.')}
-              className="pf-v"
-            />
-          )}
+          {isEmpty(usedSourceNetworks) &&
+            isEmpty(otherSourceNetworks) &&
+            !sourceNetworksLoading && (
+              <Alert
+                variant={AlertVariant.warning}
+                isInline
+                title={t('No source networks are available for the selected VMs.')}
+                className="pf-v"
+              />
+            )}
 
           <PlanNetworkMapFieldsTable
             oVirtNicProfiles={oVirtNicProfiles}


### PR DESCRIPTION
## Links

- [MTV-5454](https://redhat.atlassian.net/browse/MTV-5454)

## Description

Fixed the misleading "No source networks are available for the selected VMs" warning that appeared on the EC2 network mapping step even though VPC subnets were available in the dropdown and mapping rows could be created normally.

- Changed the warning condition in `NewNetworkMapFields` (plan creation wizard) to only show when no source networks exist in the inventory, instead of when no networks could be auto-matched to VMs
- Applied the same fix in `PlanNetworkMapEdit` (plan edit modal) — the warning now requires both `usedSourceNetworks` and `otherSourceNetworks` to be empty
- Added unit tests for `getSourceNetworkValues` covering EC2 subnet categorization, VPC vs subnet matching, and SubnetId fallback behavior

## Demo

Before: The warning appeared whenever VMs' subnet IDs could not be matched to available networks, even though subnets were visible in the dropdown.
After: The warning only appears when no source networks exist at all. When subnets are available (even if not auto-matched to VMs), users can create mappings without the misleading warning.

Made with [Cursor](https://cursor.com)

[MTV-5454]: https://redhat.atlassian.net/browse/MTV-5454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network-availability warning logic in network mapping so alerts show only when no source networks exist and loading has completed, preventing premature or missing warnings.

* **Tests**
  * Added comprehensive tests for network categorization across EC2 scenarios, covering subnet/VM configurations and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->