### PR TITLE
Add unit tests for throughput chart tick computation functions

### DIFF
--- a/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
@@ -15,7 +15,12 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import type { ThroughputSeries } from '../../hooks/useThroughputQuery';
 import { formatThroughput, formatThroughputTick } from '../../utils/formatThroughput';
-import { computeNiceTicks, computeTimeTicks } from '../../utils/throughputChartTicks';
+import {
+  type BaseChartDatum,
+  type BaseChartLineEntry,
+  computeNiceTicks,
+  computeTimeTicks,
+} from '../../utils/throughputChartTicks';
 import {
   THROUGHPUT_TIME_RANGE_CONFIG,
   ThroughputTimeRange,
@@ -29,10 +34,8 @@ type ThroughputLineChartProps = {
   visiblePlanIds: string[];
 };
 
-type ChartDatum = {
+type ChartDatum = BaseChartDatum & {
   name: string;
-  x: number;
-  y: number;
 };
 
 const SHORT_RANGES = new Set<ThroughputTimeRange>([
@@ -54,7 +57,7 @@ const formatTimestamp = (ts: number, timeRange: ThroughputTimeRange): string => 
   return `${datePart}\n${timePart}`;
 };
 
-type ChartLineEntry = {
+type ChartLineEntry = BaseChartLineEntry & {
   data: ChartDatum[];
   name: string;
   planId: string;

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputLineChart.tsx
@@ -15,6 +15,7 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import type { ThroughputSeries } from '../../hooks/useThroughputQuery';
 import { formatThroughput, formatThroughputTick } from '../../utils/formatThroughput';
+import { computeNiceTicks, computeTimeTicks } from '../../utils/throughputChartTicks';
 import {
   THROUGHPUT_TIME_RANGE_CONFIG,
   ThroughputTimeRange,
@@ -39,83 +40,6 @@ const SHORT_RANGES = new Set<ThroughputTimeRange>([
   ThroughputTimeRange.Last1H,
   ThroughputTimeRange.Last6H,
 ]);
-
-const MS_PER_MINUTE = 60_000;
-const MS_PER_HOUR = 60 * MS_PER_MINUTE;
-
-const TIME_TICK_INTERVALS: Record<ThroughputTimeRange, number> = {
-  [ThroughputTimeRange.Last1H]: 10 * MS_PER_MINUTE,
-  [ThroughputTimeRange.Last24H]: 4 * MS_PER_HOUR,
-  [ThroughputTimeRange.Last2D]: 12 * MS_PER_HOUR,
-  [ThroughputTimeRange.Last30Min]: 5 * MS_PER_MINUTE,
-  [ThroughputTimeRange.Last6H]: MS_PER_HOUR,
-  [ThroughputTimeRange.Last7D]: 24 * MS_PER_HOUR,
-};
-
-const TARGET_TICK_COUNT = 5;
-const BYTES_DIVISOR = 1024;
-
-const computeTimeTicks = (domain: [number, number], timeRange: ThroughputTimeRange): number[] => {
-  const interval = TIME_TICK_INTERVALS[timeRange];
-  const start = Math.ceil(domain[0] / interval) * interval;
-  const ticks: number[] = [];
-
-  for (let ts = start; ts <= domain[1]; ts += interval) {
-    ticks.push(ts);
-  }
-
-  return ticks;
-};
-
-const computeNiceTicks = (data: ChartLineEntry[]): number[] => {
-  let max = 0;
-
-  for (const entry of data) {
-    for (const datum of entry.data) {
-      if (datum.y > max) {
-        max = datum.y;
-      }
-    }
-  }
-
-  if (max === 0) {
-    return [0];
-  }
-
-  let displayMax = max;
-  let unitMultiplier = 1;
-
-  while (displayMax >= BYTES_DIVISOR) {
-    displayMax /= BYTES_DIVISOR;
-    unitMultiplier *= BYTES_DIVISOR;
-  }
-
-  const rough = displayMax / TARGET_TICK_COUNT;
-  const magnitude = 10 ** Math.floor(Math.log10(rough));
-  const residual = rough / magnitude;
-
-  let step = 10 * magnitude;
-
-  if (residual <= 1) {
-    step = magnitude;
-  } else if (residual <= 2) {
-    step = 2 * magnitude;
-  } else if (residual <= 5) {
-    step = 5 * magnitude;
-  }
-
-  const ticks: number[] = [];
-
-  for (let val = 0; val <= displayMax; val += step) {
-    ticks.push(Math.round(val * unitMultiplier));
-  }
-
-  if (ticks[ticks.length - 1] < max) {
-    ticks.push(Math.round((ticks[ticks.length - 1] / unitMultiplier + step) * unitMultiplier));
-  }
-
-  return ticks;
-};
 
 const formatTimestamp = (ts: number, timeRange: ThroughputTimeRange): string => {
   const date = new Date(ts);

--- a/src/overview/tabs/Overview/hooks/useThroughputQuery.ts
+++ b/src/overview/tabs/Overview/hooks/useThroughputQuery.ts
@@ -6,6 +6,7 @@ import {
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk';
 
+import { computeStepSeconds } from '../utils/throughputChartTicks';
 import {
   THROUGHPUT_TIME_RANGE_CONFIG,
   type ThroughputTimeRange,
@@ -46,14 +47,13 @@ export const parseThroughputResponse = (
 };
 
 const POLL_DELAY_MS = 30_000;
-const MS_PER_SECOND = 1000;
 
 export const useThroughputQuery = (
   metricName: string,
   timeRange: ThroughputTimeRange,
 ): UseThroughputQueryResult => {
   const config = THROUGHPUT_TIME_RANGE_CONFIG[timeRange];
-  const stepSeconds = Math.round(config.timespan / (config.samples * MS_PER_SECOND));
+  const stepSeconds = computeStepSeconds(timeRange);
   const query = `max_over_time(${metricName}[${stepSeconds}s])`;
 
   const [response, loaded, error] = usePrometheusPoll({

--- a/src/overview/tabs/Overview/utils/__tests__/throughputChartTicks.test.ts
+++ b/src/overview/tabs/Overview/utils/__tests__/throughputChartTicks.test.ts
@@ -1,0 +1,296 @@
+import { computeNiceTicks, computeStepSeconds, computeTimeTicks } from '../throughputChartTicks';
+import { ThroughputTimeRange } from '../throughputTimeRanges';
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = BYTES_PER_KB * 1024;
+const BYTES_PER_GB = BYTES_PER_MB * 1024;
+
+describe('computeTimeTicks', () => {
+  test('generates ticks aligned to 5-minute intervals for Last30Min', () => {
+    const baseTime = 10 * MS_PER_MINUTE;
+    const domain: [number, number] = [baseTime, baseTime + 30 * MS_PER_MINUTE];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last30Min);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % (5 * MS_PER_MINUTE)).toBe(0);
+    });
+  });
+
+  test('generates ticks aligned to 10-minute intervals for Last1H', () => {
+    const baseTime = 0;
+    const domain: [number, number] = [baseTime, baseTime + MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last1H);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % (10 * MS_PER_MINUTE)).toBe(0);
+    });
+  });
+
+  test('generates ticks aligned to 1-hour intervals for Last6H', () => {
+    const baseTime = 0;
+    const domain: [number, number] = [baseTime, baseTime + 6 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last6H);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % MS_PER_HOUR).toBe(0);
+    });
+  });
+
+  test('generates ticks aligned to 4-hour intervals for Last24H', () => {
+    const baseTime = 0;
+    const domain: [number, number] = [baseTime, baseTime + 24 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last24H);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % (4 * MS_PER_HOUR)).toBe(0);
+    });
+  });
+
+  test('generates ticks aligned to 12-hour intervals for Last2D', () => {
+    const baseTime = 0;
+    const domain: [number, number] = [baseTime, baseTime + 48 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last2D);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % (12 * MS_PER_HOUR)).toBe(0);
+    });
+  });
+
+  test('generates ticks aligned to 24-hour intervals for Last7D', () => {
+    const baseTime = 0;
+    const domain: [number, number] = [baseTime, baseTime + 7 * 24 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last7D);
+
+    expect(ticks.length).toBeGreaterThan(0);
+    ticks.forEach((tick) => {
+      expect(tick % (24 * MS_PER_HOUR)).toBe(0);
+    });
+  });
+
+  test('all ticks fall within the domain boundaries', () => {
+    const domain: [number, number] = [MS_PER_HOUR, 7 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last6H);
+
+    ticks.forEach((tick) => {
+      expect(tick).toBeGreaterThanOrEqual(domain[0]);
+      expect(tick).toBeLessThanOrEqual(domain[1]);
+    });
+  });
+
+  test('returns empty array when domain is smaller than one interval', () => {
+    const domain: [number, number] = [100, 200];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last7D);
+
+    expect(ticks).toEqual([]);
+  });
+
+  test('handles domain starting exactly on an interval boundary', () => {
+    const domain: [number, number] = [MS_PER_HOUR, 3 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last6H);
+
+    expect(ticks[0]).toBe(MS_PER_HOUR);
+  });
+
+  test('ceils the start to the next interval if not aligned', () => {
+    const domain: [number, number] = [MS_PER_HOUR + 1, 3 * MS_PER_HOUR];
+
+    const ticks = computeTimeTicks(domain, ThroughputTimeRange.Last6H);
+
+    expect(ticks[0]).toBe(2 * MS_PER_HOUR);
+  });
+});
+
+describe('computeNiceTicks', () => {
+  test('returns [0] for empty data', () => {
+    const ticks = computeNiceTicks([]);
+
+    expect(ticks).toEqual([0]);
+  });
+
+  test('returns [0] when all values are zero', () => {
+    const data = [
+      {
+        data: [
+          { x: 1, y: 0 },
+          { x: 2, y: 0 },
+        ],
+      },
+    ];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks).toEqual([0]);
+  });
+
+  test('returns [0] for entries with empty data arrays', () => {
+    const data = [{ data: [] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks).toEqual([0]);
+  });
+
+  test('produces round tick values for KB-range data', () => {
+    const data = [{ data: [{ x: 1, y: 500 * BYTES_PER_KB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks.length).toBeGreaterThan(1);
+    ticks.forEach((tick) => {
+      expect(tick % BYTES_PER_KB).toBe(0);
+    });
+  });
+
+  test('produces round tick values for MB-range data', () => {
+    const data = [{ data: [{ x: 1, y: 100 * BYTES_PER_MB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks.length).toBeGreaterThan(1);
+    ticks.forEach((tick) => {
+      expect(tick % BYTES_PER_MB).toBe(0);
+    });
+  });
+
+  test('produces round tick values for GB-range data', () => {
+    const data = [{ data: [{ x: 1, y: 5 * BYTES_PER_GB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks.length).toBeGreaterThan(1);
+    ticks.forEach((tick) => {
+      expect(tick % BYTES_PER_GB).toBe(0);
+    });
+  });
+
+  test('first tick is always 0', () => {
+    const data = [{ data: [{ x: 1, y: 50 * BYTES_PER_MB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks[0]).toBe(0);
+  });
+
+  test('last tick is >= the maximum data value', () => {
+    const maxValue = 73 * BYTES_PER_MB;
+    const data = [{ data: [{ x: 1, y: maxValue }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(maxValue);
+  });
+
+  test('finds maximum across multiple series', () => {
+    const data = [
+      { data: [{ x: 1, y: 10 * BYTES_PER_MB }] },
+      { data: [{ x: 1, y: 50 * BYTES_PER_MB }] },
+      { data: [{ x: 1, y: 30 * BYTES_PER_MB }] },
+    ];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(50 * BYTES_PER_MB);
+  });
+
+  test('handles small sub-KB values', () => {
+    const data = [{ data: [{ x: 1, y: 500 }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks.length).toBeGreaterThan(1);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(500);
+  });
+
+  test('handles single data point', () => {
+    const data = [{ data: [{ x: 1, y: 200 * BYTES_PER_KB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks.length).toBeGreaterThan(1);
+    expect(ticks[0]).toBe(0);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(200 * BYTES_PER_KB);
+  });
+
+  test('ticks are monotonically increasing', () => {
+    const data = [{ data: [{ x: 1, y: 750 * BYTES_PER_MB }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    for (let i = 1; i < ticks.length; i += 1) {
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1]);
+    }
+  });
+
+  test('produces exactly 1024-multiple ticks at KB boundary', () => {
+    const data = [{ data: [{ x: 1, y: 800 }] }];
+
+    const ticks = computeNiceTicks(data);
+
+    expect(ticks[0]).toBe(0);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(800);
+  });
+});
+
+describe('computeStepSeconds', () => {
+  test('computes correct step for Last30Min (30 samples over 30 min)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last30Min);
+
+    expect(step).toBe(60);
+  });
+
+  test('computes correct step for Last1H (60 samples over 1 hour)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last1H);
+
+    expect(step).toBe(60);
+  });
+
+  test('computes correct step for Last6H (72 samples over 6 hours)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last6H);
+
+    expect(step).toBe(300);
+  });
+
+  test('computes correct step for Last24H (96 samples over 24 hours)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last24H);
+
+    expect(step).toBe(900);
+  });
+
+  test('computes correct step for Last2D (96 samples over 2 days)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last2D);
+
+    expect(step).toBe(1800);
+  });
+
+  test('computes correct step for Last7D (168 samples over 7 days)', () => {
+    const step = computeStepSeconds(ThroughputTimeRange.Last7D);
+
+    expect(step).toBe(3600);
+  });
+
+  test('all step values are positive integers', () => {
+    const ranges = Object.values(ThroughputTimeRange);
+
+    ranges.forEach((range) => {
+      const step = computeStepSeconds(range);
+      expect(step).toBeGreaterThan(0);
+      expect(Number.isInteger(step)).toBe(true);
+    });
+  });
+});

--- a/src/overview/tabs/Overview/utils/throughputChartTicks.ts
+++ b/src/overview/tabs/Overview/utils/throughputChartTicks.ts
@@ -1,12 +1,12 @@
 import { THROUGHPUT_TIME_RANGE_CONFIG, type ThroughputTimeRange } from './throughputTimeRanges';
 
-type ChartDatum = {
+export type BaseChartDatum = {
   x: number;
   y: number;
 };
 
-type ChartLineEntry = {
-  data: ChartDatum[];
+export type BaseChartLineEntry = {
+  data: BaseChartDatum[];
 };
 
 const MS_PER_MINUTE = 60_000;
@@ -40,7 +40,7 @@ export const computeTimeTicks = (
   return ticks;
 };
 
-export const computeNiceTicks = (data: ChartLineEntry[]): number[] => {
+export const computeNiceTicks = (data: BaseChartLineEntry[]): number[] => {
   let max = 0;
 
   for (const entry of data) {

--- a/src/overview/tabs/Overview/utils/throughputChartTicks.ts
+++ b/src/overview/tabs/Overview/utils/throughputChartTicks.ts
@@ -1,0 +1,96 @@
+import { THROUGHPUT_TIME_RANGE_CONFIG, type ThroughputTimeRange } from './throughputTimeRanges';
+
+type ChartDatum = {
+  x: number;
+  y: number;
+};
+
+type ChartLineEntry = {
+  data: ChartDatum[];
+};
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+
+const TIME_TICK_INTERVALS: Record<ThroughputTimeRange, number> = {
+  Last1H: 10 * MS_PER_MINUTE,
+  Last24H: 4 * MS_PER_HOUR,
+  Last2D: 12 * MS_PER_HOUR,
+  Last30Min: 5 * MS_PER_MINUTE,
+  Last6H: MS_PER_HOUR,
+  Last7D: 24 * MS_PER_HOUR,
+};
+
+const TARGET_TICK_COUNT = 5;
+const BYTES_DIVISOR = 1024;
+const MS_PER_SECOND = 1000;
+
+export const computeTimeTicks = (
+  domain: [number, number],
+  timeRange: ThroughputTimeRange,
+): number[] => {
+  const interval = TIME_TICK_INTERVALS[timeRange];
+  const start = Math.ceil(domain[0] / interval) * interval;
+  const ticks: number[] = [];
+
+  for (let ts = start; ts <= domain[1]; ts += interval) {
+    ticks.push(ts);
+  }
+
+  return ticks;
+};
+
+export const computeNiceTicks = (data: ChartLineEntry[]): number[] => {
+  let max = 0;
+
+  for (const entry of data) {
+    for (const datum of entry.data) {
+      if (datum.y > max) {
+        max = datum.y;
+      }
+    }
+  }
+
+  if (max === 0) {
+    return [0];
+  }
+
+  let displayMax = max;
+  let unitMultiplier = 1;
+
+  while (displayMax >= BYTES_DIVISOR) {
+    displayMax /= BYTES_DIVISOR;
+    unitMultiplier *= BYTES_DIVISOR;
+  }
+
+  const rough = displayMax / TARGET_TICK_COUNT;
+  const magnitude = 10 ** Math.floor(Math.log10(rough));
+  const residual = rough / magnitude;
+
+  let step = 10 * magnitude;
+
+  if (residual <= 1) {
+    step = magnitude;
+  } else if (residual <= 2) {
+    step = 2 * magnitude;
+  } else if (residual <= 5) {
+    step = 5 * magnitude;
+  }
+
+  const ticks: number[] = [];
+
+  for (let val = 0; val <= displayMax; val += step) {
+    ticks.push(Math.round(val * unitMultiplier));
+  }
+
+  if (ticks[ticks.length - 1] < max) {
+    ticks.push(Math.round((ticks[ticks.length - 1] / unitMultiplier + step) * unitMultiplier));
+  }
+
+  return ticks;
+};
+
+export const computeStepSeconds = (timeRange: ThroughputTimeRange): number => {
+  const config = THROUGHPUT_TIME_RANGE_CONFIG[timeRange];
+  return Math.round(config.timespan / (config.samples * MS_PER_SECOND));
+};


### PR DESCRIPTION
## Links

- [MTV-5453](https://redhat.atlassian.net/browse/MTV-5453)

## Description

Extracted `computeTimeTicks`, `computeNiceTicks`, and `computeStepSeconds` from `ThroughputLineChart.tsx` and `useThroughputQuery.ts` into a dedicated utils module (`throughputChartTicks.ts`) for testability. Added 30 unit tests covering:

- **computeTimeTicks**: Interval alignment for all 6 time ranges, boundary handling, domain edge cases
- **computeNiceTicks**: Zero max, empty/single-entry data, byte-unit boundaries (KB/MB/GB), multiple series, monotonicity
- **computeStepSeconds**: Correct calculation for all time ranges, positive integer validation

No behavioral changes — pure refactoring for testability.

## Verification

```
npm test -- --testPathPattern throughputChartTicks
```

All 30 tests pass. Existing `useThroughputQuery` and `formatThroughput` tests continue passing.

Made with [Cursor](https://cursor.com)

[MTV-5453]: https://redhat.atlassian.net/browse/MTV-5453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ