### PR TITLE
MTV-4821 | Fix trailing comma on node selector display

### DIFF
--- a/src/components/NodeSelectorViewDetailsItemContent/NodeSelectorViewDetailsItemContent.tsx
+++ b/src/components/NodeSelectorViewDetailsItemContent/NodeSelectorViewDetailsItemContent.tsx
@@ -20,12 +20,13 @@ const NodeSelectorViewDetailsItemContent: FC<NodeSelectorViewDetailsItemContentP
           {t('No node selectors defined')}
         </Label>
       ) : (
-        Object.entries(labels ?? {})?.map(([key]) => {
+        Object.entries(labels ?? {}).map(([key], index, entries) => {
           const labelText = labels?.[key] ? `${key}=${labels[key]}` : key;
+          const isLast = index === entries.length - 1;
 
           return (
             <span key={key} className="co-text-node">
-              <StackItem>{labelText},</StackItem>
+              <StackItem>{isLast ? labelText : `${labelText},`}</StackItem>
             </span>
           );
         })


### PR DESCRIPTION
## 📝 Links

- [MTV-4821](https://redhat.atlassian.net/browse/MTV-4821)

## 📝 Description

Removes the trailing comma shown after a single (or last) node selector entry on the Plan Details page.

- Fixed `NodeSelectorViewDetailsItemContent` to only append `,` between entries, not after the last one
- Affects both **VM target node selector** and **Convertor pod node selector** (shared component)

## 🎥 Demo
<img width="909" height="578" alt="image" src="https://github.com/user-attachments/assets/e533fe9a-3a95-44e8-a323-9d9cd32e7b6e" />

<!-- Please add a video or an image of the behavior/changes -->

## 📝 CC://

[MTV-4821]: https://redhat.atlassian.net/browse/MTV-4821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect comma formatting in label lists displayed in node selector view details. Labels now display with commas only between items, eliminating trailing commas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->