### PR TITLE
MTV-5355: Add shared PF_LABEL_STATUS constants for Label/Icon status props

### DIFF
--- a/src/components/Concerns/utils/category.tsx
+++ b/src/components/Concerns/utils/category.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import { STATUS_ICONS } from '@components/status/statusIcons';
 import type { Concern, V1beta1PlanStatusConditions } from '@forklift-ui/types';
-import type { LabelProps } from '@patternfly/react-core';
+import { PF_LABEL_STATUS, type PfLabelStatus } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
 
@@ -35,13 +35,13 @@ const CATEGORY_ICONS: Record<ConcernCategory, ReactNode> = {
   [ConcernCategoryOptions.Warning]: STATUS_ICONS.warning,
 };
 
-const CATEGORY_STATUS: Record<ConcernCategory, LabelProps['status'] | undefined> = {
-  [ConcernCategoryOptions.Advisory]: 'info',
-  [ConcernCategoryOptions.Critical]: 'danger',
-  [ConcernCategoryOptions.Error]: 'danger',
-  [ConcernCategoryOptions.Information]: 'info',
-  [ConcernCategoryOptions.Warn]: 'warning',
-  [ConcernCategoryOptions.Warning]: 'warning',
+const CATEGORY_STATUS: Record<ConcernCategory, PfLabelStatus | undefined> = {
+  [ConcernCategoryOptions.Advisory]: PF_LABEL_STATUS.INFO,
+  [ConcernCategoryOptions.Critical]: PF_LABEL_STATUS.DANGER,
+  [ConcernCategoryOptions.Error]: PF_LABEL_STATUS.DANGER,
+  [ConcernCategoryOptions.Information]: PF_LABEL_STATUS.INFO,
+  [ConcernCategoryOptions.Warn]: PF_LABEL_STATUS.WARNING,
+  [ConcernCategoryOptions.Warning]: PF_LABEL_STATUS.WARNING,
 };
 
 const isConcernCategory = (value: string): value is ConcernCategory =>
@@ -55,9 +55,9 @@ export const getCategoryIcon = (category: string): ReactNode => {
   return isConcernCategory(category) ? CATEGORY_ICONS[category] : <></>;
 };
 
-export const getCategoryStatus = (category: string): LabelProps['status'] | undefined => {
+export const getCategoryStatus = (category: string): PfLabelStatus | undefined => {
   if (isConcernCategory(category)) return CATEGORY_STATUS[category];
-  return 'warning';
+  return PF_LABEL_STATUS.WARNING;
 };
 
 export const getCategoryLabel = (category: string): string => {

--- a/src/components/InspectVirtualMachines/ConversionPhaseLabel.tsx
+++ b/src/components/InspectVirtualMachines/ConversionPhaseLabel.tsx
@@ -8,6 +8,7 @@ import {
   InProgressIcon,
   MinusCircleIcon,
 } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { CONVERSION_PHASE } from '@utils/crds/conversion/constants';
 import type { ConversionPhase } from '@utils/crds/conversion/types';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -24,13 +25,21 @@ const getPhaseConfig = (
 ): PhaseConfig => {
   switch (phase) {
     case CONVERSION_PHASE.SUCCEEDED:
-      return { icon: <CheckCircleIcon />, label: t('Succeeded'), labelStatus: 'success' };
+      return {
+        icon: <CheckCircleIcon />,
+        label: t('Succeeded'),
+        labelStatus: PF_LABEL_STATUS.SUCCESS,
+      };
     case CONVERSION_PHASE.FAILED:
-      return { icon: <ExclamationCircleIcon />, label: t('Failed'), labelStatus: 'warning' };
+      return {
+        icon: <ExclamationCircleIcon />,
+        label: t('Failed'),
+        labelStatus: PF_LABEL_STATUS.WARNING,
+      };
     case CONVERSION_PHASE.CANCELED:
       return { icon: <BanIcon />, label: t('Canceled') };
     case CONVERSION_PHASE.RUNNING:
-      return { icon: <InProgressIcon />, label: t('Running'), labelStatus: 'info' };
+      return { icon: <InProgressIcon />, label: t('Running'), labelStatus: PF_LABEL_STATUS.INFO };
     case CONVERSION_PHASE.PENDING:
     case undefined:
     default:

--- a/src/components/InspectVirtualMachines/InspectionPassedLabel.tsx
+++ b/src/components/InspectVirtualMachines/InspectionPassedLabel.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import { Icon, Label } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
 
 type InspectionPassedLabelProps = {
@@ -15,7 +16,7 @@ const InspectionPassedLabel: FC<InspectionPassedLabelProps> = ({ passed }) => {
     return (
       <Label
         variant="filled"
-        status="success"
+        status={PF_LABEL_STATUS.SUCCESS}
         icon={
           <Icon isInline>
             <CheckCircleIcon />
@@ -30,7 +31,7 @@ const InspectionPassedLabel: FC<InspectionPassedLabelProps> = ({ passed }) => {
   return (
     <Label
       variant="filled"
-      status="warning"
+      status={PF_LABEL_STATUS.WARNING}
       icon={
         <Icon isInline>
           <ExclamationTriangleIcon />

--- a/src/components/InspectVirtualMachines/utils/getInspectionStatusConfig.tsx
+++ b/src/components/InspectVirtualMachines/utils/getInspectionStatusConfig.tsx
@@ -9,6 +9,7 @@ import {
   InProgressIcon,
   MinusCircleIcon,
 } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS, type PfLabelStatus } from '@utils/constants';
 import type { InspectionStatus } from '@utils/crds/conversion/constants';
 import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
 import type { useForkliftTranslation } from '@utils/i18n';
@@ -16,7 +17,7 @@ import type { useForkliftTranslation } from '@utils/i18n';
 type InspectionStatusConfig = {
   icon: ReactNode;
   label: string;
-  labelStatus?: 'danger' | 'info' | 'success' | 'warning';
+  labelStatus?: PfLabelStatus;
 };
 
 export const getInspectionStatusConfig = (
@@ -32,7 +33,7 @@ export const getInspectionStatusConfig = (
           </Icon>
         ),
         label: t('Inspection passed'),
-        labelStatus: 'success',
+        labelStatus: PF_LABEL_STATUS.SUCCESS,
       };
     case INSPECTION_STATUS.ISSUES_FOUND:
       return {
@@ -42,7 +43,7 @@ export const getInspectionStatusConfig = (
           </Icon>
         ),
         label: t('Issues found'),
-        labelStatus: 'warning',
+        labelStatus: PF_LABEL_STATUS.WARNING,
       };
     case INSPECTION_STATUS.FAILED:
       return {
@@ -52,7 +53,7 @@ export const getInspectionStatusConfig = (
           </Icon>
         ),
         label: t('Inspection error'),
-        labelStatus: 'warning',
+        labelStatus: PF_LABEL_STATUS.WARNING,
       };
     case INSPECTION_STATUS.RUNNING:
       return {
@@ -62,7 +63,7 @@ export const getInspectionStatusConfig = (
           </Icon>
         ),
         label: t('Running'),
-        labelStatus: 'info',
+        labelStatus: PF_LABEL_STATUS.INFO,
       };
     case INSPECTION_STATUS.PENDING:
       return {

--- a/src/components/InspectVirtualMachines/utils/types.ts
+++ b/src/components/InspectVirtualMachines/utils/types.ts
@@ -1,3 +1,4 @@
+import type { PfLabelStatus } from '@utils/constants';
 import type { InspectionStatus } from '@utils/crds/conversion/constants';
 import type { ObjectReference, V1beta1Conversion } from '@utils/crds/conversion/types';
 
@@ -38,5 +39,5 @@ export type CreateInspectionsFn = (vms: VmInspectionRef[]) => Promise<Inspection
 export type PhaseConfig = {
   icon: JSX.Element;
   label: string;
-  labelStatus?: 'danger' | 'info' | 'success' | 'warning';
+  labelStatus?: PfLabelStatus;
 };

--- a/src/components/status/statusIcons.tsx
+++ b/src/components/status/statusIcons.tsx
@@ -5,25 +5,26 @@ import {
   ExclamationTriangleIcon,
   InfoCircleIcon,
 } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 
 export const STATUS_ICONS = {
   danger: (
-    <Icon status="danger">
+    <Icon status={PF_LABEL_STATUS.DANGER}>
       <ExclamationCircleIcon />
     </Icon>
   ),
   info: (
-    <Icon status="info">
+    <Icon status={PF_LABEL_STATUS.INFO}>
       <InfoCircleIcon />
     </Icon>
   ),
   success: (
-    <Icon status="success">
+    <Icon status={PF_LABEL_STATUS.SUCCESS}>
       <CheckCircleIcon />
     </Icon>
   ),
   warning: (
-    <Icon status="warning">
+    <Icon status={PF_LABEL_STATUS.WARNING}>
       <ExclamationTriangleIcon />
     </Icon>
   ),

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
@@ -13,6 +13,7 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -86,7 +87,7 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
         <Bullseye>
           <EmptyState
             icon={ExclamationCircleIcon}
-            status="danger"
+            status={PF_LABEL_STATUS.DANGER}
             titleText={t('Unable to load throughput data')}
           >
             <EmptyStateBody>

--- a/src/plans/details/components/PlanStatus/StatusPopover.tsx
+++ b/src/plans/details/components/PlanStatus/StatusPopover.tsx
@@ -17,6 +17,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { getName, getNamespace } from '@utils/crds/common/selectors';
 import { getResourceUrl } from '@utils/getResourceUrl';
 
@@ -66,7 +67,7 @@ const StatusPopover: FC<StatusPopoverProps> = ({ count, plan, status, vms }) => 
                     {failedTaskName && (
                       <ListItem
                         icon={
-                          <Icon status="danger">
+                          <Icon status={PF_LABEL_STATUS.DANGER}>
                             <TimesIcon />
                           </Icon>
                         }

--- a/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/planStatusMapper.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { Label } from '@patternfly/react-core';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { t } from '@utils/i18n';
 
 import { PlanStatuses } from './types';
@@ -27,7 +28,12 @@ export const planStatusLabelMapper: Record<PlanStatuses, ReactNode> = {
     </Label>
   ),
   [PlanStatuses.CannotStart]: (
-    <Label status="danger" isCompact variant="filled" data-testid="plan-status-label">
+    <Label
+      status={PF_LABEL_STATUS.DANGER}
+      isCompact
+      variant="filled"
+      data-testid="plan-status-label"
+    >
       {t('Cannot start')}
     </Label>
   ),

--- a/src/plans/details/components/PlanStatus/utils/statusIconMapper.tsx
+++ b/src/plans/details/components/PlanStatus/utils/statusIconMapper.tsx
@@ -7,6 +7,7 @@ import {
   MinusCircleIcon,
   PauseCircleIcon,
 } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 
 import InProgressIcon from './InProgressIcon';
 import { MigrationVirtualMachineStatus } from './types';
@@ -18,12 +19,12 @@ export const migrationStatusIconMap: Record<MigrationVirtualMachineStatus, React
     </Icon>
   ),
   [MigrationVirtualMachineStatus.CantStart]: (
-    <Icon status="danger">
+    <Icon status={PF_LABEL_STATUS.DANGER}>
       <ExclamationCircleIcon />
     </Icon>
   ),
   [MigrationVirtualMachineStatus.Failed]: (
-    <Icon status="danger">
+    <Icon status={PF_LABEL_STATUS.DANGER}>
       <ExclamationCircleIcon />
     </Icon>
   ),
@@ -33,12 +34,12 @@ export const migrationStatusIconMap: Record<MigrationVirtualMachineStatus, React
     </Icon>
   ),
   [MigrationVirtualMachineStatus.Paused]: (
-    <Icon status="warning">
+    <Icon status={PF_LABEL_STATUS.WARNING}>
       <PauseCircleIcon />
     </Icon>
   ),
   [MigrationVirtualMachineStatus.Succeeded]: (
-    <Icon status="success">
+    <Icon status={PF_LABEL_STATUS.SUCCESS}>
       <CheckCircleIcon />
     </Icon>
   ),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/DiskLabel.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/DiskLabel.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import { Icon, Label, Tooltip } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import { getRootDiskLabelByKey, isNotFirstKeyOrRootFilesystem } from '../utils/utils';
@@ -25,7 +26,7 @@ const DiskLabel: FC<DiskLabelProps> = ({ diskKey }) => {
               'Root filesystem format should start with "/dev/sd[X]", see documentation for more information.',
             )}
           >
-            <Icon className="pf-v6-u-mr-xs" status="warning">
+            <Icon className="pf-v6-u-mr-xs" status={PF_LABEL_STATUS.WARNING}>
               <ExclamationTriangleIcon />
             </Icon>
           </Tooltip>

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.test.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.test.tsx
@@ -4,6 +4,7 @@ import type { V1beta1PlanStatusMigrationVmsPipeline } from '@forklift-ui/types';
 import { describe, expect, it } from '@jest/globals';
 import { Icon } from '@patternfly/react-core';
 import { CheckIcon, ResourcesEmptyIcon, TimesIcon } from '@patternfly/react-icons';
+import { PF_LABEL_STATUS } from '@utils/constants';
 
 import { getPipelineProgressIcon } from './icon';
 
@@ -30,7 +31,7 @@ describe('getPipelineProgressIcon', () => {
       const result = getPipelineProgressIcon(pipeline) as ReactElement<IconWithStatusProps>;
 
       expect(result.type).toBe(Icon);
-      expect(result.props.status).toBe('danger');
+      expect(result.props.status).toBe(PF_LABEL_STATUS.DANGER);
       expect(result.props.children.type).toBe(TimesIcon);
     });
   });
@@ -49,7 +50,7 @@ describe('getPipelineProgressIcon', () => {
       const result = getPipelineProgressIcon(pipeline) as ReactElement<IconWithStatusProps>;
 
       expect(result.type).toBe(Icon);
-      expect(result.props.status).toBe('success');
+      expect(result.props.status).toBe(PF_LABEL_STATUS.SUCCESS);
       expect(result.props.children.type).toBe(CheckIcon);
     });
   });
@@ -68,7 +69,7 @@ describe('getPipelineProgressIcon', () => {
       const result = getPipelineProgressIcon(pipeline) as ReactElement<IconWithStatusProps>;
 
       expect(result.type).toBe(Icon);
-      expect(result.props.status).toBe('success');
+      expect(result.props.status).toBe(PF_LABEL_STATUS.SUCCESS);
       expect(result.props.children.type).toBe(CheckIcon);
     });
 
@@ -84,7 +85,7 @@ describe('getPipelineProgressIcon', () => {
       const result = getPipelineProgressIcon(pipeline) as ReactElement<IconWithStatusProps>;
 
       expect(result.type).toBe(Icon);
-      expect(result.props.status).toBe('success');
+      expect(result.props.status).toBe(PF_LABEL_STATUS.SUCCESS);
       expect(result.props.children.type).toBe(CheckIcon);
     });
   });
@@ -162,7 +163,7 @@ describe('getPipelineProgressIcon', () => {
       const result = getPipelineProgressIcon(pipeline) as ReactElement<IconWithStatusProps>;
 
       expect(result.type).toBe(Icon);
-      expect(result.props.status).toBe('success');
+      expect(result.props.status).toBe(PF_LABEL_STATUS.SUCCESS);
       expect(result.props.children.type).toBe(CheckIcon);
     });
 

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
@@ -1,12 +1,12 @@
 import type { V1beta1PlanStatusMigrationVmsPipeline } from '@forklift-ui/types';
 import { Icon } from '@patternfly/react-core';
 import { CheckIcon, ResourcesEmptyIcon, TimesIcon } from '@patternfly/react-icons';
-import { taskStatuses } from '@utils/constants';
+import { PF_LABEL_STATUS, taskStatuses } from '@utils/constants';
 
 export const getPipelineProgressIcon = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
   if (pipeline?.error)
     return (
-      <Icon status="danger">
+      <Icon status={PF_LABEL_STATUS.DANGER}>
         <TimesIcon />
       </Icon>
     );
@@ -17,7 +17,7 @@ export const getPipelineProgressIcon = (pipeline: V1beta1PlanStatusMigrationVmsP
 
   if (isCompleted)
     return (
-      <Icon status="success">
+      <Icon status={PF_LABEL_STATUS.SUCCESS}>
         <CheckIcon />
       </Icon>
     );

--- a/src/providers/details/tabs/Details/components/DetailsSection/ApplianceManagementDetailsItem.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/ApplianceManagementDetailsItem.tsx
@@ -4,6 +4,7 @@ import { OVA_APPLIANCE_MANAGEMENT_DESCRIPTION } from 'src/providers/utils/consta
 
 import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { isApplianceManagementEnabled } from '@utils/crds/common/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -28,7 +29,7 @@ const ApplianceManagementDetailsItem: FC<ProviderDetailsItemProps> = ({
       title={t('Appliance management')}
       content={
         isEnabled ? (
-          <Label isCompact status="success">
+          <Label isCompact status={PF_LABEL_STATUS.SUCCESS}>
             {t('Enabled')}
           </Label>
         ) : (

--- a/src/providers/details/tabs/Details/components/DetailsSection/VDDKDetailsItem.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/VDDKDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 
 import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
-import { CREATE_VDDK_HELP_LINK } from '@utils/constants';
+import { CREATE_VDDK_HELP_LINK, PF_LABEL_STATUS } from '@utils/constants';
 import { getVddkInitImage } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
@@ -38,7 +38,7 @@ export const VDDKDetailsItem: FC<ProviderDetailsItemProps> = ({
       title={t('VDDK init image')}
       content={
         isEmpty(vddkInitImage) ? (
-          <Label isCompact status="warning">
+          <Label isCompact status={PF_LABEL_STATUS.WARNING}>
             {t('Empty')}
           </Label>
         ) : (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -72,6 +72,16 @@ export const FEATURE_NAMES = {
   VOLUME_POPULATOR: 'feature_volume_populator',
 } as const;
 
+export const PF_LABEL_STATUS = {
+  CUSTOM: 'custom',
+  DANGER: 'danger',
+  INFO: 'info',
+  SUCCESS: 'success',
+  WARNING: 'warning',
+} as const;
+
+export type PfLabelStatus = (typeof PF_LABEL_STATUS)[keyof typeof PF_LABEL_STATUS];
+
 /**
  * Default values for feature flags when not specified in the ForkliftController CR.
  * If a feature is not in this list, it defaults to false.


### PR DESCRIPTION
## Summary
- Add `PF_LABEL_STATUS` and `PfLabelStatus` to `src/utils/constants.ts` for PatternFly Label/Icon status values
- Replace hardcoded `'danger'`, `'warning'`, `'info'`, `'success'`, and `'custom'` string literals across 15 components and 1 unit test file
- Update type annotations to use `PfLabelStatus` instead of inline union strings

## Test plan
- [x] `npm run build` passes
- [x] ESLint clean on changed files
- [x] `icon.test.tsx` unit tests pass (10/10)
- [ ] No visual regression — Label/Icon colors unchanged (refactor only)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated status constants across the application to use standardized PatternFly label status values. No user-visible changes to functionality or appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->