### PR TITLE
Resolves: MTV-4384 | Fix hook job status showing Pending after completion

### DIFF
--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/__tests__/getJobPhase.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/__tests__/getJobPhase.test.ts
@@ -1,6 +1,6 @@
 import type { IoK8sApiBatchV1Job } from '@forklift-ui/types';
 import { describe, expect, it } from '@jest/globals';
-import { taskStatuses } from '@utils/constants';
+import { CATEGORY_TYPES, CONDITION_STATUS, PHASES, taskStatuses } from '@utils/constants';
 
 import { getJobPhase } from '../utils';
 
@@ -23,7 +23,7 @@ describe('getJobPhase', () => {
 
   it('returns Completed when condition type is Complete', () => {
     const job = createJob({
-      conditions: [{ status: 'True', type: 'Complete' }],
+      conditions: [{ status: CONDITION_STATUS.TRUE, type: PHASES.COMPLETE }],
     });
 
     expect(getJobPhase(job)).toBe(taskStatuses.completed);
@@ -31,7 +31,7 @@ describe('getJobPhase', () => {
 
   it('returns Completed when condition type is SuccessCriteriaMet', () => {
     const job = createJob({
-      conditions: [{ status: 'True', type: 'SuccessCriteriaMet' }],
+      conditions: [{ status: CONDITION_STATUS.TRUE, type: CATEGORY_TYPES.CRITERIA_MET }],
     });
 
     expect(getJobPhase(job)).toBe(taskStatuses.completed);
@@ -40,8 +40,8 @@ describe('getJobPhase', () => {
   it('returns Completed when both Complete and SuccessCriteriaMet are present', () => {
     const job = createJob({
       conditions: [
-        { status: 'True', type: 'SuccessCriteriaMet' },
-        { status: 'True', type: 'Complete' },
+        { status: CONDITION_STATUS.TRUE, type: CATEGORY_TYPES.CRITERIA_MET },
+        { status: CONDITION_STATUS.TRUE, type: PHASES.COMPLETE },
       ],
     });
 
@@ -50,7 +50,7 @@ describe('getJobPhase', () => {
 
   it('returns Pending when Complete condition status is False', () => {
     const job = createJob({
-      conditions: [{ status: 'False', type: 'Complete' }],
+      conditions: [{ status: CONDITION_STATUS.FALSE, type: PHASES.COMPLETE }],
     });
 
     expect(getJobPhase(job)).toBe(taskStatuses.pending);
@@ -70,7 +70,7 @@ describe('getJobPhase', () => {
 
   it('prioritizes Error over Completed', () => {
     const job = createJob({
-      conditions: [{ status: 'True', type: 'Complete' }],
+      conditions: [{ status: CONDITION_STATUS.TRUE, type: PHASES.COMPLETE }],
       failed: 1,
     });
 

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/__tests__/getJobPhase.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/__tests__/getJobPhase.test.ts
@@ -1,0 +1,79 @@
+import type { IoK8sApiBatchV1Job } from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+import { taskStatuses } from '@utils/constants';
+
+import { getJobPhase } from '../utils';
+
+const createJob = (overrides: Partial<IoK8sApiBatchV1Job['status']> = {}): IoK8sApiBatchV1Job =>
+  ({
+    status: {
+      conditions: [],
+      failed: undefined,
+      succeeded: undefined,
+      ...overrides,
+    },
+  }) as unknown as IoK8sApiBatchV1Job;
+
+describe('getJobPhase', () => {
+  it('returns Error when failed > 0', () => {
+    const job = createJob({ failed: 1 });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.error);
+  });
+
+  it('returns Completed when condition type is Complete', () => {
+    const job = createJob({
+      conditions: [{ status: 'True', type: 'Complete' }],
+    });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.completed);
+  });
+
+  it('returns Completed when condition type is SuccessCriteriaMet', () => {
+    const job = createJob({
+      conditions: [{ status: 'True', type: 'SuccessCriteriaMet' }],
+    });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.completed);
+  });
+
+  it('returns Completed when both Complete and SuccessCriteriaMet are present', () => {
+    const job = createJob({
+      conditions: [
+        { status: 'True', type: 'SuccessCriteriaMet' },
+        { status: 'True', type: 'Complete' },
+      ],
+    });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.completed);
+  });
+
+  it('returns Pending when Complete condition status is False', () => {
+    const job = createJob({
+      conditions: [{ status: 'False', type: 'Complete' }],
+    });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.pending);
+  });
+
+  it('returns Pending when no conditions exist', () => {
+    const job = createJob();
+
+    expect(getJobPhase(job)).toBe(taskStatuses.pending);
+  });
+
+  it('returns Pending when conditions is undefined', () => {
+    const job = createJob({ conditions: undefined });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.pending);
+  });
+
+  it('prioritizes Error over Completed', () => {
+    const job = createJob({
+      conditions: [{ status: 'True', type: 'Complete' }],
+      failed: 1,
+    });
+
+    expect(getJobPhase(job)).toBe(taskStatuses.error);
+  });
+});

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/utils.ts
@@ -4,7 +4,13 @@ import type {
   V1beta1PlanStatusMigrationVmsPipelineTasks,
   V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
 } from '@forklift-ui/types';
-import { CATEGORY_TYPES, CONDITION_STATUS, EMPTY_MSG, taskStatuses } from '@utils/constants';
+import {
+  CATEGORY_TYPES,
+  CONDITION_STATUS,
+  EMPTY_MSG,
+  PHASES,
+  taskStatuses,
+} from '@utils/constants';
 
 import type { DiskTransferMap, TaskCounterMap } from './types';
 
@@ -92,7 +98,7 @@ export const getJobPhase = (job: IoK8sApiBatchV1Job) => {
   if (
     status?.conditions?.some(
       (condition) =>
-        condition.type === CATEGORY_TYPES.CRITERIA_MET &&
+        (condition.type === PHASES.COMPLETE || condition.type === CATEGORY_TYPES.CRITERIA_MET) &&
         condition.status === CONDITION_STATUS.TRUE,
     )
   ) {


### PR DESCRIPTION
## Links

- [MTV-4384](https://redhat.atlassian.net/browse/MTV-4384)

## Description

Fix hook job status permanently showing "Pending" after successful completion on older Kubernetes versions.

- `getJobPhase()` only checked for the `SuccessCriteriaMet` condition (Kubernetes 1.28+). On older versions, Jobs only set the standard `Complete` condition, causing the function to fall through to `Pending`.
- Added `PHASES.COMPLETE` as a valid completion condition alongside `SuccessCriteriaMet` for backward compatibility.
- Added unit tests covering all `getJobPhase` return paths.

## Demo

![Jobs showing Completed status](https://github.com/kubev2v/forklift-console-plugin/releases/download/_gh-attach-assets/MTV-4384-after-1-jobs-showing-completed.png)

## CC://

Made with Cursor


[MTV-4384]: https://redhat.atlassian.net/browse/MTV-4384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Virtual Machine migration status detection, validating detection logic across various migration states and failure conditions.

* **Bug Fixes**
  * Improved migration completion detection to recognize multiple completion indicators, ensuring accurate status reporting for Virtual Machine migrations. This enhancement better handles edge cases where migrations are marked complete through different status conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubev2v/forklift-console-plugin/pull/2445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->