### PR TITLE
Update README for dev and also lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ With a user logged in to an OpenShift cluster with the Forklift Operator availab
 
 ```bash
 # Set environment variables for your cluster
-export INVENTORY_SERVER_HOST=https://virt-konveyor-forklift.apps.<your-cluster-address>
-export SERVICES_API_SERVER_HOST=https://virt-konveyor-forklift.apps.<your-cluster-address>
-export CONSOLE_IMAGE=quay.io/openshift/origin-console:4.19
+export INVENTORY_SERVER_HOST=$(oc get route -n openshift-mtv forklift-inventory -o jsonpath='https://{.spec.host}')
+export SERVICES_API_SERVER_HOST=$(oc get route -n openshift-mtv forklift-services -o jsonpath='https://{.spec.host}')
+export CONSOLE_IMAGE=quay.io/openshift/origin-console:4.22
 
 # Start the local console server (serves at http://localhost:9000)
 npm run console

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,43 +1530,6 @@
         "url": "https://github.com/sponsors/JounQin"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,6 +1530,43 @@
         "url": "https://github.com/sponsors/JounQin"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",


### PR DESCRIPTION
## 📝 Links
> References: None
## 📝 Description
Improves the local development setup instructions in the README and re-generated the lockfile.
**README (Quick Start)**
- Replaces hardcoded placeholder URLs for `INVENTORY_SERVER_HOST` and `SERVICES_API_SERVER_HOST` with `oc get route` commands that read the Forklift inventory and services routes from the `openshift-mtv` namespace.
- Bumps the local console image from `quay.io/openshift/origin-console:4.19` to `4.22`.
**package-lock.json**
- Regenerated from `npm install`
Documentation / maintenance only — no application code changes.
## 🎥 Demo
N/A — documentation and lockfile only; no UI behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated "Quick Start" setup to derive server host values from OpenShift routes, removing hardcoded example URLs.

* **Chores**
  * Bumped console image reference to version 4.22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->