### PR TITLE
Resolves: MTV-5635 | Auto-close plan concerns drawer when conditions are resolved

### DIFF
--- a/src/plans/details/components/PlanConcernsPanel/PlanConcernsPanel.tsx
+++ b/src/plans/details/components/PlanConcernsPanel/PlanConcernsPanel.tsx
@@ -93,10 +93,22 @@ const PlanConcernsPanel: FC<PlanConcernsPanelProps> = ({
   );
 
   useEffect(() => {
-    if (showPlanConcernsPanel && (alertsNotRelevant || !showCriticalConditions)) {
+    if (
+      loaded &&
+      !loadError &&
+      showPlanConcernsPanel &&
+      (alertsNotRelevant || !showCriticalConditions)
+    ) {
       setShowPlanConcernsPanel(false);
     }
-  }, [alertsNotRelevant, setShowPlanConcernsPanel, showCriticalConditions, showPlanConcernsPanel]);
+  }, [
+    alertsNotRelevant,
+    loaded,
+    loadError,
+    setShowPlanConcernsPanel,
+    showCriticalConditions,
+    showPlanConcernsPanel,
+  ]);
 
   return (
     <DrawerPanelContent isResizable className="pfext-quick-start__base plan-concerns-panel">

--- a/src/plans/details/components/PlanConcernsPanel/PlanConcernsPanel.tsx
+++ b/src/plans/details/components/PlanConcernsPanel/PlanConcernsPanel.tsx
@@ -1,10 +1,8 @@
-import { type FC, useMemo } from 'react';
+import { type FC, useEffect, useMemo } from 'react';
 import { loadUserSettings } from 'src/components/common/Page/userSettings';
-import { useForkliftTranslation } from 'src/utils/i18n';
 
 import StandardPage from '@components/page/StandardPage';
 import {
-  Bullseye,
   DrawerActions,
   DrawerCloseButton,
   DrawerHead,
@@ -51,8 +49,6 @@ const PlanConcernsPanel: FC<PlanConcernsPanelProps> = ({
   setShowPlanConcernsPanel,
   showPlanConcernsPanel,
 }) => {
-  const { t } = useForkliftTranslation();
-
   const userSettings = useMemo(
     () => loadUserSettings({ pageId: 'MigrationPlanConcernsPanel' }),
     [],
@@ -96,9 +92,11 @@ const PlanConcernsPanel: FC<PlanConcernsPanelProps> = ({
     [status],
   );
 
-  if (showPlanConcernsPanel && (alertsNotRelevant || !showCriticalConditions)) {
-    return <Bullseye className="text-muted">{t('No data available.')}</Bullseye>;
-  }
+  useEffect(() => {
+    if (showPlanConcernsPanel && (alertsNotRelevant || !showCriticalConditions)) {
+      setShowPlanConcernsPanel(false);
+    }
+  }, [alertsNotRelevant, setShowPlanConcernsPanel, showCriticalConditions, showPlanConcernsPanel]);
 
   return (
     <DrawerPanelContent isResizable className="pfext-quick-start__base plan-concerns-panel">


### PR DESCRIPTION
## Links

- [MTV-5635](https://issues.redhat.com/browse/MTV-5635)

## Description

Auto-close the plan concerns drawer when critical conditions are resolved.

- Added a `useEffect` in `PlanConcernsPanel` that calls `setShowPlanConcernsPanel(false)` when the drawer is open and critical conditions are no longer present (resolved or plan completed/archived)
- Removed the early return that rendered a "No data available." `Bullseye`, which left an empty panel occupying the right side of the plan details page
- Cleaned up unused `Bullseye` and `useForkliftTranslation` imports

## Demo

<!-- Cluster unavailable during development; visual demo to be added after verification -->

## CC://

Made with Cursor


[MTV-5635]: https://redhat.atlassian.net/browse/MTV-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan Concerns panel now automatically closes when open but there are no relevant alerts or critical conditions to display, reducing unnecessary UI clutter and improving workflow focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->