### PR TITLE
Resolves: MTV-5647 | Add Frontend Architect agent persona

### DIFF
--- a/.cursor/rules/agents/architect.mdc
+++ b/.cursor/rules/agents/architect.mdc
@@ -1,0 +1,82 @@
+---
+description: Frontend Architect agent - page composition, blast radius analysis, component maps
+alwaysApply: false
+---
+
+# Frontend Architect Agent
+
+Invoke with: *"as architect"*, *"component map"*, *"blast radius"*, *"which pages are affected"*
+
+## Your Role
+
+You are a **frontend architect** who knows exactly how every page in the Forklift Console Plugin is composed. When someone implements a feature or fixes a bug, you identify **all** affected pages, components, and data flows to ensure nothing is missed.
+
+Your approach:
+- Map the complete blast radius of any change
+- Identify every page and component that touches the affected code
+- Surface cross-feature dependencies that are easy to overlook
+- Provide an actionable checklist of files/components that need attention
+- Ensure test coverage accounts for all affected areas
+
+---
+
+## How to Use
+
+### Feature Implementation
+> "As architect, which pages are affected if I add a new provider type?"
+
+The agent loads the relevant knowledge files, traces the component tree, and returns a list of every file that needs modification -- from route registration to detail pages to shared selectors.
+
+### Bug Investigation
+> "Blast radius: the TableView filter is broken"
+
+The agent loads `shared-components.mdc` to find every feature that uses `TableView`, then checks each feature's knowledge file for specifics.
+
+### Change Impact Analysis
+> "Component map for the Plan create wizard"
+
+The agent loads `plans.mdc` and returns the full component tree, data sources, and cross-feature connections for the wizard.
+
+---
+
+## Knowledge Routing Table
+
+Load the relevant knowledge file(s) based on the topic:
+
+| Topic | Load file |
+|-------|-----------|
+| System architecture, CRDs, tech stack, plugin registration | `.cursor/rules/project-context.mdc` |
+| Provider list, create, details pages (per-type dispatch) | `.cursor/rules/frontend/providers.mdc` |
+| Plan list, create wizard, details tabs, migration UI | `.cursor/rules/frontend/plans.mdc` |
+| NetworkMap + StorageMap pages | `.cursor/rules/frontend/mappings.mdc` |
+| Overview dashboard, health, history, settings tabs | `.cursor/rules/frontend/overview.mdc` |
+| Shared component catalog, cross-feature usage index | `.cursor/rules/frontend/shared-components.mdc` |
+| Backend CRD types and conditions | `.cursor/rules/backend/api-types.mdc` |
+| Backend provider controller behavior | `.cursor/rules/backend/providers/*.mdc` |
+| Backend plan controller and migration pipeline | `.cursor/rules/backend/plans/*.mdc` |
+
+**Always load `shared-components.mdc`** alongside any feature file -- shared component changes have the widest blast radius.
+
+---
+
+## Analysis Checklist
+
+When analyzing a change, work through this checklist:
+
+1. **Identify the primary component(s)** being changed
+2. **Check the feature knowledge file** for the component tree and data sources
+3. **Check `shared-components.mdc`** for the "used by" index of any shared components involved
+4. **Trace cross-feature connections** -- does this feature reference or get referenced by another?
+5. **Check data sources** -- if a hook or K8s watch changes, which components consume it?
+6. **List all affected files** with their role (page, component, hook, utility, test, style)
+7. **Identify test coverage gaps** -- are there tests for all affected paths?
+
+---
+
+## Refreshing Knowledge Files
+
+To regenerate the knowledge files from current source code, use the Frontend Analyzer skill:
+
+> "Refresh frontend knowledge files"
+
+This runs parallel analysis agents across the codebase and updates all `.mdc` files under `.cursor/rules/frontend/`.

--- a/.cursor/rules/frontend/mappings.mdc
+++ b/.cursor/rules/frontend/mappings.mdc
@@ -1,0 +1,218 @@
+---
+description: Network maps and storage maps architecture -- list, create, details pages, plan integration, offload plugins
+alwaysApply: false
+---
+
+# Mappings Feature Architecture (`src/networkMaps/` + `src/storageMaps/`)
+
+> Analyzed on 2026-05-29
+
+Both features follow the same CRUD pattern (list → create form/YAML → details with tabs). Storage maps add offload-plugin complexity. Plugin registration: `networkMaps/dynamic-plugin.ts`, `storageMaps/dynamic-plugin.ts`.
+
+## Page Composition
+
+### List Pages
+
+**Network Maps** (`networkMaps/list/NetworkMapsListPage.tsx`):
+```
+LearningExperienceDrawer
+└── StandardPage<NetworkMapData>
+    ├── NetworkMapsAddButton ("Create with form" / "Create with YAML")
+    ├── NetworkMapRow → cell renderers per column
+    └── NetworkMapsEmptyState
+```
+
+**Storage Maps** (`storageMaps/list/StorageMapsListPage.tsx`): identical pattern with `StorageMap*` equivalents.
+
+**Columns** (same schema for both):
+
+| Column | Cell | Filter |
+|--------|------|--------|
+| Name | `*MapLinkCell` | freetext |
+| Namespace | `NamespaceCell` | freetext |
+| Status | `createStatusCell(ErrorStatusCell)` | enum (`MAP_STATUS`) |
+| Source provider | `ProviderLinkCell` | freetext |
+| Target provider | `ProviderLinkCell` | freetext |
+| Owner | `PlanCell` (links to owning Plan) | freetext |
+| Actions | `*MapActionsDropdown` | — |
+
+### Create Forms
+
+**Network Maps** (`networkMaps/create/NetworkMapCreatePage.tsx` → `CreateNetworkMapForm`):
+```
+CreateNetworkMapForm (react-hook-form)
+├── MapNameField (optional, generateName fallback)
+├── ProjectSelectField
+├── SourceProviderField (ProviderSelect)
+├── TargetProviderField (ProviderSelect)
+└── CreateNetworkMapFieldTable (FieldBuilderTable)
+    ├── Source: InventorySourceNetworkField
+    └── Target: TargetNetworkField (@components/mappings/network-mappings/)
+```
+
+**Storage Maps** (`storageMaps/create/StorageMapCreatePage.tsx` → `CreateStorageMapForm`): same top-level structure with:
+- `CreateStorageMapFieldTable` instead
+- Source: `InventorySourceStorageField`
+- Target: `TargetStorageField` or `TargetStorageWithSuggestion` (vSphere + copy offload)
+- Expandable `OffloadStorageRow` per row (plugin, secret, product fields)
+
+**Provider data for source options:**
+- Networks: `useSourceNetworks(provider)` → `useProviderInventory` with subPath `networks`
+- Storages: `useSourceStorages(provider)` → provider-type-specific inventory subPaths
+
+**Submit:**
+- Network: `createNetworkMap()` → `k8sCreate` with `buildNetworkMappings()`
+- Storage: `createStorageMap()` → includes NetApp Shift label detection
+
+### Details Pages
+
+**Both** share identical structure (Details + YAML tabs):
+```
+*MapDetailsPage → LoadingSuspend
+├── *MapPageHeadings (title, critical conditions, actions, learning button)
+└── HorizontalNav
+    ├── Details tab
+    │   ├── DetailsSection (name, namespace, created, owner)
+    │   ├── MapProvidersDetails (+ MapProvidersEdit modal)
+    │   ├── *MapReviewTable (+ *MapEdit modal)
+    │   └── ConditionsSection
+    └── YAML tab (ResourceYAMLEditorWrapper)
+```
+
+**Network edit:** `NetworkMapEdit` modal patches `/spec/map` via `k8sPatch`.
+**Storage edit:** `StorageMapEdit` modal with offload support, transforms via `transformStorageMapToFormValues` / `transformFormValuesToK8sSpec`.
+
+### Actions
+
+| Action | Both types |
+|--------|-----------|
+| Edit | Navigate to details or YAML tab |
+| Delete | `DeleteModal` (gated by `permissions.canDelete`) |
+
+Used in: list row actions + details page header.
+
+## Shared Component Usage
+
+| Component | Used by |
+|-----------|---------|
+| `StandardPage` | Both list pages |
+| `FieldBuilderTable` | Both create/edit mapping tables |
+| `ProviderSelect` | Both source/target provider fields |
+| `ProjectSelect` | Both project fields |
+| `ModalForm` + patch constants | Both edit modals |
+| `FormGroupWithErrorText`, `FormErrorHelperText` | Both create forms |
+| `common/Select` | Inventory source fields, storage target, offload fields |
+| `HelpIconPopover` | Project select, offload fields |
+| `LoadingSuspend` | Both details/YAML tabs |
+| `ResourceYAMLEditorWrapper` | Both YAML tabs |
+| `MapProvidersDetails` / `MapProvidersEdit` | Both details tabs |
+| `SectionHeadingWithEdit`, `SectionHeading` | Both details tabs |
+| `DetailItems/*` (Name, Namespace, etc.) | Both details sections |
+| `ConditionsSection` | Both details tabs |
+| `DeleteModal` | Both actions |
+| `TableLinkCell`, `createStatusCell`, `ErrorStatusCell` | Both list rows |
+| `TargetNetworkField` | Network create/edit only (from `@components/mappings/network-mappings/`) |
+
+## Data Sources
+
+### K8s Watches
+
+| Resource | Network Maps | Storage Maps |
+|----------|:-----------:|:------------:|
+| `NetworkMap` (list/single) | ✓ | — |
+| `StorageMap` (list/single) | — | ✓ |
+| `Provider` (source/dest) | ✓ | ✓ |
+| `CustomResourceDefinition` (StorageMap CRD) | — | ✓ |
+| `Secret` | — | ✓ (offload) |
+
+### Inventory / Feature Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `useSourceNetworks` | Source networks via provider inventory REST |
+| `useOpenShiftNetworks` | NADs on OpenShift target |
+| `useTargetNetworks` | Target network select options |
+| `useSourceStorages` | Source datastores/storage domains (provider-type-specific) |
+| `useTargetStorages` | Target StorageClasses (+ default ordering, NetApp Shift) |
+| `useProviderInventory` | Low-level Forklift inventory REST client |
+| `useStorageMapCrd` | CRD schema for enum discovery |
+| `useOffloadPlugins` | Offload plugin names from CRD + constants |
+| `useStorageVendorProducts` | Vendor product enum from CRD |
+| `useDatastoreVendor` | vSphere SCSI disk → vendor for offload hints |
+| `useFeatureFlags` | `feature_copy_offload` gate (storage only) |
+
+## Cross-Feature Connections
+
+### Plans → Mappings (heaviest integration)
+
+**Plan wizard:**
+- `NetworkMapStep` — existing map select or new map via `NetworkMapFieldTable`
+- `StorageMapStep` — existing map select or new map via `CreatePlanStorageMapFieldTable`
+
+**Plan submit:**
+- Network: plan-local `createNetworkMap.ts` (duplicated, not shared)
+- Storage: reuses `storageMaps/create/utils/createStorageMap.ts` (shared)
+- Existing maps cloned with `copyNetworkMap.ts` / `copyStorageMap.ts`
+
+**Plan details — Mappings tab:**
+- `PlanNetworkMapEdit`, `PlanStorageMapEdit` use same field tables/validation
+- `usePlanNetworkMapResources`, `usePlanStorageMapResources` import `getMappingValues` / `getStorageMappingValues`
+
+**Review tables:**
+- `NetworkMapReviewTable` (from `plans/create/steps/review/`) used on network map details
+- `StorageMapReviewTable` used on storage map details
+
+### Providers → Mappings
+- Both require source + target providers with collected inventory (Ready phase)
+- `PROVIDER_TYPES` used in `buildNetworkMappings`, `buildStorageMappings`
+- Empty states redirect to providers list when `useHasSufficientProviders` is false
+
+### External imports of mapping code
+
+| Consumer | Imports |
+|----------|---------|
+| `plans/**` | Types, constants, build utils, storage components, review tables |
+| `utils/crds/maps/shared.ts` | `NetworkMapData`, `StorageMapData` types |
+| `utils/hooks/useTargetStorages.ts` | `TargetStorage`, NetApp Shift utils from storageMaps |
+
+## Structural Similarities and Differences
+
+### Shared patterns
+- Identical list column schema and filter types
+- Same `MapProvidersDetails` shared component
+- Same `ModalForm` + `k8sPatch` edit pattern
+- Same owner-reference semantics (Plan-owned maps in Owner column)
+
+### Divergences
+
+| Aspect | Network Maps | Storage Maps |
+|--------|-------------|--------------|
+| Complexity | Simple 2-column mapping | Offload plugins, vendor products, secrets, NetApp Shift |
+| Target field | Shared `@components/mappings/` | Feature-local `TargetStorageField` etc. |
+| CRD schema hooks | None | `useStorageMapCrd`, offload/product enum discovery |
+| Plan create util | Duplicated in plans | Reused from storageMaps |
+| Feature flags | None | `FEATURE_NAMES.COPY_OFFLOAD` for vSphere XCOPY |
+| Extra hooks | None | `storageMaps/hooks/` (5 hooks) |
+
+## Blast Radius Notes
+
+### Changes to shared components that break both mappings
+- `StandardPage` → both list pages
+- `FieldBuilderTable` → all create/edit mapping tables
+- `MapProvidersDetails/Edit` → both details provider sections
+- `ModalForm` → all edit modals
+- `ProviderSelect` → both create forms
+- `getMapPhase` (`utils/crds/maps/shared.ts`) → both list status columns
+
+### Network-specific exports consumed elsewhere
+- `TargetNetworkField` → plan wizard, plan edit, network map create/edit
+- `buildNetworkMappings` / `getMappingValues` → plan mapping hooks
+- `NetworkMapReviewTable` → network map details, plan mappings page, plan review
+
+### Storage-specific exports consumed elsewhere (high blast radius)
+- `TargetStorageField`, `TargetStorageWithSuggestion` → plan wizard, plan storage edit
+- `GroupedSourceStorageField`, `OffloadStorageRow` → plan wizard, plan storage edit
+- `createStorageMap`, `buildStorageMappings` → plan submit, plan edit utils
+- `validateOffloadFields`, offload utils → plan storage validation
+- `TargetStorage` type, `useTargetStorages` → shared utils hook
+- `StorageMapReviewTable` → storage details, plan mappings, plan review

--- a/.cursor/rules/frontend/overview.mdc
+++ b/.cursor/rules/frontend/overview.mdc
@@ -1,0 +1,198 @@
+---
+description: Overview/dashboard feature architecture -- tabbed layout, dashboard cards, health, history, settings
+alwaysApply: false
+---
+
+# Overview Feature Architecture (`src/overview/`)
+
+> Analyzed on 2026-05-29
+
+Route: `/mtv/overview`. Plugin registration: `src/overview/dynamic-plugin.ts` (admin + virtualization-perspective, requires `CAN_LIST_NS`).
+
+## Page Composition
+
+### Main Page (`OverviewPage.tsx`)
+
+```
+LearningExperienceDrawer
+└── forklift-details-page-layout
+    ├── PageSection: H1 title + LearningExperienceButton
+    ├── PageSection (conditional): InventoryNotReachable alert
+    ├── PageSection (conditional): LightspeedMcpWarning
+    ├── RoutedTabs (5 tabs, telemetry on click)
+    └── Routes → active tab component
+```
+
+### Tabs (from `constants.ts` — `OverviewTabHref`)
+
+| Tab | Component | Path |
+|-----|-----------|------|
+| Overview | `ForkliftControllerOverviewTab` | `tabs/Overview/` |
+| YAML | `ForkliftControllerYAMLTab` | `tabs/YAML/` |
+| Health | `ForkliftControllerHealthTab` | `tabs/Health/` |
+| History | `ForkliftControllerHistoryTab` | `tabs/History/` |
+| Settings | `ForkliftControllerSettingsTab` | `tabs/Settings/` |
+
+### Overview Tab — Dashboard Cards
+
+```
+ForkliftControllerOverviewTab (vertical Flex)
+├── WelcomeCard (full width, expandable intro + provider tiles)
+├── Row: VmMigrationsDonutCard (325px) | VmMigrationsHistoryCard (flex-1)
+├── Row: MigrationPlansDonutCard (325px) | ControllerCard limit=6 (flex-1)
+└── Row: ThroughputCard (network) | ThroughputCard (storage)
+```
+
+| Card | Data Shown |
+|------|-----------|
+| `WelcomeCard` | Expandable intro; clickable provider tiles → provider create |
+| `VmMigrationsDonutCard` | VM migration counts by status (Running/Failed/Succeeded/Canceled) + time-range filter |
+| `VmMigrationsHistoryCard` | Stacked area chart of VM migrations over time |
+| `MigrationPlansDonutCard` | Plan counts by UI status (9 statuses) |
+| `ControllerCard` | Forklift pods (label `app=forklift`), limited to 6 on overview |
+| `ThroughputCard` (x2) | Prometheus metrics: net + storage throughput per plan |
+
+### Health Tab
+
+```
+ForkliftControllerHealthTab
+├── ControllerCard (full pod list, no limit)
+│   └── PodsTable (pagination when >10)
+└── ConditionsCard
+    └── ConditionsSection
+```
+
+### History Tab
+
+```
+ForkliftControllerHistoryTab → HistoryCard
+└── MigrationsListPage (StandardPage)
+    └── MigrationRow
+```
+
+Filterable table of all Migration CRs. Columns: Migration name, Status, Plan, Started at, Completed at.
+Filters: freetext (name, plan), enum (status), date range, "Group by plan" toggle (`SwitchFilter`).
+Deep-linking from overview charts via `navigateToHistoryTab()` query params.
+
+### Settings Tab
+
+```
+ForkliftControllerSettingsTab → SettingsCard
+├── SectionHeadingWithEdit → SettingsEdit modal
+└── DescriptionList of DetailsItem rows
+    └── SettingsEdit (ModalForm + react-hook-form)
+        └── 10 field editors → k8sPatch on ForkliftControllerModel
+```
+
+**Configurable settings** (10 fields from `SettingsFields` enum):
+
+| Setting | Spec field | Default |
+|---------|-----------|---------|
+| Max concurrent VM migrations | `controller_max_vm_inflight` | 20 |
+| Controller CPU limit | `controller_container_limits_cpu` | 500m |
+| Controller memory limit | `controller_container_limits_memory` | 800Mi |
+| Inventory memory limit | `inventory_container_limits_memory` | 1000Mi |
+| Precopy interval | `controller_precopy_interval` | 60 min |
+| Snapshot polling interval | `controller_snapshot_status_check_rate_seconds` | 10s |
+| Controller transfer network | `controller_transfer_network` | None |
+| AAP URL | `aap_url` | Not configured |
+| AAP token secret | `aap_token_secret_name` | Not configured |
+| AAP timeout | `aap_timeout` | 0 |
+
+Note: Feature flags (`feature_copy_offload`, `feature_ocp_live_migration`, `feature_volume_populator`) are NOT in this Settings UI — only visible in YAML tab.
+
+## Shared Component Usage
+
+| Component | Used in |
+|-----------|---------|
+| `RoutedTabs` | Main page tab navigation |
+| `LightspeedMcpWarning` | Page banner |
+| `LoadingSuspend` | VM donut/history cards, ControllerCard, MigrationsListPage |
+| `ModalForm` + patch constants | SettingsEdit |
+| `FormGroupWithHelpText`, `HelpIconPopover` | All settings editors |
+| `DetailsItem`, `SectionHeadingWithEdit` | Settings card |
+| `ResourceYAMLEditorWrapper` | YAML tab |
+| `StandardPage` + filter types | History tab table |
+| `ConsoleTimestamp`, `TableLinkCell`, `VisibleTableData` | History rows |
+| `ConditionsSection` | Health conditions |
+| `StatusIcon` | Pod status |
+| `SwitchFilter` | History "group by plan" filter |
+
+## Data Sources
+
+### K8s Watches
+
+| Resource | Where |
+|----------|-------|
+| `ForkliftController` | `useK8sWatchForkliftController` (central hook) |
+| `Plan` | `usePlanStatusCounts`, history plan links |
+| `Migration` | `useVmMigrationsDataPoints`, `useMigrationCounts`, history table |
+| `Pod` | `ControllerCard` (selector: `app=forklift`) |
+| `NetworkAttachmentDefinition` | `EditControllerTransferNetwork` |
+| `Secret` | `EditAapTokenSecret` |
+
+### Other Hooks
+
+| Hook | Source |
+|------|--------|
+| `useProvidersInventoryIsLive` | REST poll to inventory API |
+| `useThroughputQuery` | `usePrometheusPoll` (Prometheus QUERY_RANGE) |
+| `usePlanStatusCounts` | Derived from Plans watch |
+| `useVmMigrationsDataPoints` | Derived from Migrations watch (bucketed by time range) |
+| `useOverviewContext` | Local state + localStorage persistence |
+
+### Context Providers
+- `OverviewContext` (registered in `dynamic-plugin.ts`) — welcome card collapsed state, VM chart time ranges
+
+## Cross-Feature Connections
+
+### Overview imports from other features
+
+| Feature | Import | Purpose |
+|---------|--------|---------|
+| **providers** | `InventoryNotReachable`, `getInventoryApiUrl`, `PROVIDER_TYPES` | Alert, liveness, welcome card |
+| **plans** | `PlanStatuses`, `getPlanStatus`, `getMigrationVMsStatusCounts`, `VMStatusIconsRow` | Charts, history status |
+
+### Overview exports used by other features
+
+| Export | Consumer | Purpose |
+|--------|----------|---------|
+| `useK8sWatchForkliftController` | `plans/.../useAapConfig.ts` | Read AAP config during plan creation |
+| `SettingsFields`, `EnhancedForkliftController` | `plans/.../useAapConfig.ts` | Field enum for AAP detection |
+| `TabTitle` | `plans/.../PlanHooksPage.tsx` | Consistent tab title + help icon |
+| `OVERVIEW_BASE_PATH`, `OverviewTabHref` | `utils/helpers/getOverviewPath.ts` | Build overview URLs from anywhere |
+
+### Navigation cross-links from overview
+
+| From | To |
+|------|----|
+| WelcomeCard provider tiles | Provider create (`~new?providerType=...`) |
+| MigrationPlansDonutCard slices | Plans list filtered by phase |
+| VM donut/history chart | History tab with filters |
+| History empty state | Plan create |
+| ControllerCard (overview) | Health tab |
+
+## Blast Radius Notes
+
+### Changes to shared components that break overview
+- `RoutedTabs` → entire tab navigation
+- `LoadingSuspend` → 4+ cards loading states
+- `StandardPage` + filter types → entire History tab
+- `ModalForm` + `FormGroupWithHelpText` → Settings edit flow
+- `ConditionsSection` → Health conditions
+- `ResourceYAMLEditorWrapper` → YAML tab
+
+### Changes to plans utilities that break overview
+- `getPlanStatus` / `PlanStatuses` → migration plans donut counts
+- `getMigrationVMsStatusCounts` → history status column, VM donut
+- `VMStatusIconsRow` → history status icons
+
+### Overview exports — changes affect consumers
+- `useK8sWatchForkliftController` → plans hook creation flow (AAP config)
+- `SettingsFields` → field renames break AAP config detection
+- `OVERVIEW_BASE_PATH` → URL structure changes break nav links
+
+### External infrastructure dependencies
+- Monitoring/Prometheus unavailable → throughput cards error empty state
+- Inventory REST API down → `InventoryNotReachable` banner
+- ForkliftController CR missing → Settings, YAML, Health conditions fail to load

--- a/.cursor/rules/frontend/plans.mdc
+++ b/.cursor/rules/frontend/plans.mdc
@@ -1,0 +1,309 @@
+---
+description: Plan pages - list, create wizard (9 steps), details tabs, migration actions
+alwaysApply: false
+---
+
+# Plan Pages
+
+> Analyzed on 2026-05-29 — ~240 `.tsx` files, the largest feature in the plugin.
+
+---
+
+## Plugin Registration (`dynamic-plugin.ts`)
+
+Exposes three modules to the Console SDK:
+
+| Extension type | Module | Component |
+|---|---|---|
+| `console.navigation/resource-ns` | — | Nav items (admin + virt perspectives) |
+| `console.page/resource/list` | `PlansListPage` | `PlansListPage` |
+| `console.page/resource/details` | `PlanDetailsNav` | `PlanDetailsNav` |
+| `console.resource/create` | `PlanCreatePage` | `PlanCreatePage` |
+
+All use `PlanModelGroupVersionKind` from `@forklift-ui/types`.
+
+---
+
+## Page Composition
+
+### 1. List Page — `PlansListPage`
+
+```
+PlansListPage
+├── LearningExperienceDrawer
+└── StandardPage                      ← shared, data-driven table
+    ├── PlansAddButton                ← gated by useGetDeleteAndEditAccessReview
+    ├── PlansEmptyState
+    └── PlanRow (per row)
+        └── usePlanListRowFields      ← renders each column cell
+```
+
+**Data source:** `useK8sWatchResource<V1beta1Plan[]>` (list, namespaced).
+
+**Table columns** (defined in `planFields`): Name, Project, Source provider, Target project, Virtual machines count, Migration status, Migration type, Migration started, Description, Actions. Plus a hidden "Archived" slider filter.
+
+**Post-filter:** Archived plans are hidden by default; toggling the "Show archived" slider includes them.
+
+### 2. Create Page — `PlanCreatePage` → `CreatePlanWizard`
+
+```
+PlanCreatePage
+├── LearningExperienceDrawer
+├── Title ("Create migration plan")
+└── CreatePlanWizard
+    ├── FormProvider (react-hook-form)
+    ├── CreatePlanWizardContextProvider
+    └── CreatePlanWizardInner          ← PF6 Wizard shell
+        ├── WizardStep (Basic setup)   ← expandable parent
+        │   ├── GeneralInformationStep
+        │   ├── VirtualMachinesStep
+        │   ├── NetworkMapStep
+        │   ├── StorageMapStep
+        │   └── MigrationTypeStep      ← conditionally hidden
+        ├── WizardStep (Additional setup) ← expandable parent
+        │   ├── OtherSettingsStep
+        │   ├── CustomScriptsStep
+        │   └── HooksStep
+        └── WizardStep (Review and create)
+            └── ReviewStep
+```
+
+**Form framework:** `react-hook-form` via `useCreatePlanForm` (custom hook wrapping `useForm`). The form context is accessed by steps via `useCreatePlanFormContext`. All step field IDs are defined in each step's `constants.ts`.
+
+**Step navigation:** `useStepNavigation` tracks the current step and per-step error state. Steps ahead of the current one are disabled if previous steps have errors (`hasPreviousStepErrors`). The wizard enforces `isVisitRequired`.
+
+**URL params on entry:** `?planProject=<ns>&sourceProvider=<name>` pre-fills the general step (used when navigating from a provider's detail page).
+
+### 3. Details Page — `PlanDetailsNav`
+
+```
+PlanDetailsNav
+├── LearningExperienceDrawer
+├── PlanConcernsDrawer                ← side panel for VM concerns
+├── PlanPageHeader
+│   ├── PageHeadings (shared)
+│   ├── PlanStatusLabel
+│   ├── PlanEditCutoverButton
+│   ├── PlanActionsDropdown
+│   └── PlanAlerts
+└── HorizontalNav                     ← Console SDK tabbed nav
+    └── (tabs defined by usePlanPages)
+```
+
+**Data source:** `usePlan(name, namespace)` — wraps `useK8sWatchResource<V1beta1Plan>` (single resource watch).
+
+---
+
+## Create Wizard Steps
+
+The wizard has two expandable groups plus the review step.
+
+### Group 1 — Basic Setup
+
+| # | Step ID | Component | Key fields | Notes |
+|---|---|---|---|---|
+| 1 | `general` | `GeneralInformationStep` | planName, planProject, planDescription, sourceProvider, targetProvider, targetProject | Uses `ProviderSelect` (shared). Changing source provider resets VMs, network map, storage map, migration type. |
+| 2 | `virtual-machines` | `VirtualMachinesStep` | vms (object keyed by VM ID) | `VirtualMachinesTable` fetches inventory from source provider. Has custom footer (`VirtualMachinesStepFooter`). Changing VM selection unregisters network/storage map fields. |
+| 3 | `network-map` | `NetworkMapStep` | networkMapType, existingNetworkMap OR (networkMap, networkMapName) | Radio: existing (no ownerRef) vs. new. New shows `NewNetworkMapFields` mapping table. |
+| 4 | `storage-map` | `StorageMapStep` | storageMapType, existingStorageMap OR (storageMap, storageMapName) | Same pattern as network map. |
+| 5 | `migration-type` | `MigrationTypeStep` | migrationType (Cold/Warm/Live) | **Conditionally hidden** when source provider doesn't support warm or live. For vSphere, warns about VMs without CBT enabled. |
+
+### Group 2 — Additional Setup
+
+| # | Step ID | Component | Key fields | Notes |
+|---|---|---|---|---|
+| 6 | `other-settings` | `OtherSettingsStep` | transferNetwork, preserveStaticIps, rootDevice, targetPowerState, instanceTypes, nbdeClevis, diskDecryptionPassPhrases, migrateSharedDisks | Several fields are vSphere-only. Transfer network hidden for live migration. |
+| 7 | `automation` | `CustomScriptsStep` | scriptsType (Existing/New), existingConfigMap OR customScripts | Tech Preview. Customization scripts injected via virt-customize. |
+| 8 | `hooks` | `HooksStep` | hookSource (local/AAP), preMigration, postMigration, AAP fields | Two sources: local Ansible playbooks or AAP job templates. Pre/post migration hooks with runner image and service account. |
+
+### Review
+
+| # | Step ID | Component | Notes |
+|---|---|---|---|
+| 9 | `review-and-create` | `ReviewStep` | Shows all 8 review sections. Displays spinner during submit, error state on failure. "Create plan" button triggers `submitMigrationPlan`. |
+
+### Submission Flow (`submitMigrationPlan`)
+
+Creates resources in parallel via `Promise.all`:
+1. **NetworkMap** — copy existing or create new
+2. **StorageMap** — copy existing or create new
+3. **Decryption Secret** — if disk passphrases provided (vSphere LUKS)
+4. **Hooks** — local or AAP, creates Hook CRDs
+5. **Scripts ConfigMap** — if custom scripts configured
+
+Then creates the **Plan** CRD, then patches all created resources to add the plan as owner reference (`addPlanResourceOwnerRefs`).
+
+Telemetry events are fired: `PLAN_CREATE_STARTED`, `PLAN_CREATE_COMPLETED`, `PLAN_CREATE_FAILED`.
+
+---
+
+## Details Tabs
+
+Defined in `usePlanPages` — returns `NavPage[]` consumed by Console SDK `HorizontalNav`.
+
+| Tab | Component | href | Data sources | Key sub-components |
+|---|---|---|---|---|
+| **Details** | `PlanDetailsPage` | `""` | `usePlan` | DetailsSection, ProvidersSection, SettingsSection, MigrationsSection (expandable), ConditionsSection (expandable) |
+| **YAML** | `PlanYAMLPage` | `yaml` | `usePlan` | `ResourceYAMLEditor` (Console SDK) |
+| **Virtual machines** | `PlanVirtualMachinesPage` | `vms` | `usePlan` | Switches between `PlanSpecVirtualMachinesList` (pre-execution) and `MigrationStatusVirtualMachinesList` (during/after execution, wrapped in `DrawerProvider`) |
+| **Resources** | `PlanResourcesPage` | `resources` | `usePlan`, `useK8sWatchResource<V1beta1Provider>`, `useProviderInventory` (REST API: `vms?detail=4`) | `PlanResourcesTable` — shows CPU, memory, disks per VM |
+| **Mappings** | `PlanMappingsPage` | `mappings` | `usePlan`, `usePlanProviders`, `usePlanMappingVms`, `usePlanNetworkMapResources`, `usePlanStorageMapResources` | Network/storage map review tables with edit modals (`PlanNetworkMapEdit`, `PlanStorageMapEdit`). Editable when plan is in Ready/Canceled/Incomplete/Unknown/CannotStart. |
+| **Automation** | `PlanAutomationPage` | `automation` | `usePlan`, `usePlanCustomScripts` | `ScriptsSection` — shows configured virt-customize scripts from ConfigMap |
+| **Hooks** | `PlanHooksPage` | `hooks` | `usePlan`, `usePlanHooks` | Pre/post migration `HookSection` components, warning when hooks were manually configured |
+
+---
+
+## Plan Actions
+
+`PlanActionsDropdown` → `PlanActionsDropdownItems` renders a `DropdownList` with these actions:
+
+| Action | Modal | Condition |
+|---|---|---|
+| **Edit** | navigates to details or YAML | Disabled when Executing/Paused/Pending/Archived |
+| **Start / Restart** | `PlanStartMigrationModal` | `canPlanStart` or `canPlanReStart`, no active migration |
+| **Schedule / Edit cutover** | `PlanCutoverMigrationModal` | Warm + Executing + not Archived + not Pending |
+| **Duplicate** | `DuplicateModal` | Disabled when CannotStart |
+| **Archive** | `ArchiveModal` | Requires delete permission, not already archived |
+| **Delete** | `PlanDeleteModal` | Requires delete permission |
+
+The details header also has a standalone `PlanEditCutoverButton` (primary variant).
+
+---
+
+## Plan Statuses
+
+Computed by `getPlanStatus(plan)` in `PlanStatus/utils/utils.ts`. Evaluation order:
+
+1. `Archived` — `spec.archived` or Archived condition
+2. `Unknown` — no conditions
+3. `Completed` — Succeeded condition
+4. `Canceled` — Canceled condition
+5. `Paused` — warm + executing + VMs paused (waiting for cutover)
+6. `CannotStart` — Critical condition present
+7. `Incomplete` — Failed condition or any VM has error
+8. `Pending` — Executing but no VM started yet
+9. `Executing` — Executing condition
+10. `Ready` — Ready condition
+11. `Unknown` — fallback
+
+**Editable statuses** (for mapping edits): Ready, Canceled, Incomplete, Unknown, CannotStart.
+
+**VM-level statuses** (`MigrationVirtualMachineStatus`): Succeeded, Failed, Canceled, InProgress (Running), Paused, CantStart.
+
+---
+
+## Shared Component Usage
+
+| Shared component | Used in |
+|---|---|
+| `StandardPage` | List page (data table with filters, pagination, column management) |
+| `LoadingSuspend` | Resources tab, Automation tab, Hooks tab |
+| `PageHeadings` | Details header |
+| `ProviderSelect` | General step (source + target provider selects) |
+| `WizardStepContainer` | Every wizard step |
+| `FormGroupWithErrorText` | General step, Migration type step |
+| `ModalForm` | Action modals |
+| `DetailsItem` / `DescriptionList` | Mappings tab |
+| `SectionHeading` / `SectionHeadingWithEdit` | Detail tabs |
+| `ExpandableSectionHeading` | Migrations history, Conditions sections |
+| `ResourceYAMLEditorWrapper` | YAML tab |
+| `LearningExperienceDrawer` | List, Create, Details pages |
+| `StatusIcon` | Conditions section |
+| `DrawerProvider` / `DrawerContext` | VM tab (migration status drawer) |
+| `TechPreviewLabel` | Custom scripts step |
+
+---
+
+## Data Sources
+
+### K8s Watches (`useK8sWatchResource`)
+
+| Resource | GVK constant | Where used |
+|---|---|---|
+| `V1beta1Plan` (list) | `PlanModelGroupVersionKind` | List page |
+| `V1beta1Plan` (single) | `PlanModelGroupVersionKind` | `usePlan` → all detail tabs |
+| `V1beta1Provider` | `ProviderModelGroupVersionKind` | Resources tab, Mappings tab (via `usePlanProviders`) |
+| `V1beta1Migration` (list) | `MigrationModelGroupVersionKind` | `usePlanMigration` → actions dropdown |
+| `V1beta1NetworkMap` | `NetworkMapModelGroupVersionKind` | Mappings tab |
+| `V1beta1StorageMap` | `StorageMapModelGroupVersionKind` | Mappings tab |
+
+### REST Inventory API (`useProviderInventory`)
+
+| Endpoint | Where used |
+|---|---|
+| `vms?detail=4` | Resources tab (CPU/memory/disk details), VM selection in wizard |
+| Source networks/storages | Mappings tab (via `usePlanNetworkMapResources`, `usePlanStorageMapResources`) |
+
+### Custom Hooks
+
+| Hook | Purpose |
+|---|---|
+| `usePlan` | Single plan watch — used by all detail pages |
+| `usePlanMigration` | Finds active Migration CR owned by the plan |
+| `usePlanPages` | Defines the 7 detail tabs |
+| `useCreatePlanForm` | Initializes react-hook-form with default values |
+| `useCreatePlanFormContext` | Provides form methods to wizard steps |
+| `useStepNavigation` | Tracks wizard step, validates field groups |
+| `useSourceProviderFromSearchParams` | Pre-fills source provider from URL |
+| `usePlanProviders` | Resolves source + target provider objects from plan spec |
+| `usePlanMappingVms` | Fetches inventory VMs for mapping pages |
+| `usePlanNetworkMapResources` | Loads network map, source/target networks, NIC profiles |
+| `usePlanStorageMapResources` | Loads storage map, source/target storages, VM disks |
+| `usePlanCustomScripts` | Loads ConfigMap with virt-customize scripts |
+| `usePlanHooks` | Loads pre/post Hook CRDs |
+| `useFeatureFlags` | Gates migration type step (live migration) |
+| `useTargetStorages` | Fetches target storage classes for wizard submission |
+
+---
+
+## Cross-Feature Connections
+
+### Plans → Providers
+- Plan spec references source + target providers by name/namespace
+- General step uses shared `ProviderSelect` which watches all providers in the plan project
+- Migration type step checks `sourceProvider.spec.type` (vSphere warm, OCP live)
+- Resources tab watches the source provider to fetch inventory
+- `useSourceProviderFromSearchParams` enables deep-linking from provider pages
+
+### Plans → NetworkMaps
+- Plan spec references a NetworkMap by name/namespace
+- Wizard creates or copies a NetworkMap during submission (owned by plan)
+- Mappings tab watches the plan's NetworkMap and allows editing via `PlanNetworkMapEdit` modal
+- Reuses `NetworkMapReviewTable` from wizard review step in Mappings tab
+
+### Plans → StorageMaps
+- Same pattern as NetworkMaps — plan references, wizard creates/copies, Mappings tab allows editing
+- Reuses `StorageMapReviewTable` from wizard review step
+- `createStorageMap` utility imported from `src/storageMaps/create/utils/`
+
+### Plans → Migrations
+- `usePlanMigration` watches all Migrations in the namespace, filters by owner UID
+- Active migration determines if Start action is disabled and if cutover is available
+- VMs tab switches rendering mode based on execution state
+
+### Plans → Hooks
+- Plan spec embeds pre/post hook references in `spec.vms[].hooks`
+- Wizard creates Hook CRDs during submission
+- Hooks tab loads Hook resources via `usePlanHooks`
+
+### Plans → ConfigMaps (Custom Scripts)
+- Plan spec references a ConfigMap for virt-customize scripts
+- Wizard creates or references an existing ConfigMap
+- Automation tab loads via `usePlanCustomScripts`
+
+### Plans → Secrets (Disk Encryption)
+- Plan spec may reference a LUKS decryption Secret
+- Wizard creates Secret via `createDecryptionSecret` (vSphere only)
+
+---
+
+## Blast Radius Notes
+
+- **`StandardPage` changes** affect all list pages (providers, plans, network maps, storage maps). Plans list adds custom `postFilterData` for archived plans.
+- **`ProviderSelect` changes** affect both the plan wizard (general step) and provider pages.
+- **`PlanStatus/utils/utils.ts`** is imported by: list page (field filters), actions dropdown (enable/disable logic), VM tab (rendering mode), Mappings tab (`isPlanEditable`). Changes here affect all plan views.
+- **`submitMigrationPlan`** orchestrates creation of 5+ K8s resources in parallel. Failures mid-submission can leave orphaned resources (NetworkMap, StorageMap, Hooks, Secret). Owner references are added in a second pass.
+- **Wizard step field IDs** (`constants.ts` in each step) are referenced by `stepFieldMap` for validation and by `submitMigrationPlan` for extraction. Renaming a field ID requires updating both.
+- **Mapping components** are shared between wizard review and detail Mappings tab (`NetworkMapReviewTable`, `StorageMapReviewTable`). Changes affect both contexts.
+- **Feature flags** (`OCP_LIVE_MIGRATION`) gate the migration type step visibility and transfer network visibility in other settings. Must be tested with flag on/off.
+- **`usePlan` hook** is the single data source for all 7 detail tabs. Any K8s watch issues affect the entire details view.

--- a/.cursor/rules/frontend/providers.mdc
+++ b/.cursor/rules/frontend/providers.mdc
@@ -1,0 +1,387 @@
+---
+description: Provider pages - list, create, details (per-type dispatch), tabs, actions, modals
+alwaysApply: false
+---
+
+# Provider Pages
+
+> Analyzed on 2026-05-29
+
+## Extension Registration (`src/providers/dynamic-plugin.ts`)
+
+Three exposed modules registered via Console SDK extensions:
+
+| Extension type | Module | Component |
+|---|---|---|
+| `console.page/resource/list` | `ProvidersListPage` | `src/providers/list/ProvidersListPage.tsx` |
+| `console.page/resource/details` | `ProviderDetailsPage` | `src/providers/details/ProviderDetailsPage.tsx` |
+| `console.resource/create` | `ProvidersCreatePage` | `src/providers/create/ProvidersCreatePage.tsx` |
+
+Two nav items (`console.navigation/resource-ns`) are registered: one for `admin` perspective, one for `virtualization-perspective`.
+
+---
+
+## Page Composition
+
+### 1. List Page (`src/providers/list/ProvidersListPage.tsx`)
+
+```
+ProvidersListPage
+├── LearningExperienceDrawer
+│   └── StandardPage<ProviderData>
+│       ├── ProvidersAddButton              (add button)
+│       ├── ProviderRow                     (row component)
+│       │   └── ProviderDataCell            (cell renderer per field)
+│       ├── ProvidersEmptyState             (no results)
+│       └── InventoryNotReachable           (alert when inventory API is down)
+```
+
+**Data sources:**
+- `useK8sWatchResource<V1beta1Provider[]>` — watches Provider CRs in namespace
+- `useProvidersInventoryList(namespace)` — polls inventory REST API every 20s
+- `useGetDeleteAndEditAccessReview({ model: ProviderModel })` — RBAC permissions
+
+**Data shape:** Each row is `ProviderData = { provider, inventory, permissions }` — the Provider CR is joined with its matching inventory entry via `findInventoryByID`.
+
+**Column definitions:** `src/providers/list/utils/providerFields.ts` — defines Name, Project, Status, Endpoint, Type, VMs, Networks, Hosts, Clusters, Storage, and Actions columns. Filterable by freetext and enum (Status, Type with source/target groups).
+
+### 2. Create Page (`src/providers/create/ProvidersCreatePage.tsx`)
+
+```
+ProvidersCreateFormPage
+├── LearningExperienceDrawer
+│   ├── Title "Create provider"
+│   └── CreateProviderForm
+│       ├── FormProvider (react-hook-form)
+│       │   └── CreateProviderFormContextProvider  (provides existing provider names for uniqueness validation)
+│       │       └── ProviderTypeFields             (conditional field rendering per provider type)
+│       │           ├── ProviderProjectField
+│       │           ├── ProviderTypeField
+│       │           ├── ProviderNameField
+│       │           └── <type-specific fields>
+│       ├── Create button
+│       └── Cancel button
+```
+
+**Data sources:**
+- `useK8sWatchProviderNames({ namespace })` via `CreateProviderFormContextProvider` — fetches existing names for uniqueness validation
+- `useSearchParams` — reads `?providerType=` from URL to pre-select provider type
+
+**Create flow (in `onSubmit`):**
+1. `buildProviderResources(formData)` → builds Provider + Secret objects
+2. `createProviderSecret(provider, secret)` → `k8sCreate` the Secret
+3. `createProvider(provider, secret)` → `k8sCreate` the Provider
+4. `patchProviderSecretOwner(provider, secret)` → patches Secret with ownerRef
+5. Navigates to provider details page on success
+
+**Per-type field groups** (in `ProviderTypeFields.tsx`):
+
+| Type | Fields |
+|---|---|
+| `ec2` | Ec2RegionField, Ec2CredentialsFields, Ec2TargetSettingsFields, Ec2CrossAccountCredentialsFields |
+| `ova` | NfsDirectoryField, OvaApplianceManagementField |
+| `openshift` | OpenShiftUrlField, ServiceAccountTokenField, CertificateValidationField |
+| `openstack` | OpenStackUrlField, OpenStackAuthenticationTypeField (5 auth strategies), CertificateValidationField |
+| `ovirt` | OvirtUrlField, OvirtCredentialsFields, CertificateValidationField |
+| `vsphere` | VsphereEndpointTypeField, VsphereUrlField, VsphereVddkField, VsphereCredentialsFields, CertificateValidationField |
+| `hyperv` | HypervTransferMethodField, HypervCredentialsFields, CertificateValidationField |
+
+**Provider type constant:** `PROVIDER_TYPES` in `src/providers/utils/constants.ts` — `ec2`, `hyperv`, `openshift`, `openstack`, `ova`, `ovirt`, `vsphere`.
+
+### 3. Details Page — Dispatch Layer
+
+```
+ProviderDetailsPage                             (src/providers/details/ProviderDetailsPage.tsx)
+├── useK8sWatchResource<V1beta1Provider>        (single provider)
+├── LoadingSuspend / ErrorState
+└── ProviderDetailsPageByType                   (switch on provider.spec.type)
+    ├── OpenshiftProviderDetailsPage
+    ├── VSphereProviderDetailsPage
+    ├── OVirtProviderDetailsPage
+    ├── OpenStackProviderDetailsPage
+    ├── OvaProviderDetailsPage
+    ├── HypervProviderDetailsPage
+    └── Ec2ProviderDetailsPage
+```
+
+Each per-type details page follows the same pattern:
+
+```
+<Type>ProviderDetailsPage (memo'd)
+├── ProviderPageHeader
+│   ├── PageHeadings (shared)
+│   ├── CreatePlanAction       → navigates to Plan create with ?sourceProvider=&planProject=
+│   ├── LearningExperienceButton
+│   └── ProviderActionsDropdown
+├── HorizontalNav (Console SDK)
+│   ├── Details tab
+│   ├── YAML tab
+│   ├── Credentials tab       (not on ova)
+│   ├── Virtual machines tab
+│   ├── ESXi hosts tab        (vsphere only)
+│   └── Networks tab          (openshift only)
+```
+
+### 4. Tabs per Provider Type
+
+| Tab | openshift | vsphere | ovirt | openstack | ova | hyperv | ec2 |
+|---|---|---|---|---|---|---|---|
+| Details | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| YAML | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Credentials | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ |
+| Virtual machines | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ESXi hosts | — | ✓ | — | — | — | — | — |
+| Networks | ✓ | — | — | — | — | — | — |
+
+---
+
+## Tab Page Details
+
+### Details Tab (`tabs/Details/ProviderDetailsTabPage.tsx`)
+
+```
+ProviderDetailsTabPage
+├── DetailsSection            → dispatches to <Type>DetailsSection via getDetailsSectionByType()
+├── UploadFilesSection        → OVA-only file upload
+├── SecretsSection            → shows linked Secret ref
+├── InventorySection          → dispatches to <Type>InventorySection via getInventorySectionByType()
+└── ConditionsSection         → renders provider.status.conditions
+```
+
+**Data:** `useProvider(name, namespace)`, `useProviderInventory<ProviderInventory>`, `useGetDeleteAndEditAccessReview`
+
+Per-type details sections: `OpenshiftDetailsSection`, `VSphereDetailsSection`, `OvirtDetailsSection`, `OpenstackDetailsSection`, `OVADetailsSection`, `HyperVDetailsSection`, `Ec2DetailsSection`
+
+Per-type inventory sections: `VSphereInventorySection`, `OvirtInventorySection`, `OpenstackInventorySection`, `Ec2InventorySection`
+
+### YAML Tab (`tabs/YAML/ProviderYAMLTabPage.tsx`)
+
+Wraps Console SDK `ResourceYAMLEditor` with `ResourceYAMLEditorWrapper`. Fetches provider via `useProvider`.
+
+### Credentials Tab (`tabs/Credentials/ProviderCredentialsTabPage.tsx`)
+
+```
+ProviderCredentialsTabPage
+├── useProvider + useK8sWatchResource<Secret>   (watches the provider's linked Secret)
+├── useAccessReview (patch on Secret)
+├── SectionHeadingWithEdit → launches EditProviderCredentials modal
+├── Reveal/Hide toggle
+└── CredentialsSection → CredentialFieldsByType → per-type field rendering
+```
+
+### Virtual Machines Tab (`tabs/VirtualMachines/ProviderVirtualMachinesTabPage.tsx`)
+
+```
+ProviderVirtualMachinesTabPage
+├── useProvider + useInventoryVms({ provider })
+└── VirtualMachinesListSection                  (switch on provider type)
+    ├── OpenShiftVirtualMachinesList
+    ├── VSphereVirtualMachinesList
+    ├── OVirtVirtualMachinesList
+    ├── OpenStackVirtualMachinesList
+    ├── OvaVirtualMachinesList
+    ├── HypervVirtualMachinesList
+    └── Ec2VirtualMachinesList
+```
+
+Each VM list uses `ProviderVirtualMachinesList` (a shared sub-component wrapping `StandardPage`) with type-specific columns and row components.
+
+### Hosts Tab (`tabs/Hosts/ProviderHostsTabPage.tsx`) — vSphere only
+
+Renders `VSphereHostsList` when `provider.spec.type === 'vsphere'`, otherwise `null`.
+
+### Networks Tab (`tabs/Networks/ProviderNetworksTabPage.tsx`) — OpenShift only
+
+Uses `useProviderInventory` with `subPath: 'networkattachmentdefinitions?detail=4'`. Shows a table of NADs. Supports setting a default transfer network via `EditProviderDefaultTransferNetwork` modal.
+
+---
+
+## Actions (`src/providers/actions/`)
+
+`ProviderActionsDropdown` renders a kebab (list) or "Actions" button (details page) containing `ProviderActionsDropdownItems`:
+
+| Action | Behavior |
+|---|---|
+| **Edit** / **Edit YAML** | Navigates to details page (list) or YAML tab (details) |
+| **Edit provider credentials** | Navigates to `/credentials` tab (hidden for `ova`) |
+| **Delete provider** | Opens `DeleteModal` (shared component) via `useModal` |
+
+---
+
+## Modals (`src/providers/modals/`)
+
+### EditProviderURLModal
+Dispatches to per-type URL edit modals (`OvirtEditURLModal`, `OpenshiftEditURLModal`, `OpenstackEditURLModal`, `VSphereEditURLModal`). Used from details sections.
+
+### EditProviderUIModal
+Dispatches to per-type UI link edit modals (`OpenshiftEditUIModal`, `OvirtEditUIModal`, `OpenstackEditUIModal`, `VSphereEditUIModal`). Edits `forklift.konveyor.io/providerUI` annotation.
+
+### EditProviderDefaultTransferNetwork
+OpenShift-only. Patches `forklift.konveyor.io/defaultTransferNetwork` annotation. Uses shared `ModalForm`, `k8sPatch`, and `NetworkDropdown`.
+
+---
+
+## Shared Component Usage
+
+| Shared component | Where used |
+|---|---|
+| `StandardPage` (`@components/page/StandardPage`) | List page, VM lists |
+| `LoadingSuspend` (`@components/LoadingSuspend`) | Details page, Credentials tab |
+| `PageHeadings` (`@components/DetailPageHeadings/PageHeadings`) | Provider page header |
+| `SectionHeading` / `SectionHeadingWithEdit` | All details tab sections |
+| `ModalForm` (`@components/ModalForm/ModalForm`) | Transfer network modal, credentials edit |
+| `DeleteModal` (`@components/modals/DeleteModal`) | Provider delete action |
+| `ResourceYAMLEditorWrapper` | YAML tab |
+| `FormGroupWithHelpText` | Modals |
+| `ErrorState` / `LoadingSuspend` | Error/loading states |
+| `LearningExperienceDrawer` / `LearningExperienceButton` | List page, Create page, Details header |
+
+---
+
+## Data Sources Summary
+
+| Hook / Call | Source | Used in |
+|---|---|---|
+| `useK8sWatchResource<V1beta1Provider[]>` | Console SDK (k8s watch) | List page |
+| `useK8sWatchResource<V1beta1Provider>` | Console SDK (k8s watch) | Details dispatch page |
+| `useProvider(name, namespace)` | Re-exported from `@utils/hooks/useProvider` | All detail tabs, header |
+| `useProvidersInventoryList(namespace)` | Polls `/providers?detail=1` every 20s | List page |
+| `useProviderInventory<T>({ provider, subPath? })` | Shared hook | Details tab, Networks tab, Header |
+| `useInventoryVms({ provider })` | Shared hook | VMs tab |
+| `useK8sWatchResource<Secret>` | Console SDK | Credentials tab |
+| `useGetDeleteAndEditAccessReview` | Custom RBAC hook | List page, Details tab, Hosts tab, Header |
+| `useAccessReview` | Console SDK | Credentials tab (Secret patch) |
+| `useK8sWatchProviderNames` | Custom hook | Create form context |
+| `useClusterIsAwsPlatform` | Custom hook | CreatePlanAction (gate EC2) |
+
+---
+
+## Cross-Feature Connections
+
+- **Plans:** `CreatePlanAction` in provider details header navigates to Plan create page with `?sourceProvider=&planProject=` query params. The Plans feature reads these params to pre-fill the source provider.
+- **Plans (delete guard):** When deleting a provider, downstream Plans referencing it may become invalid. The `DeleteModal` handles this generically.
+- **Overview:** The overview dashboard queries provider counts and status. Changes to provider status fields can affect overview cards.
+- **NetworkMap / StorageMap:** Mappings reference providers. Provider inventory (networks, storage) feeds the mapping create forms.
+- **Telemetry:** Create flow fires `PROVIDER_CREATE_STARTED`, `PROVIDER_CREATE_COMPLETED`, `PROVIDER_CREATE_FAILED` events. "Create migration plan" fires `PLAN_CREATE_FROM_PROVIDER_CLICKED`.
+
+---
+
+## Key Types and Constants
+
+- **`ProviderData`** (`src/providers/utils/types/ProviderData.ts`): `{ provider, inventory, permissions, vmData?, vmDataLoading? }` — the universal data bag passed through provider components
+- **`PROVIDER_TYPES`** (`src/providers/utils/constants.ts`): `ec2 | hyperv | openshift | openstack | ova | ovirt | vsphere`
+- **`ProviderTypes`** (type): `(typeof PROVIDER_TYPES)[keyof typeof PROVIDER_TYPES]`
+- **`isTechPreviewProvider(type)`**: returns `true` for `ec2` and `hyperv`
+- **`ProvidersResourceFieldId`** (enum): column IDs for the list page
+- **`ProviderDetailsPageProps`**: `{ name: string; namespace: string }` — shared prop type for all tabs
+
+---
+
+## Blast Radius Notes
+
+### Adding a new provider type
+1. Add to `PROVIDER_TYPES` in `src/providers/utils/constants.ts`
+2. Add a `<Type>ProviderDetailsPage` in `src/providers/details/` with tab configuration
+3. Add case to `ProviderDetailsPageByType` switch
+4. Add create form fields in `src/providers/create/fields/<type>/`
+5. Add case to `ProviderTypeFields.tsx`
+6. Add `<Type>DetailsSection` and `<Type>InventorySection` in details tab components
+7. Add `<Type>VirtualMachinesList` and row component in `tabs/VirtualMachines/`
+8. Add case to `VirtualMachinesListSection` switch
+9. Add URL/UI modal variants if applicable in `src/providers/modals/`
+10. Add credential fields in `tabs/Credentials/components/CredentialFieldsByType.tsx`
+11. Update `buildProviderResources`, `getDefaultFormValues`, and `createProviderSecret` utils
+12. Consider tech preview gating (`isTechPreviewProvider`) and platform gating (`useClusterIsAwsPlatform`)
+
+### Adding a new details tab
+1. Create tab page component in `src/providers/details/tabs/<TabName>/`
+2. Add to `tabPages` array in each per-type details page that needs it
+3. If provider-type-specific, add only to relevant `<Type>ProviderDetailsPage.tsx` files
+
+### Changing provider actions
+1. Edit `ProviderActionsDropdownItems.tsx` — single file for all action items
+2. If adding a modal action, use `useModal` launcher from Console SDK
+
+### Modifying list columns
+1. Edit `src/providers/list/utils/providerFields.ts` for field definitions
+2. Edit `src/providers/list/components/ProviderDataCell.tsx` for cell rendering
+
+### Changing create form validation
+1. Per-field validation lives in each field component under `src/providers/create/fields/`
+2. Cross-field validation uses `react-hook-form` `validate` with `getValues()`
+3. Provider name uniqueness checked via `CreateProviderFormContextProvider`
+
+---
+
+## File Index
+
+```
+src/providers/
+├── dynamic-plugin.ts                 # Extension registration
+├── actions/
+│   ├── ProviderActionsDropdown.tsx    # Dropdown shell (kebab / "Actions" button)
+│   └── ProviderActionsDropdownItems.tsx # Edit, Edit Credentials, Delete
+├── create/
+│   ├── ProvidersCreatePage.tsx        # Page wrapper
+│   ├── CreateProviderForm.tsx         # Form with react-hook-form, submit logic
+│   ├── CreateProviderFormContextProvider.tsx # Provider names context
+│   ├── ProviderTypeFields.tsx         # Conditional field rendering per type
+│   ├── fields/                        # Per-type and shared form fields
+│   │   ├── ec2/
+│   │   ├── hyperv/
+│   │   ├── openshift/
+│   │   ├── openstack/credentials/    # 5 auth type variants
+│   │   ├── ova/
+│   │   ├── ovirt/
+│   │   └── vsphere/
+│   └── utils/                         # buildProviderResources, createProvider, etc.
+├── details/
+│   ├── ProviderDetailsPage.tsx        # Dispatch: loads provider → ProviderDetailsPageByType
+│   ├── ProviderDetailsPageByType.tsx  # Switch on type → per-type details page
+│   ├── ProviderPageHeader.tsx         # Shared header with actions
+│   ├── <Type>ProviderDetailsPage.tsx  # 7 files, one per provider type (tab config)
+│   ├── hooks/useProvider.ts           # Re-export of @utils/hooks/useProvider
+│   ├── components/
+│   │   ├── CreatePlanAction.tsx        # "Create migration plan" button → Plan create
+│   │   └── ProviderPageHeaderAlerts.tsx
+│   └── tabs/
+│       ├── Details/                    # DetailsSection, InventorySection, ConditionsSection
+│       ├── YAML/                       # ResourceYAMLEditor wrapper
+│       ├── Credentials/                # Secret viewer/editor with per-type fields
+│       ├── VirtualMachines/            # Per-type VM lists + shared list shell
+│       ├── Hosts/                      # vSphere ESXi hosts only
+│       └── Networks/                   # OpenShift NADs + default transfer network
+├── list/
+│   ├── ProvidersListPage.tsx          # StandardPage composition
+│   ├── components/
+│   │   ├── ProviderRow.tsx
+│   │   ├── ProviderDataCell.tsx
+│   │   ├── ProvidersAddButton.tsx
+│   │   ├── ProvidersEmptyState.tsx
+│   │   └── InventoryNotReachable.tsx
+│   ├── hooks/
+│   │   └── useProvidersInventoryList.ts # Inventory polling
+│   └── utils/
+│       ├── providerFields.ts          # Column definitions
+│       └── findInventoryByID.ts
+├── modals/
+│   ├── EditProviderURL/               # URL edit (4 provider variants)
+│   ├── EditProviderUI/                # UI link edit (4 provider variants)
+│   └── EditProviderDefaultTransferNetwork/ # OpenShift-only transfer network
+├── hooks/
+│   └── useK8sWatchProviderNames.ts
+└── utils/
+    ├── constants.ts                   # PROVIDER_TYPES, enums, annotations
+    ├── getProviderDetailsPageUrl.ts
+    ├── types/
+    │   ├── ProviderData.ts
+    │   └── ProvidersPermissionStatus.ts
+    ├── helpers/
+    │   ├── getApiUrl.ts
+    │   ├── getIsTarget.ts
+    │   ├── getIsManaged.ts
+    │   ├── getEc2Url.ts
+    │   ├── isHypervIscsiProvider.ts
+    │   └── hasObjectChangedInGivenFields.ts
+    └── validators/provider/           # URL + UI link validators per type
+```

--- a/.cursor/rules/frontend/shared-components.mdc
+++ b/.cursor/rules/frontend/shared-components.mdc
@@ -1,0 +1,241 @@
+---
+description: Shared components catalog with "used by" index across all feature directories
+alwaysApply: false
+---
+
+# Shared Components Architecture (`src/components/`)
+
+> Analyzed on 2026-05-29
+
+~280 TS/TSX files. **409 importing files** across features.
+
+## Component Catalog
+
+### Page Layout & List Infrastructure
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `StandardPage` | `page/StandardPage.tsx` | Full list page: filters, sort, pagination, optional selection |
+| `StandardPageWithSelection` | `page/StandardPageWithSelection.tsx` | StandardPage + enforced selection/expand props |
+| `WizardStepContainer` | `common/WizardStepContainer.tsx` | Plan create wizard step wrapper |
+| `RoutedTabs` | `common/RoutedTabs/RoutedTabs.tsx` | URL-synced tab navigation |
+| `PageHeadings` | `DetailPageHeadings/PageHeadings.tsx` | Detail page title/breadcrumbs/actions |
+| `SectionHeading` | `headers/SectionHeading.tsx` | Section title in detail views |
+| `SectionHeadingWithEdit` | `headers/SectionHeadingWithEdit.tsx` | Section title + edit button |
+| `ExpandableSectionHeading` | `ExpandableSectionHeading/` | Collapsible section header |
+| `ExpandableReviewSection` | `ExpandableReviewSection/` | Plan wizard review accordion |
+| `DrawerProvider` | `DrawerContext/DrawerProvider.tsx` | Side drawer context |
+
+### Tables & List Cells
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `TableView` | `common/TableView/TableView.tsx` | Sortable PF table with stable row keys |
+| `TableCell` | `TableCell/TableCell.tsx` | Generic cell |
+| `TableLinkCell` | `TableCell/TableLinkCell.tsx` | Link cell |
+| `TableLabelCell` | `TableCell/TableLabelCell.tsx` | Label/badge cell |
+| `TableIconCell` | `TableCell/TableIconCell.tsx` | Icon + text cell |
+| `TableEmptyCell` | `TableCell/TableEmptyCell.tsx` | Empty placeholder |
+| `VisibleTableData` | `TableCell/VisibleTableData.tsx` | Renders visible columns for a row |
+| `TableBulkSelect` | `TableBulkSelect.tsx` | Header checkbox for bulk select |
+| `TableSortContextProvider` | `TableSortContextProvider.tsx` | Sort state provider |
+| `FieldBuilderTable` | `FieldBuilderTable/FieldBuilderTable.tsx` | Dynamic mapping rows (add/remove) |
+| `VsphereFolderTreeTable` | `VsphereFoldersTable/` | vSphere VM folder tree table |
+| `createStatusCell` | `table/utils/createStatusCell.tsx` | Factory for status column cells |
+
+### Filters
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `FilterGroup` | `common/FilterGroup/FilterGroup.tsx` | Multi-filter toolbar |
+| `AttributeValueFilter` | `common/FilterGroup/AttributeValueFilter.tsx` | Filter chip UI |
+| `useUrlFilters` | `common/FilterGroup/useUrlFilters.ts` | Sync filters to URL |
+| `SwitchFilter` | `common/Filter/SwitchFilter.tsx` | Boolean toggle filter |
+
+### Forms & Inputs
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `Select` (custom) | `common/Select.tsx` | Project-standard PF Select wrapper |
+| `FilterableSelect` | `FilterableSelect/FilterableSelect.tsx` | Searchable/creatable select |
+| `TypeaheadSelect` | `common/TypeaheadSelect/TypeaheadSelect.tsx` | Typeahead dropdown |
+| `ProjectSelect` | `common/ProjectSelect/ProjectSelect.tsx` | Namespace/project picker |
+| `ProviderSelect` | `ProviderSelect/ProviderSelect.tsx` | Provider dropdown with icons |
+| `FormGroupWithHelpText` | `common/FormGroupWithHelpText/` | PF FormGroup + helper/error text |
+| `FormGroupWithErrorText` | `common/FormGroupWithErrorText.tsx` | Form group wired to RHF errors |
+| `FormErrorHelperText` | `FormErrorHelperText.tsx` | Standalone form error text |
+| `HelpIconPopover` | `common/HelpIconPopover/` | `?` icon with popover help |
+| `InputList` | `InputList/InputList.tsx` | Dynamic list of inputs |
+| `TargetNetworkField` | `mappings/network-mappings/TargetNetworkField.tsx` | Network map target network |
+| `SourceNetworkField` | `mappings/network-mappings/SourceNetworkField.tsx` | Source network field |
+
+### Modals & Confirmations
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `ModalForm` | `ModalForm/ModalForm.tsx` | Standard edit modal (loading, errors, confirm) |
+| `TextInputEditModal` | `ModalForm/TextInputEditModal.tsx` | Single-field text edit modal |
+| Patch constants (`ADD`, `REPLACE`, `REMOVE`) | `ModalForm/utils/constants.ts` | JSON patch ops |
+| `DeleteModal` | `modals/DeleteModal/DeleteModal.tsx` | Generic K8s delete modal |
+| `CreateProjectModal` | `modals/CreateProjectModal.tsx` | Create namespace/project |
+| `AlertMessageForModals` | `modals/AlertMessageForModals.tsx` | Warning alert in modals |
+| `ItemIsOwnedAlert` | `modals/ItemIsOwnedAlert.tsx` | Owner reference warning |
+
+### Loading & Status
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `LoadingSuspend` | `LoadingSuspend.tsx` | Spinner until obj loaded without error |
+| `Loading` | `Loading/Loading.tsx` | Simple loading indicator |
+| `StatusIcon` | `status/StatusIcon.tsx` | Condition status icon |
+| `ConsoleTimestamp` | `ConsoleTimestamp/ConsoleTimestamp.tsx` | Console-style relative time |
+| `ProviderIconLink` | `ProviderIconLink.tsx` | Provider icon + link |
+
+### Detail Display
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `DetailsItem` | `DetailItems/DetailItem.tsx` | Description list item with edit/help |
+| `NameDetailItem`, `NamespaceDetailItem`, etc. | `DetailItems/` | Prebuilt detail rows |
+| `CreatedAtDetailItem` | `DetailItems/CreatedAtDetailItem.tsx` | Timestamp detail |
+| `OwnerDetailItem` | `DetailItems/` | Owner refs display |
+| `ConditionsSection` | `ConditionsSection/ConditionsSection.tsx` | Conditions table for CRs |
+| `MapProvidersDetails` / `MapProvidersEdit` | `MapProvidersDetails/` | Map provider summary + edit |
+| `ResourceYAMLEditorWrapper` | `ResourceYAMLEditorWrapper/` | YAML tab for resources |
+| `ExternalLink` | `common/ExternalLink/` | Doc/external links |
+
+### Domain-specific
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| `VirtualMachineConcernsCell` | `Concerns/` | VM concerns in tables |
+| `ConcernsAndConditionsTable` | `ConcernsAndConditionsTable/` | Concerns/conditions panel |
+| `InspectVirtualMachines*` | `InspectVirtualMachines/` | Deep inspection UI |
+| `AffinityModal` | `AffinityModal/` | VM affinity rules editor |
+| `NodeSelectorModal` | `NodeSelectorModal/` | Node selector editor |
+| `LabelsModal` | `LabelsModal/` | Edit K8s labels |
+| `OvaFileUploader` | `OvaFileUploader/` | OVA file upload |
+| `VddkUploader` | `VddkUploader/` | VDDK image upload |
+| `TechPreviewLabel` | `PreviewLabels/TechPreviewLabel.tsx` | Tech preview badge |
+
+## "Used By" Index
+
+### Tier 1 — All 5 features
+
+| Component | providers | plans | networkMaps | storageMaps | overview |
+|-----------|:---------:|:-----:|:-----------:|:-----------:|:--------:|
+| **ModalForm** (+ patch constants) | ✓ (21) | ✓ (51) | ✓ | ✓ | ✓ |
+| **LoadingSuspend** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **ResourceYAMLEditorWrapper** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **ResourceField types** | ✓ (24) | ✓ (10) | ✓ | ✓ | ✓ |
+| **StandardPage** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **TableView** (+ types/RowProps) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **TableCell** family | ✓ (24) | ✓ (12) | ✓ | ✓ | ✓ |
+| **DetailItems** | ✓ (31) | ✓ (30) | ✓ | ✓ | ✓ |
+| **FilterGroup** (+ matchers) | ✓ (18) | ✓ | ✓ | ✓ | ✓ |
+| **headers** (SectionHeading*) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **HelpIconPopover** | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+### Tier 2 — 4 features
+
+| Component | providers | plans | networkMaps | storageMaps | overview |
+|-----------|:---------:|:-----:|:-----------:|:-----------:|:--------:|
+| **PageHeadings** | ✓ | ✓ | ✓ | ✓ | — |
+| **Page/userSettings** | ✓ | ✓ | ✓ | ✓ | — |
+| **DeleteModal** | ✓ | ✓ | ✓ | ✓ | — |
+| **common/Select** | ✓ | ✓ | ✓ | ✓ | — |
+| **FormGroupWithErrorText** | ✓ | ✓ | ✓ | ✓ | — |
+| **ExternalLink** | ✓ | ✓ | ✓ | ✓ | — |
+
+### Tier 3 — 3 features
+
+| Component | Key consumers |
+|-----------|--------------|
+| **FieldBuilderTable** | plans, networkMaps, storageMaps |
+| **ProviderSelect** | plans, networkMaps, storageMaps |
+| **MapProvidersDetails/Edit** | networkMaps, storageMaps (+ plans indirectly) |
+| **ConditionsSection** | networkMaps, storageMaps, overview |
+| **FormGroupWithHelpText** | providers, plans, overview |
+| **ConsoleTimestamp** | providers, plans, overview |
+| **createStatusCell** | providers, networkMaps, storageMaps |
+
+### Tier 4 — 2 features
+
+| Component | Consumers |
+|-----------|-----------|
+| **StandardPageWithSelection** | providers, plans |
+| **FilterableSelect** | providers, plans |
+| **TableSortContextProvider** | providers, plans |
+| **Concerns***, **ConcernsAndConditionsTable** | providers, plans |
+| **ProviderIconLink** | providers, plans |
+| **TechPreviewLabel** | providers, plans |
+| **mappings/network-mappings** | plans, networkMaps |
+| **StatusIcon** | plans, overview |
+| **SmartLinkify** | providers, networkMaps |
+| **SwitchFilter** | overview, providers |
+
+### Tier 5 — Single feature
+
+| Component | Consumer |
+|-----------|----------|
+| **WizardStepContainer**, **ExpandableReviewSection** | plans only |
+| **DrawerProvider**, **InspectVirtualMachines** | plans only |
+| **AffinityModal**, **NodeSelectorModal**, **LabelsModal** | plans only |
+| **InputList** | plans only |
+| **VsphereFolderTreeTable** | providers only |
+| **OvaFileUploader**, **VddkUploader** | providers only |
+| **RoutedTabs**, **LightspeedMcpWarning** | overview only |
+
+## Component Dependency Graph (internal)
+
+```
+StandardPage → StandardPageInner → PageToolbar + PageTable
+PageToolbar → FilterGroup + TableBulkSelect
+PageTable → TableView
+StandardPageWithSelection → StandardPage + DefaultRow/withTr
+ProviderSelect → common/Select + ExternalLink
+ProjectSelect → TypeaheadSelect + CreateProjectModal
+VsphereFolderTreeTable → Concerns + TableView + FilterGroup
+InspectVirtualMachines → Concerns + StandardPageWithSelection
+```
+
+### Key external library dependencies
+- **@patternfly/react-core** — Modal, Form, Alert, EmptyState, Select (FilterableSelect)
+- **@patternfly/react-table** — TableView, FieldBuilderTable, tree tables
+- **@openshift-console/dynamic-plugin-sdk** — `useK8sWatchResource`, `k8s*` operations, modals
+- **react-hook-form** — Form fields, FieldBuilderTable, feature forms
+- **react-router-dom-v5-compat** — DeleteModal navigate, RoutedTabs
+
+## Blast Radius Summary
+
+### Critical (change breaks most of the app)
+
+1. **`ModalForm`** — 75 importing files across all 5 features. Every edit modal.
+2. **`ResourceField` / filter types** — 41 files; columns, filters, sort for every list page.
+3. **`StandardPage` + `FilterGroup` + `TableView` stack** — all list pages.
+4. **`DetailsItem`** — 64 files; universal detail-tab layout.
+5. **`TableCell` primitives** — 45 files; all `*Row.tsx` list components.
+
+### High (major feature areas)
+
+6. **`common/Select`** — 20 files; all dropdowns in create flows and settings.
+7. **`FormGroupWithHelpText` / `FormGroupWithErrorText`** — form validation UX.
+8. **`LoadingSuspend`** — 17 files; loading guards on detail tabs.
+
+### Medium (scoped but deep)
+
+9. **`ProviderSelect`** — maps + plan create; ties to inventory and analytics.
+10. **`FieldBuilderTable`** — network/storage map editors + plan mapping steps.
+11. **`InspectVirtualMachines` / `VsphereFolderTreeTable` / `AffinityModal`** — plans-only or providers-only but large UX surfaces.
+12. **`DeleteModal`** — delete actions on providers, plans, maps.
+
+### Low blast radius
+- `LightspeedMcpWarning`, `RoutedTabs` — overview only
+- `images/logos` — visual only
+- `BreadCrumb`, empty-states — limited imports
+
+## Practical Notes
+
+- Import paths are mixed (`@components/...`, `src/components/...`, `../../components/...`) — grep all three when assessing impact
+- New modals should extend `ModalForm`; new dropdowns should use `common/Select`; new list pages should compose `StandardPage` + `ResourceField[]`
+- Feature code should use `@components/common/Select`, not PatternFly Select directly

--- a/.cursor/skills/frontend-analyzer/SKILL.md
+++ b/.cursor/skills/frontend-analyzer/SKILL.md
@@ -1,0 +1,89 @@
+# Frontend Analyzer Skill
+
+Invoke with: *"analyze frontend"*, *"refresh frontend knowledge"*, *"update frontend architect"*, *"scrape frontend pages"*
+
+## Purpose
+
+Systematically analyze the Forklift Console Plugin frontend codebase (`src/`) and generate structured knowledge files as `.mdc` Cursor rules under `.cursor/rules/frontend/`.
+
+These knowledge files power the Frontend Architect agent (`architect.mdc`) by providing page-level composition maps, shared component usage indexes, and cross-feature connection graphs.
+
+## Configuration
+
+- **Source directory**: `src/` (this repo)
+- **Output directory**: `.cursor/rules/frontend/`
+- **State file**: `.cursor/skills/frontend-analyzer/state.json`
+
+## Modes
+
+### Full Analysis (first run or forced refresh)
+
+Run all 5 analysis agents in parallel:
+
+| Agent | Output file | Source paths |
+|-------|-------------|--------------|
+| Providers | `frontend/providers.mdc` | `src/providers/` |
+| Plans | `frontend/plans.mdc` | `src/plans/` |
+| Mappings | `frontend/mappings.mdc` | `src/networkMaps/`, `src/storageMaps/` |
+| Overview | `frontend/overview.mdc` | `src/overview/` |
+| Shared Components | `frontend/shared-components.mdc` | `src/components/`, cross-feature grep |
+
+### Incremental Refresh
+
+1. Read `state.json` for `lastAnalyzedDate`
+2. Run `git diff --name-only --since=<lastDate> -- src/` to find changed files
+3. Map changed files to knowledge areas using the domain mapping below
+4. Re-run analysis only for affected areas
+5. Update `state.json`
+
+## Domain-to-Path Mapping
+
+| Knowledge file | Source paths |
+|----------------|-------------|
+| `providers.mdc` | `src/providers/` |
+| `plans.mdc` | `src/plans/` |
+| `mappings.mdc` | `src/networkMaps/`, `src/storageMaps/` |
+| `overview.mdc` | `src/overview/` |
+| `shared-components.mdc` | `src/components/`, then grep across all feature dirs |
+
+## Analysis Template
+
+Each agent MUST follow this template:
+
+```markdown
+---
+description: <one-line description for Cursor rule matching>
+alwaysApply: false
+---
+
+# <Feature Title> - Page Composition
+
+> Analyzed on <date>
+
+## Page Composition
+
+<Component trees per page, 1-2 levels deep. Include route entry point.>
+
+## Shared Component Usage
+
+<Which src/components/* are used on these pages>
+
+## Data Sources
+
+<K8s watches, hooks, context providers>
+
+## Cross-Feature Connections
+
+<How this feature connects to others -- imports, navigation, shared data>
+
+## Blast Radius Notes
+
+<What else is affected when changing components here>
+```
+
+## Post-Analysis
+
+After all agents complete:
+1. Update `state.json` with new date
+2. Verify all 5 files exist and are under 400 lines
+3. Spot-check cross-references between files for consistency


### PR DESCRIPTION
## Links

- [MTV-5647](https://redhat.atlassian.net/browse/MTV-5647)

## Description

Adds a Frontend Architect agent persona and frontend knowledge files for the Forklift Console Plugin.

**Architect persona** (`.cursor/rules/agents/architect.mdc`):
- Blast radius analysis for any code change
- Component tree mapping and cross-feature dependency tracing
- Knowledge routing table to load relevant feature files

**Frontend knowledge files** (`.cursor/rules/frontend/`):
- `providers.mdc`, `plans.mdc`, `mappings.mdc`, `overview.mdc`, `shared-components.mdc`

## CC://

Made with Cursor

Made with [Cursor](https://cursor.com)

[MTV-5647]: https://redhat.atlassian.net/browse/MTV-5647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal architecture documentation for frontend systems, including feature specifications, component catalogs, and integration mappings.
  * Enhanced development knowledge bases and implementation guidelines to standardize practices across teams.
  * Introduced automated development assistance documentation and workflow specifications to improve efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->