### PR TITLE
fix(e2e): stabilize global setup, auth state, i18n leakage, and PF v6 selector fixes

### DIFF
--- a/testing/playwright.config.ts
+++ b/testing/playwright.config.ts
@@ -5,10 +5,17 @@ import { defineConfig, devices } from '@playwright/test';
 const authFile = 'playwright/.auth/user.json';
 
 const ENV_RELAY_FILE = 'playwright/.env-relay.json';
+
+// Capture keys explicitly set by the user (shell / e2e.env) *before* the relay is loaded.
+// global.setup.ts reads this list to decide whether a version was user-set vs stale-relay.
+process.env.PLAYWRIGHT_USER_SET_KEYS = Object.keys(process.env).join(',');
+
 if (existsSync(ENV_RELAY_FILE)) {
   const relay = JSON.parse(readFileSync(ENV_RELAY_FILE, 'utf8')) as Record<string, string>;
   for (const [key, value] of Object.entries(relay)) {
-    if (value !== '') {
+    // ??= semantics: shell / e2e.env values take priority over relay.
+    // This prevents a stale relay from overwriting what the user explicitly exported.
+    if (value !== '' && !process.env[key]) {
       process.env[key] = value;
     }
   }

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -59,7 +59,10 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
     // Wait for console SPA to initialize its auth token before patching the ConfigMap.
     // domcontentloaded fires for the HTML shell; the auth token is loaded asynchronously.
     // Waiting for networkidle gives the console time to complete auth initialization.
-    await page.waitForLoadState('networkidle');
+    // Add a catch so this never hangs forever on a very busy cluster.
+    await page.waitForLoadState('networkidle', { timeout: 60_000 }).catch(() => {
+      // networkidle may never fire on very busy clusters — proceed anyway.
+    });
     await restoreConsoleLanguage(page);
     await context.close();
   });

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -56,7 +56,10 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
     });
     const page = await context.newPage();
     await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
+    // Wait for console SPA to initialize its auth token before patching the ConfigMap.
+    // domcontentloaded fires for the HTML shell; the auth token is loaded asynchronously.
+    // Waiting for networkidle gives the console time to complete auth initialization.
+    await page.waitForLoadState('networkidle');
     await restoreConsoleLanguage(page);
     await context.close();
   });

--- a/testing/playwright/e2e/downstream/providers/provider-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/provider-deep-inspection.spec.ts
@@ -15,6 +15,7 @@ const setupProviderDetailsPage = async (
   if (!testProvider) throw new Error('testProvider is required');
   const providerDetailsPage = new ProviderDetailsPage(page);
   await providerDetailsPage.navigate(testProvider.metadata.name, testProvider.metadata.namespace);
+  await providerDetailsPage.waitForInventoryReady();
   await providerDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
   return providerDetailsPage;
 };

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -1,13 +1,23 @@
-import { existsSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 
 import { chromium, type FullConfig, type Page } from '@playwright/test';
 
+import { restoreConsoleLanguage } from './fixtures/helpers/languageHelpers';
 import { LoginPage } from './page-objects/LoginPage';
 import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
 import { CNV_VERSION_ENV_VAR, VERSION_ENV_VAR } from './utils/version/constants';
 
 const RESOURCES_FILE = 'playwright/.resources.json';
+
+/**
+ * Hardcoded auth file path — must match playwright.config.ts.
+ * Never read this from config.projects[0].use.storageState: that value is computed by
+ * existsSync() at config-evaluation time and will be `undefined` if the file was deleted
+ * (e.g. by a previous failed run). Always writing to this constant path keeps the file
+ * alive for config evaluation on the next run.
+ */
+const AUTH_FILE = 'playwright/.auth/user.json';
 
 /**
  * Playwright workers do not inherit env vars that were already set before Playwright
@@ -28,35 +38,46 @@ const ENV_KEYS_TO_RELAY = [
 ] as const;
 
 /**
+ * Keys that were present in process.env *before* playwright.config.ts loaded the relay.
+ * Used to distinguish "user explicitly set this in e2e.env / shell" from "stale relay value".
+ */
+const USER_SET_KEYS = new Set(
+  (process.env.PLAYWRIGHT_USER_SET_KEYS ?? '').split(',').filter(Boolean),
+);
+
+/**
  * Auto-detect the Forklift/MTV operator version from the cluster CSV.
- * When FORKLIFT_VERSION is already set (manual override), the pre-set value wins.
+ *
+ * Always fetches from the cluster. If the user explicitly set FORKLIFT_VERSION in e2e.env / shell,
+ * the detected value is discarded in favour of theirs (intentional override). This ensures a stale
+ * relay value is never silently carried forward across runs.
  */
 const detectForkliftVersion = async (page: Page): Promise<void> => {
-  const detectedVersion = await ResourceFetcher.fetchMtvVersion(page);
-
-  const existing = process.env[VERSION_ENV_VAR];
-  if (existing) {
-    console.error(`📌 Using pre-set Forklift version: ${existing}`);
-  } else if (detectedVersion) {
-    process.env[VERSION_ENV_VAR] = detectedVersion;
-    console.error(`🔍 Auto-detected Forklift version: ${detectedVersion}`);
-  } else {
-    console.error('⚠️ Could not auto-detect Forklift version from cluster');
+  try {
+    const detectedVersion = await ResourceFetcher.fetchMtvVersion(page);
+    if (process.env[VERSION_ENV_VAR] && USER_SET_KEYS.has(VERSION_ENV_VAR)) {
+      console.error(`📌 Using user-set Forklift version: ${process.env[VERSION_ENV_VAR]}`);
+    } else if (detectedVersion) {
+      process.env[VERSION_ENV_VAR] = detectedVersion;
+      console.error(`🔍 Auto-detected Forklift version: ${detectedVersion}`);
+    } else {
+      console.error('⚠️ Could not auto-detect Forklift version from cluster');
+    }
+  } catch (error) {
+    console.error('⚠️ Forklift version detection failed (version gating will be skipped):', error);
   }
 };
 
 /**
  * Auto-detect the CNV (OpenShift Virtualization) operator version from the cluster CSV.
- * When CNV_VERSION is already set (manual override), the pre-set value wins.
+ * When CNV_VERSION was explicitly set by the user in e2e.env / shell, respect it.
  * Unlike Forklift, CNV version is optional — tests run when it's unknown.
  */
 const detectCnvVersion = async (page: Page): Promise<void> => {
   try {
     const detectedVersion = await ResourceFetcher.fetchCnvVersion(page);
-
-    const existing = process.env[CNV_VERSION_ENV_VAR];
-    if (existing) {
-      console.error(`📌 Using pre-set CNV version: ${existing}`);
+    if (process.env[CNV_VERSION_ENV_VAR] && USER_SET_KEYS.has(CNV_VERSION_ENV_VAR)) {
+      console.error(`📌 Using user-set CNV version: ${process.env[CNV_VERSION_ENV_VAR]}`);
     } else if (detectedVersion) {
       process.env[CNV_VERSION_ENV_VAR] = detectedVersion;
       console.error(`🔍 Auto-detected CNV version: ${detectedVersion}`);
@@ -77,7 +98,7 @@ const globalSetup = async (config: FullConfig) => {
     unlinkSync(RESOURCES_FILE);
   }
 
-  const { baseURL, storageState } = config.projects[0].use;
+  const { baseURL } = config.projects[0].use;
   const username = process.env.CLUSTER_USERNAME;
   const password = process.env.CLUSTER_PASSWORD;
 
@@ -86,6 +107,8 @@ const globalSetup = async (config: FullConfig) => {
   }
 
   if (username && password) {
+    mkdirSync('playwright/.auth', { recursive: true });
+
     const browser = await chromium.launch();
     const page = await browser.newPage({ ignoreHTTPSErrors: true });
 
@@ -93,18 +116,32 @@ const globalSetup = async (config: FullConfig) => {
       console.error(`🚨 Page error: ${error.message}`);
     });
 
-    await disableGuidedTour(page);
-
     try {
       const loginPage = new LoginPage(page);
       await loginPage.login(baseURL, username, password);
 
-      await page.context().storageState({ path: storageState as string });
+      await disableGuidedTour(page);
+
+      // Wait for the console SPA to finish initialising its Kubernetes proxy session.
+      // The proxy authenticates via the session-token cookie, but that binding is
+      // completed asynchronously after the OAuth redirect.  Sending the ConfigMap
+      // PATCH before networkidle resolves causes a 403 ("system:anonymous").
+      await page.waitForLoadState('networkidle', { timeout: 60_000 }).catch(() => {
+        // networkidle may never fire on very busy clusters — proceed anyway.
+        console.error('⚠️ networkidle timed out before language restore; proceeding');
+      });
+
+      await restoreConsoleLanguage(page);
+
+      await page.context().storageState({ path: AUTH_FILE });
       console.error('✅ Authentication completed successfully');
 
       await detectForkliftVersion(page);
       await detectCnvVersion(page);
     } catch (error) {
+      const screenshotPath = 'playwright/test-results/global-setup-login-failure.png';
+      await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => undefined);
+      console.error(`📸 Login failure screenshot: ${screenshotPath} (URL: ${page.url()})`);
       console.error('❌ Login failed in global setup:', error);
       throw error;
     } finally {

--- a/testing/playwright/page-objects/CreatePlanWizard/CreatePlanWizardPage.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/CreatePlanWizardPage.ts
@@ -91,19 +91,19 @@ export class CreatePlanWizardPage {
     await this.clickNext();
   }
 
-  async clickBack() {
+  async clickBack(): Promise<void> {
     await this.page.getByTestId('wizard-back-button').click();
   }
 
-  async clickCreatePlan() {
+  async clickCreatePlan(): Promise<void> {
     await this.page.getByTestId('wizard-create-button').click();
   }
 
-  async clickNext() {
+  async clickNext(): Promise<void> {
     await this.page.getByTestId('wizard-next-button').click();
   }
 
-  async clickSkipToReview() {
+  async clickSkipToReview(): Promise<void> {
     await this.page.getByTestId('wizard-review-button').click();
   }
 

--- a/testing/playwright/page-objects/LoginPage.ts
+++ b/testing/playwright/page-objects/LoginPage.ts
@@ -1,8 +1,12 @@
 import type { Page } from '@playwright/test';
 
-/** Post-login console routes (default landing pages vary by cluster/version). */
+/**
+ * Post-login console routes (default landing pages vary by cluster/version).
+ * Anchored to the path portion (^[^?#]*) so OAuth query params containing
+ * "console" or similar words cannot trigger a false-positive success match.
+ */
 const POST_LOGIN_URL_PATTERN =
-  /\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)/;
+  /^[^?#]*\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)\//;
 
 const OAUTH_ACCESS_DENIED_PATTERN = /reason=access_denied/;
 
@@ -68,7 +72,13 @@ export class LoginPage {
       );
     });
 
-    if (outcome === 'access_denied' || outcome === 'invalid_credentials') {
+    if (outcome === 'access_denied') {
+      throw new Error(
+        `Login failed: OAuth access denied for user "${username}". URL: ${this.page.url()}`,
+      );
+    }
+
+    if (outcome === 'invalid_credentials') {
       throw new Error(
         `Login failed: invalid credentials for user "${username}". URL: ${this.page.url()}`,
       );

--- a/testing/playwright/page-objects/LoginPage.ts
+++ b/testing/playwright/page-objects/LoginPage.ts
@@ -1,5 +1,13 @@
 import type { Page } from '@playwright/test';
 
+/** Post-login console routes (default landing pages vary by cluster/version). */
+const POST_LOGIN_URL_PATTERN =
+  /\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)/;
+
+const OAUTH_ACCESS_DENIED_PATTERN = /reason=access_denied/;
+
+const LOGIN_ERROR_TEXT = /invalid login or password/i;
+
 export class LoginPage {
   private readonly page: Page;
 
@@ -7,7 +15,7 @@ export class LoginPage {
     this.page = page;
   }
 
-  async login(baseURL: string, username: string, password?: string) {
+  async login(baseURL: string, username: string, password?: string): Promise<void> {
     await this.page.goto(baseURL);
     await this.page.waitForSelector('#co-login-form', { timeout: 30000 });
     await this.page.fill('#inputUsername', username);
@@ -24,6 +32,46 @@ export class LoginPage {
       { timeout: 10000 },
     );
     await this.page.click('#co-login-button');
-    await this.page.waitForURL(/\/(?:dashboards|console|k8s|overview)/, { timeout: 30000 });
+
+    const loginError = this.page.getByText(LOGIN_ERROR_TEXT);
+
+    const outcome = await Promise.race([
+      this.page
+        .waitForURL(POST_LOGIN_URL_PATTERN, { timeout: 30000 })
+        .then(() => 'success' as const),
+      this.page
+        .waitForURL(OAUTH_ACCESS_DENIED_PATTERN, { timeout: 30000 })
+        .then(() => 'access_denied' as const),
+      loginError
+        .waitFor({ state: 'visible', timeout: 30000 })
+        .then(() => 'invalid_credentials' as const),
+    ]).catch(async () => {
+      const url = this.page.url();
+      const hasLoginError = await loginError.isVisible().catch(() => false);
+      const loginFormVisible = await this.page
+        .locator('#co-login-form')
+        .isVisible()
+        .catch(() => false);
+
+      throw new Error(
+        [
+          `Login timed out waiting for console redirect (30s).`,
+          `URL: ${url}`,
+          loginFormVisible
+            ? 'Login form is still visible — credentials may be wrong or OAuth flow blocked.'
+            : '',
+          hasLoginError ? 'Page shows: "Invalid login or password."' : '',
+          `Expected URL to match: ${POST_LOGIN_URL_PATTERN}`,
+        ]
+          .filter(Boolean)
+          .join(' '),
+      );
+    });
+
+    if (outcome === 'access_denied' || outcome === 'invalid_credentials') {
+      throw new Error(
+        `Login failed: invalid credentials for user "${username}". URL: ${this.page.url()}`,
+      );
+    }
   }
 }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
@@ -80,13 +80,15 @@ export class ConcernsHelpers {
   }
 
   async verifyExpandedRowHasConcernDetails(): Promise<void> {
+    // PatternFly v6 compact nested tables do not expose <Th> as columnheader in the
+    // accessibility tree when rendered inside an expandable row — use th element locator.
     for (const col of ['Issue', 'Severity', 'Description']) {
-      await expect(this.page.getByRole('columnheader', { name: col })).toBeVisible();
+      await expect(this.page.locator('th', { hasText: col })).toBeVisible();
     }
   }
 
   async verifyExpandedRowIsCollapsed(): Promise<void> {
-    await expect(this.page.getByRole('columnheader', { name: 'Issue' })).not.toBeVisible();
+    await expect(this.page.locator('th', { hasText: 'Issue' })).not.toBeVisible();
   }
 
   async verifyFilteredRowsHaveBadge(category: ConcernCategory, timeout = 60000): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
@@ -82,13 +82,19 @@ export class ConcernsHelpers {
   async verifyExpandedRowHasConcernDetails(): Promise<void> {
     // PatternFly v6 compact nested tables do not expose <Th> as columnheader in the
     // accessibility tree when rendered inside an expandable row — use th element locator.
+    // Scope to the last row in vmTable that contains a <th> (the expanded details row)
+    // so assertions cannot spuriously match headers from other tables on the page.
+    const expandedRow = this.vmTable
+      .getByRole('row')
+      .filter({ has: this.page.locator('th') })
+      .last();
     for (const col of ['Issue', 'Severity', 'Description']) {
-      await expect(this.page.locator('th', { hasText: col })).toBeVisible();
+      await expect(expandedRow.locator('th', { hasText: col })).toBeVisible();
     }
   }
 
   async verifyExpandedRowIsCollapsed(): Promise<void> {
-    await expect(this.page.locator('th', { hasText: 'Issue' })).not.toBeVisible();
+    await expect(this.vmTable.locator('th', { hasText: 'Issue' })).not.toBeVisible();
   }
 
   async verifyFilteredRowsHaveBadge(category: ConcernCategory, timeout = 60000): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
@@ -154,6 +154,7 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
   async navigateToVirtualMachinesTab(): Promise<void> {
     await this.page.locator('[data-test-id="horizontal-link-Virtual machines"]').click();
     await this.page.waitForURL((url) => url.toString().endsWith('/vms'));
+    await this.table.waitForTableLoad();
   }
 
   async openInstanceTypeDialog(vmName: string): Promise<void> {

--- a/testing/playwright/page-objects/common/Table.ts
+++ b/testing/playwright/page-objects/common/Table.ts
@@ -83,7 +83,7 @@ export class Table {
     await saveButton.click();
 
     await expect(modalBody).not.toBeVisible();
-    await this.waitForTableLoad();
+    await expect.poll(async () => this.isColumnVisible(columnName)).toBe(false);
   }
 
   async enableColumn(columnName: string): Promise<void> {
@@ -124,7 +124,7 @@ export class Table {
     await saveButton.click();
 
     await expect(modalBody).not.toBeVisible();
-    await this.waitForTableLoad();
+    await expect.poll(async () => this.isColumnVisible(columnName)).toBe(true);
   }
 
   async getCell(

--- a/testing/playwright/page-objects/common/Table.ts
+++ b/testing/playwright/page-objects/common/Table.ts
@@ -83,6 +83,7 @@ export class Table {
     await saveButton.click();
 
     await expect(modalBody).not.toBeVisible();
+    await this.waitForTableLoad();
   }
 
   async enableColumn(columnName: string): Promise<void> {
@@ -123,6 +124,7 @@ export class Table {
     await saveButton.click();
 
     await expect(modalBody).not.toBeVisible();
+    await this.waitForTableLoad();
   }
 
   async getCell(


### PR DESCRIPTION
## Summary

* **`global.setup.ts` — auth file stability** — hardcode `AUTH_FILE` to `playwright/.auth/user.json` and create the directory with `mkdirSync`. Previously the path was read from `config.projects[0].use.storageState`, which resolves to `undefined` when the file doesn't exist (e.g. after a failed run), causing every worker to land on the login page.

* **`global.setup.ts` — language restore** — call `restoreConsoleLanguage(page)` after login, behind a `networkidle` wait. Without this, an i18n test that leaves the cluster ConfigMap set to Spanish will cause all subsequent workers to run against a Spanish UI. The `networkidle` wait ensures the console SPA has finished initialising its Kubernetes proxy session before the ConfigMap PATCH is sent — sending it earlier triggers a `403 system:anonymous`.

* **`playwright.config.ts` — stale relay guard** — add `!process.env[key]` to the relay-loading loop so a stale `.env-relay.json` from a previous run can never overwrite credentials the user has just updated. Capture `PLAYWRIGHT_USER_SET_KEYS` before the relay loads so `global.setup.ts` can distinguish an explicit user override from a relay-set value and always auto-detect operator versions unless the user has intentionally pinned one.

* **`LoginPage.ts` — actionable login errors** — replace the single `waitForURL` with a `Promise.race` that immediately detects `access_denied` (wrong credentials) and `invalid_credentials` (on-page error text) outcomes, instead of waiting the full 30 s before reporting a generic timeout.

* **`i18n-smoke.spec.ts` `afterAll` — fix 403 on language restore** — change `waitForLoadState('domcontentloaded')` to `waitForLoadState('networkidle')` before calling `restoreConsoleLanguage`. `domcontentloaded` fires for the HTML shell; the console SPA completes its auth-token binding asynchronously, so the ConfigMap PATCH was arriving as `system:anonymous` and silently failing.

* **`provider-deep-inspection.spec.ts` — inventory readiness** — call `waitForInventoryReady()` in `setupProviderDetailsPage` before navigating to the VMs tab. Without this the deep-inspection tests start against an uninitialised provider and fail to find the expected buttons.

* **`ConcernsHelpers.ts` — PF v6 accessibility tree fix** — switch from `getByRole('columnheader')` to `locator('th')` for the expanded-row concern detail headers. PatternFly v6 compact nested tables do not expose `<Th>` as `columnheader` in the accessibility tree when rendered inside an expandable row.

* **`VirtualMachinesTab.ts` / `Table.ts` — table stability** — add `waitForTableLoad()` after navigating to the VMs tab and after saving column-visibility changes, so assertions run against a stable DOM rather than a still-loading table.

* **`CreatePlanWizardPage.ts`** — add explicit `Promise<void>` return types per coding standards.

## Test plan

* Re-run the full downstream suite — workers no longer land on the login page between runs.
* Run `plan-vm-concerns.spec.ts` — concern column headers in expanded rows are found correctly.
* Run `provider-deep-inspection.spec.ts` — all four deep-inspection tests pass with inventory ready before the VMs tab is used.
* Re-run after executing an i18n test — the UI language is restored to English before the next test worker starts.
* Pass wrong credentials in `e2e.env`, rerun — login failure is reported immediately with the specific reason instead of timing out after 30 s.

Resolves: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test synchronization and wait conditions across the Playwright suite to improve reliability
  * Improved environment-variable handling to avoid stale test relay values overriding explicit settings
  * Persisted test auth state to ensure stable authentication across runs
  * Wait for full network idle before restoring console language to reduce flakiness
  * Updated login detection and error handling with multiple outcome checks
  * Fixed page state synchronization for provider details and virtual machines navigation
  * Refined test assertions for improved accessibility-tree compatibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->