### PR TITLE
Resolves: MTV-5490 | Add waiting-for-build Cursor skill for automated QE transition

### DIFF
--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: waiting-for-build
-disable-model-invocation: true
 description: >-
   Query the active sprint on the Migrations & Networking Frontend Jira board for all
   MTV tickets in the "Waiting on build" column, find their merge commits in the local

--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: waiting-for-build
+disable-model-invocation: true
 description: >-
   Query the active sprint on the Migrations & Networking Frontend Jira board for all
   MTV tickets in the "Waiting on build" column, find their merge commits in the local
@@ -236,9 +237,11 @@ The script reads from `.mcp.json` → `mcpServers.jira-mcp.env`:
 
 ## Commit-search heuristic
 
-The script runs `git log --all --grep=<KEY> -i` (case-insensitive). Most commits
-follow `Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`. If a ticket
-has no match, `commit` is `null` — investigate manually with:
+The script runs `git log --all --grep=<KEY> -i` (case-insensitive), then
+post-filters results to **whole-word matches** so that e.g. `MTV-5` does not
+accidentally match `MTV-50` or `MTV-500`. Most commits follow
+`Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`.
+If a ticket has no match, `commit` is `null` — investigate manually with:
 
 ```bash
 git log --all --oneline | grep -i "keyword from summary"

--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -20,18 +20,17 @@ description: >-
 3. Checks whether each commit is an ancestor of the latest build tip hashes (fetched
    automatically from the `#mtv-builds` Slack channel via `fetch-build.py`).
 4. **Transitions all `in_build: true` tickets to `ON_QA`** in Jira (transition ID `41`).
-5. Renders an interactive canvas at
-   `~/.cursor/projects/Users-pabreu-forklift-console-plugin/canvases/waiting-for-build.canvas.tsx`.
+5. Renders an interactive canvas (`waiting-for-build.canvas.tsx`) via the canvas skill.
 
 > **Default behaviour:** transition is always performed. If the user explicitly says
 > "just check" or "don't transition", skip step 4.
 
 ## Step 0 — Get build tip hashes automatically from Slack
 
-Run `fetch-build.py` to pull the latest build's commits from the `#mtv-builds` channel:
+Run `fetch-build.py` to pull the latest build's commits from the `#mtv-builds` channel
+(from the repository root):
 
 ```bash
-cd /Users/pabreu/forklift-console-plugin
 python3 .cursor/skills/waiting-for-build/scripts/fetch-build.py
 ```
 
@@ -112,7 +111,6 @@ python3 .cursor/skills/waiting-for-build/scripts/fetch-build.py
 ## Step 1 — Run the query script
 
 ```bash
-cd /Users/pabreu/forklift-console-plugin
 python3 .cursor/skills/waiting-for-build/scripts/query.py [hash1] [hash2] ...
 ```
 
@@ -160,8 +158,12 @@ Key fields:
 For every issue where `in_build: true`, call the Jira transitions API:
 
 ```bash
+# Read credentials from .mcp.json first:
+JIRA_USERNAME=$(python3 -c "import json; d=json.load(open('.mcp.json')); print(d['mcpServers']['jira-mcp']['env']['JIRA_USERNAME'])")
+JIRA_API_TOKEN=$(python3 -c "import json; d=json.load(open('.mcp.json')); print(d['mcpServers']['jira-mcp']['env']['JIRA_API_TOKEN'])")
+
 curl -s -X POST \
-  -u "pabreu@redhat.com:$JIRA_API_TOKEN" \
+  -u "$JIRA_USERNAME:$JIRA_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"transition": {"id": "41"}}' \
   "https://redhat.atlassian.net/rest/api/3/issue/<KEY>/transitions"
@@ -171,13 +173,16 @@ curl -s -X POST \
 Or via Python (using credentials from `.mcp.json`):
 
 ```python
-import requests, base64
-creds = base64.b64encode(b"pabreu@redhat.com:<token>").decode()
+import json, requests
+from base64 import b64encode
+from pathlib import Path
+
+env = json.loads(Path(".mcp.json").read_text())["mcpServers"]["jira-mcp"]["env"]
+creds = b64encode(f"{env['JIRA_USERNAME']}:{env['JIRA_API_TOKEN']}".encode()).decode()
 requests.post(
     f"https://redhat.atlassian.net/rest/api/3/issue/{key}/transitions",
     headers={"Authorization": f"Basic {creds}", "Content-Type": "application/json"},
     json={"transition": {"id": "41"}},
-    verify=False,
 )
 ```
 
@@ -205,9 +210,9 @@ Read the canvas skill (`~/.cursor/skills-cursor/canvas/SKILL.md`) and produce a
 - **Filterable table**: build status (In build / Missing), priority, key, summary, PR link + date, commit hash
 - **Row tones**: `success` for in-build, `warning` for Major-not-in-build, `danger` for Blocker/Critical
 
-Reuse the canvas at
-`~/.cursor/projects/Users-pabreu-forklift-console-plugin/canvases/waiting-for-build.canvas.tsx`
-if it already exists (update in place).
+Reuse the canvas named `waiting-for-build.canvas.tsx` in this workspace's Cursor canvases
+directory if it already exists (update in place). The canvas skill determines the correct
+path for the current workspace automatically.
 
 ## Board & filter constants
 
@@ -226,7 +231,7 @@ if it already exists (update in place).
 
 The script reads from `.mcp.json` → `mcpServers.jira-mcp.env`:
 - `JIRA_URL` — `https://redhat.atlassian.net`
-- `JIRA_USERNAME` — `pabreu@redhat.com`
+- `JIRA_USERNAME` — your Atlassian account email
 - `JIRA_API_TOKEN` — Atlassian Cloud API token
 
 ## Commit-search heuristic

--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: waiting-for-build
+description: >-
+  Query the active sprint on the Migrations & Networking Frontend Jira board for all
+  MTV tickets in the "Waiting on build" column, find their merge commits in the local
+  git repo, and check which are included in a given build (supplied as commit hashes).
+  Renders results in an interactive canvas. Use when the user asks about "waiting for
+  build", which tickets are in the build, build inclusion check, sprint tickets vs
+  build, or wants to know what MTV fixes are waiting for QA.
+---
+
+# Waiting-for-Build Skill
+
+## What this does
+
+1. Queries Jira board 11806 (Migrations & Networking Frontend) — active sprint, MTV
+   quickfilter, "Waiting on build" column (statuses: `MODIFIED`, `Dev Complete`).
+2. Finds each ticket's merge commit in the local git repo (searches `git log --all`
+   for the ticket key).
+3. Checks whether each commit is an ancestor of the latest build tip hashes (fetched
+   automatically from the `#mtv-builds` Slack channel via `fetch-build.py`).
+4. **Transitions all `in_build: true` tickets to `ON_QA`** in Jira (transition ID `41`).
+5. Renders an interactive canvas at
+   `~/.cursor/projects/Users-pabreu-forklift-console-plugin/canvases/waiting-for-build.canvas.tsx`.
+
+> **Default behaviour:** transition is always performed. If the user explicitly says
+> "just check" or "don't transition", skip step 4.
+
+## Step 0 — Get build tip hashes automatically from Slack
+
+Run `fetch-build.py` to pull the latest build's commits from the `#mtv-builds` channel:
+
+```bash
+cd /Users/pabreu/forklift-console-plugin
+python3 .cursor/skills/waiting-for-build/scripts/fetch-build.py
+```
+
+Output example:
+```json
+{
+  "build_label": "IIB 2.12.0-44 | 02.06.2026 19:04 UTC",
+  "console_plugin_commits": ["8e059c6", "cfc05ae"],
+  "mtv_console_plugin_container": "8e059c6f48a7715179038e9bd12151c88c5f9bf1"
+}
+```
+
+Pass `console_plugin_commits` as arguments to `query.py` (Step 1).
+
+**How it works:** Uses `slackdump` to archive channel `C09DS44AQ65` (#mtv-builds),
+then queries the SQLite database for the latest IIB build thread.
+
+**Credentials** are stored in `.mcp.json → mcpServers.slack.env`:
+- `SLACK_TOKEN` — `xoxc-...` (Red Hat workspace, from Slack desktop app `localStorage`)
+- `SLACK_COOKIE` — `xoxd-...` (d= cookie from Slack desktop app)
+- `SLACK_CHANNEL_ID` — `C09DS44AQ65` (#mtv-builds)
+- `SLACKDUMP_WORKSPACE` — `redhat`
+
+**If `fetch-build.py` returns an error or empty commits**, the Slack session token
+has expired (they rotate every few hours). Follow this recovery procedure:
+
+> **Agent instruction:** If `fetch-build.py` fails with any auth/empty-result error,
+> tell the user their Slack credentials have expired and walk them through the steps
+> below to get fresh ones. Do NOT skip this — without valid credentials the script
+> cannot fetch build data.
+
+### Credential refresh procedure
+
+**Step 1 — Get a fresh `xoxc-` token**
+
+Ask the user to open the **Slack desktop app**, then open DevTools (`Cmd+Option+I`)
+and run in the **Console** tab:
+
+```javascript
+Object.values(JSON.parse(localStorage["localConfig_v2"]).teams)
+  .find(t => t.name === "Red Hat")?.token
+```
+
+Copy the full `xoxc-3016...` value.
+
+**Step 2 — Get a fresh `d` cookie**
+
+In the **same DevTools session**, go to **Application → Storage → Cookies →
+`https://app.slack.com`**, click the row named **`d`**, and copy the full value
+from the **Cookie Value panel at the bottom** (starts with `xoxd-`).
+
+**Step 3 — Update `.mcp.json`**
+
+Replace both values in `.mcp.json → mcpServers.slack.env`:
+- `SLACK_TOKEN` ← new `xoxc-...` value
+- `SLACK_COOKIE` ← new `xoxd-...` value
+
+**Step 4 — Re-register with slackdump**
+
+```bash
+slackdump workspace new -no-encryption \
+  -token "<new xoxc token>" \
+  -cookie "<new xoxd cookie>" \
+  redhat
+slackdump workspace select redhat
+```
+
+**Step 5 — Re-run `fetch-build.py`**
+
+```bash
+python3 .cursor/skills/waiting-for-build/scripts/fetch-build.py
+```
+
+**Dependencies:** `brew install slackdump` (already installed).
+
+---
+
+## Step 1 — Run the query script
+
+```bash
+cd /Users/pabreu/forklift-console-plugin
+python3 .cursor/skills/waiting-for-build/scripts/query.py [hash1] [hash2] ...
+```
+
+- Pass **one or more build tip commit hashes** as positional arguments.
+  Omit them to get the ticket/commit table without build-inclusion analysis.
+- The script reads Jira credentials from `.mcp.json` automatically (no extra setup).
+- Output is JSON printed to stdout.
+
+**Example:**
+```bash
+python3 .cursor/skills/waiting-for-build/scripts/query.py 8e059c6 cfc05ae
+```
+
+If `requests` is missing: `pip3 install requests`
+
+## Step 2 — Interpret the JSON output
+
+The output shape:
+```json
+{
+  "sprint":     { "id": 66444, "name": "...", "end": "2026-06-04" },
+  "build_tips": ["8e059c6", "cfc05ae"],
+  "issues": [
+    {
+      "key":        "MTV-5388",
+      "status":     "MODIFIED",
+      "priority":   "Major",
+      "summary":    "...",
+      "commit":     "22da1d1",   // null if no commit found in git log
+      "pr":         2427,        // null if PR # not in commit subject
+      "merge_date": "2026-05-20",
+      "in_build":   false        // null if no build tips supplied
+    }
+  ]
+}
+```
+
+Key fields:
+- `in_build: true`  → fix is in the deployed build, ready to verify
+- `in_build: false` → fix was merged after the build was cut, needs next build
+- `commit: null`    → no merge commit found; ticket may be missing `Resolves:` line
+
+## Step 2b — Transition in-build tickets to ON_QA
+
+For every issue where `in_build: true`, call the Jira transitions API:
+
+```bash
+curl -s -X POST \
+  -u "pabreu@redhat.com:$JIRA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"transition": {"id": "41"}}' \
+  "https://redhat.atlassian.net/rest/api/3/issue/<KEY>/transitions"
+# 204 = success
+```
+
+Or via Python (using credentials from `.mcp.json`):
+
+```python
+import requests, base64
+creds = base64.b64encode(b"pabreu@redhat.com:<token>").decode()
+requests.post(
+    f"https://redhat.atlassian.net/rest/api/3/issue/{key}/transitions",
+    headers={"Authorization": f"Basic {creds}", "Content-Type": "application/json"},
+    json={"transition": {"id": "41"}},
+    verify=False,
+)
+```
+
+**Transition IDs for MTV project:**
+
+| ID | Status |
+|----|--------|
+| 11 | New |
+| 21 | ASSIGNED |
+| 31 | POST |
+| 41 | **ON_QA** ← use this |
+| 61 | Verified |
+| 71 | Release Pending |
+| 81 | Closed |
+
+Skip this step only if the user explicitly says "just check" or "don't transition".
+
+## Step 3 — Render the canvas
+
+Read the canvas skill (`~/.cursor/skills-cursor/canvas/SKILL.md`) and produce a
+`.canvas.tsx` at the standard path. Include:
+
+- **Summary stats**: total tickets, in-build count, not-in-build count, major priority count
+- **Callout** naming which tickets are in the build vs waiting for the next build
+- **Filterable table**: build status (In build / Missing), priority, key, summary, PR link + date, commit hash
+- **Row tones**: `success` for in-build, `warning` for Major-not-in-build, `danger` for Blocker/Critical
+
+Reuse the canvas at
+`~/.cursor/projects/Users-pabreu-forklift-console-plugin/canvases/waiting-for-build.canvas.tsx`
+if it already exists (update in place).
+
+## Board & filter constants
+
+| Setting | Value |
+|---------|-------|
+| Board ID | `11806` |
+| Board name | Migrations & Networking Frontend |
+| Project | Migration Toolkit for Virtualization (MTV) |
+| QuickFilter ID | `91499` (name: "MTV") |
+| QuickFilter JQL | `project = "Migration Toolkit for Virtualization"` |
+| "Waiting on build" statuses | `MODIFIED` (ID 10284), `Dev Complete` (ID 10155) |
+| Sprint endpoint | `GET /rest/agile/1.0/board/11806/sprint?state=active` |
+| Issues endpoint | `GET /rest/agile/1.0/sprint/{id}/issue?jql=...` |
+
+## Credentials
+
+The script reads from `.mcp.json` → `mcpServers.jira-mcp.env`:
+- `JIRA_URL` — `https://redhat.atlassian.net`
+- `JIRA_USERNAME` — `pabreu@redhat.com`
+- `JIRA_API_TOKEN` — Atlassian Cloud API token
+
+## Commit-search heuristic
+
+The script runs `git log --all --grep=<KEY> -i` (case-insensitive). Most commits
+follow `Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`. If a ticket
+has no match, `commit` is `null` — investigate manually with:
+
+```bash
+git log --all --oneline | grep -i "keyword from summary"
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `ModuleNotFoundError: requests` | `pip3 install requests` |
+| `Jira credentials missing` | Check `.mcp.json` has `JIRA_USERNAME` + `JIRA_API_TOKEN` |
+| `No active sprint` | Sprint may have just ended; query `/sprint?state=closed` to see last sprint |
+| `commit: null` for a ticket | Ticket key not in any commit message; search git log manually |
+| Wrong ticket count | Board filter or sprint may have changed; re-run script to refresh |
+| `slackdump not found` | `brew install slackdump` |
+| `fetch-build.py` returns empty commits | Credentials expired — get fresh `SLACK_TOKEN` + `SLACK_COOKIE` from Slack desktop app DevTools |
+| fetch-build.py takes >60 s | Rate-limited by Slack; reduce `--days` (e.g. `--days 7`) |

--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -238,8 +238,12 @@ The script reads from `.mcp.json` → `mcpServers.jira-mcp.env`:
 
 The script runs `git log --all --grep=<KEY> -i` (case-insensitive), then
 post-filters results to **whole-word matches** so that e.g. `MTV-5` does not
-accidentally match `MTV-50` or `MTV-500`. Most commits follow
-`Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`.
+accidentally match `MTV-50` or `MTV-500`. The post-filter checks **both** the
+commit subject and the full commit body, so commits that put the reference only
+in the body (e.g. `Resolves: MTV-XXXX` on its own line, with a generic subject
+like `Fix React crashes (#2420)`) are correctly identified.
+
+Most commits follow `Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`.
 If a ticket has no match, `commit` is `null` — investigate manually with:
 
 ```bash

--- a/.cursor/skills/waiting-for-build/scripts/fetch-build.py
+++ b/.cursor/skills/waiting-for-build/scripts/fetch-build.py
@@ -51,6 +51,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 # ── Constants ─────────────────────────────────────────────────────────────────
@@ -70,6 +71,7 @@ COMMIT_SHORT_RE = re.compile(r'\b([0-9a-f]{7,40})\b')
 # ── Config from .mcp.json ─────────────────────────────────────────────────────
 
 def _load_mcp_env() -> dict:
+    """Return the Slack env block from .mcp.json, or an empty dict on failure."""
     mcp_path = REPO_DIR / ".mcp.json"
     try:
         mcp = json.loads(mcp_path.read_text())
@@ -81,6 +83,7 @@ def _load_mcp_env() -> dict:
 # ── slackdump helpers ──────────────────────────────────────────────────────────
 
 def _slackdump_bin() -> str:
+    """Return the path to the slackdump binary, or exit with an error if not found."""
     sd = shutil.which("slackdump")
     if not sd:
         print("ERROR: slackdump not found. Install with: brew install slackdump", file=sys.stderr)
@@ -113,8 +116,9 @@ def _ensure_workspace(workspace: str, token: str, cookie: str) -> None:
         )
         sys.exit(1)
 
-    cookie_file = Path(tempfile.mktemp(suffix=".txt"))
-    cookie_file.write_text(cookie)
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as tmp:
+        tmp.write(cookie)
+        cookie_file = Path(tmp.name)
     try:
         r = subprocess.run(
             [sd, "workspace", "new", "-no-encryption",
@@ -145,8 +149,7 @@ def _archive_channel(channel_id: str, days: int) -> Path:
     )
 
     # Run for up to 45 s (rate-limited; usually done in < 20 s for 30-day window)
-    import threading
-    def _kill():
+    def _kill() -> None:
         proc.kill()
 
     timer = threading.Timer(45, _kill)
@@ -199,6 +202,7 @@ def _parse_block_table_commits(data_json: str) -> list[str]:
 
 
 def _extract_build_data(db_path: Path) -> list[dict]:
+    """Parse the slackdump SQLite archive and return a list of IIB build records."""
     conn = sqlite3.connect(str(db_path))
     cur  = conn.cursor()
 
@@ -275,8 +279,7 @@ def main() -> None:
     try:
         builds = _extract_build_data(db_path)
     finally:
-        import shutil as _sh
-        _sh.rmtree(db_path.parent, ignore_errors=True)
+        shutil.rmtree(db_path.parent, ignore_errors=True)
 
     if not builds:
         print(

--- a/.cursor/skills/waiting-for-build/scripts/fetch-build.py
+++ b/.cursor/skills/waiting-for-build/scripts/fetch-build.py
@@ -203,60 +203,60 @@ def _parse_block_table_commits(data_json: str) -> list[str]:
 
 def _extract_build_data(db_path: Path) -> list[dict]:
     """Parse the slackdump SQLite archive and return a list of IIB build records."""
-    conn = sqlite3.connect(str(db_path))
-    cur  = conn.cursor()
-
-    # Find all IIB build parent messages, latest first
-    cur.execute(
-        "SELECT TXT, TS, THREAD_TS FROM MESSAGE "
-        "WHERE IS_PARENT = 1 AND TXT LIKE '%IIB %' "
-        "ORDER BY TS DESC LIMIT 10"
-    )
-    parents = [(r[0], r[1], r[2]) for r in cur.fetchall()
-               if IIB_TITLE_RE.search(r[0] or "")]
-
     results: list[dict] = []
-    for txt, ts, thread_ts in parents:
-        title = (txt or "").splitlines()[0].strip()
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.cursor()
 
-        # Fetch all thread replies
+        # Find all IIB build parent messages, latest first
         cur.execute(
-            "SELECT TXT, DATA FROM MESSAGE WHERE THREAD_TS = ? ORDER BY TS",
-            (thread_ts,)
+            "SELECT TXT, TS, THREAD_TS FROM MESSAGE "
+            "WHERE IS_PARENT = 1 AND TXT LIKE '%IIB %' "
+            "ORDER BY TS DESC LIMIT 10"
         )
-        replies = cur.fetchall()
+        parents = [(r[0], r[1], r[2]) for r in cur.fetchall()
+                   if IIB_TITLE_RE.search(r[0] or "")]
 
-        container_sha   = ""
-        plugin_commits: list[str] = []
+        for txt, ts, thread_ts in parents:
+            title = (txt or "").splitlines()[0].strip()
 
-        for reply_txt, reply_data in replies:
-            reply_txt = reply_txt or ""
+            # Fetch all thread replies
+            cur.execute(
+                "SELECT TXT, DATA FROM MESSAGE WHERE THREAD_TS = ? ORDER BY TS",
+                (thread_ts,)
+            )
+            replies = cur.fetchall()
 
-            # Konflux Bundle message contains the full container SHA
-            if not container_sha:
-                m = CONTAINER_RE.search(reply_txt)
-                if m:
-                    container_sha = m.group(1)
+            container_sha   = ""
+            plugin_commits: list[str] = []
 
-            # forklift-console-plugin changes message (block-kit table)
-            if not plugin_commits and "forklift-console-plugin" in reply_txt:
-                if reply_data:
-                    plugin_commits = _parse_block_table_commits(reply_data)
+            for reply_txt, reply_data in replies:
+                reply_txt = reply_txt or ""
 
-        results.append({
-            "build_label":                  title,
-            "ts":                           ts,
-            "console_plugin_commits":       plugin_commits,
-            "mtv_console_plugin_container": container_sha,
-        })
+                # Konflux Bundle message contains the full container SHA
+                if not container_sha:
+                    m = CONTAINER_RE.search(reply_txt)
+                    if m:
+                        container_sha = m.group(1)
 
-    conn.close()
+                # forklift-console-plugin changes message (block-kit table)
+                if not plugin_commits and "forklift-console-plugin" in reply_txt:
+                    if reply_data:
+                        plugin_commits = _parse_block_table_commits(reply_data)
+
+            results.append({
+                "build_label":                  title,
+                "ts":                           ts,
+                "console_plugin_commits":       plugin_commits,
+                "mtv_console_plugin_container": container_sha,
+            })
+
     return results
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main() -> None:
+    """Parse arguments, fetch the latest build from Slack, and print JSON to stdout."""
     env = _load_mcp_env()
 
     parser = argparse.ArgumentParser(description="Fetch latest MTV build info from Slack")
@@ -296,7 +296,7 @@ def main() -> None:
     output = builds if args.show_all else builds[0]
 
     # Warn if the latest build has no commits — likely a partial/stale archive
-    latest = builds[0] if not args.show_all else (builds[0] if builds else {})
+    latest = builds[0]
     if not latest.get("console_plugin_commits") and not latest.get("mtv_console_plugin_container"):
         print(
             "WARNING: Latest build was found but has no console-plugin commits.\n"

--- a/.cursor/skills/waiting-for-build/scripts/fetch-build.py
+++ b/.cursor/skills/waiting-for-build/scripts/fetch-build.py
@@ -150,6 +150,7 @@ def _archive_channel(channel_id: str, days: int) -> Path:
 
     # Run for up to 45 s (rate-limited; usually done in < 20 s for 30-day window)
     def _kill() -> None:
+        """Terminate the slackdump archive process after the timeout fires."""
         proc.kill()
 
     timer = threading.Timer(45, _kill)

--- a/.cursor/skills/waiting-for-build/scripts/fetch-build.py
+++ b/.cursor/skills/waiting-for-build/scripts/fetch-build.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Find the latest MTV build post in the #mtv-builds Slack channel and extract
+the forklift-console-plugin commit hashes.
+
+Uses `slackdump` (https://github.com/rusq/slackdump) to read the channel
+history — no Slack app token required, works with existing desktop-app session.
+
+Usage:
+  python fetch-build.py [--channel CHANNEL_ID] [--all] [--days N]
+
+Output (JSON to stdout):
+  {
+    "build_label": "IIB 2.12.0-44 | 02.06.2026 19:04 UTC",
+    "ts": "1780427056.785919",
+    "console_plugin_commits": ["8e059c6", "cfc05ae"],
+    "mtv_console_plugin_container": "8e059c6f48a7715179038e9bd12151c88c5f9bf1"
+  }
+
+Pass the first commit from console_plugin_commits (or mtv_console_plugin_container)
+to query.py as the build tip hash.
+
+─── Setup (one-time) ─────────────────────────────────────────────────────────
+
+1. Install slackdump:
+     brew install slackdump
+
+2. Get credentials from the Slack desktop app DevTools console:
+     Object.values(JSON.parse(localStorage["localConfig_v2"]).teams)
+       .map(t => ({name: t.name, token: t.token}))[0]
+   Copy the token for the "Red Hat" workspace.
+
+3. Run once to authenticate:
+     slackdump workspace new -no-encryption -token <xoxc-token> -cookie <xoxd-cookie> redhat
+     slackdump workspace select redhat
+
+4. Store credentials in .mcp.json (mcpServers.slack.env):
+     SLACK_TOKEN       xoxc-... (Red Hat workspace)
+     SLACK_COOKIE      xoxd-... (d= cookie from Slack desktop)
+     SLACK_CHANNEL_ID  C09DS44AQ65 (mtv-builds channel ID)
+     SLACKDUMP_WORKSPACE  redhat (name used in step 3)
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_here       = Path(__file__).resolve()
+REPO_DIR    = _here.parents[4]
+
+DEFAULT_CHANNEL_ID = "C09DS44AQ65"
+DEFAULT_WORKSPACE  = "redhat"
+DEFAULT_DAYS       = 30
+
+IIB_TITLE_RE    = re.compile(r'IIB\s+[\d.]+[-\w]*\s*\|', re.IGNORECASE)
+CONTAINER_RE    = re.compile(r'mtv-console-plugin-container:\s*([0-9a-f]{40})', re.IGNORECASE)
+COMMIT_SHORT_RE = re.compile(r'\b([0-9a-f]{7,40})\b')
+
+
+# ── Config from .mcp.json ─────────────────────────────────────────────────────
+
+def _load_mcp_env() -> dict:
+    mcp_path = REPO_DIR / ".mcp.json"
+    try:
+        mcp = json.loads(mcp_path.read_text())
+        return mcp.get("mcpServers", {}).get("slack", {}).get("env", {})
+    except Exception:
+        return {}
+
+
+# ── slackdump helpers ──────────────────────────────────────────────────────────
+
+def _slackdump_bin() -> str:
+    sd = shutil.which("slackdump")
+    if not sd:
+        print("ERROR: slackdump not found. Install with: brew install slackdump", file=sys.stderr)
+        sys.exit(1)
+    return sd
+
+
+def _ensure_workspace(workspace: str, token: str, cookie: str) -> None:
+    """Authenticate slackdump workspace if not already set up."""
+    sd = _slackdump_bin()
+
+    result = subprocess.run([sd, "workspace", "list"], capture_output=True, text=True)
+    if workspace in result.stdout:
+        # Select it as active
+        subprocess.run([sd, "workspace", "select", workspace],
+                       capture_output=True, text=True)
+        return
+
+    if not token:
+        print(
+            "ERROR: slackdump workspace not configured and no SLACK_TOKEN provided.\n\n"
+            "Run once to set up:\n"
+            "  slackdump workspace new -no-encryption -token <xoxc-...> -cookie <xoxd-...> redhat\n\n"
+            "Or add to .mcp.json → mcpServers.slack.env:\n"
+            "  SLACK_TOKEN=xoxc-...\n"
+            "  SLACK_COOKIE=xoxd-...\n"
+            "  SLACK_CHANNEL_ID=C09DS44AQ65\n"
+            "  SLACKDUMP_WORKSPACE=redhat",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    cookie_file = Path(tempfile.mktemp(suffix=".txt"))
+    cookie_file.write_text(cookie)
+    try:
+        r = subprocess.run(
+            [sd, "workspace", "new", "-no-encryption",
+             "-token", token, "-cookie", str(cookie_file), workspace],
+            capture_output=True, text=True,
+        )
+        if r.returncode != 0:
+            print("ERROR: slackdump workspace new failed:", r.stderr, file=sys.stderr)
+            sys.exit(1)
+    finally:
+        cookie_file.unlink(missing_ok=True)
+
+    subprocess.run([sd, "workspace", "select", workspace], capture_output=True)
+
+
+def _archive_channel(channel_id: str, days: int) -> Path:
+    """Archive recent channel history into a temp SQLite DB and return the path."""
+    sd    = _slackdump_bin()
+    tmpdir = Path(tempfile.mkdtemp(prefix="fetch-build-"))
+    since = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)).strftime("%Y-%m-%dT00:00:00")
+
+    proc = subprocess.Popen(
+        [sd, "archive", "-no-encryption", "-enterprise",
+         "-time-from", since, "-o", str(tmpdir), channel_id],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # Run for up to 45 s (rate-limited; usually done in < 20 s for 30-day window)
+    import threading
+    def _kill():
+        proc.kill()
+
+    timer = threading.Timer(45, _kill)
+    timer.start()
+    try:
+        proc.wait()
+    finally:
+        timer.cancel()
+
+    db_path = tmpdir / "slackdump.sqlite"
+    if not db_path.exists():
+        print(
+            "ERROR: slackdump archive produced no database.\n\n"
+            "This usually means the Slack session token has expired.\n"
+            "Follow the credential refresh procedure in SKILL.md → Step 0.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return db_path
+
+
+# ── Message parsing ────────────────────────────────────────────────────────────
+
+def _parse_block_table_commits(data_json: str) -> list[str]:
+    """Extract 7-char SHAs from a block-kit table's SHA column."""
+    try:
+        data   = json.loads(data_json)
+        blocks = data.get("blocks", [])
+    except Exception:
+        return []
+
+    commits: list[str] = []
+    seen: set[str]     = set()
+
+    for block in blocks:
+        if block.get("type") != "table":
+            continue
+        for row in block.get("rows", []):
+            # Each row is a list of rich_text cells; SHA is typically the 3rd column
+            for cell in row:
+                for section in cell.get("elements", []):
+                    for el in section.get("elements", []):
+                        text = el.get("text", "")
+                        for sha in COMMIT_SHORT_RE.findall(text):
+                            short = sha[:7]
+                            if len(sha) <= 40 and short not in seen:
+                                seen.add(short)
+                                commits.append(sha)
+    return commits
+
+
+def _extract_build_data(db_path: Path) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    cur  = conn.cursor()
+
+    # Find all IIB build parent messages, latest first
+    cur.execute(
+        "SELECT TXT, TS, THREAD_TS FROM MESSAGE "
+        "WHERE IS_PARENT = 1 AND TXT LIKE '%IIB %' "
+        "ORDER BY TS DESC LIMIT 10"
+    )
+    parents = [(r[0], r[1], r[2]) for r in cur.fetchall()
+               if IIB_TITLE_RE.search(r[0] or "")]
+
+    results: list[dict] = []
+    for txt, ts, thread_ts in parents:
+        title = (txt or "").splitlines()[0].strip()
+
+        # Fetch all thread replies
+        cur.execute(
+            "SELECT TXT, DATA FROM MESSAGE WHERE THREAD_TS = ? ORDER BY TS",
+            (thread_ts,)
+        )
+        replies = cur.fetchall()
+
+        container_sha   = ""
+        plugin_commits: list[str] = []
+
+        for reply_txt, reply_data in replies:
+            reply_txt = reply_txt or ""
+
+            # Konflux Bundle message contains the full container SHA
+            if not container_sha:
+                m = CONTAINER_RE.search(reply_txt)
+                if m:
+                    container_sha = m.group(1)
+
+            # forklift-console-plugin changes message (block-kit table)
+            if not plugin_commits and "forklift-console-plugin" in reply_txt:
+                if reply_data:
+                    plugin_commits = _parse_block_table_commits(reply_data)
+
+        results.append({
+            "build_label":                  title,
+            "ts":                           ts,
+            "console_plugin_commits":       plugin_commits,
+            "mtv_console_plugin_container": container_sha,
+        })
+
+    conn.close()
+    return results
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    env = _load_mcp_env()
+
+    parser = argparse.ArgumentParser(description="Fetch latest MTV build info from Slack")
+    parser.add_argument("--channel",   default=env.get("SLACK_CHANNEL_ID", DEFAULT_CHANNEL_ID),
+                        help="Slack channel ID (default: mtv-builds)")
+    parser.add_argument("--workspace", default=env.get("SLACKDUMP_WORKSPACE", DEFAULT_WORKSPACE),
+                        help="slackdump workspace name")
+    parser.add_argument("--days",      type=int, default=DEFAULT_DAYS,
+                        help="How many days back to scan (default: 30)")
+    parser.add_argument("--all",       dest="show_all", action="store_true",
+                        help="Print all recent builds, not just the latest")
+    args = parser.parse_args()
+
+    token  = os.getenv("SLACK_TOKEN")  or env.get("SLACK_TOKEN",  "")
+    cookie = os.getenv("SLACK_COOKIE") or env.get("SLACK_COOKIE", "")
+
+    _ensure_workspace(args.workspace, token, cookie)
+
+    db_path = _archive_channel(args.channel, args.days)
+    try:
+        builds = _extract_build_data(db_path)
+    finally:
+        import shutil as _sh
+        _sh.rmtree(db_path.parent, ignore_errors=True)
+
+    if not builds:
+        print(
+            "ERROR: No IIB build posts found in the channel archive.\n\n"
+            "Possible causes:\n"
+            "  1. Slack session expired — refresh SLACK_TOKEN + SLACK_COOKIE in .mcp.json\n"
+            "     (see SKILL.md → Step 0 → Credential refresh procedure)\n"
+            "  2. Wrong channel — check SLACK_CHANNEL_ID in .mcp.json (should be C09DS44AQ65)\n"
+            "  3. No builds posted in the last --days window (default 30)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    output = builds if args.show_all else builds[0]
+
+    # Warn if the latest build has no commits — likely a partial/stale archive
+    latest = builds[0] if not args.show_all else (builds[0] if builds else {})
+    if not latest.get("console_plugin_commits") and not latest.get("mtv_console_plugin_container"):
+        print(
+            "WARNING: Latest build was found but has no console-plugin commits.\n"
+            "The Slack session may be stale — thread replies were not fetched.\n"
+            "Try refreshing credentials (see SKILL.md → Step 0 → Credential refresh procedure).",
+            file=sys.stderr,
+        )
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/waiting-for-build/scripts/query.py
+++ b/.cursor/skills/waiting-for-build/scripts/query.py
@@ -154,14 +154,33 @@ def get_waiting_for_build_issues(sprint_id: int, headers: dict, base: str) -> li
 def _git(args: list[str]) -> str:
     """Run a git command in REPO_DIR and return stdout as a stripped string."""
     return subprocess.check_output(
-        ["git"] + args, cwd=REPO_DIR, stderr=subprocess.DEVNULL, text=True
+        ["git", *args], cwd=REPO_DIR, stderr=subprocess.DEVNULL, text=True
     ).strip()
 
 
-def find_merge_commit(ticket_key: str) -> Optional[dict]:
+def _parse_commit_line(line: str) -> Optional[dict]:
+    """Parse a single 'git log --format=%H %ad %s' line into a commit dict, or None."""
+    parts = line.split(" ", 2)
+    if len(parts) < 3:
+        return None
+    full_hash, date, subject = parts[0], parts[1], parts[2]
+    pr_match = re.search(r'\(#(\d+)\)', subject)
+    return {
+        "commit":     full_hash[:7],
+        "merge_date": date,
+        "pr":         int(pr_match.group(1)) if pr_match else None,
+        "subject":    subject,
+    }
+
+
+def find_merge_commit(ticket_key: str, build_tips: Optional[list[str]] = None) -> Optional[dict]:
     """Return the merge commit info for a Jira ticket key, or None.
 
     Uses a whole-word grep so MTV-5 does not accidentally match MTV-50 or MTV-500.
+    When build_tips are provided, prefers the most recent commit that is an
+    ancestor of any build tip — avoiding false negatives when a ticket has
+    multiple commits (e.g., original merge plus a follow-up fix or cherry-pick).
+    Falls back to the first whole-word match if none are build-reachable.
     """
     try:
         out = _git([
@@ -170,19 +189,23 @@ def find_merge_commit(ticket_key: str) -> Optional[dict]:
         ])
         if not out:
             return None
-        # Post-filter to whole-word matches to avoid MTV-5 matching MTV-50, etc.
         pattern = re.compile(rf'\b{re.escape(ticket_key)}\b', re.IGNORECASE)
-        lines = [line for line in out.splitlines() if pattern.search(line)]
-        if not lines:
+        candidates = [
+            _parse_commit_line(line)
+            for line in out.splitlines()
+            if pattern.search(line)
+        ]
+        candidates = [c for c in candidates if c is not None]
+        if not candidates:
             return None
-        parts = lines[0].split(" ", 2)
-        if len(parts) < 3:
-            return None
-        full_hash, date, subject = parts[0], parts[1], parts[2]
-        short_hash = full_hash[:7]
-        pr_match   = re.search(r'\(#(\d+)\)', subject)
-        pr         = int(pr_match.group(1)) if pr_match else None
-        return {"commit": short_hash, "merge_date": date, "pr": pr, "subject": subject}
+
+        # Prefer the most recent commit reachable from the build when tips are known.
+        if build_tips:
+            for candidate in candidates:
+                if check_in_build(candidate["commit"], build_tips):
+                    return candidate
+
+        return candidates[0]
     except subprocess.CalledProcessError:
         return None
 
@@ -217,7 +240,7 @@ def main() -> None:
 
     enriched = []
     for issue in issues:
-        commit_info = find_merge_commit(issue["key"])
+        commit_info = find_merge_commit(issue["key"], build_tips or None)
         in_build: Optional[bool] = None
         if commit_info and build_tips:
             in_build = check_in_build(commit_info["commit"], build_tips)

--- a/.cursor/skills/waiting-for-build/scripts/query.py
+++ b/.cursor/skills/waiting-for-build/scripts/query.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Fetch the "Waiting on build" MTV tickets from the active sprint on board 11806,
+find their merge commits in the local git repo, and check which are included in
+one or more build tip commits.
+
+Usage:
+  python query.py [build_hash1] [build_hash2] ...
+
+  Build hashes are optional. When omitted, the script prints the ticket/commit
+  table without build-inclusion status.
+
+Output (JSON to stdout):
+  {
+    "sprint": { "id": ..., "name": ..., "end": ... },
+    "build_tips": ["8e059c6", "cfc05ae"],
+    "issues": [
+      {
+        "key": "MTV-5388",
+        "status": "MODIFIED",
+        "priority": "Major",
+        "summary": "...",
+        "commit": "22da1d1",        # null if not found
+        "pr": 2427,                  # null if not found
+        "merge_date": "2026-05-20",  # null if not found
+        "in_build": false            # null if no build tips supplied
+      },
+      ...
+    ]
+  }
+
+Requires:
+  pip install requests
+
+Reads credentials from environment variables (or .mcp.json fallback):
+  JIRA_URL          https://redhat.atlassian.net
+  JIRA_USERNAME     pabreu@redhat.com
+  JIRA_API_TOKEN    ATATT3x...
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from base64 import b64encode
+from typing import Optional
+import requests
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+BOARD_ID       = 11806
+QUICK_FILTER   = "project = \"Migration Toolkit for Virtualization\""
+# "Waiting on build" column status IDs on board 11806
+WAITING_STATUSES = ["MODIFIED", "Dev Complete"]
+
+_here    = os.path.abspath(__file__)                         # .../scripts/query.py
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(_here)))))
+
+# ── Credentials ───────────────────────────────────────────────────────────────
+
+def _load_mcp_creds() -> tuple[str, str, str]:
+    """Fall back to reading .mcp.json when env vars are absent."""
+    mcp_path = os.path.join(REPO_DIR, ".mcp.json")
+    try:
+        with open(mcp_path) as f:
+            mcp = json.load(f)
+        env = mcp.get("mcpServers", {}).get("jira-mcp", {}).get("env", {})
+        return (
+            env.get("JIRA_URL", ""),
+            env.get("JIRA_USERNAME", ""),
+            env.get("JIRA_API_TOKEN", ""),
+        )
+    except Exception:
+        return ("", "", "")
+
+
+def get_auth_header() -> dict:
+    url      = os.getenv("JIRA_URL")      or _load_mcp_creds()[0]
+    username = os.getenv("JIRA_USERNAME") or _load_mcp_creds()[1]
+    token    = os.getenv("JIRA_API_TOKEN") or _load_mcp_creds()[2]
+    if not (url and username and token):
+        raise RuntimeError(
+            "Jira credentials missing. Set JIRA_URL, JIRA_USERNAME, JIRA_API_TOKEN "
+            "or populate .mcp.json with those values."
+        )
+    encoded = b64encode(f"{username}:{token}".encode()).decode()
+    return {"Authorization": f"Basic {encoded}", "Accept": "application/json"}
+
+
+def jira_get(path: str, headers: dict, base: str = "https://redhat.atlassian.net") -> dict:
+    r = requests.get(f"{base}{path}", headers=headers, timeout=20)
+    r.raise_for_status()
+    return r.json()
+
+
+# ── Jira queries ──────────────────────────────────────────────────────────────
+
+def get_active_sprint(board_id: int, headers: dict) -> dict:
+    data = jira_get(f"/rest/agile/1.0/board/{board_id}/sprint?state=active", headers)
+    sprints = data.get("values", [])
+    if not sprints:
+        raise RuntimeError(f"No active sprint found on board {board_id}")
+    return sprints[0]
+
+
+def get_waiting_for_build_issues(sprint_id: int, headers: dict) -> list[dict]:
+    status_clause = ",".join(f'"{s}"' for s in WAITING_STATUSES)
+    jql = (
+        f'({QUICK_FILTER}) AND status in ({status_clause})'
+    )
+    import urllib.parse
+    encoded_jql = urllib.parse.quote(jql)
+    fields = "summary,status,assignee,priority,fixVersions"
+    path = (
+        f"/rest/agile/1.0/sprint/{sprint_id}/issue"
+        f"?jql={encoded_jql}&fields={fields}&maxResults=100"
+    )
+    data = jira_get(path, headers)
+    issues = data.get("issues", [])
+    result = []
+    for issue in issues:
+        f = issue.get("fields", {})
+        result.append({
+            "key":      issue["key"],
+            "status":   (f.get("status") or {}).get("name", "?"),
+            "priority": (f.get("priority") or {}).get("name", "?"),
+            "assignee": (f.get("assignee") or {}).get("displayName", "Unassigned"),
+            "summary":  f.get("summary", ""),
+            "fixVersions": [v.get("name", "") for v in f.get("fixVersions", [])],
+        })
+    return result
+
+
+# ── Git queries ───────────────────────────────────────────────────────────────
+
+def _git(args: list[str]) -> str:
+    return subprocess.check_output(
+        ["git"] + args, cwd=REPO_DIR, stderr=subprocess.DEVNULL, text=True
+    ).strip()
+
+
+def find_merge_commit(ticket_key: str) -> Optional[dict]:
+    """Return the merge commit info for a Jira ticket key, or None."""
+    try:
+        # Search by ticket key in commit message (case-insensitive)
+        out = _git(["log", "--oneline", "--all", f"--grep={ticket_key}", "-i", "--format=%H %ad %s", "--date=short"])
+        if not out:
+            return None
+        # Take the first (most recent) match
+        first_line = out.splitlines()[0]
+        parts = first_line.split(" ", 2)
+        if len(parts) < 3:
+            return None
+        full_hash, date, subject = parts[0], parts[1], parts[2]
+        short_hash = full_hash[:7]
+        # Extract PR number from subject like "(#2442)"
+        pr_match = re.search(r'\(#(\d+)\)', subject)
+        pr = int(pr_match.group(1)) if pr_match else None
+        return {"commit": short_hash, "merge_date": date, "pr": pr, "subject": subject}
+    except subprocess.CalledProcessError:
+        return None
+
+
+def is_ancestor(commit: str, build_tip: str) -> bool:
+    """Return True if `commit` is an ancestor of (or equal to) `build_tip`."""
+    try:
+        subprocess.check_call(
+            ["git", "merge-base", "--is-ancestor", commit, build_tip],
+            cwd=REPO_DIR, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def check_in_build(commit: str, build_tips: list[str]) -> bool:
+    """Return True if `commit` is reachable from any of the build tip commits."""
+    return any(is_ancestor(commit, tip) for tip in build_tips)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    build_tips = sys.argv[1:]  # optional positional args
+
+    headers = get_auth_header()
+
+    sprint = get_active_sprint(BOARD_ID, headers)
+    issues = get_waiting_for_build_issues(sprint["id"], headers)
+
+    enriched = []
+    for issue in issues:
+        commit_info = find_merge_commit(issue["key"])
+        in_build: Optional[bool] = None
+        if commit_info and build_tips:
+            in_build = check_in_build(commit_info["commit"], build_tips)
+        enriched.append({
+            "key":        issue["key"],
+            "status":     issue["status"],
+            "priority":   issue["priority"],
+            "assignee":   issue["assignee"],
+            "summary":    issue["summary"],
+            "fixVersions": issue["fixVersions"],
+            "commit":     commit_info["commit"] if commit_info else None,
+            "pr":         commit_info["pr"] if commit_info else None,
+            "merge_date": commit_info["merge_date"] if commit_info else None,
+            "subject":    commit_info["subject"] if commit_info else None,
+            "in_build":   in_build,
+        })
+
+    output = {
+        "board_id":   BOARD_ID,
+        "sprint":     {
+            "id":    sprint["id"],
+            "name":  sprint["name"],
+            "state": sprint["state"],
+            "end":   sprint.get("endDate", "")[:10],
+        },
+        "build_tips": build_tips,
+        "issues":     enriched,
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/waiting-for-build/scripts/query.py
+++ b/.cursor/skills/waiting-for-build/scripts/query.py
@@ -34,7 +34,7 @@ Requires:
 
 Reads credentials from environment variables (or .mcp.json fallback):
   JIRA_URL          https://redhat.atlassian.net
-  JIRA_USERNAME     pabreu@redhat.com
+  JIRA_USERNAME     <your Atlassian account email>
   JIRA_API_TOKEN    ATATT3x...
 """
 
@@ -43,15 +43,16 @@ import os
 import re
 import subprocess
 import sys
+import urllib.parse
 from base64 import b64encode
 from typing import Optional
+
 import requests
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
-BOARD_ID       = 11806
-QUICK_FILTER   = "project = \"Migration Toolkit for Virtualization\""
-# "Waiting on build" column status IDs on board 11806
+BOARD_ID         = 11806
+QUICK_FILTER     = "project = \"Migration Toolkit for Virtualization\""
 WAITING_STATUSES = ["MODIFIED", "Dev Complete"]
 
 _here    = os.path.abspath(__file__)                         # .../scripts/query.py
@@ -60,7 +61,7 @@ REPO_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.pa
 # ── Credentials ───────────────────────────────────────────────────────────────
 
 def _load_mcp_creds() -> tuple[str, str, str]:
-    """Fall back to reading .mcp.json when env vars are absent."""
+    """Return (url, username, token) from .mcp.json, or empty strings on failure."""
     mcp_path = os.path.join(REPO_DIR, ".mcp.json")
     try:
         with open(mcp_path) as f:
@@ -75,20 +76,23 @@ def _load_mcp_creds() -> tuple[str, str, str]:
         return ("", "", "")
 
 
-def get_auth_header() -> dict:
-    url      = os.getenv("JIRA_URL")      or _load_mcp_creds()[0]
-    username = os.getenv("JIRA_USERNAME") or _load_mcp_creds()[1]
-    token    = os.getenv("JIRA_API_TOKEN") or _load_mcp_creds()[2]
+def get_auth_config() -> tuple[str, dict]:
+    """Return (jira_base_url, auth_headers) using env vars with .mcp.json fallback."""
+    _url, _user, _token = _load_mcp_creds()
+    url      = os.getenv("JIRA_URL")       or _url
+    username = os.getenv("JIRA_USERNAME")  or _user
+    token    = os.getenv("JIRA_API_TOKEN") or _token
     if not (url and username and token):
         raise RuntimeError(
             "Jira credentials missing. Set JIRA_URL, JIRA_USERNAME, JIRA_API_TOKEN "
             "or populate .mcp.json with those values."
         )
     encoded = b64encode(f"{username}:{token}".encode()).decode()
-    return {"Authorization": f"Basic {encoded}", "Accept": "application/json"}
+    return url, {"Authorization": f"Basic {encoded}", "Accept": "application/json"}
 
 
-def jira_get(path: str, headers: dict, base: str = "https://redhat.atlassian.net") -> dict:
+def jira_get(path: str, headers: dict, base: str) -> dict:
+    """Perform a GET request against the Jira REST API and return the JSON response."""
     r = requests.get(f"{base}{path}", headers=headers, timeout=20)
     r.raise_for_status()
     return r.json()
@@ -96,37 +100,50 @@ def jira_get(path: str, headers: dict, base: str = "https://redhat.atlassian.net
 
 # ── Jira queries ──────────────────────────────────────────────────────────────
 
-def get_active_sprint(board_id: int, headers: dict) -> dict:
-    data = jira_get(f"/rest/agile/1.0/board/{board_id}/sprint?state=active", headers)
+def get_active_sprint(board_id: int, headers: dict, base: str) -> dict:
+    """Return the first active sprint for the given Agile board."""
+    data = jira_get(f"/rest/agile/1.0/board/{board_id}/sprint?state=active", headers, base)
     sprints = data.get("values", [])
     if not sprints:
         raise RuntimeError(f"No active sprint found on board {board_id}")
     return sprints[0]
 
 
-def get_waiting_for_build_issues(sprint_id: int, headers: dict) -> list[dict]:
+def get_waiting_for_build_issues(sprint_id: int, headers: dict, base: str) -> list[dict]:
+    """Return all MTV issues in the 'Waiting on build' column for the given sprint.
+
+    Paginates automatically if the result set exceeds the page size.
+    """
     status_clause = ",".join(f'"{s}"' for s in WAITING_STATUSES)
-    jql = (
-        f'({QUICK_FILTER}) AND status in ({status_clause})'
-    )
-    import urllib.parse
-    encoded_jql = urllib.parse.quote(jql)
-    fields = "summary,status,assignee,priority,fixVersions"
-    path = (
-        f"/rest/agile/1.0/sprint/{sprint_id}/issue"
-        f"?jql={encoded_jql}&fields={fields}&maxResults=100"
-    )
-    data = jira_get(path, headers)
-    issues = data.get("issues", [])
+    jql           = f'({QUICK_FILTER}) AND status in ({status_clause})'
+    encoded_jql   = urllib.parse.quote(jql)
+    fields        = "summary,status,assignee,priority,fixVersions"
+
+    page_size = 100
+    start_at  = 0
+    raw: list[dict] = []
+    while True:
+        path = (
+            f"/rest/agile/1.0/sprint/{sprint_id}/issue"
+            f"?jql={encoded_jql}&fields={fields}&maxResults={page_size}&startAt={start_at}"
+        )
+        data  = jira_get(path, headers, base)
+        page  = data.get("issues", [])
+        raw.extend(page)
+        total    = data.get("total", len(raw))
+        start_at += len(page)
+        if start_at >= total or not page:
+            break
+
     result = []
-    for issue in issues:
+    for issue in raw:
         f = issue.get("fields", {})
         result.append({
-            "key":      issue["key"],
-            "status":   (f.get("status") or {}).get("name", "?"),
-            "priority": (f.get("priority") or {}).get("name", "?"),
-            "assignee": (f.get("assignee") or {}).get("displayName", "Unassigned"),
-            "summary":  f.get("summary", ""),
+            "key":         issue["key"],
+            "status":      (f.get("status")   or {}).get("name", "?"),
+            "priority":    (f.get("priority") or {}).get("name", "?"),
+            "assignee":    (f.get("assignee") or {}).get("displayName", "Unassigned"),
+            "summary":     f.get("summary", ""),
             "fixVersions": [v.get("name", "") for v in f.get("fixVersions", [])],
         })
     return result
@@ -135,28 +152,36 @@ def get_waiting_for_build_issues(sprint_id: int, headers: dict) -> list[dict]:
 # ── Git queries ───────────────────────────────────────────────────────────────
 
 def _git(args: list[str]) -> str:
+    """Run a git command in REPO_DIR and return stdout as a stripped string."""
     return subprocess.check_output(
         ["git"] + args, cwd=REPO_DIR, stderr=subprocess.DEVNULL, text=True
     ).strip()
 
 
 def find_merge_commit(ticket_key: str) -> Optional[dict]:
-    """Return the merge commit info for a Jira ticket key, or None."""
+    """Return the merge commit info for a Jira ticket key, or None.
+
+    Uses a whole-word grep so MTV-5 does not accidentally match MTV-50 or MTV-500.
+    """
     try:
-        # Search by ticket key in commit message (case-insensitive)
-        out = _git(["log", "--oneline", "--all", f"--grep={ticket_key}", "-i", "--format=%H %ad %s", "--date=short"])
+        out = _git([
+            "log", "--all", f"--grep={ticket_key}", "-i",
+            "--format=%H %ad %s", "--date=short",
+        ])
         if not out:
             return None
-        # Take the first (most recent) match
-        first_line = out.splitlines()[0]
-        parts = first_line.split(" ", 2)
+        # Post-filter to whole-word matches to avoid MTV-5 matching MTV-50, etc.
+        pattern = re.compile(rf'\b{re.escape(ticket_key)}\b', re.IGNORECASE)
+        lines = [line for line in out.splitlines() if pattern.search(line)]
+        if not lines:
+            return None
+        parts = lines[0].split(" ", 2)
         if len(parts) < 3:
             return None
         full_hash, date, subject = parts[0], parts[1], parts[2]
         short_hash = full_hash[:7]
-        # Extract PR number from subject like "(#2442)"
-        pr_match = re.search(r'\(#(\d+)\)', subject)
-        pr = int(pr_match.group(1)) if pr_match else None
+        pr_match   = re.search(r'\(#(\d+)\)', subject)
+        pr         = int(pr_match.group(1)) if pr_match else None
         return {"commit": short_hash, "merge_date": date, "pr": pr, "subject": subject}
     except subprocess.CalledProcessError:
         return None
@@ -181,13 +206,14 @@ def check_in_build(commit: str, build_tips: list[str]) -> bool:
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
-def main():
+def main() -> None:
+    """Entry point: query Jira + git and print JSON to stdout."""
     build_tips = sys.argv[1:]  # optional positional args
 
-    headers = get_auth_header()
+    jira_base, headers = get_auth_config()
 
-    sprint = get_active_sprint(BOARD_ID, headers)
-    issues = get_waiting_for_build_issues(sprint["id"], headers)
+    sprint = get_active_sprint(BOARD_ID, headers, jira_base)
+    issues = get_waiting_for_build_issues(sprint["id"], headers, jira_base)
 
     enriched = []
     for issue in issues:
@@ -196,22 +222,22 @@ def main():
         if commit_info and build_tips:
             in_build = check_in_build(commit_info["commit"], build_tips)
         enriched.append({
-            "key":        issue["key"],
-            "status":     issue["status"],
-            "priority":   issue["priority"],
-            "assignee":   issue["assignee"],
-            "summary":    issue["summary"],
+            "key":         issue["key"],
+            "status":      issue["status"],
+            "priority":    issue["priority"],
+            "assignee":    issue["assignee"],
+            "summary":     issue["summary"],
             "fixVersions": issue["fixVersions"],
-            "commit":     commit_info["commit"] if commit_info else None,
-            "pr":         commit_info["pr"] if commit_info else None,
-            "merge_date": commit_info["merge_date"] if commit_info else None,
-            "subject":    commit_info["subject"] if commit_info else None,
-            "in_build":   in_build,
+            "commit":      commit_info["commit"]     if commit_info else None,
+            "pr":          commit_info["pr"]         if commit_info else None,
+            "merge_date":  commit_info["merge_date"] if commit_info else None,
+            "subject":     commit_info["subject"]    if commit_info else None,
+            "in_build":    in_build,
         })
 
     output = {
-        "board_id":   BOARD_ID,
-        "sprint":     {
+        "board_id": BOARD_ID,
+        "sprint": {
             "id":    sprint["id"],
             "name":  sprint["name"],
             "state": sprint["state"],

--- a/.cursor/skills/waiting-for-build/scripts/query.py
+++ b/.cursor/skills/waiting-for-build/scripts/query.py
@@ -177,6 +177,9 @@ def find_merge_commit(ticket_key: str, build_tips: Optional[list[str]] = None) -
     """Return the merge commit info for a Jira ticket key, or None.
 
     Uses a whole-word grep so MTV-5 does not accidentally match MTV-50 or MTV-500.
+    Checks both the commit subject and body for the ticket key, so commits that
+    place the reference only in the body (e.g. "Resolves: MTV-XXXX" on its own
+    line) are not silently dropped by the subject-only post-filter.
     When build_tips are provided, prefers the most recent commit that is an
     ancestor of any build tip — avoiding false negatives when a ticket has
     multiple commits (e.g., original merge plus a follow-up fix or cherry-pick).
@@ -190,12 +193,28 @@ def find_merge_commit(ticket_key: str, build_tips: Optional[list[str]] = None) -
         if not out:
             return None
         pattern = re.compile(rf'\b{re.escape(ticket_key)}\b', re.IGNORECASE)
-        candidates = [
-            _parse_commit_line(line)
-            for line in out.splitlines()
-            if pattern.search(line)
-        ]
-        candidates = [c for c in candidates if c is not None]
+        candidates = []
+        for line in out.splitlines():
+            if pattern.search(line):
+                # Key is present in the subject line — fast path.
+                c = _parse_commit_line(line)
+                if c:
+                    candidates.append(c)
+                continue
+            # Key may be only in the commit body (e.g. "Resolves: MTV-XXXX" on
+            # its own line). git's --grep found it there; verify with the full body.
+            parts = line.split(" ", 2)
+            if not parts:
+                continue
+            try:
+                body = _git(["log", "-1", "--format=%B", parts[0]])
+                if pattern.search(body):
+                    c = _parse_commit_line(line)
+                    if c:
+                        candidates.append(c)
+            except subprocess.CalledProcessError:
+                pass
+
         if not candidates:
             return None
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Cursor skills in `.cursor/skills/` contain executable workflows.
 - **i18n/Translation:** `.cursor/skills/i18n-memsource/SKILL.md` - Memsource upload/download workflow
 - **Backend Analysis:** `.cursor/skills/backend-analyzer/SKILL.md` - Analyze Go backend codebase
 - **Type Updates:** `.cursor/skills/types-update/SKILL.md` - Update @forklift-ui/types
+- **Build Tracking:** `.cursor/skills/waiting-for-build/SKILL.md` - Automate QE sprint transition (Waiting for Build → ON_QA)
 
 For full workflow details, read the relevant SKILL.md file.
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -325,6 +325,7 @@ export const createEslintConfig = () =>
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/require-await': 'off',
         'max-lines-per-function': 'off',
         'no-await-in-loop': 'off',
         'no-console': 'off',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "po-to-i18n": "ocp-i18n-po-to-i18n",
     "memsource-upload": "ocp-i18n-memsource-upload",
     "memsource-download": "ocp-i18n-memsource-download",
-    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' plugin-extensions.ts plugin-metadata.ts environment-defaults.ts --cache --cache-location .eslintcache && stylelint \"src/**/*.css\" --allow-empty-input",
+    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' 'testing/playwright/**/*.ts' plugin-extensions.ts plugin-metadata.ts environment-defaults.ts --cache --cache-location .eslintcache && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "lint:ia": "rm -rf node_modules/.cache/eslint-interactive && npx eslint-interactive .",
     "test:i18n": "bash ./ci/test-i18n.sh",


### PR DESCRIPTION
## 📝 Links

- [MTV-5490](https://redhat.atlassian.net/browse/MTV-5490)

## 📝 Description

Adds a new Cursor AI skill that automates the manual process of identifying which "Waiting for Build" Jira tickets are included in a given build and transitioning them to ON\_QA.

- **`SKILL.md`** — step-by-step instructions for the AI agent: query Jira, resolve commits, check build ancestry, auto-transition to ON\_QA, and render an interactive canvas; includes a credential-refresh procedure for expired Slack session tokens
- **`scripts/query.py`** — fetches "Waiting for Build" tickets from Jira via MCP, resolves each ticket to its merge commit with `git log`, checks if the commit is an ancestor of the build tip hashes using `git merge-base --is-ancestor`, and calls the Jira transitions API to move in-build tickets to ON\_QA
- **`scripts/fetch-build.py`** — uses `slackdump` to archive the `#mtv-builds` Slack channel into a temporary SQLite database, finds the latest IIB build post, and extracts the `forklift-console-plugin` commit SHAs from the Slack Block Kit table in thread replies — eliminating the need to manually supply build hashes each sprint

Credentials (Slack session tokens, Jira API token) are stored in the local-only `.mcp.json`, which is excluded from version control.

## 🎥 Demo

Invoke with: **"Run the waiting-for-build skill"**

The agent will:
1. Fetch the latest build hashes automatically from `#mtv-builds` Slack channel
2. Query Jira for all "Waiting for Build" tickets in the current sprint
3. Resolve each ticket's merge commit and check build inclusion
4. Transition any in-build tickets to ON\_QA automatically
5. Render an interactive canvas showing all tickets, their status, and build inclusion

## 📝 CC://

[MTV-5490]: https://redhat.atlassian.net/browse/MTV-5490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Build Tracking workflow: CLI tools to fetch build tips from Slack, correlate them with Jira issues and local git commits, emit machine-readable reports, and optionally transition ready issues to QA.
* **Documentation**
  * Comprehensive user-facing docs covering setup, CLI usage, credential refresh, expected outputs, and troubleshooting; added listing in skills index.
* **Chores**
  * Expanded linting to include Playwright tests and relaxed a testing-specific lint rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->