### PR TITLE
WIP fix(lint): disable require-await for testing and add playwright to lint script

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -325,6 +325,7 @@ export const createEslintConfig = () =>
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/require-await': 'off',
         'max-lines-per-function': 'off',
         'no-await-in-loop': 'off',
         'no-console': 'off',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "po-to-i18n": "ocp-i18n-po-to-i18n",
     "memsource-upload": "ocp-i18n-memsource-upload",
     "memsource-download": "ocp-i18n-memsource-download",
-    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' plugin-extensions.ts plugin-metadata.ts environment-defaults.ts --cache --cache-location .eslintcache && stylelint \"src/**/*.css\" --allow-empty-input",
+    "lint": "eslint 'src/**/*.{ts,tsx,js,jsx}' 'testing/playwright/**/*.ts' plugin-extensions.ts plugin-metadata.ts environment-defaults.ts --cache --cache-location .eslintcache && stylelint \"src/**/*.css\" --allow-empty-input",
     "lint:fix": "eslint . --fix && stylelint \"src/**/*.css\" --allow-empty-input --fix",
     "lint:ia": "rm -rf node_modules/.cache/eslint-interactive && npx eslint-interactive .",
     "test:i18n": "bash ./ci/test-i18n.sh",

--- a/testing/playwright/page-objects/LoginPage.ts
+++ b/testing/playwright/page-objects/LoginPage.ts
@@ -6,7 +6,7 @@ import type { Page } from '@playwright/test';
  * "console" or similar words cannot trigger a false-positive success match.
  */
 const POST_LOGIN_URL_PATTERN =
-  /^[^?#]*\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)\//;
+  /^[^?#]*\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)(?:\/|$)/;
 
 const OAUTH_ACCESS_DENIED_PATTERN = /reason=access_denied/;
 


### PR DESCRIPTION
## Summary

- Add `@typescript-eslint/require-await: off` to the testing block in `eslint.config.ts` — async-without-await is a standard Playwright page object pattern for interface consistency.
- Add `testing/playwright/**/*.ts` to `npm run lint` so CI enforces lint on E2E test files going forward (previously only `src/` was covered, allowing lint debt to accumulate silently and block contributors).

## Test plan

- [ ] `npm run lint` passes locally