### PR TITLE
fix(e2e): centralize auth constants, stabilize provider/plan page objects, and refactor instance-type tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -325,6 +325,9 @@ export const createEslintConfig = () =>
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        // Many page-object getter methods are async for API consistency but call
+        // Playwright locator APIs that return Promises without needing await.
+        // TODO: audit and fix each site, then remove this override.
         '@typescript-eslint/require-await': 'off',
         'max-lines-per-function': 'off',
         'no-await-in-loop': 'off',

--- a/testing/playwright.config.ts
+++ b/testing/playwright.config.ts
@@ -2,9 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 
 import { defineConfig, devices } from '@playwright/test';
 
-const authFile = 'playwright/.auth/user.json';
-
-const ENV_RELAY_FILE = 'playwright/.env-relay.json';
+import { AUTH_FILE as authFile, ENV_RELAY_FILE } from './playwright/utils/constants';
 
 // Capture keys explicitly set by the user (shell / e2e.env) *before* the relay is loaded.
 // global.setup.ts reads this list to decide whether a version was user-set vs stale-relay.

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -8,6 +8,7 @@ import {
   setConsoleLanguage,
   type SupportedLanguage,
 } from '../../fixtures/helpers/languageHelpers';
+import { AUTH_FILE } from '../../utils/constants';
 import { NavigationHelper } from '../../utils/NavigationHelper';
 import { disableGuidedTour } from '../../utils/utils';
 import { V2_12_0 } from '../../utils/version/constants';
@@ -49,7 +50,6 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
   test.describe.configure({ mode: 'serial' });
 
   test.afterAll(async ({ browser }) => {
-    const AUTH_FILE = 'playwright/.auth/user.json';
     const context = await browser.newContext({
       ignoreHTTPSErrors: true,
       storageState: existsSync(AUTH_FILE) ? AUTH_FILE : undefined,

--- a/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
+++ b/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
@@ -153,7 +153,10 @@ test.describe.serial('Plans - VSphere to Host Happy Path Cold Migration', () => 
       await plansPage.navigateToPlan(planName);
       await planDetailsPage.verifyPlanTitle(planName);
 
-      await planDetailsPage.verifyPlanStatus('Ready for migration', true);
+      // After creation the controller runs VDDK validation, which can transiently surface
+      // 'Cannot start' before clearing. waitForPlanReady uses a 5-minute budget so the
+      // soft-assertion window doesn't expire before the plan becomes genuinely ready.
+      await planDetailsPage.waitForPlanReady();
 
       await planDetailsPage.clickActionsMenuAndStart();
 

--- a/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
+++ b/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
@@ -116,7 +116,7 @@ test.describe.serial('Plans - VSphere to Host Happy Path Cold Migration', () => 
       tag: ['@downstream'],
     },
     async ({ page }) => {
-      test.setTimeout(60000);
+      test.setTimeout(120_000);
       const providerDetailsPage = new ProviderDetailsPage(page);
       const createWizard = new CreatePlanWizardPage(page, resourceManager);
       const planDetailsPage = new PlanDetailsPage(page);

--- a/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
@@ -13,15 +13,22 @@ import {
 import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
-// Deep inspection creates vSphere snapshots during the inspection process. A leftover
-// snapshot on mtv-func-rhel9 triggers VMHasSnapshots (Critical) on any subsequent warm
-// plan, keeping it in CannotStart. Using mtv-func-win2019 here keeps the two VMs isolated.
+// Deep inspection creates vSphere snapshots during the inspection process. Leftover snapshots
+// trigger VMHasSnapshots (Critical) on any subsequent plan, keeping it in CannotStart.
+//
+// VM ownership map — keep these isolated; each VM must appear in at most one snapshot-creating suite:
+//   mtv-func-rhel9       → migration-happy-path (cold migration)
+//   mtv-func-win2019     → migration-happy-path (cold migration)
+//   mtv-func-rhel9-uefi  → plan-migration-type  (warm migration)
+//   mtv-func-win2022     → plan-deep-inspection  (this file — inspection snapshots)
+//
+// mtv-func-win2022 has no other test consumers and is confirmed snapshot-free in the inventory.
 const test = sharedProviderFixtures.extend<{ testPlan: Awaited<ReturnType<typeof createPlan>> }>({
   testPlan: async ({ page, resourceManager, testProvider }, setValue) => {
     if (!testProvider) throw new Error('testPlan fixture requires testProvider');
     const plan = await createPlan(page, resourceManager, {
       sourceProvider: testProvider,
-      customPlanData: { virtualMachines: [{ folder: 'vm', sourceName: 'mtv-func-win2019' }] },
+      customPlanData: { virtualMachines: [{ folder: 'vm', sourceName: 'mtv-func-win2022' }] },
     });
     await setValue(plan);
   },

--- a/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
@@ -1,14 +1,71 @@
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 import { providerOnlyFixtures as test } from '../../../fixtures/resourceFixtures';
 import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import type { VirtualMachinesTab } from '../../../page-objects/PlanDetailsPage/tabs/VirtualMachinesTab';
 import { createPlanTestData, type PlanTestData } from '../../../types/test-data';
+import type { ResourceManager } from '../../../utils/resource-manager/ResourceManager';
 import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 const VM_RHEL = 'mtv-func-rhel9';
 const VM_WIN = 'mtv-func-win2019';
+
+/**
+ * Creates a plan via the wizard, waits for it to become editable, and navigates
+ * to the VMs tab with the Instance type column enabled.
+ *
+ * Calling this in each test makes the tests independent — every test owns its
+ * full setup so `--last-failed` re-runs the whole scenario from scratch.
+ */
+const createReadyPlan = async (
+  page: Page,
+  testProvider: { metadata?: { name?: string } } | undefined,
+  resourceManager: ResourceManager,
+): Promise<{ planDetailsPage: PlanDetailsPage; vmName: string }> => {
+  const testData: PlanTestData = createPlanTestData({
+    sourceProvider: testProvider?.metadata?.name ?? '',
+  });
+  resourceManager.addPlan(testData.planName, testData.planProject);
+
+  const wizard = new CreatePlanWizardPage(page, resourceManager);
+  await wizard.navigate();
+  await wizard.waitForWizardLoad();
+  await wizard.fillAndSubmit(testData);
+
+  const planDetailsPage = new PlanDetailsPage(page);
+  await planDetailsPage.waitForPlanEditable();
+  await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
+  await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
+
+  const vmName = testData.virtualMachines?.[0]?.sourceName ?? '';
+  return { planDetailsPage, vmName };
+};
+
+/**
+ * Opens the instance-type dialog for a VM, selects the first non-None option,
+ * saves, and waits for the table cell to reflect the change.
+ *
+ * Returns the label of the selected option so callers can assert against it.
+ */
+const pickAndSaveNonNoneInstanceType = async (
+  page: Page,
+  virtualMachinesTab: VirtualMachinesTab,
+  vmName: string,
+): Promise<string> => {
+  await virtualMachinesTab.openInstanceTypeDialog(vmName);
+  await virtualMachinesTab.instanceTypeModalSelect.click();
+  const listbox = page.getByRole('listbox');
+  await expect(listbox).toBeVisible();
+  const secondOption = listbox.getByRole('option').nth(1);
+  const picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
+  await secondOption.click();
+  await virtualMachinesTab.instanceTypeModalSaveButton.click();
+  await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
+  await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
+  return picked;
+};
 
 test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, () => {
   requireVersion(test, V2_12_0);
@@ -59,33 +116,17 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
     await planDetailsPage.virtualMachinesTab.waitForVMInstanceType(VM_WIN, winLabel);
   });
 
-  test('should edit instance type from plan details VM kebab menu', async ({
+  test('should set instance type from plan details VM kebab menu', async ({
     page,
     testProvider,
     resourceManager,
   }) => {
-    const testData: PlanTestData = createPlanTestData({
-      sourceProvider: testProvider?.metadata?.name ?? '',
-    });
-    resourceManager.addPlan(testData.planName, testData.planProject);
+    const { planDetailsPage, vmName } =
+      await test.step('Create plan and navigate to VMs tab', async () =>
+        createReadyPlan(page, testProvider, resourceManager));
+    const { virtualMachinesTab } = planDetailsPage;
 
-    await test.step('Create plan via wizard', async () => {
-      const wizard = new CreatePlanWizardPage(page, resourceManager);
-      await wizard.navigate();
-      await wizard.waitForWizardLoad();
-      await wizard.fillAndSubmit(testData);
-    });
-
-    const planDetailsPage = new PlanDetailsPage(page);
-    await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
-    await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
-
-    const vmName = testData.virtualMachines?.[0]?.sourceName ?? '';
-
-    let picked = '';
-
-    await test.step('Set instance type from modal', async () => {
-      const { virtualMachinesTab } = planDetailsPage;
+    await test.step('Verify initial state, then select and save instance type', async () => {
       await virtualMachinesTab.openInstanceTypeDialog(vmName);
       await expect(virtualMachinesTab.editInstanceTypeModal).toBeVisible();
       await expect(virtualMachinesTab.instanceTypeModalSelect).toBeVisible();
@@ -95,15 +136,28 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
       const listbox = page.getByRole('listbox');
       await expect(listbox).toBeVisible();
       const secondOption = listbox.getByRole('option').nth(1);
-      picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
+      const picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
       await secondOption.click();
       await virtualMachinesTab.instanceTypeModalSaveButton.click();
       await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
       await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
     });
+  });
 
-    await test.step('Cancel discards changes', async () => {
-      const { virtualMachinesTab } = planDetailsPage;
+  test('should cancel instance type modal without saving changes', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    const { planDetailsPage, vmName } =
+      await test.step('Create plan and navigate to VMs tab', async () =>
+        createReadyPlan(page, testProvider, resourceManager));
+    const { virtualMachinesTab } = planDetailsPage;
+
+    const picked = await test.step('Set initial instance type', async () =>
+      pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName));
+
+    await test.step('Cancel preserves the existing instance type', async () => {
       await virtualMachinesTab.openInstanceTypeDialog(vmName);
       await virtualMachinesTab.instanceTypeModalSelect.click();
       await page.getByRole('option', { name: /^None/ }).click();
@@ -111,9 +165,19 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
       await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
       await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
     });
+  });
 
-    await test.step('Clear instance type to None', async () => {
-      const { virtualMachinesTab } = planDetailsPage;
+  test('should clear instance type to None', async ({ page, testProvider, resourceManager }) => {
+    const { planDetailsPage, vmName } =
+      await test.step('Create plan and navigate to VMs tab', async () =>
+        createReadyPlan(page, testProvider, resourceManager));
+    const { virtualMachinesTab } = planDetailsPage;
+
+    await test.step('Set initial instance type', async () => {
+      await pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName);
+    });
+
+    await test.step('Select None and save clears instance type', async () => {
       await virtualMachinesTab.openInstanceTypeDialog(vmName);
       await virtualMachinesTab.instanceTypeModalSelect.click();
       await page.getByRole('option', { name: /^None/ }).click();

--- a/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
@@ -39,7 +39,10 @@ const createReadyPlan = async (
   await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
   await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
 
-  const vmName = testData.virtualMachines?.[0]?.sourceName ?? '';
+  const vmName = testData.virtualMachines?.[0]?.sourceName;
+  if (!vmName) {
+    throw new Error('createReadyPlan: testData must include at least one VM with sourceName');
+  }
   return { planDetailsPage, vmName };
 };
 
@@ -58,9 +61,10 @@ const pickAndSaveNonNoneInstanceType = async (
   await virtualMachinesTab.instanceTypeModalSelect.click();
   const listbox = page.getByRole('listbox');
   await expect(listbox).toBeVisible();
-  const secondOption = listbox.getByRole('option').nth(1);
-  const picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
-  await secondOption.click();
+  const nonNoneOption = listbox.getByRole('option').filter({ hasNotText: /^None/ }).first();
+  const picked = (await nonNoneOption.innerText()).split('\n')[0]?.trim() ?? '';
+  if (!picked) throw new Error('pickAndSaveNonNoneInstanceType: no non-None option available');
+  await nonNoneOption.click();
   await virtualMachinesTab.instanceTypeModalSaveButton.click();
   await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
   await virtualMachinesTab.waitForVMInstanceType(vmName, picked);
@@ -141,9 +145,9 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
       await virtualMachinesTab.instanceTypeModalSelect.click();
       const listbox = page.getByRole('listbox');
       await expect(listbox).toBeVisible();
-      const secondOption = listbox.getByRole('option').nth(1);
-      const picked = (await secondOption.innerText()).split('\n')[0]?.trim() ?? '';
-      await secondOption.click();
+      const nonNoneOption = listbox.getByRole('option').filter({ hasNotText: /^None/ }).first();
+      const picked = (await nonNoneOption.innerText()).split('\n')[0]?.trim() ?? '';
+      await nonNoneOption.click();
       await virtualMachinesTab.instanceTypeModalSaveButton.click();
       await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();
       await virtualMachinesTab.waitForVMInstanceType(vmName, picked);

--- a/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
@@ -109,6 +109,7 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
     await wizard.waitForPlanCreation();
 
     const planDetailsPage = new PlanDetailsPage(page);
+    await planDetailsPage.waitForPlanEditable();
     await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
     await planDetailsPage.virtualMachinesTab.enableColumn('Instance type');
 
@@ -126,12 +127,17 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
         createReadyPlan(page, testProvider, resourceManager));
     const { virtualMachinesTab } = planDetailsPage;
 
-    await test.step('Verify initial state, then select and save instance type', async () => {
-      await virtualMachinesTab.openInstanceTypeDialog(vmName);
+    // Open the modal once; both steps operate within the same modal session so we
+    // also verify that the full open → verify → select → save flow works end-to-end.
+    await virtualMachinesTab.openInstanceTypeDialog(vmName);
+
+    await test.step('Verify modal initial state — save disabled before selection', async () => {
       await expect(virtualMachinesTab.editInstanceTypeModal).toBeVisible();
       await expect(virtualMachinesTab.instanceTypeModalSelect).toBeVisible();
       await expect(virtualMachinesTab.instanceTypeModalSaveButton).toBeDisabled();
+    });
 
+    await test.step('Select instance type and save', async () => {
       await virtualMachinesTab.instanceTypeModalSelect.click();
       const listbox = page.getByRole('listbox');
       await expect(listbox).toBeVisible();
@@ -154,8 +160,7 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
         createReadyPlan(page, testProvider, resourceManager));
     const { virtualMachinesTab } = planDetailsPage;
 
-    const picked = await test.step('Set initial instance type', async () =>
-      pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName));
+    const picked = await pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName);
 
     await test.step('Cancel preserves the existing instance type', async () => {
       await virtualMachinesTab.openInstanceTypeDialog(vmName);
@@ -173,9 +178,7 @@ test.describe('Plan per-VM instance type (MTV-1661)', { tag: '@downstream' }, ()
         createReadyPlan(page, testProvider, resourceManager));
     const { virtualMachinesTab } = planDetailsPage;
 
-    await test.step('Set initial instance type', async () => {
-      await pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName);
-    });
+    await pickAndSaveNonNoneInstanceType(page, virtualMachinesTab, vmName);
 
     await test.step('Select None and save clears instance type', async () => {
       await virtualMachinesTab.openInstanceTypeDialog(vmName);

--- a/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
@@ -63,12 +63,13 @@ test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
     resourceManager,
     testProvider: _testProvider,
   }) => {
-    // mtv-func-rhel9 is powered-off and has no IPs — preserveStaticIPs must be false
+    // mtv-func-rhel9-uefi is powered-off and has no IPs — preserveStaticIPs must be false
     // to avoid the VMMissingGuestIPs critical condition that would put the plan in CannotStart.
     // The VM must also have no pre-existing snapshots on vSphere; snapshots are incompatible
     // with warm migration (VMHasSnapshots → CannotStart → Duplicate disabled).
     const originalPlan = await createCustomPlan({
       migrationType: MigrationType.WARM,
+      virtualMachines: [{ folder: 'vm', sourceName: 'mtv-func-rhel9-uefi' }],
       additionalPlanSettings: { preserveStaticIPs: false },
     });
     const duplicatePlanName = `dup-${originalPlan.metadata.name}`;

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -1,6 +1,9 @@
-import { type Page, test as base } from '@playwright/test';
+import { existsSync } from 'node:fs';
+
+import { type Browser, test as base } from '@playwright/test';
 
 import type { createPlanTestData } from '../types/test-data';
+import { AUTH_FILE } from '../utils/constants';
 import { ResourceManager } from '../utils/resource-manager/ResourceManager';
 
 import {
@@ -16,6 +19,12 @@ import {
   type TestProvider,
   type TestStorageMap,
 } from './helpers/resourceCreationHelpers';
+
+const createAuthenticatedContext = async (browser: Browser) =>
+  browser.newContext({
+    ignoreHTTPSErrors: true,
+    storageState: existsSync(AUTH_FILE) ? AUTH_FILE : undefined,
+  });
 
 export interface FixtureConfig {
   providerScope?: 'test' | 'worker';
@@ -66,12 +75,12 @@ export const createResourceFixtures = (
       providerScope === 'worker'
         ? ([
             async ({ browser }: { browser: any }, use: any) => {
-              const context = await browser.newContext({ ignoreHTTPSErrors: true });
+              const context = await createAuthenticatedContext(browser);
               const page = await context.newPage();
               const tempResourceManager = new ResourceManager();
 
               try {
-                const provider = await createProvider(page as Page, tempResourceManager, {
+                const provider = await createProvider(page, tempResourceManager, {
                   namePrefix: providerPrefix,
                   skipProviderReadyWait,
                 });
@@ -84,7 +93,7 @@ export const createResourceFixtures = (
 
                 await use(provider);
 
-                const cleanupContext = await browser.newContext({ ignoreHTTPSErrors: true });
+                const cleanupContext = await createAuthenticatedContext(browser);
                 const cleanupManager = new ResourceManager();
 
                 try {

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 
-import { type Browser, test as base } from '@playwright/test';
+import { type Browser, type BrowserContext, test as base } from '@playwright/test';
 
 import type { createPlanTestData } from '../types/test-data';
 import { AUTH_FILE } from '../utils/constants';
@@ -20,11 +20,12 @@ import {
   type TestStorageMap,
 } from './helpers/resourceCreationHelpers';
 
-const createAuthenticatedContext = async (browser: Browser) =>
-  browser.newContext({
+const createAuthenticatedContext = async (browser: Browser): Promise<BrowserContext> => {
+  return await browser.newContext({
     ignoreHTTPSErrors: true,
     storageState: existsSync(AUTH_FILE) ? AUTH_FILE : undefined,
   });
+};
 
 export interface FixtureConfig {
   providerScope?: 'test' | 'worker';

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -94,15 +94,9 @@ export const createResourceFixtures = (
 
                 await use(provider);
 
-                const cleanupContext = await createAuthenticatedContext(browser);
                 const cleanupManager = new ResourceManager();
-
-                try {
-                  cleanupManager.addResource(provider);
-                  await cleanupManager.instantCleanup();
-                } finally {
-                  await cleanupContext.close();
-                }
+                cleanupManager.addResource(provider);
+                await cleanupManager.instantCleanup();
               } catch (error) {
                 throw new Error(`Failed to create or use provider: ${String(error)}`, {
                   cause: error,

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -4,28 +4,11 @@ import { chromium, type FullConfig, type Page } from '@playwright/test';
 
 import { restoreConsoleLanguage } from './fixtures/helpers/languageHelpers';
 import { LoginPage } from './page-objects/LoginPage';
+import { AUTH_FILE, ENV_RELAY_FILE } from './utils/constants';
+import { RESOURCES_FILE } from './utils/resource-manager/constants';
 import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
 import { CNV_VERSION_ENV_VAR, VERSION_ENV_VAR } from './utils/version/constants';
-
-const RESOURCES_FILE = 'playwright/.resources.json';
-
-/**
- * Hardcoded auth file path — must match playwright.config.ts.
- * Never read this from config.projects[0].use.storageState: that value is computed by
- * existsSync() at config-evaluation time and will be `undefined` if the file was deleted
- * (e.g. by a previous failed run). Always writing to this constant path keeps the file
- * alive for config evaluation on the next run.
- */
-const AUTH_FILE = 'playwright/.auth/user.json';
-
-/**
- * Playwright workers do not inherit env vars that were already set before Playwright
- * started — only vars that changed during globalSetup are diffed and forwarded.
- * Write a relay file here so playwright.config.ts (re-evaluated in each worker) can
- * restore them. See github.com/microsoft/playwright/issues/21565.
- */
-const ENV_RELAY_FILE = 'playwright/.env-relay.json';
 
 const ENV_KEYS_TO_RELAY = [
   'BASE_ADDRESS',

--- a/testing/playwright/page-objects/CreateProviderPage.ts
+++ b/testing/playwright/page-objects/CreateProviderPage.ts
@@ -215,7 +215,7 @@ export class CreateProviderPage {
 
     await this.waitForWizardLoad();
     await this.fillAndSubmit(testData);
-    await providerDetailsPage.waitForPageLoad();
+    await providerDetailsPage.waitForProviderCreation(testData.name, testData.projectName);
 
     if (waitForReady) {
       await providerDetailsPage.waitForReadyStatus();

--- a/testing/playwright/page-objects/LoginPage.ts
+++ b/testing/playwright/page-objects/LoginPage.ts
@@ -6,7 +6,7 @@ import type { Page } from '@playwright/test';
  * "console" or similar words cannot trigger a false-positive success match.
  */
 const POST_LOGIN_URL_PATTERN =
-  /^[^?#]*\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)\//;
+  /^[^?#]*\/(?:dashboards|console|k8s|overview|monitoring|topology|dev-console)(?:\/|$)/;
 
 const OAUTH_ACCESS_DENIED_PATTERN = /reason=access_denied/;
 

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -325,6 +325,20 @@ export class PlanDetailsPage {
     }
   }
 
+  /**
+   * Waits until the plan reaches a status where VM/plan edits are allowed.
+   * New plans stay in Validating (VDDK check) until reconciliation finishes.
+   */
+  async waitForPlanEditable(): Promise<void> {
+    const statusLabel = this.page
+      .getByTestId('plan-status-container')
+      .getByTestId('plan-status-label');
+    await expect(statusLabel).toHaveText(
+      /Ready for migration|Cannot start|Incomplete|Canceled|Unknown/i,
+      { timeout: K8S_RECONCILE_TIMEOUT },
+    );
+  }
+
   async waitForPlanStatus(expectedStatus: string): Promise<void> {
     const statusLabel = this.page
       .getByTestId('plan-status-container')

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -2,7 +2,7 @@ import { expect, type Page } from '@playwright/test';
 
 import type { PlanTestData } from '../../types/test-data';
 import { NavigationHelper } from '../../utils/NavigationHelper';
-import { K8S_RECONCILE_TIMEOUT } from '../../utils/resource-manager/constants';
+import { K8S_RECONCILE_TIMEOUT, PLAN_READY_TIMEOUT } from '../../utils/resource-manager/constants';
 import { disableGuidedTour, isEmpty } from '../../utils/utils';
 import { InspectVirtualMachinesModal } from '../InspectVirtualMachinesModal';
 
@@ -338,6 +338,19 @@ export class PlanDetailsPage {
       /Ready for migration|Cannot start|Incomplete|Canceled|Unknown/i,
       { timeout: K8S_RECONCILE_TIMEOUT },
     );
+  }
+
+  /**
+   * Waits until the plan reaches 'Ready for migration'.
+   * After creation, the controller runs VDDK validation which can transiently surface
+   * 'Cannot start' before clearing. Use this instead of a soft verifyPlanStatus when
+   * the test must block until the plan is genuinely ready to start.
+   */
+  async waitForPlanReady(timeoutMs = PLAN_READY_TIMEOUT): Promise<void> {
+    const statusLabel = this.page
+      .getByTestId('plan-status-container')
+      .getByTestId('plan-status-label');
+    await expect(statusLabel).toContainText('Ready for migration', { timeout: timeoutMs });
   }
 
   async waitForPlanStatus(expectedStatus: string): Promise<void> {

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -229,6 +229,7 @@ export class PlanDetailsPage {
     await this.verifyNavigationTabs();
     await this.detailsTab.navigateToDetailsTab();
     await this.detailsTab.verifyDetailsTab(planData);
+    await this.waitForPlanEditable();
     await this.virtualMachinesTab.navigateToVirtualMachinesTab();
     await this.virtualMachinesTab.verifyVirtualMachinesTab(planData);
   }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/PlanVmInstanceTypeModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/PlanVmInstanceTypeModal.ts
@@ -1,4 +1,6 @@
-import type { Locator, Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+import { K8S_RECONCILE_TIMEOUT } from '../../../utils/resource-manager/constants';
 
 /** Edit instance type modal opened from Plan details → VMs tab kebab menu */
 export class PlanVmInstanceTypeModal {
@@ -21,8 +23,10 @@ export class PlanVmInstanceTypeModal {
     await getVmActionsMenu(vmName).click();
     const menuItem = this.page.getByTestId('edit-vm-instance-type-menu-item');
     await menuItem.waitFor({ state: 'visible' });
-    await this.page.waitForTimeout(200);
-    await menuItem.click({ force: true });
+    // PF6 marks disabled menu items with pf-m-disabled (CSS class, not the disabled attribute).
+    // VM actions are disabled while the plan is Validating or otherwise not editable.
+    await expect(menuItem).not.toHaveClass(/pf-m-disabled/, { timeout: K8S_RECONCILE_TIMEOUT });
+    await menuItem.click();
     await this.root.waitFor({ state: 'visible' });
   }
 

--- a/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
@@ -11,6 +11,9 @@ import { CredentialsTab } from './tabs/CredentialsTab';
 import { DetailsTab } from './tabs/DetailsTab';
 import { VirtualMachinesTab } from './tabs/VirtualMachinesTab';
 
+/** URL navigation timeout after the Create Provider wizard submits — not full K8s reconciliation. */
+const PROVIDER_CREATION_TIMEOUT_MS = 60_000;
+
 export class ProviderDetailsPage {
   private readonly navigation: NavigationHelper;
   public readonly credentialsTab: CredentialsTab;
@@ -185,7 +188,7 @@ export class ProviderDetailsPage {
   async waitForProviderCreation(
     providerName: string,
     namespace: string,
-    timeoutMs = 60000,
+    timeoutMs = PROVIDER_CREATION_TIMEOUT_MS,
   ): Promise<void> {
     try {
       await this.page.waitForURL((url) => this.isProviderDetailsUrl(url, providerName, namespace), {

--- a/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
@@ -39,6 +39,17 @@ export class ProviderDetailsPage {
     return typeMap[type] ?? type;
   }
 
+  private isProviderDetailsUrl(url: URL, providerName: string, namespace: string): boolean {
+    const urlStr = url.toString();
+    const encodedName = encodeURIComponent(providerName);
+
+    return (
+      urlStr.includes(`/ns/${namespace}/`) &&
+      urlStr.includes(`forklift.konveyor.io~v1beta1~Provider/${encodedName}`) &&
+      !urlStr.includes('~new')
+    );
+  }
+
   async clickCreatePlanButton(): Promise<void> {
     const createPlanButton = isVersionAtLeast(V2_12_0)
       ? this.page.getByTestId('create-plan-from-provider-button')
@@ -136,7 +147,7 @@ export class ProviderDetailsPage {
 
   async verifyProviderDetailsURL(providerName: string, namespace: string): Promise<void> {
     await expect(this.page).toHaveURL((url) =>
-      url.toString().includes(`forklift.konveyor.io~v1beta1~Provider/${namespace}/${providerName}`),
+      this.isProviderDetailsUrl(url, providerName, namespace),
     );
   }
 
@@ -168,6 +179,28 @@ export class ProviderDetailsPage {
   }
 
   async waitForPageLoad(): Promise<void> {
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async waitForProviderCreation(
+    providerName: string,
+    namespace: string,
+    timeoutMs = 60000,
+  ): Promise<void> {
+    try {
+      await this.page.waitForURL((url) => this.isProviderDetailsUrl(url, providerName, namespace), {
+        timeout: timeoutMs,
+        waitUntil: 'commit',
+      });
+    } catch (error) {
+      const creationError = this.page.getByRole('heading', { name: /Error creating provider/i });
+      if (await creationError.isVisible()) {
+        const alert = this.page.getByRole('alert').filter({ hasText: 'Error creating provider' });
+        const message = (await alert.textContent())?.trim() ?? 'unknown error';
+        throw new Error(`Provider creation failed: ${message}`, { cause: error });
+      }
+      throw error;
+    }
     await this.page.waitForLoadState('domcontentloaded');
   }
 

--- a/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
@@ -199,7 +199,9 @@ export class ProviderDetailsPage {
       const creationError = this.page.getByRole('heading', { name: /Error creating provider/i });
       if (await creationError.isVisible()) {
         const alert = this.page.getByRole('alert').filter({ hasText: 'Error creating provider' });
-        const message = (await alert.textContent())?.trim() ?? 'unknown error';
+        await expect(alert.first()).toBeVisible({ timeout: 5_000 });
+        const rawMessage = ((await alert.first().textContent()) ?? '').trim();
+        const message = rawMessage.length > 0 ? rawMessage : 'unknown error';
         throw new Error(`Provider creation failed: ${message}`, { cause: error });
       }
       throw error;

--- a/testing/playwright/utils/constants.ts
+++ b/testing/playwright/utils/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Hardcoded auth file path — must match playwright.config.ts.
+ * Never read this from config.projects[0].use.storageState: that value is computed by
+ * existsSync() at config-evaluation time and will be `undefined` if the file was deleted
+ * (e.g. by a previous failed run). Always writing to this constant path keeps the file
+ * alive for config evaluation on the next run.
+ */
+export const AUTH_FILE = 'playwright/.auth/user.json';
+
+/**
+ * Relay file written by global.setup.ts so playwright.config.ts (re-evaluated in each
+ * worker) can restore env vars that Playwright workers do not inherit.
+ * See https://github.com/microsoft/playwright/issues/21565
+ */
+export const ENV_RELAY_FILE = 'playwright/.env-relay.json';

--- a/testing/playwright/utils/resource-manager/ResourceCleaner.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCleaner.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 import type { BrowserContextOptions, Page } from '@playwright/test';
 
+import { AUTH_FILE } from '../constants';
 import { isEmpty } from '../utils';
 
 import { BaseResourceManager } from './BaseResourceManager';
@@ -203,11 +204,10 @@ export class ResourceCleaner extends BaseResourceManager {
       ignoreHTTPSErrors: true,
     };
 
-    const defaultAuthPath = 'playwright/.auth/user.json';
     if (storageStatePath) {
       contextOptions.storageState = storageStatePath;
-    } else if (existsSync(defaultAuthPath)) {
-      contextOptions.storageState = defaultAuthPath;
+    } else if (existsSync(AUTH_FILE)) {
+      contextOptions.storageState = AUTH_FILE;
     }
 
     const context = await browser.newContext(contextOptions);

--- a/testing/playwright/utils/resource-manager/constants.ts
+++ b/testing/playwright/utils/resource-manager/constants.ts
@@ -3,6 +3,10 @@
 export const ELEMENT_TIMEOUT = 15_000;
 export const K8S_RECONCILE_TIMEOUT = 40_000;
 export const PAGE_LOAD_TIMEOUT = 30_000;
+// After plan creation the controller runs VDDK validation, which can surface a
+// transient 'Cannot start' state before the plan reaches 'Ready for migration'.
+// This budget covers that initial validation window end-to-end.
+export const PLAN_READY_TIMEOUT = 5 * 60_000;
 export const MTV_NAMESPACE = 'openshift-mtv';
 
 export const RESOURCE_KINDS = {


### PR DESCRIPTION
## Summary

* **`utils/constants.ts` — single source of truth for auth/relay paths** — extract `AUTH_FILE` and `ENV_RELAY_FILE` into a new shared constants file. Previously the auth path was a hardcoded string in four separate files; a stale copy could silently break auth for workers. All callers now import from one place.
* **`resourceFixtures.ts` — authenticated contexts for worker-scoped fixtures** — use `createAuthenticatedContext()` (with `AUTH_FILE` storageState) when creating and cleaning up worker-scoped provider contexts so those workers share the same authenticated session instead of starting unauthenticated.
* **`ProviderDetailsPage.ts` — deterministic provider creation wait** — add `isProviderDetailsUrl()` and `waitForProviderCreation()` that wait for the correct details URL (namespace + URL-encoded name, without `~new`) and surface a readable error when creation fails. Fix `verifyProviderDetailsURL` to use the same helper.
* **`CreateProviderPage.ts`** — call `waitForProviderCreation()` instead of the generic `waitForPageLoad()` after wizard submission.
* **`PlanDetailsPage.ts`** — promote `waitForPlanEditable()` from the instance-type spec into the page object so it is reusable.
* **`PlanVmInstanceTypeModal.ts`** — replace `waitForTimeout + force-click` with `expect().not.toHaveClass(/pf-m-disabled/)` guard before clicking the kebab menu item — matches the PF v6 disabled-item pattern used elsewhere.
* **`plan-instance-type.spec.ts` — independent tests** — split the sequential `should edit instance type from plan details VM kebab menu` test into three independent tests (`set` / `cancel` / `clear`), each creating its own plan. Extracts `createReadyPlan()` and `pickAndSaveNonNoneInstanceType()` helpers. Each test is now fully self-contained: `--last-failed` reruns the correct scenario from scratch without depending on state from a prior test.
* **`plan-migration-type.spec.ts`** — switch `should change migration type on duplicated warm plan` to use `mtv-func-rhel9-uefi`; pass it explicitly via `virtualMachines` so the VM choice is visible at the call site.

## Test plan

- [ ] Re-run the downstream suite — worker-scoped provider fixtures use authenticated contexts and no longer fail to find resources
- [ ] Run `plan-instance-type.spec.ts` — all four instance-type tests pass independently; `--last-failed` on any single test reruns only that test
- [ ] Run `plan-migration-type.spec.ts` — `should change migration type on duplicated warm plan` runs against `mtv-func-rhel9-uefi`
- [ ] Run with a missing `playwright/.auth/user.json` — constants are read from one file; no stale hardcoded path issues

Resolves: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure and configuration for improved reliability and consistency across the test suite.
  * Enhanced test synchronization mechanisms and timing configurations.
  * Refactored test utilities and constants for better maintainability.

**Note:** This release contains no user-visible changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->