### PR TITLE
Resolves: MTV-5734 | Fix OVA storage and network map empty in plan wizard

### DIFF
--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -54,7 +54,15 @@ const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
       }, []);
     }
     case PROVIDER_TYPES.ova: {
-      return vm?.networks?.map((network) => network.id) ?? [];
+      // The OVA backend returns embedded network objects with PascalCase field names (ID),
+      // while @forklift-ui/types defines them as camelCase (id). Access ID directly
+      // and fall back to id so the code keeps working if the API is ever aligned.
+      type RawOvaNet = { ID?: string };
+      return (
+        vm?.networks
+          ?.map((network) => (network as unknown as RawOvaNet).ID ?? network.id)
+          .filter((id): id is string => Boolean(id)) ?? []
+      );
     }
     case PROVIDER_TYPES.hyperv:
       return vm?.networks?.map((network) => network?.id) ?? [];

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -29,7 +29,15 @@ const getNetworksForVM = (vm: ProviderVirtualMachine) => {
     case PROVIDER_TYPES.hyperv:
       return vm?.networks?.map((network) => network?.id) ?? [];
     case PROVIDER_TYPES.ova: {
-      return vm?.networks?.map((network) => network?.id) ?? [];
+      // The OVA backend returns embedded network objects with PascalCase field names (ID),
+      // while @forklift-ui/types defines them as camelCase (id). Access ID directly
+      // and fall back to id so the code keeps working if the API is ever aligned.
+      type RawOvaNet = { ID?: string };
+      return (
+        vm?.networks
+          ?.map((network) => (network as unknown as RawOvaNet).ID ?? network?.id)
+          .filter((id): id is string => Boolean(id)) ?? []
+      );
     }
     default:
       return [];

--- a/src/storageMaps/utils/__tests__/getSourceStorageValues.test.ts
+++ b/src/storageMaps/utils/__tests__/getSourceStorageValues.test.ts
@@ -1,0 +1,121 @@
+import type { TypedOvaResource, V1beta1Provider } from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+import { PROVIDER_TYPES } from '@utils/providers/constants';
+
+import type { InventoryStorage } from '../../../utils/hooks/useStorages';
+import { getSourceStorageValuesForSelectedVms } from '../getSourceStorageValues';
+
+const makeOvaProvider = (): V1beta1Provider =>
+  ({ spec: { type: PROVIDER_TYPES.ova } }) as unknown as V1beta1Provider;
+
+const makeOvaStorage = (id: string, name: string): InventoryStorage =>
+  ({
+    id,
+    name,
+    providerType: PROVIDER_TYPES.ova,
+    revision: 1,
+    selfLink: '',
+  }) as TypedOvaResource;
+
+/**
+ * Simulates the actual OVA API response for a VM with disks.
+ *
+ * The OVA backend returns embedded disk objects with PascalCase fields (e.g. ID),
+ * while @forklift-ui/types defines them as camelCase (e.g. id).
+ * This factory uses PascalCase to match real API responses.
+ */
+const makeOvaVm = (diskUppercaseID: string) => ({
+  cpuCount: 1,
+  // Simulates actual API response: disk uses PascalCase `ID`, not camelCase `id`
+  disks: [
+    {
+      ID: diskUppercaseID,
+      Capacity: 1073741824,
+      CapacityAllocationUnits: 'byte * 2^30',
+      DiskId: 'vmdisk1',
+      FileRef: 'file1',
+      FilePath: '/ova/vm.ova',
+      Format: 'vmdk',
+      Name: `${diskUppercaseID}.vmdk`,
+      PopulatedSize: 1073741824,
+      Revision: 0,
+      Variant: '',
+    },
+  ],
+  memoryMB: 1024,
+  networks: [],
+  powerState: 'On',
+  providerType: PROVIDER_TYPES.ova,
+});
+
+describe('getSourceStorageValuesForSelectedVms — OVA', () => {
+  const ovaProvider = makeOvaProvider();
+
+  it('places storages into used when disk.ID (PascalCase) matches storage.id', () => {
+    const hash = '2624ee502583f9280a1b885e281a45b51186';
+    const storages = [makeOvaStorage(hash, 'disk1.vmdk')];
+    const vms = [makeOvaVm(hash)];
+
+    const result = getSourceStorageValuesForSelectedVms(ovaProvider, storages, vms as never);
+
+    expect(result.used).toHaveLength(1);
+    expect(result.used[0].id).toBe(hash);
+    expect(result.other).toHaveLength(0);
+  });
+
+  it('does not match when disk.ID does not match any storage.id', () => {
+    const storages = [makeOvaStorage('storage-hash-abc', 'disk1.vmdk')];
+    const vms = [makeOvaVm('different-hash-xyz')];
+
+    const result = getSourceStorageValuesForSelectedVms(ovaProvider, storages, vms as never);
+
+    expect(result.used).toHaveLength(0);
+    expect(result.other).toHaveLength(0);
+  });
+
+  it('handles VMs with multiple disks', () => {
+    const hash1 = 'aabbccdd11223344556677889900aabbcc11';
+    const hash2 = 'bbccddee22334455667788990011bbccdd22';
+    const hash3 = 'ccddee0033445566778899001122ccddee33';
+
+    const storages = [
+      makeOvaStorage(hash1, 'disk1.vmdk'),
+      makeOvaStorage(hash2, 'disk2.vmdk'),
+      makeOvaStorage(hash3, 'disk3.vmdk'),
+    ];
+    const vm = {
+      ...makeOvaVm(hash1),
+      disks: [
+        { ...makeOvaVm(hash1).disks[0], ID: hash1 },
+        { ...makeOvaVm(hash2).disks[0], ID: hash2 },
+      ],
+    };
+
+    const result = getSourceStorageValuesForSelectedVms(ovaProvider, storages, [vm] as never);
+
+    expect(result.used).toHaveLength(2);
+    const usedIds = result.used.map((storage) => storage.id);
+    expect(usedIds).toContain(hash1);
+    expect(usedIds).toContain(hash2);
+    expect(result.other).toHaveLength(0);
+  });
+
+  it('returns empty used and other when no VMs are selected', () => {
+    const storages = [makeOvaStorage('abc123', 'disk1.vmdk')];
+
+    const result = getSourceStorageValuesForSelectedVms(ovaProvider, storages, []);
+
+    expect(result.used).toHaveLength(0);
+    expect(result.other).toHaveLength(0);
+  });
+
+  it('handles OVA disk with empty ID gracefully', () => {
+    const storages = [makeOvaStorage('abc123', 'disk1.vmdk')];
+    const vms = [makeOvaVm('')];
+
+    const result = getSourceStorageValuesForSelectedVms(ovaProvider, storages, vms as never);
+
+    expect(result.used).toHaveLength(0);
+    expect(result.other).toHaveLength(0);
+  });
+});

--- a/src/storageMaps/utils/getSourceStorageValues.ts
+++ b/src/storageMaps/utils/getSourceStorageValues.ts
@@ -51,10 +51,21 @@ const getVSphereStorageIds = (vm: ProviderVirtualMachine): string[] => {
 };
 
 /**
- * Extracts storage IDs from OVA VMs
+ * Extracts storage IDs from OVA VMs.
+ *
+ * The OVA backend returns embedded disk objects with PascalCase field names (e.g. `ID`),
+ * while @forklift-ui/types defines them as camelCase (e.g. `id`). Access `ID` directly
+ * and fall back to `id` so the code keeps working if the API is ever aligned.
  */
-const getOvaStorageIds = (vm: EnhancedOvaVM): string[] =>
-  vm.disks?.reduce<string[]>((acc, disk) => (disk.id ? [...acc, disk.id] : acc), []) ?? [];
+const getOvaStorageIds = (vm: EnhancedOvaVM): string[] => {
+  type RawDisk = { ID?: string };
+  return (
+    vm.disks?.reduce<string[]>((acc, disk) => {
+      const id = (disk as unknown as RawDisk).ID ?? disk.id;
+      return id ? [...acc, id] : acc;
+    }, []) ?? []
+  );
+};
 
 /**
  * Extracts storage IDs from Hyper-V VMs


### PR DESCRIPTION
## Links

- [MTV-5734](https://issues.redhat.com/browse/MTV-5734)

## Description

The `@forklift-ui/types` 1.0.10 bump (MTV-5199) changed OVA type field names from PascalCase to camelCase (e.g. `OvaDisk.ID` → `OvaDisk.id`). However, the OVA backend still returns embedded disk and network objects within VM responses using **PascalCase** field names (`ID`, `DiskId`, `Name`...). Standalone inventory endpoints (`/storages`, `/networks`) correctly return lowercase `id`.

This caused two regressions in the plan creation wizard for OVA providers:

- **Storage map**: `getOvaStorageIds` extracted `disk.id` (always `undefined` at runtime since the API returns `ID`) — `filterStoragesByVmUsage` returned `[]` so the storage map step showed no storages in either category ("Storages used by the selected VMs" and "Other storages" both empty).
- **Network map**: `toNetworksOrProfiles` extracted `network.id` (always `undefined`) instead of `network.ID`, so no networks were categorised as `used`.

**Fix**: Access the uppercase `ID` field using a type assertion and fall back to lowercase `id` for forward-compatibility when the API is eventually aligned.

**Files changed:**
- `src/storageMaps/utils/getSourceStorageValues.ts` — fix `getOvaStorageIds` to use `disk.ID ?? disk.id`
- `src/plans/create/steps/network-map/utils.ts` — fix `toNetworksOrProfiles` OVA case to use `network.ID ?? network.id`
- `src/plans/create/utils/getVMNetworksOrProfiles.ts` — same fix in the parallel network utility
- `src/storageMaps/utils/__tests__/getSourceStorageValues.test.ts` — new unit tests with correct PascalCase API fixtures

## Demo

**Before:** Storage map wizard step shows "No source storages are available for the selected VMs" for OVA providers — both categories empty despite inventory having storages.

**After:** Storage map wizard correctly shows OVA storages categorised as used/other based on selected VMs.




https://github.com/user-attachments/assets/87238737-b818-44d5-b1ca-6fe28e1f71e8




## CC://

Made with Cursor


[MTV-5734]: https://redhat.atlassian.net/browse/MTV-5734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OVA provider resource mapping to correctly handle backend field naming conventions during plan creation, ensuring networks and storage are properly identified regardless of field casing inconsistencies.

* **Tests**
  * Added comprehensive test coverage for OVA storage mapping scenarios, including validation of disk identification and storage categorization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->