### PR TITLE
ci: bump codecov-action to v5.5.5 (GPG key fix)

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -77,7 +77,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Test coverage
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps `codecov/codecov-action` from v5.5.4 to v5.5.5 to fix GPG signature verification failure
- Codecov migrated their keybase account from `keybase.io/codecovsecurity` to `keybase.io/codecovsecops` ([codecov/codecov-action#1956](https://github.com/codecov/codecov-action/issues/1956)), causing all PRs to fail at the coverage upload step
- v5.5.5 contains only this single-line keybase URL fix -- no breaking changes

## Test plan
- [ ] CI passes on this PR (the codecov step itself proves the fix works)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting integration in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->