### PR TITLE
feat(waiting-for-build): use Jira dev-status API to resolve PR commits

### DIFF
--- a/.cursor/skills/waiting-for-build/SKILL.md
+++ b/.cursor/skills/waiting-for-build/SKILL.md
@@ -236,15 +236,21 @@ The script reads from `.mcp.json` → `mcpServers.jira-mcp.env`:
 
 ## Commit-search heuristic
 
-The script runs `git log --all --grep=<KEY> -i` (case-insensitive), then
-post-filters results to **whole-word matches** so that e.g. `MTV-5` does not
-accidentally match `MTV-50` or `MTV-500`. The post-filter checks **both** the
-commit subject and the full commit body, so commits that put the reference only
-in the body (e.g. `Resolves: MTV-XXXX` on its own line, with a generic subject
-like `Fix React crashes (#2420)`) are correctly identified.
+The script uses a three-stage search for each ticket's merge commit:
+
+**Stage 1 — git grep (subject + body):** Runs `git log --all --grep=<KEY> -i`,
+post-filters to **whole-word matches** (`\b` boundary) so `MTV-5` cannot match
+`MTV-50` or `MTV-500`. Checks both the subject line and the full commit body, so
+commits with `Resolves: MTV-XXXX` only in the body are correctly found.
+
+**Stage 2 — Jira dev-status API (fallback):** If git grep finds nothing, queries
+`/rest/dev-status/1.0/issue/detail` for GitHub PRs directly linked to the ticket
+in Jira. For each MERGED PR returned, searches git log for `(#<number>)` to find
+the merge commit. This catches PRs whose commit messages contain no ticket key at all.
 
 Most commits follow `Resolves: MTV-XXXX | title (#PR)` or `MTV-XXXX | title (#PR)`.
-If a ticket has no match, `commit` is `null` — investigate manually with:
+If a ticket still has no match after both stages, `commit` is `null` — investigate
+manually with:
 
 ```bash
 git log --all --oneline | grep -i "keyword from summary"

--- a/.cursor/skills/waiting-for-build/scripts/query.py
+++ b/.cursor/skills/waiting-for-build/scripts/query.py
@@ -113,6 +113,7 @@ def get_waiting_for_build_issues(sprint_id: int, headers: dict, base: str) -> li
     """Return all MTV issues in the 'Waiting on build' column for the given sprint.
 
     Paginates automatically if the result set exceeds the page size.
+    Includes the numeric issue id so callers can query the dev-status API.
     """
     status_clause = ",".join(f'"{s}"' for s in WAITING_STATUSES)
     jql           = f'({QUICK_FILTER}) AND status in ({status_clause})'
@@ -139,6 +140,7 @@ def get_waiting_for_build_issues(sprint_id: int, headers: dict, base: str) -> li
     for issue in raw:
         f = issue.get("fields", {})
         result.append({
+            "id":          issue["id"],   # numeric id needed for dev-status API
             "key":         issue["key"],
             "status":      (f.get("status")   or {}).get("name", "?"),
             "priority":    (f.get("priority") or {}).get("name", "?"),
@@ -147,6 +149,51 @@ def get_waiting_for_build_issues(sprint_id: int, headers: dict, base: str) -> li
             "fixVersions": [v.get("name", "") for v in f.get("fixVersions", [])],
         })
     return result
+
+
+def get_prs_from_jira(issue_id: str, headers: dict, base: str) -> list[int]:
+    """Return merged GitHub PR numbers linked to the issue via Jira's dev-status API.
+
+    Falls back to an empty list on any error (permission denied, no links, etc.).
+    """
+    try:
+        r = requests.get(
+            f"{base}/rest/dev-status/1.0/issue/detail",
+            headers=headers,
+            params={"issueId": issue_id, "applicationType": "GitHub", "dataType": "pullrequest"},
+            timeout=20,
+        )
+        if not r.ok:
+            return []
+        prs = []
+        for detail in r.json().get("detail", []):
+            for pr in detail.get("pullRequests", []):
+                if pr.get("status") == "MERGED":
+                    pr_id = pr.get("id", "")          # e.g. "#2427"
+                    m = re.search(r'(\d+)', pr_id)
+                    if m:
+                        prs.append(int(m.group(1)))
+        return prs
+    except Exception:
+        return []
+
+
+def find_commit_by_pr(pr_number: int) -> Optional[dict]:
+    """Search git log for a merge commit that references a GitHub PR number.
+
+    Looks for the pattern (#<number>) that GitHub adds to merge commit subjects.
+    """
+    try:
+        out = _git([
+            "log", "--all", f"--grep=(#{pr_number})",
+            "--format=%H %ad %s", "--date=short",
+        ])
+        for line in out.splitlines():
+            if f"(#{pr_number})" in line:
+                return _parse_commit_line(line)
+        return None
+    except subprocess.CalledProcessError:
+        return None
 
 
 # ── Git queries ───────────────────────────────────────────────────────────────
@@ -259,7 +306,40 @@ def main() -> None:
 
     enriched = []
     for issue in issues:
-        commit_info = find_merge_commit(issue["key"], build_tips or None)
+        # Collect candidates from two independent sources and merge them.
+        #
+        # Source A — Jira dev-status API: PRs that a developer explicitly linked to
+        # the ticket in Jira's development panel. This is the authoritative signal;
+        # it works even when the commit message contains no ticket key.
+        #
+        # Source B — git grep: commits whose message (subject or body) mentions the
+        # ticket key. Covers the common "Resolves: MTV-XXXX" convention but can
+        # produce false positives when unrelated commits reference the key in passing.
+        #
+        # Jira candidates are placed first so they take priority in the preference
+        # logic below (in-build → most recent).
+        jira_candidates: list[dict] = []
+        for pr_num in get_prs_from_jira(issue["id"], headers, jira_base):
+            c = find_commit_by_pr(pr_num)
+            if c:
+                jira_candidates.append(c)
+
+        grep_candidate = find_merge_commit(issue["key"], build_tips or None)
+
+        # Prefer any Jira-linked commit over git-grep results.  When both agree
+        # (same PR number), deduplication via the build-preference loop is harmless.
+        candidates = jira_candidates + ([grep_candidate] if grep_candidate else [])
+
+        commit_info: Optional[dict] = None
+        if candidates:
+            if build_tips:
+                for c in candidates:
+                    if check_in_build(c["commit"], build_tips):
+                        commit_info = c
+                        break
+            if not commit_info:
+                commit_info = candidates[0]
+
         in_build: Optional[bool] = None
         if commit_info and build_tips:
             in_build = check_in_build(commit_info["commit"], build_tips)


### PR DESCRIPTION
## Summary

Follow-up to #2459 (merged today). The `query.py` script in the `waiting-for-build` skill can produce **false-positive commit links** when an unrelated commit merely mentions a ticket key in passing (e.g. in docs, changelog, or review comments). This was observed for **MTV-5388**, where the grep stage returned a documentation commit instead of the real fix ([PR #2427](https://github.com/kubev2v/forklift-console-plugin/pull/2427)).

### Root cause

`git log --grep=<KEY>` matches any commit whose message body contains the key — including documentation, changelogs, or skill scripts that reference a ticket as an example. There is no reliable way to distinguish a "fixing" commit from a "mentioning" commit by message text alone.

### Fix — two-source merge strategy

`query.py` now queries the **Jira dev-status API** for every ticket:

```
GET /rest/dev-status/1.0/issue/detail
    ?issueId=<id>&applicationType=GitHub&dataType=pullrequest
```

This returns the GitHub PRs that a developer explicitly linked in Jira's development panel — the authoritative source. For each MERGED PR, `query.py` locates the merge commit by the `(#NNN)` pattern in git log.

Jira-sourced candidates are placed **first** in the candidate list and take priority over git-grep results. The two sources complement each other:

| Source | Strength | Weakness |
|--------|----------|----------|
| Jira dev-status | Authoritative (developer-linked) | Requires Jira ↔ GitHub integration |
| git grep | Works without Jira links | Can produce false positives |

With this change **MTV-5388** correctly reports `22da1d1` / `#2427` instead of a spurious documentation commit.

## Test plan

- [ ] Run `python query.py <build_hash>` and verify MTV-5388 shows `pr=#2427`
- [ ] Verify tickets with `Resolves: MTV-XXXX` in commit body still resolve correctly (regression check for the body-grep fix from #2459)
- [ ] Verify tickets with no Jira-linked PR still fall back to git-grep correctly

Resolves: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit-search heuristic documentation with a new two-stage lookup process for improved merge commit identification.

* **Chores**
  * Enhanced build tracking with improved GitHub PR discovery from Jira and more robust git history searching capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->