### PR TITLE
MTV-5679 | Fix disk progress display for copy-offload migrations

### DIFF
--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
@@ -1,12 +1,18 @@
-import type { V1beta1PlanStatusMigrationVms } from '@forklift-ui/types';
+import type {
+  V1beta1PlanStatusMigrationVms,
+  V1beta1PlanStatusMigrationVmsPipeline,
+} from '@forklift-ui/types';
 import type { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { taskStatuses } from '@utils/constants';
+import { isEmpty } from '@utils/helpers';
 import { t } from '@utils/i18n';
 
 import type { MigrationStatusVirtualMachinePageData } from './types';
 
 export const VIRTUAL_MACHINE_CREATION_NAME = 'VirtualMachineCreation';
 export const CUTOVER_NAME = 'Cutover';
+const DISK_ALLOCATION_NAME = 'DiskAllocation';
+const DISK_TRANSFER_PREFIX = 'DiskTransfer';
 
 export const getVMMigrationStatus = (obj: unknown) => {
   const vmMigrationStatusData = obj as MigrationStatusVirtualMachinePageData;
@@ -53,9 +59,39 @@ export const isVirtualMachineCreationCompleted = (
   );
 };
 
-export const getVMDiskTransferPipeline = (statusVM: V1beta1PlanStatusMigrationVms | undefined) => {
-  const diskTransfer = statusVM?.pipeline.find((pipe) => pipe.name.startsWith('DiskTransfer'));
-  return diskTransfer;
+const isDiskTransferStep = (pipe: V1beta1PlanStatusMigrationVmsPipeline): boolean =>
+  pipe?.name?.startsWith(DISK_TRANSFER_PREFIX) || pipe?.name === DISK_ALLOCATION_NAME;
+
+const isStepActive = (pipe: V1beta1PlanStatusMigrationVmsPipeline): boolean =>
+  Boolean(pipe.phase) &&
+  pipe.phase !== taskStatuses.pending &&
+  pipe.phase !== taskStatuses.completed;
+
+/**
+ * Returns the pipeline step representing disk transfer progress.
+ * For copy-offload migrations, actual transfer happens in DiskAllocation
+ * while DiskTransferV2v runs instantly with no per-task progress.
+ * Prefers the currently active step; falls back to the one with more progress.
+ */
+export const getVMDiskTransferPipeline = (
+  statusVM: V1beta1PlanStatusMigrationVms | undefined,
+): V1beta1PlanStatusMigrationVmsPipeline | undefined => {
+  const pipeline = statusVM?.pipeline ?? [];
+  const diskSteps = pipeline.filter(isDiskTransferStep);
+
+  if (isEmpty(diskSteps)) return undefined;
+  if (diskSteps.length === 1) return diskSteps[0];
+
+  const running = diskSteps.find(isStepActive);
+  if (running) return running;
+
+  const diskTransfer = diskSteps.find((pipe) => pipe.name.startsWith(DISK_TRANSFER_PREFIX));
+  const diskAllocation = diskSteps.find((pipe) => pipe.name === DISK_ALLOCATION_NAME);
+
+  if ((diskTransfer?.progress?.completed ?? 0) > 0) return diskTransfer;
+  if ((diskAllocation?.progress?.completed ?? 0) > 0) return diskAllocation;
+
+  return diskTransfer ?? diskAllocation;
 };
 
 export const getVMDiskProgress = (obj: unknown) => {


### PR DESCRIPTION
getVMDiskTransferPipeline only matched pipeline steps starting with "DiskTransfer", missing the DiskAllocation step where the actual disk transfer happens during copy-offload (storage offload) migrations. This caused the Disk transfer and Disk counter columns to show 0 values until the migration completed.

Now considers both DiskAllocation and DiskTransfer* steps, preferring whichever is currently active (running phase).

Resolves: MTV-5679

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Links

<!---
> References: <Jira ticket urls>

> Add more JIRA, Docs, and other PR/Issue links
-->

## 📝 Description

<!---
> Add a brief description
-->

## 🎥 Demo

<!---
> Please add a video or an image of the behavior/changes
-->

## 📝 CC://

<!---
> @tag as needed
-->

---

<details>
<summary>Merge automation commands</summary>

| Command | Description |
|---------|-------------|
| `/lgtm` or `/approve` | Add the `approved` label — PR will auto-merge when all checks pass |
| `/retest` | Re-trigger **Konflux** pipelines (handled by Pipelines as Code) |
| `/retest-gh` | Re-run **failed** GitHub Actions jobs |
| `/retest-gh-all` | Re-run **all** GitHub Actions workflows from scratch |
| `/retest-all` | Re-run failed GitHub Actions jobs **+** Konflux pipelines |
| `/hold` | Prevent auto-merge even if approved and checks pass |
| `/unhold` | Remove the hold and allow auto-merge again |

Submitting a **GitHub review approval** (Approve) also adds the `approved` label.

When checks fail on an approved PR, the bot automatically retries failed GitHub Actions up to **3 times**.
Konflux pipeline failures require a manual `/retest` to re-trigger.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM disk migration progress tracking by refining how the app determines the active and completed disk migration step, resulting in more accurate disk transfer vs allocation progress reporting during migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->