### PR TITLE
Fix duplicate plan to also copy Hooks and ConfigMap

### DIFF
--- a/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
+++ b/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
@@ -1,28 +1,48 @@
 import { useCallback, useState } from 'react';
 import { FormGroupWithHelpText } from 'src/components/common/FormGroupWithHelpText/FormGroupWithHelpText';
+import { CONFIG_MAP_GVK } from 'src/plans/create/steps/customization-scripts/constants';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import {
+  HookModelGroupVersionKind,
+  type IoK8sApiCoreV1ConfigMap,
   NetworkMapModelGroupVersionKind,
   StorageMapModelGroupVersionKind,
+  type V1beta1Hook,
   type V1beta1NetworkMap,
+  type V1beta1Plan,
   type V1beta1StorageMap,
 } from '@forklift-ui/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { Stack, StackItem, TextInput } from '@patternfly/react-core';
-import { getName } from '@utils/crds/common/selectors';
+import { getName, getNamespace } from '@utils/crds/common/selectors';
 import {
   getPlanNetworkMapName,
   getPlanNetworkMapNamespace,
   getPlanStorageMapName,
   getPlanStorageMapNamespace,
+  getPlanVirtualMachines,
 } from '@utils/crds/plans/selectors';
+import { isEmpty } from '@utils/helpers';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
 
 import type { PlanModalProps } from '../types';
 
 import { createDuplicatePlanAndMapResources } from './utils/utils';
+
+const getPlanHookNames = (plan: V1beta1Plan): { postHookName?: string; preHookName?: string } => {
+  const allHooks = getPlanVirtualMachines(plan).flatMap((vm) => vm.hooks ?? []);
+
+  if (isEmpty(allHooks)) {
+    return {};
+  }
+
+  const preHookName = allHooks.find((hook) => hook.step === 'PreHook')?.hook?.name;
+  const postHookName = allHooks.find((hook) => hook.step === 'PostHook')?.hook?.name;
+
+  return { postHookName, preHookName };
+};
 
 const DuplicateModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
   const { t } = useForkliftTranslation();
@@ -55,14 +75,62 @@ const DuplicateModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
       : null,
   );
 
+  const { postHookName, preHookName } = getPlanHookNames(plan);
+  const planNamespace = getNamespace(plan);
+
+  const [preHook] = useK8sWatchResource<V1beta1Hook>(
+    preHookName
+      ? {
+          groupVersionKind: HookModelGroupVersionKind,
+          isList: false,
+          name: preHookName,
+          namespace: planNamespace,
+          namespaced: true,
+        }
+      : null,
+  );
+
+  const [postHook] = useK8sWatchResource<V1beta1Hook>(
+    postHookName
+      ? {
+          groupVersionKind: HookModelGroupVersionKind,
+          isList: false,
+          name: postHookName,
+          namespace: planNamespace,
+          namespaced: true,
+        }
+      : null,
+  );
+
+  const scriptsRef = plan?.spec?.customizationScripts;
+  const [configMap] = useK8sWatchResource<IoK8sApiCoreV1ConfigMap>(
+    scriptsRef?.name
+      ? {
+          groupVersionKind: CONFIG_MAP_GVK,
+          isList: false,
+          name: scriptsRef.name,
+          namespace: scriptsRef.namespace,
+          namespaced: true,
+        }
+      : null,
+  );
+
   const onChange = (value: string): void => {
     setNewName(value);
   };
 
   const onDuplicate = useCallback(
     async () =>
-      createDuplicatePlanAndMapResources({ networkMap, newPlanName: newName, plan, storageMap }),
-    [newName, networkMap, storageMap, plan],
+      createDuplicatePlanAndMapResources({
+        configMap,
+        networkMap,
+        newPlanName: newName,
+        plan,
+        postHook,
+        preHook,
+        storageMap,
+      }),
+    [configMap, networkMap, newName, plan, postHook, preHook, storageMap],
   );
 
   return (

--- a/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
+++ b/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
@@ -1,0 +1,298 @@
+import type {
+  IoK8sApiCoreV1ConfigMap,
+  V1beta1Hook,
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1StorageMap,
+} from '@forklift-ui/types';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+
+import { createDuplicatePlanAndMapResources } from '../utils';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: jest.fn(),
+}));
+
+jest.mock('src/plans/create/utils/addOwnerRefs', () => ({
+  addOwnerRefs: jest.fn(async () => undefined),
+}));
+
+jest.mock('@utils/crds/common/utils', () => ({
+  getRandomChars: () => 'abcde',
+}));
+
+const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
+
+const basePlan: V1beta1Plan = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Plan',
+  metadata: { name: 'original-plan', namespace: 'openshift-mtv', uid: 'plan-uid-1' },
+  spec: {
+    archived: false,
+    map: {
+      network: { name: 'old-netmap', namespace: 'openshift-mtv' },
+      storage: { name: 'old-storagemap', namespace: 'openshift-mtv' },
+    },
+    provider: {
+      destination: { name: 'target', namespace: 'openshift-mtv' },
+      source: { name: 'source', namespace: 'openshift-mtv' },
+    },
+    targetNamespace: 'default',
+    vms: [
+      {
+        hooks: [
+          { hook: { name: 'original-plan-pre-hook', namespace: 'openshift-mtv' }, step: 'PreHook' },
+          {
+            hook: { name: 'original-plan-post-hook', namespace: 'openshift-mtv' },
+            step: 'PostHook',
+          },
+        ],
+        id: 'vm-1',
+        name: 'test-vm',
+      },
+    ],
+  },
+};
+
+const baseNetworkMap: V1beta1NetworkMap = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'NetworkMap',
+  metadata: { name: 'old-netmap', namespace: 'openshift-mtv' },
+  spec: { map: [], provider: { destination: { name: 'target' }, source: { name: 'source' } } },
+};
+
+const baseStorageMap: V1beta1StorageMap = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'StorageMap',
+  metadata: { name: 'old-storagemap', namespace: 'openshift-mtv' },
+  spec: { map: [], provider: { destination: { name: 'target' }, source: { name: 'source' } } },
+};
+
+const preHook: V1beta1Hook = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Hook',
+  metadata: { name: 'original-plan-pre-hook', namespace: 'openshift-mtv' },
+  spec: { image: 'quay.io/konveyor/hook-runner', playbook: 'pre-playbook' },
+};
+
+const postHook: V1beta1Hook = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Hook',
+  metadata: { name: 'original-plan-post-hook', namespace: 'openshift-mtv' },
+  spec: { image: 'quay.io/konveyor/hook-runner', playbook: 'post-playbook' },
+};
+
+const configMap: IoK8sApiCoreV1ConfigMap = {
+  apiVersion: 'v1',
+  data: { 'script.sh': '#!/bin/bash\necho hello' },
+  kind: 'ConfigMap',
+  metadata: { name: 'original-plan-scripts', namespace: 'openshift-mtv' },
+};
+
+describe('createDuplicatePlanAndMapResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockK8sCreate.mockImplementation(async ({ data }) => ({
+      ...data,
+      metadata: { ...data.metadata, uid: `uid-${data.metadata?.name}` },
+    }));
+  });
+
+  it('creates duplicated hooks when plan has hooks', async () => {
+    await createDuplicatePlanAndMapResources({
+      configMap: undefined,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: basePlan,
+      postHook,
+      preHook,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const hookCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'Hook',
+    );
+
+    expect(hookCreates).toHaveLength(2);
+
+    const preHookData = (hookCreates[0][0] as { data: V1beta1Hook }).data;
+    expect(preHookData.metadata?.name).toBe('copy-of-plan-pre-hook-abcde');
+    expect(preHookData.spec?.playbook).toBe('pre-playbook');
+
+    const postHookData = (hookCreates[1][0] as { data: V1beta1Hook }).data;
+    expect(postHookData.metadata?.name).toBe('copy-of-plan-post-hook-abcde');
+    expect(postHookData.spec?.playbook).toBe('post-playbook');
+  });
+
+  it('creates duplicated ConfigMap when plan has customization scripts', async () => {
+    const planWithScripts: V1beta1Plan = {
+      ...basePlan,
+      spec: {
+        ...basePlan.spec!,
+        customizationScripts: { name: 'original-plan-scripts', namespace: 'openshift-mtv' },
+        vms: [{ id: 'vm-1', name: 'test-vm' }],
+      },
+    };
+
+    await createDuplicatePlanAndMapResources({
+      configMap,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: planWithScripts,
+      postHook: undefined,
+      preHook: undefined,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const configMapCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'ConfigMap',
+    );
+
+    expect(configMapCreates).toHaveLength(1);
+
+    const cmData = (configMapCreates[0][0] as { data: IoK8sApiCoreV1ConfigMap }).data;
+    expect(cmData.metadata?.name).toBe('copy-of-plan-scripts-abcde');
+    expect(cmData.data).toEqual({ 'script.sh': '#!/bin/bash\necho hello' });
+  });
+
+  it('updates plan vms hooks to reference new hooks', async () => {
+    await createDuplicatePlanAndMapResources({
+      configMap: undefined,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: basePlan,
+      postHook,
+      preHook,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const planCreate = createCalls.find(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'Plan',
+    );
+
+    expect(planCreate).toBeDefined();
+    const planData = (planCreate![0] as { data: V1beta1Plan }).data;
+    const vmHooks = planData.spec?.vms?.[0]?.hooks;
+
+    expect(vmHooks).toHaveLength(2);
+    expect(vmHooks?.[0]?.hook?.name).toBe('copy-of-plan-pre-hook-abcde');
+    expect(vmHooks?.[1]?.hook?.name).toBe('copy-of-plan-post-hook-abcde');
+  });
+
+  it('sets customizationScripts on new plan referencing the new ConfigMap', async () => {
+    const planWithScripts: V1beta1Plan = {
+      ...basePlan,
+      spec: {
+        ...basePlan.spec!,
+        customizationScripts: { name: 'original-plan-scripts', namespace: 'openshift-mtv' },
+        vms: [{ id: 'vm-1', name: 'test-vm' }],
+      },
+    };
+
+    await createDuplicatePlanAndMapResources({
+      configMap,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: planWithScripts,
+      postHook: undefined,
+      preHook: undefined,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const planCreate = createCalls.find(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'Plan',
+    );
+
+    expect(planCreate).toBeDefined();
+    const planData = (planCreate![0] as { data: V1beta1Plan }).data;
+    expect(planData.spec?.customizationScripts?.name).toBe('copy-of-plan-scripts-abcde');
+    expect(planData.spec?.customizationScripts?.namespace).toBe('openshift-mtv');
+  });
+
+  it('does not create hooks when plan has no hooks', async () => {
+    const planNoHooks: V1beta1Plan = {
+      ...basePlan,
+      spec: { ...basePlan.spec!, vms: [{ id: 'vm-1', name: 'test-vm' }] },
+    };
+
+    await createDuplicatePlanAndMapResources({
+      configMap: undefined,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: planNoHooks,
+      postHook: undefined,
+      preHook: undefined,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const hookCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'Hook',
+    );
+
+    expect(hookCreates).toHaveLength(0);
+  });
+
+  it('does not create ConfigMap when plan has no customization scripts', async () => {
+    const planNoScripts: V1beta1Plan = {
+      ...basePlan,
+      spec: { ...basePlan.spec!, vms: [{ id: 'vm-1', name: 'test-vm' }] },
+    };
+
+    await createDuplicatePlanAndMapResources({
+      configMap: undefined,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: planNoScripts,
+      postHook: undefined,
+      preHook: undefined,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const configMapCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'ConfigMap',
+    );
+
+    expect(configMapCreates).toHaveLength(0);
+  });
+
+  it('always creates new NetworkMap and StorageMap', async () => {
+    const planNoHooks: V1beta1Plan = {
+      ...basePlan,
+      spec: { ...basePlan.spec!, vms: [{ id: 'vm-1', name: 'test-vm' }] },
+    };
+
+    await createDuplicatePlanAndMapResources({
+      configMap: undefined,
+      networkMap: baseNetworkMap,
+      newPlanName: 'copy-of-plan',
+      plan: planNoHooks,
+      postHook: undefined,
+      preHook: undefined,
+      storageMap: baseStorageMap,
+    });
+
+    const createCalls = mockK8sCreate.mock.calls;
+    const networkMapCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'NetworkMap',
+    );
+    const storageMapCreates = createCalls.filter(
+      ([args]) => (args as { data: { kind: string } }).data.kind === 'StorageMap',
+    );
+
+    expect(networkMapCreates).toHaveLength(1);
+    expect(storageMapCreates).toHaveLength(1);
+    expect((networkMapCreates[0][0] as { data: V1beta1NetworkMap }).data.metadata?.name).toBe(
+      'copy-of-plan-abcde',
+    );
+    expect((storageMapCreates[0][0] as { data: V1beta1StorageMap }).data.metadata?.name).toBe(
+      'copy-of-plan-abcde',
+    );
+  });
+});

--- a/src/plans/actions/components/DuplicateModal/utils/utils.ts
+++ b/src/plans/actions/components/DuplicateModal/utils/utils.ts
@@ -1,30 +1,215 @@
-import { ADD } from '@components/ModalForm/utils/constants';
-import {
-  NetworkMapModel,
-  PlanModel,
-  StorageMapModel,
-  type V1beta1NetworkMap,
-  type V1beta1Plan,
-  type V1beta1PlanSpecMap,
-  type V1beta1StorageMap,
+import { addOwnerRefs } from 'src/plans/create/utils/addOwnerRefs';
+
+import type {
+  IoK8sApiCoreV1ConfigMap,
+  V1beta1Hook,
+  V1beta1NetworkMap,
+  V1beta1Plan,
+  V1beta1PlanSpecMap,
+  V1beta1PlanSpecVms,
+  V1beta1StorageMap,
 } from '@forklift-ui/types';
-import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import { getName, getNamespace } from '@utils/crds/common/selectors';
-import { buildOwnerReference, getRandomChars } from '@utils/crds/common/utils';
+import { HookModel, NetworkMapModel, PlanModel, StorageMapModel } from '@forklift-ui/types';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import { ConfigMapModel } from '@utils/constants';
+import { getAnnotations, getName, getNamespace, getUID } from '@utils/crds/common/selectors';
+import { getRandomChars } from '@utils/crds/common/utils';
+import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
+import { isEmpty } from '@utils/helpers';
+import type { ObjectRef } from '@utils/helpers/getObjectRef';
 
 type CreateDuplicatePlanParams = {
-  plan: V1beta1Plan;
+  configMap?: IoK8sApiCoreV1ConfigMap;
   networkMap: V1beta1NetworkMap;
-  storageMap: V1beta1StorageMap;
   newPlanName: string;
+  plan: V1beta1Plan;
+  postHook?: V1beta1Hook;
+  preHook?: V1beta1Hook;
+  storageMap: V1beta1StorageMap;
 };
+
+type OwnerRefResources = {
+  configMap?: IoK8sApiCoreV1ConfigMap;
+  networkMap: V1beta1NetworkMap;
+  postHook?: V1beta1Hook;
+  preHook?: V1beta1Hook;
+  storageMap: V1beta1StorageMap;
+};
+
+const buildDuplicateHook = (
+  hook: V1beta1Hook,
+  planName: string,
+  hookType: 'pre' | 'post',
+  namespace: string,
+): V1beta1Hook => ({
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Hook',
+  metadata: {
+    name: `${planName}-${hookType}-hook-${getRandomChars(5)}`,
+    namespace,
+    ...(getAnnotations(hook) && { annotations: getAnnotations(hook) }),
+  },
+  spec: { ...hook.spec },
+});
+
+const buildDuplicateConfigMap = (
+  configMap: IoK8sApiCoreV1ConfigMap,
+  planName: string,
+  namespace: string,
+): IoK8sApiCoreV1ConfigMap => ({
+  apiVersion: 'v1',
+  data: configMap.data,
+  kind: 'ConfigMap',
+  metadata: {
+    name: `${planName}-scripts-${getRandomChars(5)}`,
+    namespace,
+  },
+});
+
+const buildUpdatedVmsWithHooks = (
+  plan: V1beta1Plan,
+  newPreHook?: V1beta1Hook,
+  newPostHook?: V1beta1Hook,
+): V1beta1PlanSpecVms[] => {
+  const vms = getPlanVirtualMachines(plan);
+
+  if (!newPreHook && !newPostHook) {
+    return vms;
+  }
+
+  return vms.map((vm) => {
+    if (isEmpty(vm.hooks)) {
+      return vm;
+    }
+
+    const updatedHooks = vm.hooks!.map((hookEntry) => {
+      if (hookEntry.step === 'PreHook' && newPreHook) {
+        return {
+          ...hookEntry,
+          hook: { name: getName(newPreHook), namespace: getNamespace(newPreHook) },
+        };
+      }
+
+      if (hookEntry.step === 'PostHook' && newPostHook) {
+        return {
+          ...hookEntry,
+          hook: { name: getName(newPostHook), namespace: getNamespace(newPostHook) },
+        };
+      }
+
+      return hookEntry;
+    });
+
+    return { ...vm, hooks: updatedHooks };
+  });
+};
+
+const addOwnerRefsToResources = async (
+  planRef: ObjectRef,
+  resources: OwnerRefResources,
+): Promise<void> => {
+  const requests: ReturnType<typeof addOwnerRefs>[] = [
+    addOwnerRefs(NetworkMapModel, resources.networkMap, [planRef]),
+    addOwnerRefs(StorageMapModel, resources.storageMap, [planRef]),
+  ];
+
+  if (resources.preHook) {
+    requests.push(addOwnerRefs(HookModel, resources.preHook, [planRef]));
+  }
+
+  if (resources.postHook) {
+    requests.push(addOwnerRefs(HookModel, resources.postHook, [planRef]));
+  }
+
+  if (resources.configMap) {
+    requests.push(addOwnerRefs(ConfigMapModel, resources.configMap, [planRef]));
+  }
+
+  await Promise.all(requests);
+};
+
 export const createDuplicatePlanAndMapResources = async ({
+  configMap,
   networkMap,
   newPlanName,
   plan,
+  postHook,
+  preHook,
   storageMap,
-}: CreateDuplicatePlanParams) => {
-  const namespace = getNamespace(plan);
+}: CreateDuplicatePlanParams): Promise<V1beta1Plan> => {
+  const namespace = getNamespace(plan) ?? '';
+
+  const vmHooks = getPlanVirtualMachines(plan).flatMap((vm) => vm.hooks ?? []);
+  const hasPreHookRef = vmHooks.some((entry) => entry.step === 'PreHook');
+  const hasPostHookRef = vmHooks.some((entry) => entry.step === 'PostHook');
+  const hasScriptsRef = !isEmpty(plan.spec?.customizationScripts?.name);
+
+  if (hasPreHookRef && !preHook) {
+    throw new Error('Plan references a PreHook but it was not resolved for duplication.');
+  }
+  if (hasPostHookRef && !postHook) {
+    throw new Error('Plan references a PostHook but it was not resolved for duplication.');
+  }
+  if (hasScriptsRef && !configMap) {
+    throw new Error('Plan references customization scripts but ConfigMap was not resolved.');
+  }
+
+  const newPreHook = preHook
+    ? await k8sCreate({
+        data: buildDuplicateHook(preHook, newPlanName, 'pre', namespace),
+        model: HookModel,
+      })
+    : undefined;
+
+  const newPostHook = postHook
+    ? await k8sCreate({
+        data: buildDuplicateHook(postHook, newPlanName, 'post', namespace),
+        model: HookModel,
+      })
+    : undefined;
+
+  const newConfigMap = configMap
+    ? await k8sCreate({
+        data: buildDuplicateConfigMap(configMap, newPlanName, namespace),
+        model: ConfigMapModel,
+      })
+    : undefined;
+
+  const newNetworkMapData: V1beta1NetworkMap = {
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    kind: 'NetworkMap',
+    metadata: {
+      name: `${newPlanName}-${getRandomChars(5)}`,
+      namespace,
+    },
+    spec: networkMap.spec,
+  };
+
+  const newStorageMapData: V1beta1StorageMap = {
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    kind: 'StorageMap',
+    metadata: {
+      name: `${newPlanName}-${getRandomChars(5)}`,
+      namespace,
+    },
+    spec: storageMap.spec,
+  };
+
+  const createdNetworkMap = await k8sCreate({ data: newNetworkMapData, model: NetworkMapModel });
+  const createdStorageMap = await k8sCreate({ data: newStorageMapData, model: StorageMapModel });
+
+  const mappings: V1beta1PlanSpecMap = {
+    network: {
+      name: getName(createdNetworkMap),
+      namespace: getNamespace(createdNetworkMap),
+    },
+    storage: {
+      name: getName(createdStorageMap),
+      namespace: getNamespace(createdStorageMap),
+    },
+  };
+
+  const vms = buildUpdatedVmsWithHooks(plan, newPreHook, newPostHook);
 
   const newPlanData: V1beta1Plan = {
     apiVersion: 'forklift.konveyor.io/v1beta1',
@@ -36,62 +221,35 @@ export const createDuplicatePlanAndMapResources = async ({
     spec: {
       ...plan.spec!,
       archived: false,
+      customizationScripts: newConfigMap
+        ? { name: getName(newConfigMap), namespace: getNamespace(newConfigMap) }
+        : undefined,
+      map: mappings,
+      vms,
     },
   };
-  const initPlan = await k8sCreate({ data: newPlanData, model: PlanModel });
 
-  const newPlanOwnerReference = buildOwnerReference(initPlan, {
-    blockOwnerDeletion: false,
+  if (!newConfigMap) {
+    delete newPlanData.spec!.customizationScripts;
+  }
+
+  const createdPlan = await k8sCreate({ data: newPlanData, model: PlanModel });
+
+  const planRef: ObjectRef = {
+    apiVersion: createdPlan.apiVersion,
+    kind: createdPlan.kind,
+    name: getName(createdPlan)!,
+    namespace: getNamespace(createdPlan),
+    uid: getUID(createdPlan)!,
+  };
+
+  await addOwnerRefsToResources(planRef, {
+    configMap: newConfigMap,
+    networkMap: createdNetworkMap,
+    postHook: newPostHook,
+    preHook: newPreHook,
+    storageMap: createdStorageMap,
   });
 
-  const newNetworkMapData: V1beta1NetworkMap = {
-    apiVersion: 'forklift.konveyor.io/v1beta1',
-    kind: 'NetworkMap',
-    metadata: {
-      name: `${newPlanName}-${getRandomChars(5)}`,
-      namespace,
-      ownerReferences: [newPlanOwnerReference],
-    },
-    spec: networkMap.spec,
-  };
-
-  const newStorageMapData: V1beta1StorageMap = {
-    apiVersion: 'forklift.konveyor.io/v1beta1',
-    kind: 'StorageMap',
-    metadata: {
-      name: `${newPlanName}-${getRandomChars(5)}`,
-      namespace,
-      ownerReferences: [newPlanOwnerReference],
-    },
-    spec: storageMap.spec,
-  };
-
-  await k8sCreate({ data: newNetworkMapData, model: NetworkMapModel });
-
-  await k8sCreate({ data: newStorageMapData, model: StorageMapModel });
-
-  const mappings: V1beta1PlanSpecMap = {
-    network: {
-      name: getName(newNetworkMapData),
-      namespace: getNamespace(newNetworkMapData),
-    },
-    storage: {
-      name: getName(newStorageMapData),
-      namespace: getNamespace(newStorageMapData),
-    },
-  };
-
-  const newPlan = await k8sPatch({
-    data: [
-      {
-        op: ADD,
-        path: '/spec/map',
-        value: mappings,
-      },
-    ],
-    model: PlanModel,
-    resource: initPlan,
-  });
-
-  return newPlan;
+  return createdPlan;
 };

--- a/src/utils/crds/common/selectors.ts
+++ b/src/utils/crds/common/selectors.ts
@@ -17,8 +17,6 @@ export const getOwnerReference = (resource: K8sResourceCommon) =>
 
 export const getKind = (resource: K8sResourceCommon) => resource?.kind;
 
-export const getApiVersion = (resource: K8sResourceCommon) => resource?.apiVersion;
-
 const getSettings = (provider: V1beta1Provider) => provider?.spec?.settings;
 
 export const getVddkInitImage = (provider: V1beta1Provider) => getSettings(provider)?.vddkInitImage;
@@ -37,7 +35,8 @@ export const isApplianceManagementEnabled = (provider: V1beta1Provider) =>
 export const getAnnotation = (resource: K8sResourceCommon, key: string): string | undefined =>
   resource?.metadata?.annotations?.[key];
 
-export const getAnnotations = (provider: V1beta1Provider) => provider?.metadata?.annotations;
+export const getAnnotations = (resource: K8sResourceCommon | undefined) =>
+  resource?.metadata?.annotations;
 
 export const getUrl = (provider: V1beta1Provider) => provider?.spec?.url;
 

--- a/src/utils/crds/common/utils.ts
+++ b/src/utils/crds/common/utils.ts
@@ -1,28 +1,3 @@
-import type { K8sResourceCommon } from '@forklift-ui/types';
-import type { OwnerReference } from '@openshift-console/dynamic-plugin-sdk';
-
-import { getApiVersion, getKind, getName, getUID } from './selectors';
-
-/**
- * function for creating a resource's owner reference from a resource
- * @param {K8sResourceCommon} owner resource to create an owner reference from
- * @param opts optional additional options
- * @param {boolean} opts.blockOwnerDeletion http://kubevirt.io/api-reference/v0.51.0/definitions.html#_k8s_io_apimachinery_pkg_apis_meta_v1_ownerreference
- * @param {boolean} opts.controller http://kubevirt.io/api-reference/v0.51.0/definitions.html#_k8s_io_apimachinery_pkg_apis_meta_v1_ownerreference
- * @returns a resource's owner reference
- */
-export const buildOwnerReference = (
-  owner: K8sResourceCommon,
-  opts: { blockOwnerDeletion?: boolean; controller?: boolean } = { blockOwnerDeletion: true },
-): OwnerReference => ({
-  apiVersion: getApiVersion(owner)!,
-  blockOwnerDeletion: opts?.blockOwnerDeletion,
-  controller: opts?.controller,
-  kind: getKind(owner)!,
-  name: getName(owner)!,
-  uid: getUID(owner)!,
-});
-
 export const getRandomChars = (len = 6): string => {
   const array = new Uint8Array(len);
   crypto.getRandomValues(array);


### PR DESCRIPTION
## Summary

- Fixes the "Duplicate" plan action to also create copies of Hook resources (pre/post migration) and the scripts ConfigMap, so the cloned plan is fully independent from the original
- Previously, only NetworkMap and StorageMap were duplicated; Hooks and ConfigMap were shared via references, causing the cloned plan to break when the original was deleted (K8s garbage collection removed the owned resources)
- Uses a safer resource-first creation order: sub-resources are created before the plan, so partial failures result in orphaned resources rather than a broken plan

## Root Cause

`createDuplicatePlanAndMapResources` only duplicated NetworkMap and StorageMap. The plan's `spec.vms[].hooks` and `spec.customizationScripts` still referenced the original plan's resources, which are removed by Kubernetes garbage collection when the original plan is deleted.

## Changes

| File | Change |
|------|--------|
| `DuplicateModal.tsx` | Fetch Hook resources and ConfigMap referenced by the plan |
| `utils/utils.ts` | Duplicate hooks and ConfigMap with randomized names, create resources before the plan, set ownerReferences, update plan spec references |
| `utils/__tests__/utils.test.ts` | Unit tests covering all scenarios (with/without hooks, with/without scripts) |

## Test plan

- [x] Unit tests: 7 tests covering hooks duplication, ConfigMap duplication, VM hook reference updates, no-op cases
- [x] Manual E2E: Create a plan with hooks/scripts → Duplicate → Delete original → Start cloned plan (cluster did not have duplicatable plans at dev time)

Resolves: MTV-5749

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Plan duplication now copies pre/post VM hooks and customization scripts, and updates all references in the duplicated plan to point to the newly created resources with consistent randomized names.
  * Adds safer handling to ensure required hook/script inputs are present when referenced by the source plan.
* **Tests**
  * Added Jest coverage validating correct resource creation and reference rewrites for hook-backed plans and script-backed plans, including deterministic naming via mocked randomness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->