### PR TITLE
Hide Hyper-V iSCSI transfer method until backend support lands

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -29,7 +29,12 @@ export default {
     'src/storageMaps/yamlTemplates/defaultYamlTemplate.ts',
     'src/storageMaps/create/StorageMapCreatePage.tsx',
   ],
-  ignore: ['i18next-parser.config.ts', 'testing/**', 'eslint.ide.config.ts'],
+  ignore: [
+    'i18next-parser.config.ts',
+    'testing/**',
+    'eslint.ide.config.ts',
+    'src/providers/create/fields/hyperv/HypervTransferMethodField.tsx', // hidden until backend iSCSI support lands (kubev2v/forklift#6014)
+  ],
   ignoreBinaries: [
     'kubectl',
     'ocp-i18n-defaults',

--- a/src/providers/create/ProviderTypeFields.tsx
+++ b/src/providers/create/ProviderTypeFields.tsx
@@ -12,7 +12,6 @@ import Ec2CrossAccountCredentialsFields from './fields/ec2/Ec2CrossAccountCreden
 import Ec2RegionField from './fields/ec2/Ec2RegionField';
 import Ec2TargetSettingsFields from './fields/ec2/Ec2TargetSettingsFields';
 import HypervCredentialsFields from './fields/hyperv/HypervCredentialsFields';
-import HypervTransferMethodField from './fields/hyperv/HypervTransferMethodField';
 import OpenShiftUrlField from './fields/openshift/OpenShiftUrlField';
 import ServiceAccountTokenField from './fields/openshift/ServiceAccountTokenField';
 import OpenStackAuthenticationTypeField from './fields/openstack/OpenStackAuthenticationTypeField';
@@ -109,7 +108,6 @@ const ProviderTypeFields: FC = () => {
 
       {selectedProviderType === PROVIDER_TYPES.hyperv && (
         <>
-          <HypervTransferMethodField />
           <SectionHeading text={t('Provider credentials')} />
           <HypervCredentialsFields />
           <CertificateValidationField />


### PR DESCRIPTION
## Summary
- Hide the iSCSI transfer method radio selector from the Hyper-V provider create form
- The UI option was added in #2373 (MTV-5076) but the backend PR (kubev2v/forklift#6014, MTV-5072) has not merged yet, so iSCSI is not functional
- All iSCSI-related code (constants, helpers, build logic, tests) is preserved for re-enablement once backend support lands

## Test plan
- [x] Open the "Create provider" form and select Microsoft Hyper-V
- [x] Verify the "Transfer method" radio group (SMB / iSCSI) is no longer shown
- [ ] Verify the form defaults to SMB credentials (SMB share URL field appears)
- [ ] Verify creating a Hyper-V provider still works correctly with SMB

Resolves: MTV-5785

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Hyper-V provider configuration by removing the transfer method field from the UI, simplifying the setup experience.
  * Adjusted repository analysis settings to ignore an additional Hyper-V field file until related backend support is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->