### PR TITLE
Resolves: MTV-5779 | replace console-proxy auth with kubeconfig and add ordered cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,11 @@
-# Build context for testing/PlaywrightContainerFile must be the project root
-# so that locales/ is available alongside testing/.
-# Exclude everything that the test image does not need.
+# Root .dockerignore — applies to all container builds from this directory.
+# Must NOT exclude src/, plugins/, or public/ — the main app container needs them.
+# The Playwright test container uses testing/.dockerignore via --ignorefile.
 
 .git/
 node_modules/
 dist/
 coverage/
-src/
-plugins/
-public/
 
 # Testing artifacts and local-only files
 testing/.providers.json
@@ -16,6 +13,3 @@ testing/playwright-report/
 testing/test-results/
 testing/.cursor/
 testing/node_modules/
-
-# Keep: testing/ (test code and runner)
-# Keep: locales/ (i18n smoke tests read locale JSON from /test-runner/locales/)

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Build context for testing/PlaywrightContainerFile must be the project root
+# so that locales/ is available alongside testing/.
+# Exclude everything that the test image does not need.
+
+.git/
+node_modules/
+dist/
+coverage/
+src/
+plugins/
+public/
+
+# Testing artifacts and local-only files
+testing/.providers.json
+testing/playwright-report/
+testing/test-results/
+testing/.cursor/
+testing/node_modules/
+
+# Keep: testing/ (test code and runner)
+# Keep: locales/ (i18n smoke tests read locale JSON from /test-runner/locales/)

--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -35,10 +35,15 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     PyYAML requests lxml 'reportportal-client~=5.0.0' \
     xmltodict jinja2 packaging setuptools suds-py3
 
-COPY package.json package-lock.json ./
+# Build context must be the project root (run: podman build -f testing/PlaywrightContainerFile .)
+# so that locales/ is reachable alongside testing/.
+COPY testing/package.json testing/package-lock.json ./
 RUN npm ci --ignore-scripts
 
-COPY . .
+COPY testing/ .
+
+# Include locale files so the i18n smoke tests can find them at /test-runner/locales/
+COPY locales/ locales/
 
 RUN chmod +x run-tests.sh && \
     chown -R 1001:0 /test-runner && \

--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -35,15 +35,12 @@ RUN pip3 install --no-cache-dir --break-system-packages \
     PyYAML requests lxml 'reportportal-client~=5.0.0' \
     xmltodict jinja2 packaging setuptools suds-py3
 
-# Build context must be the project root (run: podman build -f testing/PlaywrightContainerFile .)
-# so that locales/ is reachable alongside testing/.
-COPY testing/package.json testing/package-lock.json ./
+COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
-COPY testing/ .
-
-# Include locale files so the i18n smoke tests can find them at /test-runner/locales/
-COPY locales/ locales/
+# Build context is ./testing (GitHub Actions workflow pre-copies locales/ into testing/locales/).
+# Run: cp -r locales/ testing/locales/ && podman build -f testing/PlaywrightContainerFile ./testing
+COPY . .
 
 RUN chmod +x run-tests.sh && \
     chown -R 1001:0 /test-runner && \

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -12,6 +12,7 @@
         "@forklift-ui/types": "1.0.7"
       },
       "devDependencies": {
+        "@kubernetes/client-node": "^1.4.0",
         "@playwright/test": "^1.60.0",
         "@types/node": "^20.0.0",
         "playwright": "^1.60.0",
@@ -24,6 +25,74 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
@@ -41,12 +110,340 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.30",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -62,6 +459,297 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/playwright": {
@@ -96,6 +784,142 @@
         "node": ">=18"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -112,6 +936,53 @@
       "version": "6.21.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/testing/package.json
+++ b/testing/package.json
@@ -9,12 +9,14 @@
     "test:downstream:remote:docker": "bash run-e2e-docker.sh",
     "test:downstream:local": "BASE_ADDRESS=http://localhost:9000 npx playwright test --grep @downstream",
     "test:upstream": "npx playwright test playwright/e2e/upstream/",
-    "check:version-gating": "bash check-version-gating.sh"
+    "check:version-gating": "bash check-version-gating.sh",
+    "coverage:extract": "npx ts-node scripts/extract-tests.ts"
   },
   "author": "",
   "license": "ISC",
   "description": "",
   "devDependencies": {
+    "@kubernetes/client-node": "^1.4.0",
     "@playwright/test": "^1.60.0",
     "@types/node": "^20.0.0",
     "playwright": "^1.60.0",

--- a/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
+++ b/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
@@ -176,7 +176,6 @@ test.describe.serial('Plans - VSphere to Host Happy Path Cold Migration', () => 
 
         // Fetch the migrated VM to verify it exists
         const vmResource = await resourceManager.fetchVirtualMachine(
-          page,
           migratedVMName,
           testPlanData.targetProject.name,
         );

--- a/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
+++ b/testing/playwright/e2e/downstream/migration-happy-path.spec.ts
@@ -283,6 +283,6 @@ test.describe.serial('Plans - VSphere to Host Happy Path Cold Migration', () => 
   );
 
   test.afterAll(async () => {
-    await resourceManager.instantCleanup();
+    await resourceManager.cleanupAll();
   });
 });

--- a/testing/playwright/e2e/downstream/overview-page.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-page.spec.ts
@@ -43,7 +43,10 @@ test.describe(
         const context = await browser.newContext({ ignoreHTTPSErrors: true });
         const page = await context.newPage();
         await page.goto(process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS ?? '/');
-        await restoreForkliftSettings(originalSettings);
+        const restored = await restoreForkliftSettings(originalSettings);
+        if (!restored) {
+          throw new Error('Failed to restore Forklift settings in afterAll');
+        }
         await context.close();
       }
       await resourceManager.instantCleanup();

--- a/testing/playwright/e2e/downstream/overview-page.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-page.spec.ts
@@ -28,12 +28,12 @@ test.describe(
       const context = await browser.newContext({ ignoreHTTPSErrors: true });
       const page = await context.newPage();
 
-      await createTestNad(page, resourceManager, {
+      await createTestNad(resourceManager, {
         namespace: MTV_NAMESPACE,
       });
 
       await page.goto(process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS ?? '/');
-      originalSettings = await initializeForkliftSettings(page);
+      originalSettings = await initializeForkliftSettings();
 
       await context.close();
     });
@@ -43,7 +43,7 @@ test.describe(
         const context = await browser.newContext({ ignoreHTTPSErrors: true });
         const page = await context.newPage();
         await page.goto(process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS ?? '/');
-        await restoreForkliftSettings(page, originalSettings);
+        await restoreForkliftSettings(originalSettings);
         await context.close();
       }
       await resourceManager.instantCleanup();

--- a/testing/playwright/e2e/downstream/overview-page.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-page.spec.ts
@@ -49,7 +49,7 @@ test.describe(
         }
         await context.close();
       }
-      await resourceManager.instantCleanup();
+      await resourceManager.cleanupAll();
     });
 
     test('should navigate to settings tab, edit settings, and verify changes', async ({ page }) => {

--- a/testing/playwright/e2e/downstream/plans/ec2-plan-wizard-mappings.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/ec2-plan-wizard-mappings.spec.ts
@@ -92,7 +92,7 @@ test.describe.serial('EC2 Plan Wizard — Mapping Auto-Population', () => {
   });
 
   test.afterAll(async () => {
-    await resourceManager.instantCleanup();
+    await resourceManager.cleanupAll();
   });
 
   test(

--- a/testing/playwright/e2e/downstream/plans/plan-add-virtual-machines.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-add-virtual-machines.spec.ts
@@ -32,14 +32,14 @@ test.describe('Plan Details - Add Virtual Machines', { tag: '@downstream' }, () 
     const planNamespace = testPlan.metadata.namespace;
 
     // Remove the last VM from the plan via API so it becomes available for the "add" flow
-    const plan = await resourceManager.fetchPlan(page, planName, planNamespace);
+    const plan = await resourceManager.fetchPlan(planName, planNamespace);
     const vms = plan?.spec?.vms ?? [];
     expect(vms.length).toBeGreaterThan(1);
 
     const removedVm = vms[vms.length - 1];
     const remainingVms = vms.slice(0, -1);
 
-    const patchResult = await resourceManager.patchResource(page, {
+    const patchResult = await resourceManager.patchResource({
       kind: 'Plan',
       resourceName: planName,
       namespace: planNamespace,
@@ -95,7 +95,7 @@ test.describe('Plan Details - Add Virtual Machines', { tag: '@downstream' }, () 
       await planDetailsPage.virtualMachinesTab.verifyRowIsVisible({ Name: removedVm.name! });
 
       // API-level verification
-      const updatedPlan = await resourceManager.fetchPlan(page, planName, planNamespace);
+      const updatedPlan = await resourceManager.fetchPlan(planName, planNamespace);
       const planVmNames = (updatedPlan?.spec?.vms ?? []).map((vm) => vm.name);
       expect(planVmNames).toContain(removedVm.name);
     });
@@ -109,7 +109,7 @@ test.describe('Plan Details - Add Virtual Machines', { tag: '@downstream' }, () 
     });
 
     await test.step('6. Verify button is disabled for non-editable plans (archived)', async () => {
-      const archiveResult = await resourceManager.patchResource(page, {
+      const archiveResult = await resourceManager.patchResource({
         kind: 'Plan',
         resourceName: planName,
         namespace: planNamespace,

--- a/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
@@ -19,7 +19,7 @@ test.describe('Storage Offloading - Plan Details Mappings Tab', { tag: '@downstr
     if (!testPlan) throw new Error('testPlan is required');
 
     const planDetailsPage = new PlanDetailsPage(page);
-    const secretName = await createOffloadTestSecret(page, resourceManager);
+    const secretName = await createOffloadTestSecret(resourceManager);
 
     await test.step('Navigate to Mappings tab', async () => {
       await planDetailsPage.mappingsTab.navigateToMappingsTab();

--- a/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-migration-type.spec.ts
@@ -108,7 +108,7 @@ test.describe('Plan Details - Migration Type', { tag: '@downstream' }, () => {
     await test.step('Verify spec.type and spec.warm are both updated via API', async () => {
       await expect
         .poll(async () => {
-          const plan = await resourceManager.fetchPlan(page, duplicatePlanName);
+          const plan = await resourceManager.fetchPlan(duplicatePlanName);
           return { type: plan?.spec?.type, warm: plan?.spec?.warm };
         })
         .toEqual({ type: 'cold', warm: false });

--- a/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
@@ -1,5 +1,4 @@
-import type { V1beta1Plan } from '@forklift-ui/types';
-import { expect, type Page } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { sharedProviderFixtures as test } from '../../../fixtures/resourceFixtures';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
@@ -39,19 +38,17 @@ const findStaleMapCondition = (conditions: Condition[], mapKind: string): Condit
 type MapVerifyOptions = {
   fallbackNamespace: string;
   mapKind: 'network' | 'storage';
-  page: Page;
   planConditions: Condition[];
   ref: { name?: string; namespace?: string } | undefined;
   resourceManager: ResourceManager;
 };
 
 const verifyMapNotStale = async (opts: MapVerifyOptions): Promise<void> => {
-  const { fallbackNamespace, mapKind, page, planConditions, ref, resourceManager } = opts;
+  const { fallbackNamespace, mapKind, planConditions, ref, resourceManager } = opts;
   if (!ref?.name) return;
 
   const fetchMethod = mapKind === 'network' ? 'fetchNetworkMap' : 'fetchStorageMap';
   const mapResource = await resourceManager[fetchMethod](
-    page,
     ref.name,
     ref.namespace ?? fallbackNamespace,
   );
@@ -97,7 +94,7 @@ test.describe(
       });
 
       const plan = await test.step('Fetch Plan CR via API', async () => {
-        const fetched = await resourceManager.fetchPlan(page, planName, planNamespace);
+        const fetched = await resourceManager.fetchPlan(planName, planNamespace);
         expect(fetched).not.toBeNull();
         return fetched!;
       });
@@ -137,7 +134,7 @@ test.describe(
       });
 
       await test.step('Verify maps are Ready with no stale plan conditions', async () => {
-        const common = { fallbackNamespace: planNamespace, page, planConditions, resourceManager };
+        const common = { fallbackNamespace: planNamespace, planConditions, resourceManager };
         await verifyMapNotStale({ ...common, mapKind: 'network', ref: plan.spec?.map?.network });
         await verifyMapNotStale({ ...common, mapKind: 'storage', ref: plan.spec?.map?.storage });
       });
@@ -157,7 +154,7 @@ test.describe(
       const planDetailsPage = new PlanDetailsPage(page);
 
       const plan = await test.step('Fetch Plan CR', async () => {
-        const fetched = await resourceManager.fetchPlan(page, planName, planNamespace);
+        const fetched = await resourceManager.fetchPlan(planName, planNamespace);
         expect(fetched).not.toBeNull();
         return fetched!;
       });
@@ -171,7 +168,6 @@ test.describe(
       const nmNamespace = networkMapRef.namespace ?? planNamespace;
 
       const originalNetworkMap = await resourceManager.fetchNetworkMap(
-        page,
         networkMapRef.name,
         nmNamespace,
       );
@@ -187,7 +183,7 @@ test.describe(
 
       try {
         await test.step('Break NetworkMap by pointing to non-existent provider', async () => {
-          const patched = await resourceManager.patchResource(page, {
+          const patched = await resourceManager.patchResource({
             kind: 'NetworkMap',
             resourceName: networkMapRef.name!,
             namespace: nmNamespace,
@@ -206,7 +202,7 @@ test.describe(
         });
       } finally {
         await test.step('Restore NetworkMap to original provider', async () => {
-          await resourceManager.patchResource(page, {
+          await resourceManager.patchResource({
             kind: 'NetworkMap',
             resourceName: networkMapRef.name!,
             namespace: nmNamespace,
@@ -221,7 +217,7 @@ test.describe(
         await page.reload();
         await planDetailsPage.waitForPlanStatus('Ready for migration');
 
-        const refreshed = await resourceManager.fetchPlan(page, planName, planNamespace);
+        const refreshed = await resourceManager.fetchPlan(planName, planNamespace);
         expect(refreshed).not.toBeNull();
 
         const conditions = (refreshed!.status?.conditions ?? []) as Condition[];

--- a/testing/playwright/e2e/downstream/plans/plan-vm-concerns.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-vm-concerns.spec.ts
@@ -87,12 +87,12 @@ customPlanTest.describe('Plan Details - VM Concerns', { tag: '@downstream' }, ()
         const planNamespace = testPlan.metadata.namespace;
 
         // Add a duplicate VM to trigger Critical:DuplicateVM condition
-        const plan = await resourceManager.fetchPlan(page, planName, planNamespace);
+        const plan = await resourceManager.fetchPlan(planName, planNamespace);
         const vms = plan?.spec?.vms ?? [];
         expect(vms.length).toBeGreaterThan(0);
 
         const [firstVm] = vms;
-        const patchedPlan = await resourceManager.patchResource(page, {
+        const patchedPlan = await resourceManager.patchResource({
           kind: 'Plan',
           resourceName: planName,
           namespace: planNamespace,

--- a/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
@@ -33,7 +33,7 @@ test.describe(
       });
 
       const wizard = new CreatePlanWizardPage(page, resourceManager);
-      const secretName = await createOffloadTestSecret(page, resourceManager);
+      const secretName = await createOffloadTestSecret(resourceManager);
 
       await test.step('Navigate to Storage Map step', async () => {
         await wizard.navigate();

--- a/testing/playwright/e2e/downstream/providers/certificate-validation.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/certificate-validation.spec.ts
@@ -28,7 +28,7 @@ test.describe('vSphere Provider Certificate Validation', () => {
   const resourceManager = new ResourceManager();
 
   test.afterAll(async () => {
-    await resourceManager.instantCleanup();
+    await resourceManager.cleanupAll();
   });
 
   test(

--- a/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
@@ -58,10 +58,7 @@ test.describe('Provider Creation Tests', () => {
           });
 
           await test.step('Verify provider resource', async () => {
-            const providerResource = await resourceManager.fetchProvider(
-              page,
-              testProviderData.name,
-            );
+            const providerResource = await resourceManager.fetchProvider(testProviderData.name);
             expect(providerResource).not.toBeNull();
             expect(providerResource?.spec?.type).toBe(providerType);
 

--- a/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/create-provider.spec.ts
@@ -76,7 +76,7 @@ test.describe('Provider Creation Tests', () => {
   );
 
   test.afterAll(async () => {
-    await resourceManager.instantCleanup();
+    await resourceManager.cleanupAll();
   });
 
   test(

--- a/testing/playwright/e2e/downstream/providers/ec2-target-az.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/ec2-target-az.spec.ts
@@ -91,6 +91,6 @@ test.describe('EC2 Provider target-az CR Verification', () => {
   );
 
   test.afterAll(async () => {
-    await resourceManager.instantCleanup();
+    await resourceManager.cleanupAll();
   });
 });

--- a/testing/playwright/e2e/downstream/providers/ec2-target-az.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/ec2-target-az.spec.ts
@@ -31,7 +31,7 @@ const fetchProviderSettings = async (
   resourceManager: ResourceManager,
   providerName: string,
 ): Promise<Record<string, string> | undefined> => {
-  const providerResource = await resourceManager.fetchProvider(page, providerName);
+  const providerResource = await resourceManager.fetchProvider(providerName);
   expect(providerResource).not.toBeNull();
   return providerResource?.spec?.settings as Record<string, string> | undefined;
 };

--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -27,7 +27,7 @@ test.describe(
       const listPage = new StorageMapsListPage(page);
       const createPage = new StorageMapCreatePage(page);
       const detailsPage = new StorageMapDetailsPage(page);
-      const secretName = await createOffloadTestSecret(page, resourceManager);
+      const secretName = await createOffloadTestSecret(resourceManager);
 
       await test.step('Navigate to Create Storage Map form', async () => {
         await listPage.navigate(MTV_NAMESPACE);

--- a/testing/playwright/fixtures/helpers/languageHelpers.ts
+++ b/testing/playwright/fixtures/helpers/languageHelpers.ts
@@ -15,11 +15,11 @@ const getConfigMapName = (): string => {
   return `user-settings-${username}`;
 };
 
-const patchLanguageConfigMap = async (page: Page, language: string): Promise<boolean> => {
+const patchLanguageConfigMap = async (language: string): Promise<boolean> => {
   const configMapName = getConfigMapName();
   const apiPath = `${API_PATHS.KUBERNETES_CORE}/namespaces/${USER_SETTINGS_NAMESPACE}/configmaps/${configMapName}`;
 
-  const result = await BaseResourceManager.apiPatch(page, apiPath, {
+  const result = await BaseResourceManager.apiPatch(apiPath, {
     data: { [LANGUAGE_KEY]: language },
   });
 
@@ -69,7 +69,7 @@ export const setConsoleLanguage = async (
   language: SupportedLanguage,
 ): Promise<void> => {
   await setLocalStorageLanguage(page, language);
-  await patchLanguageConfigMap(page, language);
+  await patchLanguageConfigMap(language);
 };
 
 /**
@@ -77,5 +77,5 @@ export const setConsoleLanguage = async (
  */
 export const restoreConsoleLanguage = async (page: Page): Promise<void> => {
   await setLocalStorageLanguage(page, 'en');
-  await patchLanguageConfigMap(page, 'en');
+  await patchLanguageConfigMap('en');
 };

--- a/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
@@ -1,8 +1,6 @@
 import type { V1beta1NetworkMap, V1beta1Provider, V1beta1StorageMap } from '@forklift-ui/types';
-import type { Page } from '@playwright/test';
 
 import type { Mapping } from '../../types/test-data';
-import { NavigationHelper } from '../../utils/NavigationHelper';
 import {
   FORKLIFT_API_VERSION,
   MTV_NAMESPACE,
@@ -18,7 +16,6 @@ import {
 import type { ResourceManager } from '../../utils/resource-manager/ResourceManager';
 
 export const createTestNad = async (
-  page: Page,
   resourceManager: ResourceManager,
   options: {
     name?: string;
@@ -28,9 +25,6 @@ export const createTestNad = async (
 ): Promise<V1NetworkAttachmentDefinition> => {
   const { namespace, bridgeName = 'br0' } = options;
   const nadName = options.name ?? `nad-test-${crypto.randomUUID().slice(0, 8)}`;
-
-  const navigationHelper = new NavigationHelper(page);
-  await navigationHelper.navigateToConsole();
 
   const nadConfig = {
     cniVersion: '0.3.1',
@@ -47,7 +41,7 @@ export const createTestNad = async (
     spec: { config: JSON.stringify(nadConfig) },
   };
 
-  const createdNad = await createNadApi(page, nad, namespace);
+  const createdNad = await createNadApi(nad, namespace);
   if (!createdNad) {
     throw new Error(`Failed to create NAD ${nadName}`);
   }
@@ -60,23 +54,22 @@ export const createTestNad = async (
 };
 
 // Network Map types and creation
-export interface TestNetworkMap {
+export type TestNetworkMap = {
   name: string;
   namespace: string;
   sourceProvider: string;
   targetProvider: string;
   mappings: Mapping[];
-}
+};
 
-export interface CreateNetworkMapOptions {
+export type CreateNetworkMapOptions = {
   sourceProvider: V1beta1Provider;
   targetProvider?: string;
   namePrefix?: string;
   mappings?: Mapping[];
-}
+};
 
 export const createNetworkMap = async (
-  page: Page,
   resourceManager: ResourceManager,
   options: CreateNetworkMapOptions,
 ): Promise<TestNetworkMap> => {
@@ -89,11 +82,6 @@ export const createNetworkMap = async (
 
   const name = `${namePrefix}-${crypto.randomUUID().slice(0, 8)}`;
 
-  const navigationHelper = new NavigationHelper(page);
-  await navigationHelper.navigateToConsole();
-
-  // Create NetworkMap with empty map array - mappings should be added via UI
-  // to ensure proper network ID resolution from provider inventory
   const networkMap: V1beta1NetworkMap = {
     apiVersion: FORKLIFT_API_VERSION,
     kind: RESOURCE_KINDS.NETWORK_MAP,
@@ -110,7 +98,7 @@ export const createNetworkMap = async (
     },
   };
 
-  const created = await createNetworkMapApi(page, networkMap, MTV_NAMESPACE);
+  const created = await createNetworkMapApi(networkMap, MTV_NAMESPACE);
   if (!created) {
     throw new Error(`Failed to create NetworkMap ${name}`);
   }
@@ -126,23 +114,22 @@ export const createNetworkMap = async (
 };
 
 // Storage Map types and creation
-export interface TestStorageMap {
+export type TestStorageMap = {
   name: string;
   namespace: string;
   sourceProvider: string;
   targetProvider: string;
   mappings: Mapping[];
-}
+};
 
-export interface CreateStorageMapOptions {
+export type CreateStorageMapOptions = {
   sourceProvider: V1beta1Provider;
   targetProvider?: string;
   namePrefix?: string;
   mappings?: Mapping[];
-}
+};
 
 export const createStorageMap = async (
-  page: Page,
   resourceManager: ResourceManager,
   options: CreateStorageMapOptions,
 ): Promise<TestStorageMap> => {
@@ -154,9 +141,6 @@ export const createStorageMap = async (
   } = options;
 
   const name = `${namePrefix}-${crypto.randomUUID().slice(0, 8)}`;
-
-  const navigationHelper = new NavigationHelper(page);
-  await navigationHelper.navigateToConsole();
 
   const storageMap: V1beta1StorageMap = {
     apiVersion: FORKLIFT_API_VERSION,
@@ -174,7 +158,7 @@ export const createStorageMap = async (
     },
   };
 
-  const created = await createStorageMapApi(page, storageMap, MTV_NAMESPACE);
+  const created = await createStorageMapApi(storageMap, MTV_NAMESPACE);
   if (!created) {
     throw new Error(`Failed to create StorageMap ${name}`);
   }

--- a/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
@@ -80,6 +80,14 @@ export const createNetworkMap = async (
     mappings = [],
   } = options;
 
+  const sourceName = sourceProvider.metadata?.name;
+  const sourceNamespace = sourceProvider.metadata?.namespace;
+  if (!sourceName || !sourceNamespace) {
+    throw new Error(
+      `sourceProvider has no metadata.name or metadata.namespace — cannot create NetworkMap`,
+    );
+  }
+
   const name = `${namePrefix}-${crypto.randomUUID().slice(0, 8)}`;
 
   const networkMap: V1beta1NetworkMap = {
@@ -89,8 +97,8 @@ export const createNetworkMap = async (
     spec: {
       provider: {
         source: {
-          name: sourceProvider.metadata!.name!,
-          namespace: sourceProvider.metadata!.namespace!,
+          name: sourceName,
+          namespace: sourceNamespace,
         },
         destination: { name: targetProvider, namespace: MTV_NAMESPACE },
       },
@@ -107,7 +115,7 @@ export const createNetworkMap = async (
   return {
     name,
     namespace: MTV_NAMESPACE,
-    sourceProvider: sourceProvider.metadata!.name!,
+    sourceProvider: sourceName,
     targetProvider,
     mappings,
   };
@@ -140,6 +148,14 @@ export const createStorageMap = async (
     mappings = [],
   } = options;
 
+  const sourceName = sourceProvider.metadata?.name;
+  const sourceNamespace = sourceProvider.metadata?.namespace;
+  if (!sourceName || !sourceNamespace) {
+    throw new Error(
+      `sourceProvider has no metadata.name or metadata.namespace — cannot create StorageMap`,
+    );
+  }
+
   const name = `${namePrefix}-${crypto.randomUUID().slice(0, 8)}`;
 
   const storageMap: V1beta1StorageMap = {
@@ -149,8 +165,8 @@ export const createStorageMap = async (
     spec: {
       provider: {
         source: {
-          name: sourceProvider.metadata!.name!,
-          namespace: sourceProvider.metadata!.namespace!,
+          name: sourceName,
+          namespace: sourceNamespace,
         },
         destination: { name: targetProvider, namespace: MTV_NAMESPACE },
       },
@@ -167,7 +183,7 @@ export const createStorageMap = async (
   return {
     name,
     namespace: MTV_NAMESPACE,
-    sourceProvider: sourceProvider.metadata!.name!,
+    sourceProvider: sourceName,
     targetProvider,
     mappings,
   };

--- a/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
@@ -55,7 +55,7 @@ const buildTestProviderResult = (providerData: ProviderData): TestProvider => {
       namespace: MTV_NAMESPACE,
     },
   };
-  (provider as any).testData = providerData;
+  (provider as unknown as { testData: ProviderData }).testData = providerData;
   return provider;
 };
 
@@ -74,25 +74,25 @@ export type TestPlan = V1beta1Plan & {
   testData: ReturnType<typeof createPlanTestData>;
 };
 
-export interface CreateProviderOptions {
+export type CreateProviderOptions = {
   providerKey?: string;
   namePrefix?: string;
   customProviderData?: Partial<ProviderData>;
   skipProviderReadyWait?: boolean;
-}
+};
 
+/**
+ * Creates an OVA provider directly via the Kubernetes API.
+ * Does not require a browser page — uses Node.js HTTP with storageState cookies.
+ */
 const createOvaProviderViaApi = async (
-  page: Page,
   resourceManager: ResourceManager,
   providerData: ProviderData,
 ): Promise<void> => {
-  const createProviderPage = new CreateProviderPage(page, resourceManager);
-  await createProviderPage.navigationHelper.navigateToConsole();
-
   const secretName = `${providerData.name}-secret`;
   const secret = createSecretObject(secretName, MTV_NAMESPACE, { url: providerData.hostname });
 
-  const createdSecret = await createSecretApi(page, secret, MTV_NAMESPACE);
+  const createdSecret = await createSecretApi(secret, MTV_NAMESPACE);
   if (!createdSecret) {
     throw new Error(`Failed to create secret for OVA provider ${providerData.name}`);
   }
@@ -105,7 +105,7 @@ const createOvaProviderViaApi = async (
     settings: { applianceManagement: 'true' },
   });
 
-  const createdProvider = await createProviderApi(page, provider, MTV_NAMESPACE);
+  const createdProvider = await createProviderApi(provider, MTV_NAMESPACE);
   if (!createdProvider) {
     throw new Error(`Failed to create OVA provider ${providerData.name}`);
   }
@@ -177,7 +177,7 @@ export const createProvider = async (
   const providerData = buildProviderData(key, providerName, customProviderData);
 
   if (providerData.type === ProviderType.OVA) {
-    await createOvaProviderViaApi(page, resourceManager, providerData);
+    await createOvaProviderViaApi(resourceManager, providerData);
   } else {
     await createProviderViaUi(page, resourceManager, providerData, !skipProviderReadyWait);
   }
@@ -185,10 +185,10 @@ export const createProvider = async (
   return buildTestProviderResult(providerData);
 };
 
-export interface CreatePlanOptions {
+export type CreatePlanOptions = {
   sourceProvider: V1beta1Provider;
   customPlanData?: Partial<ReturnType<typeof createPlanTestData>>;
-}
+};
 
 const buildPlanTestData = (
   sourceProviderName: string,

--- a/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
@@ -47,16 +47,15 @@ const createProviderObject = (
 });
 
 const buildTestProviderResult = (providerData: ProviderData): TestProvider => {
-  const provider: TestProvider = {
+  return {
     apiVersion: 'forklift.konveyor.io/v1beta1',
     kind: 'Provider',
     metadata: {
       name: providerData.name,
       namespace: MTV_NAMESPACE,
     },
+    testData: providerData,
   };
-  (provider as unknown as { testData: ProviderData }).testData = providerData;
-  return provider;
 };
 
 export type TestProvider = V1beta1Provider & {
@@ -64,6 +63,7 @@ export type TestProvider = V1beta1Provider & {
     name: string;
     namespace: string;
   };
+  testData?: ProviderData;
 };
 
 export type TestPlan = V1beta1Plan & {
@@ -215,7 +215,12 @@ export const createPlan = async (
 ): Promise<TestPlan> => {
   const { sourceProvider, customPlanData } = options;
 
-  const testPlanData = buildPlanTestData(sourceProvider.metadata!.name!, customPlanData);
+  const sourceName = sourceProvider.metadata?.name;
+  if (!sourceName) {
+    throw new Error(`sourceProvider has no metadata.name — cannot create Plan`);
+  }
+
+  const testPlanData = buildPlanTestData(sourceName, customPlanData);
 
   const createWizard = new CreatePlanWizardPage(page, resourceManager);
   const planDetailsPage = new PlanDetailsPage(page);

--- a/testing/playwright/fixtures/helpers/settingsHelpers.ts
+++ b/testing/playwright/fixtures/helpers/settingsHelpers.ts
@@ -1,5 +1,3 @@
-import type { Page } from '@playwright/test';
-
 import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 import { ResourceFetcher } from '../../utils/resource-manager/ResourceFetcher';
 import type { JsonPatchOperation } from '../../utils/resource-manager/ResourceManager';
@@ -25,17 +23,15 @@ export const KNOWN_SETTINGS = {
 
 type SettingsKey = keyof typeof KNOWN_SETTINGS;
 
-export interface OriginalSettings {
+export type OriginalSettings = {
   controllerName: string;
   values: Partial<Record<SettingsKey, string | number>>;
-}
+};
 
 export const initializeForkliftSettings = async (
-  page: Page,
   namespace = MTV_NAMESPACE,
 ): Promise<OriginalSettings | null> => {
   const controller = await ResourceFetcher.fetchForkliftController(
-    page,
     'forklift-controller',
     namespace,
   );
@@ -68,7 +64,6 @@ export const initializeForkliftSettings = async (
 
   if (patches.length > 0) {
     const result = await ResourcePatcher.patchForkliftController(
-      page,
       controllerName,
       patches,
       namespace,
@@ -83,7 +78,6 @@ export const initializeForkliftSettings = async (
 };
 
 export const restoreForkliftSettings = async (
-  page: Page,
   original: OriginalSettings,
   namespace = MTV_NAMESPACE,
 ): Promise<boolean> => {
@@ -98,7 +92,6 @@ export const restoreForkliftSettings = async (
   );
 
   const result = await ResourcePatcher.patchForkliftController(
-    page,
     original.controllerName,
     patches,
     namespace,

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -84,10 +84,13 @@ export const createResourceFixtures = (
               const page = await context.newPage();
               const tempResourceManager = new ResourceManager();
 
-              // Use promise chaining for creation so that `use` is never inside a
-              // try/catch block — required by SonarCloud S6440 (React Hook rules flag
-              // any `use()` call inside try/catch). Cleanup runs in the .catch() on
-              // creation failure, and in the finally block after the worker tests finish.
+              // Promise chaining keeps `use` outside any try block (SonarCloud S6440
+              // treats any `use()` call inside try as a React Hook violation). On
+              // creation failure the .catch() handler cleans up and rethrows so
+              // `use` is never reached. On success, Playwright worker fixtures
+              // return from `use` normally once all worker tests complete — test
+              // failures are handled by the runner, not propagated here as
+              // exceptions — so sequential cleanup after `use` is safe.
               const created = await createProvider(page, tempResourceManager, {
                 namePrefix: providerPrefix,
                 skipProviderReadyWait,
@@ -102,12 +105,9 @@ export const createResourceFixtures = (
                   throw new Error(`Failed to create provider: ${String(error)}`, { cause: error });
                 });
 
-              try {
-                await use(created);
-              } finally {
-                await context.close().catch(() => undefined);
-                await tempResourceManager.cleanupAll().catch(console.error);
-              }
+              await use(created);
+              await context.close().catch(() => undefined);
+              await tempResourceManager.cleanupAll().catch(console.error);
             },
             { scope: 'worker' },
           ] as any)

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -33,7 +33,6 @@ export type FixtureConfig = {
   networkMapScope?: 'test' | 'none';
   storageMapScope?: 'test' | 'none';
   providerPrefix?: string;
-  planPrefix?: string;
   networkMapPrefix?: string;
   storageMapPrefix?: string;
   skipProviderReadyWait?: boolean;
@@ -86,26 +85,27 @@ export const createResourceFixtures = (
               const tempResourceManager = new ResourceManager();
 
               try {
-                const provider = await createProvider(page, tempResourceManager, {
+                const created = await createProvider(page, tempResourceManager, {
                   namePrefix: providerPrefix,
                   skipProviderReadyWait,
                 });
 
-                if (!provider) {
+                if (!created) {
                   throw new Error('Failed to create provider');
                 }
 
                 await context.close();
-
-                await use(provider);
-
-                const cleanupManager = new ResourceManager();
-                cleanupManager.addResource(provider);
-                await cleanupManager.cleanupAll();
+                await use(created);
               } catch (error) {
                 throw new Error(`Failed to create or use provider: ${String(error)}`, {
                   cause: error,
                 });
+              } finally {
+                // Always close the context and clean up provider + any OVA secrets
+                // registered in tempResourceManager, even if provider creation or
+                // the test itself throws.
+                await context.close().catch(() => undefined);
+                await tempResourceManager.cleanupAll().catch(console.error);
               }
             },
             { scope: 'worker' },

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -27,7 +27,7 @@ const createAuthenticatedContext = async (browser: Browser): Promise<BrowserCont
   });
 };
 
-export interface FixtureConfig {
+export type FixtureConfig = {
   providerScope?: 'test' | 'worker';
   planScope?: 'test' | 'none';
   networkMapScope?: 'test' | 'none';
@@ -37,9 +37,9 @@ export interface FixtureConfig {
   networkMapPrefix?: string;
   storageMapPrefix?: string;
   skipProviderReadyWait?: boolean;
-}
+};
 
-export interface ConfigurableResourceFixtures {
+export type ConfigurableResourceFixtures = {
   resourceManager: ResourceManager;
   testProvider: TestProvider | undefined;
   testPlan: TestPlan | undefined;
@@ -51,7 +51,8 @@ export interface ConfigurableResourceFixtures {
   createCustomProvider: (options?: CreateProviderOptions) => Promise<TestProvider>;
   createCustomNetworkMap: (options?: Partial<CreateNetworkMapOptions>) => Promise<TestNetworkMap>;
   createCustomStorageMap: (options?: Partial<CreateStorageMapOptions>) => Promise<TestStorageMap>;
-}
+};
+
 export const createResourceFixtures = (
   config: FixtureConfig = {},
 ): ReturnType<typeof base.extend<ConfigurableResourceFixtures>> => {
@@ -70,12 +71,16 @@ export const createResourceFixtures = (
     resourceManager: async ({ page: _page }, use) => {
       const manager = new ResourceManager();
       await use(manager);
-      await manager.instantCleanup();
+      await manager.cleanupAll();
     },
+
     testProvider:
       providerScope === 'worker'
         ? ([
-            async ({ browser }: { browser: any }, use: any) => {
+            async (
+              { browser }: { browser: Browser },
+              use: (provider: TestProvider) => Promise<void>,
+            ) => {
               const context = await createAuthenticatedContext(browser);
               const page = await context.newPage();
               const tempResourceManager = new ResourceManager();
@@ -96,7 +101,7 @@ export const createResourceFixtures = (
 
                 const cleanupManager = new ResourceManager();
                 cleanupManager.addResource(provider);
-                await cleanupManager.instantCleanup();
+                await cleanupManager.cleanupAll();
               } catch (error) {
                 throw new Error(`Failed to create or use provider: ${String(error)}`, {
                   cause: error,
@@ -150,24 +155,24 @@ export const createResourceFixtures = (
     testNetworkMap:
       networkMapScope === 'none'
         ? undefined
-        : async ({ page, resourceManager, testProvider }, use) => {
+        : async ({ resourceManager, testProvider }, use) => {
             if (!testProvider) {
               throw new Error('testNetworkMap fixture requires testProvider fixture to be enabled');
             }
 
-            const networkMap = await createNetworkMap(page, resourceManager, {
+            const networkMap = await createNetworkMap(resourceManager, {
               sourceProvider: testProvider,
               namePrefix: networkMapPrefix,
             });
             await use(networkMap);
           },
 
-    createCustomNetworkMap: async ({ page, resourceManager, testProvider }, use) => {
+    createCustomNetworkMap: async ({ resourceManager, testProvider }, use) => {
       const createNetworkMapFn = async (options?: Partial<CreateNetworkMapOptions>) => {
         if (!testProvider) {
           throw new Error('createCustomNetworkMap requires testProvider fixture to be enabled');
         }
-        return createNetworkMap(page, resourceManager, {
+        return createNetworkMap(resourceManager, {
           sourceProvider: testProvider,
           ...options,
         });
@@ -178,24 +183,24 @@ export const createResourceFixtures = (
     testStorageMap:
       storageMapScope === 'none'
         ? undefined
-        : async ({ page, resourceManager, testProvider }, use) => {
+        : async ({ resourceManager, testProvider }, use) => {
             if (!testProvider) {
               throw new Error('testStorageMap fixture requires testProvider fixture to be enabled');
             }
 
-            const storageMap = await createStorageMap(page, resourceManager, {
+            const storageMap = await createStorageMap(resourceManager, {
               sourceProvider: testProvider,
               namePrefix: storageMapPrefix,
             });
             await use(storageMap);
           },
 
-    createCustomStorageMap: async ({ page, resourceManager, testProvider }, use) => {
+    createCustomStorageMap: async ({ resourceManager, testProvider }, use) => {
       const createStorageMapFn = async (options?: Partial<CreateStorageMapOptions>) => {
         if (!testProvider) {
           throw new Error('createCustomStorageMap requires testProvider fixture to be enabled');
         }
-        return createStorageMap(page, resourceManager, {
+        return createStorageMap(resourceManager, {
           sourceProvider: testProvider,
           ...options,
         });

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -94,7 +94,6 @@ export const createResourceFixtures = (
                   throw new Error('Failed to create provider');
                 }
 
-                await context.close();
                 await use(created);
               } catch (error) {
                 throw new Error(`Failed to create or use provider: ${String(error)}`, {

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -84,25 +84,27 @@ export const createResourceFixtures = (
               const page = await context.newPage();
               const tempResourceManager = new ResourceManager();
 
+              // Use promise chaining for creation so that `use` is never inside a
+              // try/catch block — required by SonarCloud S6440 (React Hook rules flag
+              // any `use()` call inside try/catch). Cleanup runs in the .catch() on
+              // creation failure, and in the finally block after the worker tests finish.
+              const created = await createProvider(page, tempResourceManager, {
+                namePrefix: providerPrefix,
+                skipProviderReadyWait,
+              })
+                .then((result) => {
+                  if (!result) throw new Error('Failed to create provider');
+                  return result;
+                })
+                .catch(async (error: unknown) => {
+                  await context.close().catch(() => undefined);
+                  await tempResourceManager.cleanupAll().catch(console.error);
+                  throw new Error(`Failed to create provider: ${String(error)}`, { cause: error });
+                });
+
               try {
-                const created = await createProvider(page, tempResourceManager, {
-                  namePrefix: providerPrefix,
-                  skipProviderReadyWait,
-                });
-
-                if (!created) {
-                  throw new Error('Failed to create provider');
-                }
-
                 await use(created);
-              } catch (error) {
-                throw new Error(`Failed to create or use provider: ${String(error)}`, {
-                  cause: error,
-                });
               } finally {
-                // Always close the context and clean up provider + any OVA secrets
-                // registered in tempResourceManager, even if provider creation or
-                // the test itself throws.
                 await context.close().catch(() => undefined);
                 await tempResourceManager.cleanupAll().catch(console.error);
               }

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -68,6 +68,8 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
   }
 
   try {
+    // Restrict PATH to fixed, non-writable system directories to prevent PATH hijacking.
+    const SAFE_PATH = '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin';
     execFileSync(
       'oc',
       [
@@ -81,7 +83,7 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
         '--kubeconfig',
         KUBECONFIG_FILE,
       ],
-      { stdio: 'pipe', timeout: 30_000 },
+      { env: { PATH: SAFE_PATH }, stdio: 'pipe', timeout: 30_000 },
     );
     Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });
     console.error(`✅ kubeconfig written to ${KUBECONFIG_FILE} — workers will use direct API auth`);

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -46,6 +46,14 @@ const fetchClusterApiUrl = async (): Promise<string | null> => {
 };
 
 /**
+ * Standard installation paths for the `oc` CLI on Linux and macOS.
+ * Using absolute paths avoids PATH-based resolution entirely (SonarCloud S4036).
+ */
+const OC_BINARY_LOCATIONS = ['/usr/local/bin/oc', '/usr/bin/oc', '/opt/homebrew/bin/oc'] as const;
+
+const findOcBinary = (): string | null => OC_BINARY_LOCATIONS.find(existsSync) ?? null;
+
+/**
  * Runs `oc login` to generate a kubeconfig at KUBECONFIG_FILE.
  * Writes KUBECONFIG_PATH into process.env so subsequent Node.js HTTP calls in
  * this process (detectForkliftVersion, etc.) use the kubeconfig-based auth path.
@@ -67,9 +75,17 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
     return;
   }
 
+  const ocBin = findOcBinary();
+  if (!ocBin) {
+    console.error(
+      `⚠️ oc binary not found in ${OC_BINARY_LOCATIONS.join(', ')} — skipping kubeconfig generation.`,
+    );
+    return;
+  }
+
   try {
     execFileSync(
-      'oc',
+      ocBin,
       [
         'login',
         clusterApiUrl,
@@ -81,14 +97,7 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
         '--kubeconfig',
         KUBECONFIG_FILE,
       ],
-      // Inline literal PATH so SonarCloud S4036 can statically verify it contains
-      // only fixed, non-writable system directories (named constants aren't tracked).
-      // NOSONAR: env intentionally omits process.env to prevent PATH hijacking.
-      {
-        env: { PATH: '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin' },
-        stdio: 'pipe',
-        timeout: 30_000,
-      },
+      { stdio: 'pipe', timeout: 30_000 },
     );
     Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });
     console.error(`✅ kubeconfig written to ${KUBECONFIG_FILE} — workers will use direct API auth`);

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 import { chromium, type FullConfig } from '@playwright/test';
 
@@ -68,8 +68,19 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
   }
 
   try {
-    execSync(
-      `oc login "${clusterApiUrl}" -u "${username}" -p "${password}" --insecure-skip-tls-verify --kubeconfig "${KUBECONFIG_FILE}"`,
+    execFileSync(
+      'oc',
+      [
+        'login',
+        clusterApiUrl,
+        '-u',
+        username,
+        '-p',
+        password,
+        '--insecure-skip-tls-verify',
+        '--kubeconfig',
+        KUBECONFIG_FILE,
+      ],
       { stdio: 'pipe', timeout: 30_000 },
     );
     Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 
-import { chromium, type FullConfig, type Page } from '@playwright/test';
+import { chromium, type FullConfig } from '@playwright/test';
 
 import { restoreConsoleLanguage } from './fixtures/helpers/languageHelpers';
 import { LoginPage } from './page-objects/LoginPage';
@@ -31,13 +31,12 @@ const USER_SET_KEYS = new Set(
 /**
  * Auto-detect the Forklift/MTV operator version from the cluster CSV.
  *
- * Always fetches from the cluster. If the user explicitly set FORKLIFT_VERSION in e2e.env / shell,
- * the detected value is discarded in favour of theirs (intentional override). This ensures a stale
- * relay value is never silently carried forward across runs.
+ * Called after browser login so user.json (storageState) is available for
+ * the Node.js HTTP client used by ResourceFetcher.
  */
-const detectForkliftVersion = async (page: Page): Promise<void> => {
+const detectForkliftVersion = async (): Promise<void> => {
   try {
-    const detectedVersion = await ResourceFetcher.fetchMtvVersion(page);
+    const detectedVersion = await ResourceFetcher.fetchMtvVersion();
     if (process.env[VERSION_ENV_VAR] && USER_SET_KEYS.has(VERSION_ENV_VAR)) {
       console.error(`📌 Using user-set Forklift version: ${process.env[VERSION_ENV_VAR]}`);
     } else if (detectedVersion) {
@@ -56,9 +55,9 @@ const detectForkliftVersion = async (page: Page): Promise<void> => {
  * When CNV_VERSION was explicitly set by the user in e2e.env / shell, respect it.
  * Unlike Forklift, CNV version is optional — tests run when it's unknown.
  */
-const detectCnvVersion = async (page: Page): Promise<void> => {
+const detectCnvVersion = async (): Promise<void> => {
   try {
-    const detectedVersion = await ResourceFetcher.fetchCnvVersion(page);
+    const detectedVersion = await ResourceFetcher.fetchCnvVersion();
     if (process.env[CNV_VERSION_ENV_VAR] && USER_SET_KEYS.has(CNV_VERSION_ENV_VAR)) {
       console.error(`📌 Using user-set CNV version: ${process.env[CNV_VERSION_ENV_VAR]}`);
     } else if (detectedVersion) {
@@ -119,8 +118,10 @@ const globalSetup = async (config: FullConfig) => {
       await page.context().storageState({ path: AUTH_FILE });
       console.error('✅ Authentication completed successfully');
 
-      await detectForkliftVersion(page);
-      await detectCnvVersion(page);
+      // Version detection uses the saved storageState (user.json) to authenticate
+      // Node.js HTTP calls — no browser page needed beyond this point.
+      await detectForkliftVersion();
+      await detectCnvVersion();
     } catch (error) {
       const screenshotPath = 'playwright/test-results/global-setup-login-failure.png';
       await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => undefined);
@@ -132,19 +133,6 @@ const globalSetup = async (config: FullConfig) => {
     }
   } else {
     console.error('⚠️ No credentials provided, skipping authentication setup');
-
-    const browser = await chromium.launch();
-    const page = await browser.newPage({ ignoreHTTPSErrors: true });
-
-    try {
-      await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 10_000 });
-      await detectForkliftVersion(page);
-      await detectCnvVersion(page);
-    } catch {
-      console.error('⚠️ Could not reach cluster for version detection, using env vars/defaults');
-    } finally {
-      await browser.close();
-    }
 
     if (!process.env[VERSION_ENV_VAR]) {
       process.env[VERSION_ENV_VAR] = 'latest';

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -13,9 +13,6 @@ import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
 import { CNV_VERSION_ENV_VAR, VERSION_ENV_VAR } from './utils/version/constants';
 
-/** Fixed, non-writable system directories used when spawning child processes (SonarCloud S4036). */
-const SAFE_EXEC_PATH = '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin';
-
 const ENV_KEYS_TO_RELAY = [
   'BASE_ADDRESS',
   'BRIDGE_BASE_ADDRESS',
@@ -84,7 +81,14 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
         '--kubeconfig',
         KUBECONFIG_FILE,
       ],
-      { env: { PATH: SAFE_EXEC_PATH }, stdio: 'pipe', timeout: 30_000 },
+      // Inline literal PATH so SonarCloud S4036 can statically verify it contains
+      // only fixed, non-writable system directories (named constants aren't tracked).
+      // NOSONAR: env intentionally omits process.env to prevent PATH hijacking.
+      {
+        env: { PATH: '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin' },
+        stdio: 'pipe',
+        timeout: 30_000,
+      },
     );
     Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });
     console.error(`✅ kubeconfig written to ${KUBECONFIG_FILE} — workers will use direct API auth`);

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -1,10 +1,13 @@
 import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'fs';
 
+import { execSync } from 'node:child_process';
+
 import { chromium, type FullConfig } from '@playwright/test';
 
 import { restoreConsoleLanguage } from './fixtures/helpers/languageHelpers';
 import { LoginPage } from './page-objects/LoginPage';
-import { AUTH_FILE, ENV_RELAY_FILE } from './utils/constants';
+import { AUTH_FILE, ENV_RELAY_FILE, KUBECONFIG_FILE } from './utils/constants';
+import { BaseResourceManager } from './utils/resource-manager/BaseResourceManager';
 import { RESOURCES_FILE } from './utils/resource-manager/constants';
 import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
@@ -16,6 +19,7 @@ const ENV_KEYS_TO_RELAY = [
   'CNV_VERSION',
   'FORKLIFT_VERSION',
   'JENKINS',
+  'KUBECONFIG_PATH',
   'LIGHTSPEED_INSTALLED',
   'VSPHERE_PROVIDER',
 ] as const;
@@ -27,6 +31,54 @@ const ENV_KEYS_TO_RELAY = [
 const USER_SET_KEYS = new Set(
   (process.env.PLAYWRIGHT_USER_SET_KEYS ?? '').split(',').filter(Boolean),
 );
+
+/**
+ * Fetches the cluster API server URL from the OpenShift infrastructure CR.
+ * Uses cookie-based auth (console proxy) — called while cookies are still fresh,
+ * before the kubeconfig is generated.
+ */
+const fetchClusterApiUrl = async (): Promise<string | null> => {
+  type InfraCluster = { status?: { apiServerURL?: string } };
+  const infra = await BaseResourceManager.apiGet<InfraCluster>(
+    '/api/kubernetes/apis/config.openshift.io/v1/infrastructures/cluster',
+  );
+  return infra?.status?.apiServerURL ?? null;
+};
+
+/**
+ * Runs `oc login` to generate a kubeconfig at KUBECONFIG_FILE.
+ * Writes KUBECONFIG_PATH into process.env so subsequent Node.js HTTP calls in
+ * this process (detectForkliftVersion, etc.) use the kubeconfig-based auth path.
+ *
+ * Falls back gracefully when:
+ *  - CLUSTER_USERNAME / CLUSTER_PASSWORD are not set
+ *  - The cluster API URL cannot be determined
+ *  - The `oc` binary is not available
+ */
+const generateKubeconfig = async (username: string, password: string): Promise<void> => {
+  const clusterApiUrl =
+    process.env.CLUSTER_API_URL?.replace(/\/$/, '') ?? (await fetchClusterApiUrl());
+
+  if (!clusterApiUrl) {
+    console.error(
+      '⚠️ Could not determine cluster API URL — skipping kubeconfig generation. ' +
+        'Set CLUSTER_API_URL env var to enable kubeconfig-based auth.',
+    );
+    return;
+  }
+
+  try {
+    execSync(
+      `oc login "${clusterApiUrl}" -u "${username}" -p "${password}" --insecure-skip-tls-verify --kubeconfig "${KUBECONFIG_FILE}"`,
+      { stdio: 'pipe', timeout: 30_000 },
+    );
+    Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });
+    console.error(`✅ kubeconfig written to ${KUBECONFIG_FILE} — workers will use direct API auth`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`⚠️ oc login failed (${message}) — workers will fall back to session cookies`);
+  }
+};
 
 /**
  * Auto-detect the Forklift/MTV operator version from the cluster CSV.
@@ -113,13 +165,19 @@ const globalSetup = async (config: FullConfig) => {
         console.error('⚠️ networkidle timed out before language restore; proceeding');
       });
 
-      await restoreConsoleLanguage(page);
-
       await page.context().storageState({ path: AUTH_FILE });
       console.error('✅ Authentication completed successfully');
 
-      // Version detection uses the saved storageState (user.json) to authenticate
-      // Node.js HTTP calls — no browser page needed beyond this point.
+      await restoreConsoleLanguage(page);
+
+      // Generate a kubeconfig using oc login so workers can talk directly to the
+      // cluster API server with a long-lived Bearer token instead of session cookies.
+      // Must happen after storageState is saved (fetchClusterApiUrl uses cookies)
+      // and before detectForkliftVersion (which will then use the kubeconfig).
+      await generateKubeconfig(username, password);
+
+      // Version detection: prefers the kubeconfig auth path if generateKubeconfig
+      // succeeded, otherwise falls back to session cookies automatically.
       await detectForkliftVersion();
       await detectCnvVersion();
     } catch (error) {

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -153,6 +153,10 @@ const detectCnvVersion = async (): Promise<void> => {
 };
 
 const globalSetup = async (config: FullConfig) => {
+  // console.error is used intentionally throughout this function.
+  // Playwright routes stderr to the test reporter unconditionally, so these
+  // lines are always visible in CI output regardless of --quiet or verbosity
+  // settings.  Do not change them to console.log.
   console.error('🚀 Starting global setup...');
 
   if (existsSync(RESOURCES_FILE)) {
@@ -197,14 +201,8 @@ const globalSetup = async (config: FullConfig) => {
 
       await restoreConsoleLanguage(page);
 
-      // Generate a kubeconfig using oc login so workers can talk directly to the
-      // cluster API server with a long-lived Bearer token instead of session cookies.
-      // Must happen after storageState is saved (fetchClusterApiUrl uses cookies)
-      // and before detectForkliftVersion (which will then use the kubeconfig).
       await generateKubeconfig(username, password);
 
-      // Version detection: prefers the kubeconfig auth path if generateKubeconfig
-      // succeeded, otherwise falls back to session cookies automatically.
       await detectForkliftVersion();
       await detectCnvVersion();
     } catch (error) {

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -13,6 +13,9 @@ import { ResourceFetcher } from './utils/resource-manager/ResourceFetcher';
 import { disableGuidedTour } from './utils/utils';
 import { CNV_VERSION_ENV_VAR, VERSION_ENV_VAR } from './utils/version/constants';
 
+/** Fixed, non-writable system directories used when spawning child processes (SonarCloud S4036). */
+const SAFE_EXEC_PATH = '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin';
+
 const ENV_KEYS_TO_RELAY = [
   'BASE_ADDRESS',
   'BRIDGE_BASE_ADDRESS',
@@ -68,8 +71,6 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
   }
 
   try {
-    // Restrict PATH to fixed, non-writable system directories to prevent PATH hijacking.
-    const SAFE_PATH = '/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin';
     execFileSync(
       'oc',
       [
@@ -83,7 +84,7 @@ const generateKubeconfig = async (username: string, password: string): Promise<v
         '--kubeconfig',
         KUBECONFIG_FILE,
       ],
-      { env: { PATH: SAFE_PATH }, stdio: 'pipe', timeout: 30_000 },
+      { env: { PATH: SAFE_EXEC_PATH }, stdio: 'pipe', timeout: 30_000 },
     );
     Object.assign(process.env, { KUBECONFIG_PATH: KUBECONFIG_FILE });
     console.error(`✅ kubeconfig written to ${KUBECONFIG_FILE} — workers will use direct API auth`);

--- a/testing/playwright/global.teardown.ts
+++ b/testing/playwright/global.teardown.ts
@@ -1,9 +1,8 @@
-import { chromium, type FullConfig } from '@playwright/test';
+import type { FullConfig } from '@playwright/test';
 
 import { ResourceManager } from './utils/resource-manager/ResourceManager';
 
-const globalTeardown = async (config: FullConfig) => {
-  const { baseURL, storageState } = config.projects[0].use;
+const globalTeardown = async (_config: FullConfig) => {
   const resourceManager = new ResourceManager();
   resourceManager.loadResourcesFromFile();
 
@@ -12,31 +11,15 @@ const globalTeardown = async (config: FullConfig) => {
     return;
   }
 
-  if (!baseURL) {
-    throw new Error('baseURL is not defined in Playwright config and is required for teardown');
-  }
-
-  const browser = await chromium.launch();
-  const context = await browser.newContext({
-    ...(storageState && { storageState: storageState as string }),
-    baseURL,
-    ignoreHTTPSErrors: true,
-  });
-  const page = await context.newPage();
-
   console.log(`🧹 Global cleanup of ${resourceManager.getResourceCount()} resources...`);
-  await page.goto('/');
-  await page.waitForLoadState('networkidle');
 
   try {
-    await resourceManager.cleanupAll(page);
+    await resourceManager.cleanupAll();
   } catch (error) {
     console.error('Error during cleanup in globalTeardown:', error);
-  } finally {
-    await context.close();
-    await browser.close();
-    console.error('Cleanup process finished.');
   }
+
+  console.error('Cleanup process finished.');
 };
 
 export default globalTeardown;

--- a/testing/playwright/global.teardown.ts
+++ b/testing/playwright/global.teardown.ts
@@ -19,7 +19,7 @@ const globalTeardown = async (_config: FullConfig) => {
     console.error('Error during cleanup in globalTeardown:', error);
   }
 
-  console.error('Cleanup process finished.');
+  console.log('Cleanup process finished.');
 };
 
 export default globalTeardown;

--- a/testing/playwright/utils/constants.ts
+++ b/testing/playwright/utils/constants.ts
@@ -8,6 +8,14 @@
 export const AUTH_FILE = 'playwright/.auth/user.json';
 
 /**
+ * Kubeconfig file written by global.setup.ts after oc login succeeds.
+ * Workers load this file via @kubernetes/client-node to authenticate directly
+ * against the cluster API server (bypassing the OpenShift console proxy).
+ * When absent, BaseResourceManager falls back to session cookies.
+ */
+export const KUBECONFIG_FILE = 'playwright/.auth/kubeconfig';
+
+/**
  * Relay file written by global.setup.ts so playwright.config.ts (re-evaluated in each
  * worker) can restore env vars that Playwright workers do not inherit.
  * See https://github.com/microsoft/playwright/issues/21565

--- a/testing/playwright/utils/offload-helpers.ts
+++ b/testing/playwright/utils/offload-helpers.ts
@@ -19,7 +19,10 @@ export const createOffloadTestSecret = async (
     type: 'Opaque',
   };
 
-  await createSecret(secret, MTV_NAMESPACE);
+  const createdSecret = await createSecret(secret, MTV_NAMESPACE);
+  if (!createdSecret) {
+    throw new Error(`Failed to create offload test secret ${secretName}`);
+  }
   resourceManager.addSecret(secretName, MTV_NAMESPACE);
 
   return secretName;

--- a/testing/playwright/utils/offload-helpers.ts
+++ b/testing/playwright/utils/offload-helpers.ts
@@ -1,5 +1,3 @@
-import type { Page } from '@playwright/test';
-
 import { MTV_NAMESPACE } from './resource-manager/constants';
 import { createSecret } from './resource-manager/ResourceCreator';
 import type { ResourceManager } from './resource-manager/ResourceManager';
@@ -9,7 +7,6 @@ import type { ResourceManager } from './resource-manager/ResourceManager';
  * and returns the generated secret name.
  */
 export const createOffloadTestSecret = async (
-  page: Page,
   resourceManager: ResourceManager,
 ): Promise<string> => {
   const secretName = `vs8-secret-${crypto.randomUUID().slice(0, 8)}`;
@@ -22,7 +19,7 @@ export const createOffloadTestSecret = async (
     type: 'Opaque',
   };
 
-  await createSecret(page, secret, MTV_NAMESPACE);
+  await createSecret(secret, MTV_NAMESPACE);
   resourceManager.addSecret(secretName, MTV_NAMESPACE);
 
   return secretName;

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -13,6 +13,7 @@ import { RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
 // When calling the API server directly we strip it ourselves so the path
 // reaches the correct endpoint (e.g. /apis/... instead of /api/kubernetes/apis/...).
 const PROXY_PREFIX = '/api/kubernetes' as const;
+const API_REQUEST_TIMEOUT_MS = 30_000;
 
 type ApiResult<T> =
   | { data: T; status: number; success: true }
@@ -66,12 +67,15 @@ const tryKubeconfigAuth = (): AuthConfig | null => {
 };
 
 /**
- * Reads session cookies from the saved Playwright storageState file.
- * These cookies are written by global.setup.ts after browser login and
- * are the same credentials the browser would use — but now consumed
- * directly by Node.js HTTP calls so that no browser page is required.
+ * Reads all session cookies from the saved Playwright storageState file and
+ * builds the Cookie header string that Node.js HTTP requests will send.
+ *
+ * The OpenShift console uses a pod-specific suffix in the auth cookie name
+ * (e.g. "openshift-session-token-console-769d4c7cf7-gqqk4"), so an exact-name
+ * lookup is not reliable.  Forwarding ALL cookies mimics credentials:'include'
+ * and works regardless of the pod suffix.
  */
-const getSessionCookies = (): { sessionToken: string; csrfToken: string } => {
+const getSessionCookies = (): { cookieHeader: string; csrfToken: string } => {
   if (!existsSync(AUTH_FILE)) {
     throw new Error(
       `Auth file not found at "${AUTH_FILE}". ` +
@@ -80,18 +84,19 @@ const getSessionCookies = (): { sessionToken: string; csrfToken: string } => {
   }
 
   const state = JSON.parse(readFileSync(AUTH_FILE, 'utf8')) as StorageState;
-  const sessionCookie = state.cookies.find((cookie) => cookie.name === 'openshift-session-token');
-  const csrfCookie = state.cookies.find((cookie) => cookie.name === 'csrf-token');
 
-  if (!sessionCookie?.value) {
+  if (!state.cookies.length) {
     throw new Error(
-      'openshift-session-token not found in auth file. ' +
+      `No cookies found in auth file "${AUTH_FILE}". ` +
         'Re-run global setup to refresh the session.',
     );
   }
 
+  const cookieHeader = state.cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+  const csrfCookie = state.cookies.find((cookie) => cookie.name === 'csrf-token');
+
   return {
-    sessionToken: sessionCookie.value,
+    cookieHeader,
     csrfToken: csrfCookie?.value ?? '',
   };
 };
@@ -110,11 +115,11 @@ const getAuthConfig = (): AuthConfig => {
   const kubeconfigAuth = tryKubeconfigAuth();
   if (kubeconfigAuth) return kubeconfigAuth;
 
-  const { sessionToken, csrfToken } = getSessionCookies();
+  const { cookieHeader, csrfToken } = getSessionCookies();
   return {
     baseUrl: getConsoleBaseUrl(),
     headers: {
-      Cookie: sessionToken,
+      Cookie: cookieHeader,
       'X-CSRFToken': csrfToken,
     },
     proxyMode: true,
@@ -133,6 +138,13 @@ const getAuthConfig = (): AuthConfig => {
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class BaseResourceManager {
+  /**
+   * Convenience wrapper for DELETE requests.
+   * `ResourceCleaner.deleteResource` calls `apiRequest` directly to inspect
+   * the raw status code (404 → skip, 403 → skip, other → throw). This method
+   * is kept as a public extension point for callers that only need a
+   * success/null response and do not need status-code dispatch.
+   */
   static async apiDelete<R>(apiPath: string): Promise<R | null> {
     const result = await BaseResourceManager.apiRequest<R>(apiPath, { method: 'DELETE' });
 
@@ -187,7 +199,7 @@ export abstract class BaseResourceManager {
     return null;
   }
 
-  private static async apiRequest<R>(
+  protected static async apiRequest<R>(
     apiPath: string,
     options: ApiRequestOptions,
   ): Promise<ApiResult<R>> {
@@ -210,6 +222,7 @@ export abstract class BaseResourceManager {
         path: fullUrl.pathname + fullUrl.search,
         method: options.method,
         rejectUnauthorized: false,
+        timeout: API_REQUEST_TIMEOUT_MS,
         headers: {
           Accept: 'application/json',
           'Content-Type': options.contentType ?? 'application/json',
@@ -235,6 +248,12 @@ export abstract class BaseResourceManager {
             resolve({ error: data || `HTTP ${status}`, status, success: false });
           }
         });
+      });
+
+      req.on('timeout', () => {
+        req.destroy(
+          new Error(`API ${options.method} ${apiPath} timed out after ${API_REQUEST_TIMEOUT_MS}ms`),
+        );
       });
 
       req.on('error', (err: Error) => {

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -3,9 +3,16 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { URL } from 'node:url';
 
+import { KubeConfig } from '@kubernetes/client-node';
+
 import { AUTH_FILE } from '../constants';
 
 import { RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
+
+// The console proxy strips this prefix before forwarding to the k8s API server.
+// When calling the API server directly we strip it ourselves so the path
+// reaches the correct endpoint (e.g. /apis/... instead of /api/kubernetes/apis/...).
+const PROXY_PREFIX = '/api/kubernetes' as const;
 
 type ApiResult<T> =
   | { data: T; status: number; success: true }
@@ -17,6 +24,13 @@ type ApiRequestOptions = {
   method: string;
 };
 
+type AuthConfig = {
+  baseUrl: string;
+  headers: Record<string, string>;
+  /** true  → talking to console proxy (cookies); false → direct API server (bearer token) */
+  proxyMode: boolean;
+};
+
 type StorageCookie = {
   name: string;
   value: string;
@@ -24,6 +38,31 @@ type StorageCookie = {
 
 type StorageState = {
   cookies: StorageCookie[];
+};
+
+/**
+ * Tries to load kubeconfig from KUBECONFIG_PATH (relayed from globalSetup via ENV_RELAY_FILE).
+ * Returns null when the path is unset, the file is missing, or the config is invalid.
+ */
+const tryKubeconfigAuth = (): AuthConfig | null => {
+  const kubeconfigPath = process.env.KUBECONFIG_PATH;
+  if (!kubeconfigPath || !existsSync(kubeconfigPath)) return null;
+
+  try {
+    const kc = new KubeConfig();
+    kc.loadFromFile(kubeconfigPath);
+    const cluster = kc.getCurrentCluster();
+    const user = kc.getCurrentUser();
+    if (!cluster?.server || !user?.token) return null;
+
+    return {
+      baseUrl: cluster.server.replace(/\/$/, ''),
+      headers: { Authorization: `Bearer ${user.token}` },
+      proxyMode: false,
+    };
+  } catch {
+    return null;
+  }
 };
 
 /**
@@ -64,12 +103,33 @@ const getConsoleBaseUrl = (): string =>
   );
 
 /**
+ * Returns the auth config to use for this request.
+ * Priority: kubeconfig (direct API server) → session cookies (console proxy).
+ */
+const getAuthConfig = (): AuthConfig => {
+  const kubeconfigAuth = tryKubeconfigAuth();
+  if (kubeconfigAuth) return kubeconfigAuth;
+
+  const { sessionToken, csrfToken } = getSessionCookies();
+  return {
+    baseUrl: getConsoleBaseUrl(),
+    headers: {
+      Cookie: sessionToken,
+      'X-CSRFToken': csrfToken,
+    },
+    proxyMode: true,
+  };
+};
+
+/**
  * Base class providing shared Node.js HTTP functionality for resource managers.
  *
- * All Kubernetes API calls go through the OpenShift console proxy
- * (/api/kubernetes/...) using the session cookies saved by global.setup.ts.
- * This decouples resource creation/deletion/fetching from any browser Page
- * instance — the browser is only required for UI interactions in actual test steps.
+ * Auth mode is resolved at call time:
+ *  - **Kubeconfig mode** (preferred): uses the kubeconfig written by globalSetup after
+ *    `oc login`. Talks directly to the cluster API server with a long-lived Bearer token.
+ *    Session expiry only affects UI test steps, not resource operations.
+ *  - **Cookie fallback**: when no kubeconfig is available, falls back to the OpenShift
+ *    console proxy (/api/kubernetes/...) using the session cookies saved in AUTH_FILE.
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class BaseResourceManager {
@@ -131,10 +191,14 @@ export abstract class BaseResourceManager {
     apiPath: string,
     options: ApiRequestOptions,
   ): Promise<ApiResult<R>> {
-    const baseUrl = getConsoleBaseUrl();
-    const { sessionToken, csrfToken } = getSessionCookies();
+    const { baseUrl, headers, proxyMode } = getAuthConfig();
 
-    const fullUrl = new URL(apiPath, baseUrl);
+    // In direct (kubeconfig) mode the caller's path still carries the console proxy
+    // prefix — strip it so the request reaches the correct API server endpoint.
+    const adjustedPath =
+      proxyMode || !apiPath.startsWith(PROXY_PREFIX) ? apiPath : apiPath.slice(PROXY_PREFIX.length);
+
+    const fullUrl = new URL(adjustedPath || '/', baseUrl);
     const isHttps = fullUrl.protocol === 'https:';
     const transport = isHttps ? https : http;
     const body = options.body === undefined ? undefined : JSON.stringify(options.body);
@@ -153,8 +217,7 @@ export abstract class BaseResourceManager {
         headers: {
           Accept: 'application/json',
           'Content-Type': options.contentType ?? 'application/json',
-          Cookie: cookieHeader,
-          'X-CSRFToken': csrfToken,
+          ...headers,
           ...(body ? { 'Content-Length': String(Buffer.byteLength(body)) } : {}),
         },
       };

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -203,10 +203,6 @@ export abstract class BaseResourceManager {
     const transport = isHttps ? https : http;
     const body = options.body === undefined ? undefined : JSON.stringify(options.body);
 
-    const cookieHeader = csrfToken
-      ? `openshift-session-token=${sessionToken}; csrf-token=${csrfToken}`
-      : `openshift-session-token=${sessionToken}`;
-
     return new Promise((resolve) => {
       const reqOptions: https.RequestOptions = {
         hostname: fullUrl.hostname,

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -1,6 +1,11 @@
-import type { Page } from '@playwright/test';
+import { existsSync, readFileSync } from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { URL } from 'node:url';
 
-import { API_PATHS, COOKIE_NAMES, HTTP_HEADERS, RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
+import { AUTH_FILE } from '../constants';
+
+import { RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
 
 type ApiResult<T> =
   | { data: T; status: number; success: true }
@@ -12,14 +17,73 @@ type ApiRequestOptions = {
   method: string;
 };
 
+type StorageCookie = {
+  name: string;
+  value: string;
+};
+
+type StorageState = {
+  cookies: StorageCookie[];
+};
+
 /**
- * Base class providing shared functionality for resource manager classes
+ * Reads session cookies from the saved Playwright storageState file.
+ * These cookies are written by global.setup.ts after browser login and
+ * are the same credentials the browser would use — but now consumed
+ * directly by Node.js HTTP calls so that no browser page is required.
+ */
+const getSessionCookies = (): { sessionToken: string; csrfToken: string } => {
+  if (!existsSync(AUTH_FILE)) {
+    throw new Error(
+      `Auth file not found at "${AUTH_FILE}". ` +
+        'Run global setup (login) before resource operations.',
+    );
+  }
+
+  const state = JSON.parse(readFileSync(AUTH_FILE, 'utf8')) as StorageState;
+  const sessionCookie = state.cookies.find((cookie) => cookie.name === 'openshift-session-token');
+  const csrfCookie = state.cookies.find((cookie) => cookie.name === 'csrf-token');
+
+  if (!sessionCookie?.value) {
+    throw new Error(
+      'openshift-session-token not found in auth file. ' +
+        'Re-run global setup to refresh the session.',
+    );
+  }
+
+  return {
+    sessionToken: sessionCookie.value,
+    csrfToken: csrfCookie?.value ?? '',
+  };
+};
+
+const getConsoleBaseUrl = (): string =>
+  (process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS ?? 'http://localhost:9000').replace(
+    /\/$/,
+    '',
+  );
+
+/**
+ * Base class providing shared Node.js HTTP functionality for resource managers.
+ *
+ * All Kubernetes API calls go through the OpenShift console proxy
+ * (/api/kubernetes/...) using the session cookies saved by global.setup.ts.
+ * This decouples resource creation/deletion/fetching from any browser Page
+ * instance — the browser is only required for UI interactions in actual test steps.
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export abstract class BaseResourceManager {
-  /** Generic GET helper — handles CSRF token, headers, and error handling. */
-  public static async apiGet<R>(page: Page, apiPath: string): Promise<R | null> {
-    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, { method: 'GET' });
+  static async apiDelete<R>(apiPath: string): Promise<R | null> {
+    const result = await BaseResourceManager.apiRequest<R>(apiPath, { method: 'DELETE' });
+
+    if (result.success) return result.data;
+
+    console.error(`API DELETE ${apiPath} failed: ${result.error}`);
+    return null;
+  }
+
+  static async apiGet<R>(apiPath: string): Promise<R | null> {
+    const result = await BaseResourceManager.apiRequest<R>(apiPath, { method: 'GET' });
 
     if (result.success) return result.data;
 
@@ -27,14 +91,12 @@ export abstract class BaseResourceManager {
     return null;
   }
 
-  /** Generic PATCH helper — handles CSRF token, headers, and error handling. */
-  public static async apiPatch<R>(
-    page: Page,
+  static async apiPatch<R>(
     apiPath: string,
     data: unknown,
     contentType = 'application/merge-patch+json',
   ): Promise<R | null> {
-    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, {
+    const result = await BaseResourceManager.apiRequest<R>(apiPath, {
       body: data,
       contentType,
       method: 'PATCH',
@@ -46,9 +108,8 @@ export abstract class BaseResourceManager {
     return null;
   }
 
-  /** Generic POST helper — handles CSRF token, headers, and error handling. */
-  public static async apiPost<R>(page: Page, apiPath: string, data: unknown): Promise<R | null> {
-    const result = await BaseResourceManager.apiRequest<R>(page, apiPath, {
+  static async apiPost<R>(apiPath: string, data: unknown): Promise<R | null> {
+    const result = await BaseResourceManager.apiRequest<R>(apiPath, {
       body: data,
       method: 'POST',
     });
@@ -67,71 +128,66 @@ export abstract class BaseResourceManager {
   }
 
   private static async apiRequest<R>(
-    page: Page,
     apiPath: string,
     options: ApiRequestOptions,
   ): Promise<ApiResult<R>> {
-    const constants = BaseResourceManager.getEvaluateConstants();
+    const baseUrl = getConsoleBaseUrl();
+    const { sessionToken, csrfToken } = getSessionCookies();
 
-    return page.evaluate(
-      async ({ body, contentType, evalConstants, method, path }): Promise<ApiResult<R>> => {
-        try {
-          const cookies = document.cookie.split('; ');
-          const csrfCookie = cookies.find((cookie) =>
-            cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
-          );
-          const csrfToken = csrfCookie ? csrfCookie.split('=')[1] : '';
+    const fullUrl = new URL(apiPath, baseUrl);
+    const isHttps = fullUrl.protocol === 'https:';
+    const transport = isHttps ? https : http;
+    const body = options.body === undefined ? undefined : JSON.stringify(options.body);
 
-          const response = await fetch(path, {
-            ...(body !== undefined && { body: JSON.stringify(body) }),
-            credentials: 'include',
-            headers: {
-              [evalConstants.CONTENT_TYPE_HEADER]: contentType ?? evalConstants.APPLICATION_JSON,
-              [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
-            },
-            method,
-          });
+    const cookieHeader = csrfToken
+      ? `openshift-session-token=${sessionToken}; csrf-token=${csrfToken}`
+      : `openshift-session-token=${sessionToken}`;
 
-          if (response.ok) {
-            return { data: await response.json(), status: response.status, success: true };
-          }
-
-          const errorText = await response.text().catch(() => response.statusText);
-          return { error: errorText, status: response.status, success: false };
-        } catch (error: unknown) {
-          const err = error as Error;
-          return { error: err?.message ?? String(error), status: 0, success: false };
-        }
-      },
-      {
-        body: options.body,
-        contentType: options.contentType,
-        evalConstants: constants,
+    return new Promise((resolve) => {
+      const reqOptions: https.RequestOptions = {
+        hostname: fullUrl.hostname,
+        port: fullUrl.port || (isHttps ? 443 : 80),
+        path: fullUrl.pathname + fullUrl.search,
         method: options.method,
-        path: apiPath,
-      },
-    );
+        rejectUnauthorized: false,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': options.contentType ?? 'application/json',
+          Cookie: cookieHeader,
+          'X-CSRFToken': csrfToken,
+          ...(body ? { 'Content-Length': String(Buffer.byteLength(body)) } : {}),
+        },
+      };
+
+      const req = transport.request(reqOptions, (res) => {
+        let data = '';
+        res.on('data', (chunk: string) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          const status = res.statusCode ?? 0;
+          if (status >= 200 && status < 300) {
+            try {
+              resolve({ data: JSON.parse(data) as R, status, success: true });
+            } catch {
+              resolve({ data: data as unknown as R, status, success: true });
+            }
+          } else {
+            resolve({ error: data || `HTTP ${status}`, status, success: false });
+          }
+        });
+      });
+
+      req.on('error', (err: Error) => {
+        resolve({ error: err.message, status: 0, success: false });
+      });
+
+      if (body) req.write(body);
+      req.end();
+    });
   }
 
-  public static getEvaluateConstants() {
-    return {
-      CSRF_TOKEN_NAME: COOKIE_NAMES.CSRF_TOKEN,
-      CONTENT_TYPE_HEADER: HTTP_HEADERS.CONTENT_TYPE,
-      APPLICATION_JSON: HTTP_HEADERS.APPLICATION_JSON,
-      CSRF_TOKEN_HEADER: HTTP_HEADERS.CSRF_TOKEN,
-      FORKLIFT_PATH: API_PATHS.FORKLIFT,
-      KUBEVIRT_PATH: API_PATHS.KUBEVIRT,
-      KUBERNETES_CORE: API_PATHS.KUBERNETES_CORE,
-      OPENSHIFT_PROJECT_PATH: API_PATHS.OPENSHIFT_PROJECT,
-      NAD_PATH: API_PATHS.NAD,
-      SECRETS_TYPE: RESOURCE_TYPES.SECRETS,
-      VIRTUAL_MACHINES_TYPE: RESOURCE_TYPES.VIRTUAL_MACHINES,
-      PROJECTS_TYPE: RESOURCE_TYPES.PROJECTS,
-      NAMESPACES_TYPE: RESOURCE_TYPES.NAMESPACES,
-    } as const;
-  }
-
-  public static getResourceTypeFromKind(kind: string): string {
+  static getResourceTypeFromKind(kind: string): string {
     const kindToType: Record<string, string> = {
       [RESOURCE_KINDS.FORKLIFT_CONTROLLER]: RESOURCE_TYPES.FORKLIFT_CONTROLLERS,
       [RESOURCE_KINDS.MIGRATION]: RESOURCE_TYPES.MIGRATIONS,

--- a/testing/playwright/utils/resource-manager/ResourceCleaner.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCleaner.ts
@@ -47,7 +47,6 @@ export class ResourceCleaner extends BaseResourceManager {
       return;
     }
 
-    // Index resources by kind for O(1) group lookup
     const byKind = new Map<string, SupportedResource[]>();
     for (const resource of resources) {
       const kind = resource.kind ?? 'unknown';

--- a/testing/playwright/utils/resource-manager/ResourceCleaner.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCleaner.ts
@@ -21,12 +21,13 @@ const CLEANUP_GROUPS = [
   // Group 1: execution resources — reference providers, maps, and each other
   [RESOURCE_KINDS.MIGRATION, RESOURCE_KINDS.PLAN],
   // Group 2: configuration resources — referenced by plans
+  // Note: FORKLIFT_CONTROLLER is intentionally excluded — deleting it would destroy
+  // the entire Forklift installation. Tests that modify it via patch must restore it.
   [
     RESOURCE_KINDS.NETWORK_MAP,
     RESOURCE_KINDS.STORAGE_MAP,
     RESOURCE_KINDS.PROVIDER,
     RESOURCE_KINDS.SECRET,
-    RESOURCE_KINDS.FORKLIFT_CONTROLLER,
   ],
   // Group 3: workload resources
   [RESOURCE_KINDS.VIRTUAL_MACHINE, RESOURCE_KINDS.NETWORK_ATTACHMENT_DEFINITION],
@@ -104,7 +105,7 @@ export class ResourceCleaner extends BaseResourceManager {
 
   private static async deleteResource(
     resource: SupportedResource,
-  ): Promise<{ success: boolean; skipped: boolean; reason?: string }> {
+  ): Promise<{ skipped: boolean; reason?: string }> {
     const resourceName = resource.metadata?.name;
     const namespace = resource.metadata?.namespace ?? MTV_NAMESPACE;
 
@@ -127,27 +128,35 @@ export class ResourceCleaner extends BaseResourceManager {
       if (resourceType === RESOURCE_TYPES.SECRETS) {
         return `${API_PATHS.KUBERNETES_CORE}/namespaces/${namespace}/${resourceType}/${resourceName}`;
       }
+      if (resourceType === RESOURCE_TYPES.NETWORK_ATTACHMENT_DEFINITIONS) {
+        return `${API_PATHS.NAD}/namespaces/${namespace}/${resourceType}/${resourceName}`;
+      }
       return `${API_PATHS.FORKLIFT}/namespaces/${namespace}/${resourceType}/${resourceName}`;
     };
 
-    const apiPath = buildApiPath();
+    const HTTP_NOT_FOUND = 404;
+    const HTTP_FORBIDDEN = 403;
 
-    try {
-      await ResourceCleaner.apiDelete(apiPath);
-      return { success: true, skipped: false };
-    } catch (error) {
-      const errorStr = String(error);
+    const result = await ResourceCleaner.apiRequest<unknown>(buildApiPath(), { method: 'DELETE' });
 
-      if (errorStr.includes('404') || errorStr.includes('not found')) {
-        return { success: true, skipped: true, reason: 'not found' };
-      }
-
-      if (errorStr.includes('403') || errorStr.includes('Forbidden')) {
-        return { success: true, skipped: true, reason: 'deletion forbidden' };
-      }
-
-      throw error;
+    if (result.success || result.status === HTTP_NOT_FOUND) {
+      return {
+        skipped: result.status === HTTP_NOT_FOUND,
+        reason: result.status === HTTP_NOT_FOUND ? 'not found' : undefined,
+      };
     }
+
+    if (result.status === HTTP_FORBIDDEN) {
+      console.warn(
+        `Cleanup: DELETE ${resourceName} (${resourceType}) returned 403 Forbidden — skipping`,
+      );
+      return { skipped: true, reason: 'deletion forbidden' };
+    }
+
+    console.error(`Cleanup: DELETE ${resourceName} (${resourceType}) failed: ${result.error}`);
+    throw new Error(
+      `DELETE ${resourceName} (${resourceType}) failed with HTTP ${result.status}: ${result.error}`,
+    );
   }
 
   private static getResourceType(resource: SupportedResource): string {

--- a/testing/playwright/utils/resource-manager/ResourceCleaner.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCleaner.ts
@@ -3,8 +3,36 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { isEmpty } from '../utils';
 
 import { BaseResourceManager } from './BaseResourceManager';
-import { API_PATHS, MTV_NAMESPACE, RESOURCE_TYPES, RESOURCES_FILE } from './constants';
+import {
+  API_PATHS,
+  MTV_NAMESPACE,
+  RESOURCE_KINDS,
+  RESOURCE_TYPES,
+  RESOURCES_FILE,
+} from './constants';
 import type { SupportedResource } from './ResourceManager';
+
+/**
+ * Deletion groups ordered by dependency: resources in later groups may reference
+ * resources in earlier groups, so earlier groups must be deleted first.
+ * Within each group all deletions run in parallel.
+ */
+const CLEANUP_GROUPS = [
+  // Group 1: execution resources — reference providers, maps, and each other
+  [RESOURCE_KINDS.MIGRATION, RESOURCE_KINDS.PLAN],
+  // Group 2: configuration resources — referenced by plans
+  [
+    RESOURCE_KINDS.NETWORK_MAP,
+    RESOURCE_KINDS.STORAGE_MAP,
+    RESOURCE_KINDS.PROVIDER,
+    RESOURCE_KINDS.SECRET,
+    RESOURCE_KINDS.FORKLIFT_CONTROLLER,
+  ],
+  // Group 3: workload resources
+  [RESOURCE_KINDS.VIRTUAL_MACHINE, RESOURCE_KINDS.NETWORK_ATTACHMENT_DEFINITION],
+  // Group 4: namespaces / projects must be last (deleting them cascades everything inside)
+  [RESOURCE_KINDS.NAMESPACE, RESOURCE_KINDS.PROJECT],
+] as const;
 
 /**
  * Handles cleanup and deletion of Kubernetes resources.
@@ -18,27 +46,53 @@ export class ResourceCleaner extends BaseResourceManager {
       return;
     }
 
-    const cleanupPromises = resources.map(async (resource) =>
-      ResourceCleaner.deleteResource(resource),
-    );
-
-    const results = await Promise.allSettled(cleanupPromises);
+    // Index resources by kind for O(1) group lookup
+    const byKind = new Map<string, SupportedResource[]>();
+    for (const resource of resources) {
+      const kind = resource.kind ?? 'unknown';
+      const bucket = byKind.get(kind) ?? [];
+      bucket.push(resource);
+      byKind.set(kind, bucket);
+    }
 
     let deletedCount = 0;
     let skippedCount = 0;
     let failureCount = 0;
 
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        const { skipped } = result.value;
-        if (skipped) {
-          skippedCount += 1;
+    const processResults = (results: PromiseSettledResult<{ skipped: boolean }>[]) => {
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          if (result.value.skipped) {
+            skippedCount += 1;
+          } else {
+            deletedCount += 1;
+          }
         } else {
-          deletedCount += 1;
+          failureCount += 1;
         }
-      } else {
-        failureCount += 1;
       }
+    };
+
+    // Delete in dependency order — each group waits for the previous to finish
+    for (const group of CLEANUP_GROUPS) {
+      const groupResources = group.flatMap((kind) => byKind.get(kind) ?? []);
+      group.forEach((kind) => byKind.delete(kind));
+
+      if (groupResources.length > 0) {
+        const results = await Promise.allSettled(
+          groupResources.map(async (resource) => ResourceCleaner.deleteResource(resource)),
+        );
+        processResults(results);
+      }
+    }
+
+    // Catch-all for any kind not covered by the groups above (future-proofing)
+    const remainingResources = [...byKind.values()].flat();
+    if (remainingResources.length > 0) {
+      const results = await Promise.allSettled(
+        remainingResources.map(async (resource) => ResourceCleaner.deleteResource(resource)),
+      );
+      processResults(results);
     }
 
     if (failureCount > 0) {

--- a/testing/playwright/utils/resource-manager/ResourceCleaner.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCleaner.ts
@@ -1,27 +1,25 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-import type { BrowserContextOptions, Page } from '@playwright/test';
-
-import { AUTH_FILE } from '../constants';
 import { isEmpty } from '../utils';
 
 import { BaseResourceManager } from './BaseResourceManager';
-import { MTV_NAMESPACE, RESOURCES_FILE } from './constants';
+import { API_PATHS, MTV_NAMESPACE, RESOURCE_TYPES, RESOURCES_FILE } from './constants';
 import type { SupportedResource } from './ResourceManager';
 
 /**
- * Handles cleanup and deletion of Kubernetes resources
+ * Handles cleanup and deletion of Kubernetes resources.
+ * All operations use Node.js HTTP directly — no browser Page required.
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResourceCleaner extends BaseResourceManager {
-  static async cleanupAll(page: Page, resources: SupportedResource[]): Promise<void> {
+  static async cleanupAll(resources: SupportedResource[]): Promise<void> {
     if (isEmpty(resources)) {
       console.log('No resources to cleanup');
       return;
     }
 
     const cleanupPromises = resources.map(async (resource) =>
-      ResourceCleaner.deleteResource(page, resource),
+      ResourceCleaner.deleteResource(resource),
     );
 
     const results = await Promise.allSettled(cleanupPromises);
@@ -33,7 +31,6 @@ export class ResourceCleaner extends BaseResourceManager {
     for (const result of results) {
       if (result.status === 'fulfilled') {
         const { skipped } = result.value;
-
         if (skipped) {
           skippedCount += 1;
         } else {
@@ -52,7 +49,6 @@ export class ResourceCleaner extends BaseResourceManager {
   }
 
   private static async deleteResource(
-    page: Page,
     resource: SupportedResource,
   ): Promise<{ success: boolean; skipped: boolean; reason?: string }> {
     const resourceName = resource.metadata?.name;
@@ -64,101 +60,26 @@ export class ResourceCleaner extends BaseResourceManager {
 
     const resourceType = ResourceCleaner.getResourceType(resource);
 
-    const constants = ResourceCleaner.getEvaluateConstants();
+    const buildApiPath = (): string => {
+      if (resourceType === RESOURCE_TYPES.VIRTUAL_MACHINES) {
+        return `${API_PATHS.KUBEVIRT}/namespaces/${namespace}/${resourceType}/${resourceName}`;
+      }
+      if (resourceType === RESOURCE_TYPES.PROJECTS) {
+        return `${API_PATHS.OPENSHIFT_PROJECT}/${resourceType}/${resourceName}`;
+      }
+      if (resourceType === RESOURCE_TYPES.NAMESPACES) {
+        return `${API_PATHS.KUBERNETES_CORE}/${resourceType}/${resourceName}`;
+      }
+      if (resourceType === RESOURCE_TYPES.SECRETS) {
+        return `${API_PATHS.KUBERNETES_CORE}/namespaces/${namespace}/${resourceType}/${resourceName}`;
+      }
+      return `${API_PATHS.FORKLIFT}/namespaces/${namespace}/${resourceType}/${resourceName}`;
+    };
+
+    const apiPath = buildApiPath();
 
     try {
-      const result = await page.evaluate(
-        async ({ resType, resName, resNamespace, evalConstants }) => {
-          try {
-            const getCsrfTokenFromCookie = () => {
-              const cookies = document.cookie.split('; ');
-              const csrfCookie = cookies.find((cookie) =>
-                cookie.startsWith(`${evalConstants.CSRF_TOKEN_NAME}=`),
-              );
-              return csrfCookie ? csrfCookie.split('=')[1] : '';
-            };
-            const csrfToken = getCsrfTokenFromCookie();
-
-            let apiPath = '';
-            if (resType === evalConstants.VIRTUAL_MACHINES_TYPE) {
-              apiPath = `${evalConstants.KUBEVIRT_PATH}/namespaces/${resNamespace}/${resType}/${resName}`;
-            } else if (resType === evalConstants.PROJECTS_TYPE) {
-              apiPath = `${evalConstants.OPENSHIFT_PROJECT_PATH}/${resType}/${resName}`;
-            } else if (resType === evalConstants.NAMESPACES_TYPE) {
-              apiPath = `${evalConstants.KUBERNETES_CORE}/${resType}/${resName}`;
-            } else if (resType === evalConstants.SECRETS_TYPE) {
-              apiPath = `${evalConstants.KUBERNETES_CORE}/namespaces/${resNamespace}/${resType}/${resName}`;
-            } else {
-              apiPath = `${evalConstants.FORKLIFT_PATH}/namespaces/${resNamespace}/${resType}/${resName}`;
-            }
-
-            const response = await fetch(apiPath, {
-              method: 'DELETE',
-              headers: {
-                [evalConstants.CONTENT_TYPE_HEADER]: evalConstants.APPLICATION_JSON,
-                [evalConstants.CSRF_TOKEN_HEADER]: csrfToken,
-              },
-              credentials: 'include',
-            });
-
-            if (response.ok || response.status === 404) {
-              return { success: true, error: null, wasNotFound: response.status === 404 };
-            }
-
-            const errorText = await response.text().catch(() => response.statusText);
-
-            return {
-              success: false,
-              error: {
-                message: errorText,
-                status: response.status,
-              },
-            };
-          } catch (error: unknown) {
-            const err = error as any;
-            return {
-              success: false,
-              error: {
-                message: err?.message ?? String(error),
-                status: err?.status ?? 'unknown',
-              },
-            };
-          }
-        },
-        {
-          resType: resourceType,
-          resName: resourceName,
-          resNamespace: namespace,
-          evalConstants: constants,
-        },
-      );
-
-      if (!result.success) {
-        const { error } = result;
-
-        if (!error) {
-          throw new Error('Failed to delete: unknown error');
-        }
-
-        if (error.status === 404 || error.message.includes('not found')) {
-          return { success: true, skipped: true, reason: 'not found' };
-        }
-
-        if (error.status === 403 || error.message.includes('Forbidden')) {
-          return {
-            success: true,
-            skipped: true,
-            reason: 'deletion forbidden',
-          };
-        }
-
-        throw new Error(`Failed to delete: ${error.message}`);
-      }
-
-      if (result.wasNotFound) {
-        return { success: true, skipped: true, reason: 'not found' };
-      }
-
+      await ResourceCleaner.apiDelete(apiPath);
       return { success: true, skipped: false };
     } catch (error) {
       const errorStr = String(error);
@@ -168,11 +89,7 @@ export class ResourceCleaner extends BaseResourceManager {
       }
 
       if (errorStr.includes('403') || errorStr.includes('Forbidden')) {
-        return {
-          success: true,
-          skipped: true,
-          reason: 'deletion forbidden',
-        };
+        return { success: true, skipped: true, reason: 'deletion forbidden' };
       }
 
       throw error;
@@ -184,46 +101,6 @@ export class ResourceCleaner extends BaseResourceManager {
       return ResourceCleaner.getResourceTypeFromKind(resource.kind);
     }
     return 'unknown';
-  }
-
-  static async instantCleanup(
-    resources: SupportedResource[],
-    baseUrl = process.env.BRIDGE_BASE_ADDRESS ??
-      process.env.BASE_ADDRESS ??
-      'http://localhost:9000',
-    storageStatePath?: string,
-  ): Promise<void> {
-    if (isEmpty(resources)) {
-      return;
-    }
-
-    const { chromium } = await import('@playwright/test');
-    const browser = await chromium.launch({ headless: true });
-
-    const contextOptions: BrowserContextOptions = {
-      ignoreHTTPSErrors: true,
-    };
-
-    if (storageStatePath) {
-      contextOptions.storageState = storageStatePath;
-    } else if (existsSync(AUTH_FILE)) {
-      contextOptions.storageState = AUTH_FILE;
-    }
-
-    const context = await browser.newContext(contextOptions);
-    const page = await context.newPage();
-
-    try {
-      await page.goto(`${baseUrl}/k8s/all-namespaces/forklift.konveyor.io~v1beta1~Provider`);
-      await page.waitForLoadState('domcontentloaded');
-      await ResourceCleaner.cleanupAll(page, resources);
-    } catch (error) {
-      console.error('Error during instant cleanup:', error);
-      throw error;
-    } finally {
-      await context.close();
-      await browser.close();
-    }
   }
 
   static loadResourcesFromFile(): SupportedResource[] {

--- a/testing/playwright/utils/resource-manager/ResourceCreator.ts
+++ b/testing/playwright/utils/resource-manager/ResourceCreator.ts
@@ -4,14 +4,10 @@ import type {
   V1beta1Provider,
   V1beta1StorageMap,
 } from '@forklift-ui/types';
-import type { Page } from '@playwright/test';
 
 import { BaseResourceManager } from './BaseResourceManager';
 import { API_PATHS, MTV_NAMESPACE } from './constants';
 
-/**
- * NetworkAttachmentDefinition type for CNI network configuration
- */
 export type V1NetworkAttachmentDefinition = {
   apiVersion: 'k8s.cni.cncf.io/v1';
   kind: 'NetworkAttachmentDefinition';
@@ -26,46 +22,41 @@ export type V1NetworkAttachmentDefinition = {
 };
 
 export const createProvider = async (
-  page: Page,
   provider: V1beta1Provider,
   namespace = MTV_NAMESPACE,
 ): Promise<V1beta1Provider | null> => {
   const apiPath = `${API_PATHS.FORKLIFT}/namespaces/${namespace}/providers`;
-  return BaseResourceManager.apiPost<V1beta1Provider>(page, apiPath, provider);
+  return BaseResourceManager.apiPost<V1beta1Provider>(apiPath, provider);
 };
 
 export const createSecret = async (
-  page: Page,
   secret: IoK8sApiCoreV1Secret,
   namespace = MTV_NAMESPACE,
 ): Promise<IoK8sApiCoreV1Secret | null> => {
   const apiPath = `${API_PATHS.KUBERNETES_CORE}/namespaces/${namespace}/secrets`;
-  return BaseResourceManager.apiPost<IoK8sApiCoreV1Secret>(page, apiPath, secret);
+  return BaseResourceManager.apiPost<IoK8sApiCoreV1Secret>(apiPath, secret);
 };
 
 export const createNad = async (
-  page: Page,
   nad: V1NetworkAttachmentDefinition,
   namespace: string,
 ): Promise<V1NetworkAttachmentDefinition | null> => {
   const apiPath = `${API_PATHS.NAD}/namespaces/${namespace}/network-attachment-definitions`;
-  return BaseResourceManager.apiPost<V1NetworkAttachmentDefinition>(page, apiPath, nad);
+  return BaseResourceManager.apiPost<V1NetworkAttachmentDefinition>(apiPath, nad);
 };
 
 export const createNetworkMap = async (
-  page: Page,
   networkMap: V1beta1NetworkMap,
   namespace = MTV_NAMESPACE,
 ): Promise<V1beta1NetworkMap | null> => {
   const apiPath = `${API_PATHS.FORKLIFT}/namespaces/${namespace}/networkmaps`;
-  return BaseResourceManager.apiPost<V1beta1NetworkMap>(page, apiPath, networkMap);
+  return BaseResourceManager.apiPost<V1beta1NetworkMap>(apiPath, networkMap);
 };
 
 export const createStorageMap = async (
-  page: Page,
   storageMap: V1beta1StorageMap,
   namespace = MTV_NAMESPACE,
 ): Promise<V1beta1StorageMap | null> => {
   const apiPath = `${API_PATHS.FORKLIFT}/namespaces/${namespace}/storagemaps`;
-  return BaseResourceManager.apiPost<V1beta1StorageMap>(page, apiPath, storageMap);
+  return BaseResourceManager.apiPost<V1beta1StorageMap>(apiPath, storageMap);
 };

--- a/testing/playwright/utils/resource-manager/ResourceFetcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourceFetcher.ts
@@ -25,26 +25,11 @@ import type { SupportedResource } from './ResourceManager';
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResourceFetcher extends BaseResourceManager {
   static async fetchCnvVersion(namespace = CNV_NAMESPACE): Promise<string | null> {
-    type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
-    type CsvList = { items?: CsvItem[] };
-
-    const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
-    const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
-
-    if (!data?.items) {
-      return null;
-    }
-
-    const operatorCsv = data.items.find((csv) =>
-      CNV_OPERATOR_CSV_PREFIXES.some((prefix) => csv.metadata?.name?.startsWith(prefix)),
+    return ResourceFetcher.fetchOperatorVersion(
+      namespace,
+      CNV_OPERATOR_CSV_PREFIXES,
+      'CNV operator',
     );
-
-    if (!operatorCsv?.spec?.version) {
-      console.error('CNV operator CSV not found among cluster service versions');
-      return null;
-    }
-
-    return operatorCsv.spec.version;
   }
 
   static async fetchForkliftController(
@@ -59,26 +44,7 @@ export class ResourceFetcher extends BaseResourceManager {
   }
 
   static async fetchMtvVersion(namespace = MTV_NAMESPACE): Promise<string | null> {
-    type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
-    type CsvList = { items?: CsvItem[] };
-
-    const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
-    const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
-
-    if (!data?.items) {
-      return null;
-    }
-
-    const operatorCsv = data.items.find((csv) =>
-      OPERATOR_CSV_PREFIXES.some((prefix) => csv.metadata?.name?.startsWith(prefix)),
-    );
-
-    if (!operatorCsv?.spec?.version) {
-      console.error('Operator CSV not found among cluster service versions');
-      return null;
-    }
-
-    return operatorCsv.spec.version;
+    return ResourceFetcher.fetchOperatorVersion(namespace, OPERATOR_CSV_PREFIXES, 'Operator');
   }
 
   static async fetchNetworkMap(
@@ -90,6 +56,31 @@ export class ResourceFetcher extends BaseResourceManager {
       resourceName: networkMapName,
       namespace,
     });
+  }
+
+  private static async fetchOperatorVersion(
+    namespace: string,
+    prefixes: readonly string[],
+    operatorLabel: string,
+  ): Promise<string | null> {
+    type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
+    type CsvList = { items?: CsvItem[] };
+
+    const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
+    const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
+
+    if (!data?.items) return null;
+
+    const csv = data.items.find((item) =>
+      prefixes.some((prefix) => item.metadata?.name?.startsWith(prefix)),
+    );
+
+    if (!csv?.spec?.version) {
+      console.error(`${operatorLabel} CSV not found among cluster service versions`);
+      return null;
+    }
+
+    return csv.spec.version;
   }
 
   static async fetchPlan(planName: string, namespace = MTV_NAMESPACE): Promise<V1beta1Plan | null> {

--- a/testing/playwright/utils/resource-manager/ResourceFetcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourceFetcher.ts
@@ -6,7 +6,6 @@ import type {
   V1beta1StorageMap,
   V1VirtualMachine,
 } from '@forklift-ui/types';
-import type { Page } from '@playwright/test';
 
 import { BaseResourceManager } from './BaseResourceManager';
 import {
@@ -20,25 +19,17 @@ import {
 import type { SupportedResource } from './ResourceManager';
 
 /**
- * Handles fetching resources from Kubernetes APIs
+ * Handles fetching resources from Kubernetes APIs.
+ * All operations use Node.js HTTP directly — no browser Page required.
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResourceFetcher extends BaseResourceManager {
-  /**
-   * Fetches the CNV (OpenShift Virtualization) operator version from the cluster
-   * by reading the ClusterServiceVersion (CSV) resource created by OLM.
-   *
-   * Looks for a CSV whose name starts with "kubevirt-hyperconverged-operator"
-   * (downstream) or "community-kubevirt-hyperconverged" (upstream).
-   *
-   * @returns The semver version string (e.g. "4.18.0") or null if not found.
-   */
-  static async fetchCnvVersion(page: Page, namespace = CNV_NAMESPACE): Promise<string | null> {
+  static async fetchCnvVersion(namespace = CNV_NAMESPACE): Promise<string | null> {
     type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
     type CsvList = { items?: CsvItem[] };
 
     const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
-    const data = await ResourceFetcher.apiGet<CsvList>(page, apiPath);
+    const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
 
     if (!data?.items) {
       return null;
@@ -57,32 +48,22 @@ export class ResourceFetcher extends BaseResourceManager {
   }
 
   static async fetchForkliftController(
-    page: Page,
     controllerName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1ForkliftController | null> {
-    return ResourceFetcher.fetchResource<V1beta1ForkliftController>(page, {
+    return ResourceFetcher.fetchResource<V1beta1ForkliftController>({
       kind: RESOURCE_KINDS.FORKLIFT_CONTROLLER,
       resourceName: controllerName,
       namespace,
     });
   }
 
-  /**
-   * Fetches the MTV/Forklift operator version from the cluster by reading the
-   * ClusterServiceVersion (CSV) resource created by OLM.
-   *
-   * Looks for a CSV whose name starts with "mtv-operator" (downstream) or
-   * "forklift-operator" (upstream) and returns its spec.version.
-   *
-   * @returns The semver version string (e.g. "2.7.0") or null if not found.
-   */
-  static async fetchMtvVersion(page: Page, namespace = MTV_NAMESPACE): Promise<string | null> {
+  static async fetchMtvVersion(namespace = MTV_NAMESPACE): Promise<string | null> {
     type CsvItem = { metadata?: { name?: string }; spec?: { version?: string } };
     type CsvList = { items?: CsvItem[] };
 
     const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
-    const data = await ResourceFetcher.apiGet<CsvList>(page, apiPath);
+    const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
 
     if (!data?.items) {
       return null;
@@ -101,23 +82,18 @@ export class ResourceFetcher extends BaseResourceManager {
   }
 
   static async fetchNetworkMap(
-    page: Page,
     networkMapName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1NetworkMap | null> {
-    return ResourceFetcher.fetchResource<V1beta1NetworkMap>(page, {
+    return ResourceFetcher.fetchResource<V1beta1NetworkMap>({
       kind: RESOURCE_KINDS.NETWORK_MAP,
       resourceName: networkMapName,
       namespace,
     });
   }
 
-  static async fetchPlan(
-    page: Page,
-    planName: string,
-    namespace = MTV_NAMESPACE,
-  ): Promise<V1beta1Plan | null> {
-    return ResourceFetcher.fetchResource<V1beta1Plan>(page, {
+  static async fetchPlan(planName: string, namespace = MTV_NAMESPACE): Promise<V1beta1Plan | null> {
+    return ResourceFetcher.fetchResource<V1beta1Plan>({
       kind: RESOURCE_KINDS.PLAN,
       resourceName: planName,
       namespace,
@@ -125,21 +101,21 @@ export class ResourceFetcher extends BaseResourceManager {
   }
 
   static async fetchProvider(
-    page: Page,
     providerName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
-    return ResourceFetcher.fetchResource<V1beta1Provider>(page, {
+    return ResourceFetcher.fetchResource<V1beta1Provider>({
       kind: RESOURCE_KINDS.PROVIDER,
       resourceName: providerName,
       namespace,
     });
   }
 
-  static async fetchResource<T extends SupportedResource>(
-    page: Page,
-    options: { kind: string; resourceName: string; namespace: string },
-  ): Promise<T | null> {
+  static async fetchResource<T extends SupportedResource>(options: {
+    kind: string;
+    resourceName: string;
+    namespace: string;
+  }): Promise<T | null> {
     const { kind, namespace, resourceName } = options;
     const resourceType = ResourceFetcher.getResourceTypeFromKind(kind);
 
@@ -147,15 +123,14 @@ export class ResourceFetcher extends BaseResourceManager {
       kind === RESOURCE_KINDS.VIRTUAL_MACHINE ? API_PATHS.KUBEVIRT : API_PATHS.FORKLIFT;
     const apiPath = `${basePath}/namespaces/${namespace}/${resourceType}/${resourceName}`;
 
-    return ResourceFetcher.apiGet<T>(page, apiPath);
+    return ResourceFetcher.apiGet<T>(apiPath);
   }
 
   static async fetchStorageMap(
-    page: Page,
     storageMapName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1StorageMap | null> {
-    return ResourceFetcher.fetchResource<V1beta1StorageMap>(page, {
+    return ResourceFetcher.fetchResource<V1beta1StorageMap>({
       kind: RESOURCE_KINDS.STORAGE_MAP,
       resourceName: storageMapName,
       namespace,
@@ -163,11 +138,10 @@ export class ResourceFetcher extends BaseResourceManager {
   }
 
   static async fetchVirtualMachine(
-    page: Page,
     vmName: string,
     namespace: string,
   ): Promise<V1VirtualMachine | null> {
-    return ResourceFetcher.fetchResource<V1VirtualMachine>(page, {
+    return ResourceFetcher.fetchResource<V1VirtualMachine>({
       kind: RESOURCE_KINDS.VIRTUAL_MACHINE,
       resourceName: vmName,
       namespace,

--- a/testing/playwright/utils/resource-manager/ResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/ResourceManager.ts
@@ -253,8 +253,8 @@ export class ResourceManager {
   }
 
   /**
-   * Alias for cleanupAll — kept for backward compatibility.
-   * Previously launched a headless browser; now uses the Node.js HTTP client.
+   * @deprecated Use cleanupAll() directly.
+   * Kept for backward compatibility — previously launched a headless browser.
    */
   async instantCleanup(): Promise<void> {
     return this.cleanupAll();

--- a/testing/playwright/utils/resource-manager/ResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/ResourceManager.ts
@@ -9,7 +9,6 @@ import type {
   V1beta1StorageMap,
   V1VirtualMachine,
 } from '@forklift-ui/types';
-import type { Page } from '@playwright/test';
 
 import {
   FORKLIFT_API_VERSION,
@@ -55,7 +54,9 @@ export type SupportedResource =
   | OpenshiftProject;
 
 /**
- * Main ResourceManager class that orchestrates resource management operations
+ * Main ResourceManager class that orchestrates resource management operations.
+ * No browser Page is required — all API calls go through Node.js HTTP using
+ * the session cookies saved by global.setup.ts.
  */
 export class ResourceManager {
   private resources: SupportedResource[] = [];
@@ -174,65 +175,55 @@ export class ResourceManager {
     this.addResource(vm);
   }
 
-  async cleanupAll(page: Page): Promise<void> {
-    await ResourceCleaner.cleanupAll(page, this.resources);
+  async cleanupAll(): Promise<void> {
+    await ResourceCleaner.cleanupAll(this.resources);
     this.resources = [];
   }
 
   async createNetworkMap(
-    page: Page,
     networkMap: V1beta1NetworkMap,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1NetworkMap | null> {
-    return createNetworkMap(page, networkMap, namespace);
+    return createNetworkMap(networkMap, namespace);
   }
 
   async createProvider(
-    page: Page,
     provider: V1beta1Provider,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
-    return createProvider(page, provider, namespace);
+    return createProvider(provider, namespace);
   }
 
   async createSecret(
-    page: Page,
     secret: IoK8sApiCoreV1Secret,
     namespace = MTV_NAMESPACE,
   ): Promise<IoK8sApiCoreV1Secret | null> {
-    return createSecret(page, secret, namespace);
+    return createSecret(secret, namespace);
   }
 
   async createStorageMap(
-    page: Page,
     storageMap: V1beta1StorageMap,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1StorageMap | null> {
-    return createStorageMap(page, storageMap, namespace);
+    return createStorageMap(storageMap, namespace);
   }
 
   async fetchForkliftController(
-    page: Page,
     controllerName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1ForkliftController | null> {
-    return ResourceFetcher.fetchForkliftController(page, controllerName, namespace);
+    return ResourceFetcher.fetchForkliftController(controllerName, namespace);
   }
 
   async fetchNetworkMap(
-    page: Page,
     networkMapName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1NetworkMap | null> {
-    return ResourceFetcher.fetchNetworkMap(page, networkMapName, namespace);
+    return ResourceFetcher.fetchNetworkMap(networkMapName, namespace);
   }
 
-  async fetchPlan(
-    page: Page,
-    planName: string,
-    namespace = MTV_NAMESPACE,
-  ): Promise<V1beta1Plan | null> {
-    return ResourceFetcher.fetchResource<V1beta1Plan>(page, {
+  async fetchPlan(planName: string, namespace = MTV_NAMESPACE): Promise<V1beta1Plan | null> {
+    return ResourceFetcher.fetchResource<V1beta1Plan>({
       kind: RESOURCE_KINDS.PLAN,
       resourceName: planName,
       namespace,
@@ -240,41 +231,33 @@ export class ResourceManager {
   }
 
   async fetchProvider(
-    page: Page,
     providerName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
-    return ResourceFetcher.fetchProvider(page, providerName, namespace);
+    return ResourceFetcher.fetchProvider(providerName, namespace);
   }
 
   async fetchStorageMap(
-    page: Page,
     storageMapName: string,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1StorageMap | null> {
-    return ResourceFetcher.fetchStorageMap(page, storageMapName, namespace);
+    return ResourceFetcher.fetchStorageMap(storageMapName, namespace);
   }
 
-  async fetchVirtualMachine(
-    page: Page,
-    vmName: string,
-    namespace: string,
-  ): Promise<V1VirtualMachine | null> {
-    return ResourceFetcher.fetchVirtualMachine(page, vmName, namespace);
+  async fetchVirtualMachine(vmName: string, namespace: string): Promise<V1VirtualMachine | null> {
+    return ResourceFetcher.fetchVirtualMachine(vmName, namespace);
   }
 
   getResourceCount(): number {
     return this.resources.length;
   }
 
-  async instantCleanup(
-    baseUrl = process.env.BRIDGE_BASE_ADDRESS ??
-      process.env.BASE_ADDRESS ??
-      'http://localhost:9000',
-    storageStatePath?: string,
-  ): Promise<void> {
-    await ResourceCleaner.instantCleanup(this.resources, baseUrl, storageStatePath);
-    this.resources = [];
+  /**
+   * Alias for cleanupAll — kept for backward compatibility.
+   * Previously launched a headless browser; now uses the Node.js HTTP client.
+   */
+  async instantCleanup(): Promise<void> {
+    return this.cleanupAll();
   }
 
   loadResourcesFromFile(): void {
@@ -282,43 +265,29 @@ export class ResourceManager {
   }
 
   async patchForkliftController(
-    page: Page,
     controllerName: string,
     patch: JsonPatchOperation[],
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1ForkliftController | null> {
-    return ResourcePatcher.patchForkliftController(page, controllerName, patch, namespace);
+    return ResourcePatcher.patchForkliftController(controllerName, patch, namespace);
   }
 
   async patchProvider(
-    page: Page,
     providerName: string,
-    patch: Record<string, any>,
+    patch: Record<string, unknown>,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
-    return ResourcePatcher.patchProvider(page, providerName, patch, namespace);
+    return ResourcePatcher.patchProvider(providerName, patch, namespace);
   }
 
-  /**
-   * Patches a Kubernetes resource using either merge patch or JSON patch.
-   * @param page - Playwright page
-   * @param options.kind - Resource kind (e.g., 'Plan', 'Provider')
-   * @param options.resourceName - Name of the resource
-   * @param options.namespace - Namespace of the resource
-   * @param options.patch - Patch data (object for merge, array of JsonPatchOperation for json)
-   * @param options.patchType - 'merge' (default) or 'json' for array operations
-   */
-  async patchResource<T extends SupportedResource>(
-    page: Page,
-    options: {
-      kind: string;
-      resourceName: string;
-      namespace: string;
-      patch: Record<string, any> | JsonPatchOperation[];
-      patchType?: PatchType;
-    },
-  ): Promise<T | null> {
-    return ResourcePatcher.patchResource<T>(page, options);
+  async patchResource<T extends SupportedResource>(options: {
+    kind: string;
+    resourceName: string;
+    namespace: string;
+    patch: Record<string, unknown> | JsonPatchOperation[];
+    patchType?: PatchType;
+  }): Promise<T | null> {
+    return ResourcePatcher.patchResource<T>(options);
   }
 
   saveForLaterCleanup(): void {

--- a/testing/playwright/utils/resource-manager/ResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/ResourceManager.ts
@@ -252,14 +252,6 @@ export class ResourceManager {
     return this.resources.length;
   }
 
-  /**
-   * @deprecated Use cleanupAll() directly.
-   * Kept for backward compatibility — previously launched a headless browser.
-   */
-  async instantCleanup(): Promise<void> {
-    return this.cleanupAll();
-  }
-
   loadResourcesFromFile(): void {
     this.resources = ResourceCleaner.loadResourcesFromFile();
   }

--- a/testing/playwright/utils/resource-manager/ResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/ResourceManager.ts
@@ -223,11 +223,7 @@ export class ResourceManager {
   }
 
   async fetchPlan(planName: string, namespace = MTV_NAMESPACE): Promise<V1beta1Plan | null> {
-    return ResourceFetcher.fetchResource<V1beta1Plan>({
-      kind: RESOURCE_KINDS.PLAN,
-      resourceName: planName,
-      namespace,
-    });
+    return ResourceFetcher.fetchPlan(planName, namespace);
   }
 
   async fetchProvider(

--- a/testing/playwright/utils/resource-manager/ResourcePatcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourcePatcher.ts
@@ -1,5 +1,4 @@
 import type { V1beta1ForkliftController, V1beta1Provider } from '@forklift-ui/types';
-import type { Page } from '@playwright/test';
 
 import { BaseResourceManager } from './BaseResourceManager';
 import { API_PATHS, MTV_NAMESPACE, RESOURCE_KINDS, RESOURCE_TYPES } from './constants';
@@ -9,12 +8,12 @@ import type { SupportedResource } from './ResourceManager';
  * JSON Patch operation for RFC 6902.
  * Export for use by consumers who need to build patch operations.
  */
-export interface JsonPatchOperation {
+export type JsonPatchOperation = {
   op: 'add' | 'remove' | 'replace' | 'move' | 'copy' | 'test';
   path: string;
   value?: unknown;
   from?: string;
-}
+};
 
 /**
  * Patch type determines the Content-Type header and body format.
@@ -24,17 +23,17 @@ export interface JsonPatchOperation {
 export type PatchType = 'merge' | 'json';
 
 /**
- * Handles patching resources in Kubernetes APIs
+ * Handles patching resources in Kubernetes APIs.
+ * All operations use Node.js HTTP directly — no browser Page required.
  */
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class ResourcePatcher extends BaseResourceManager {
   static async patchForkliftController(
-    page: Page,
     controllerName: string,
     patch: JsonPatchOperation[],
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1ForkliftController | null> {
-    return ResourcePatcher.patchResource<V1beta1ForkliftController>(page, {
+    return ResourcePatcher.patchResource<V1beta1ForkliftController>({
       kind: RESOURCE_KINDS.FORKLIFT_CONTROLLER,
       resourceName: controllerName,
       namespace,
@@ -44,12 +43,11 @@ export class ResourcePatcher extends BaseResourceManager {
   }
 
   static async patchProvider(
-    page: Page,
     providerName: string,
-    patch: Record<string, any>,
+    patch: Record<string, unknown>,
     namespace = MTV_NAMESPACE,
   ): Promise<V1beta1Provider | null> {
-    return ResourcePatcher.patchResource<V1beta1Provider>(page, {
+    return ResourcePatcher.patchResource<V1beta1Provider>({
       kind: RESOURCE_KINDS.PROVIDER,
       resourceName: providerName,
       namespace,
@@ -57,20 +55,13 @@ export class ResourcePatcher extends BaseResourceManager {
     });
   }
 
-  /**
-   * Patches a Kubernetes resource using either merge patch or JSON patch.
-   * Delegates to {@link BaseResourceManager.apiPatch} after building the path.
-   */
-  static async patchResource<T extends SupportedResource>(
-    page: Page,
-    options: {
-      kind: string;
-      resourceName: string;
-      namespace: string;
-      patch: Record<string, any> | JsonPatchOperation[];
-      patchType?: PatchType;
-    },
-  ): Promise<T | null> {
+  static async patchResource<T extends SupportedResource>(options: {
+    kind: string;
+    resourceName: string;
+    namespace: string;
+    patch: Record<string, unknown> | JsonPatchOperation[];
+    patchType?: PatchType;
+  }): Promise<T | null> {
     const { kind, resourceName, namespace, patch, patchType = 'merge' } = options;
     const resourceType = ResourcePatcher.getResourceTypeFromKind(kind);
     const contentType =
@@ -80,6 +71,6 @@ export class ResourcePatcher extends BaseResourceManager {
       resourceType === RESOURCE_TYPES.VIRTUAL_MACHINES ? API_PATHS.KUBEVIRT : API_PATHS.FORKLIFT;
     const apiPath = `${basePath}/namespaces/${namespace}/${resourceType}/${resourceName}`;
 
-    return ResourcePatcher.apiPatch<T>(page, apiPath, patch, contentType);
+    return ResourcePatcher.apiPatch<T>(apiPath, patch, contentType);
   }
 }


### PR DESCRIPTION
## 📝 Links

> References: https://issues.redhat.com/browse/MTV-5779

> **Merge this first.** [#2474](https://github.com/kubev2v/forklift-console-plugin/pull/2474) depends on this PR.
>
> **Correct merge order:** #2473 → #2474

## 📝 Description

Extends the resource manager with direct cluster API auth (kubeconfig) and adds dependency-ordered cleanup.

### Changes

- **`refactor(e2e)`** — decouple resource manager from browser session: remove `page: Page` from all ResourceCreator / Cleaner / Fetcher / Patcher / Manager signatures; Node.js HTTP replaces `page.evaluate(fetch())`
- **Direct API-server auth** (`@kubernetes/client-node`): `global.setup.ts` runs `oc login` after browser login to generate `playwright/.auth/kubeconfig`. `BaseResourceManager` resolves auth at call-time — kubeconfig (Bearer token, direct API server) takes priority; session cookies are the automatic fallback when `oc` is unavailable. Session expiry no longer cascades into resource setup/teardown failures.
- **Dependency-ordered cleanup** in `ResourceCleaner`: `cleanupAll()` now deletes in four sequential groups (Migrations/Plans → NetworkMaps/StorageMaps/Providers/Secrets → VMs/NADs → Namespaces/Projects) preventing 409/422 errors when a Plan still references a Provider at deletion time.

```
globalSetup
  1. browser login → save storageState (AUTH_FILE)
  2. fetchClusterApiUrl() via cookies  ← cookies are fresh here
  3. oc login → playwright/.auth/kubeconfig
  4. relay KUBECONFIG_PATH to workers via ENV_RELAY_FILE
  5. detectForkliftVersion / detectCnvVersion  ← now uses kubeconfig

workers (BaseResourceManager.apiRequest)
  • KUBECONFIG_PATH set → KubeConfig.loadFromFile()
      baseUrl = cluster.server, Authorization: Bearer <token>
      /api/kubernetes proxy prefix stripped transparently
  • KUBECONFIG_PATH not set → session cookies (unchanged fallback)
```

## Test plan

- [ ] Run downstream E2E suite with `oc` available — verify kubeconfig is generated and workers use direct API auth
- [ ] Run downstream E2E suite without `oc` in PATH — verify fallback to session cookies with no failures
- [ ] Run upstream E2E suite — verify no regressions
- [ ] Let OAuth session expire mid-run — resource ops should continue, only UI steps should fail

Resolves: MTV-5779

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end suites to set up, verify, and patch resources via direct cluster API calls rather than browser-based flows.
  * Improved authentication for tests by optionally generating and using a kubeconfig for direct API access.
  * Standardized test cleanup to use full cleanup consistently across suites.

* **Chores**
  * Refreshed test helper utilities to remove browser-page dependencies from API operations.
  * Added a test coverage extraction script and included a root `.dockerignore` for container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->