### PR TITLE
MTV-5868 | Display VLAN-qualified source networks in network mapping

### DIFF
--- a/src/components/mappings/network-mappings/utils/__tests__/utils.test.ts
+++ b/src/components/mappings/network-mappings/utils/__tests__/utils.test.ts
@@ -1,0 +1,89 @@
+import { NetworkMapFieldId } from '@utils/mappings/networkMap';
+
+import { isNetworkMappingDisabled, isSameSourceNetwork } from '../utils';
+
+describe('isSameSourceNetwork', () => {
+  it('matches entries with same id and no vlan', () => {
+    expect(isSameSourceNetwork({ id: 'net-1', name: 'Net' }, { id: 'net-1', name: 'Net' })).toBe(
+      true,
+    );
+  });
+
+  it('does not match entries with different ids', () => {
+    expect(isSameSourceNetwork({ id: 'net-1', name: 'Net' }, { id: 'net-2', name: 'Net' })).toBe(
+      false,
+    );
+  });
+
+  it('matches entries with same id and same vlan', () => {
+    expect(
+      isSameSourceNetwork(
+        { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+        { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not match entries with same id but different vlans', () => {
+    expect(
+      isSameSourceNetwork(
+        { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+        { id: 'net-1', name: 'Net (VLAN 200)', vlan: '200' },
+      ),
+    ).toBe(false);
+  });
+
+  it('does not match a vlan entry with a plain entry sharing same id', () => {
+    expect(
+      isSameSourceNetwork(
+        { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+        { id: 'net-1', name: 'Net' },
+      ),
+    ).toBe(false);
+  });
+
+  it('does not match a plain entry with a vlan entry sharing same id', () => {
+    expect(
+      isSameSourceNetwork(
+        { id: 'net-1', name: 'Net' },
+        { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isNetworkMappingDisabled', () => {
+  it('returns true when the network is already mapped (no vlan)', () => {
+    const mappings = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: { id: 'net-1', name: 'Net' },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'target', name: 'Target' },
+      },
+    ];
+    expect(isNetworkMappingDisabled(mappings, { id: 'net-1', name: 'Net' })).toBe(true);
+  });
+
+  it('returns false when a different vlan of same network is mapped', () => {
+    const mappings = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'target', name: 'Target' },
+      },
+    ];
+    expect(
+      isNetworkMappingDisabled(mappings, { id: 'net-1', name: 'Net (VLAN 200)', vlan: '200' }),
+    ).toBe(false);
+  });
+
+  it('returns true when the same vlan of same network is mapped', () => {
+    const mappings = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'target', name: 'Target' },
+      },
+    ];
+    expect(
+      isNetworkMappingDisabled(mappings, { id: 'net-1', name: 'Net (VLAN 100)', vlan: '100' }),
+    ).toBe(true);
+  });
+});

--- a/src/components/mappings/network-mappings/utils/utils.ts
+++ b/src/components/mappings/network-mappings/utils/utils.ts
@@ -1,11 +1,23 @@
 import { NetworkMapFieldId, type NetworkMapping } from '@utils/mappings/networkMap';
 import type { MappingValue } from '@utils/types';
 
+/**
+ * Compares two source network values accounting for VLAN disambiguation.
+ * When either value has a vlan field, both id and vlan must match.
+ */
+export const isSameSourceNetwork = (a: MappingValue, b: MappingValue): boolean => {
+  if (a.vlan || b.vlan) {
+    return a.id === b.id && a.vlan === b.vlan;
+  }
+  return a.id === b.id;
+};
+
 export const isNetworkMappingDisabled = (
   networkMappings: NetworkMapping[],
   usedNetwork: MappingValue,
-) => {
-  return networkMappings?.some(
-    (mapping: NetworkMapping) => mapping[NetworkMapFieldId.SourceNetwork].id === usedNetwork.id,
-  );
+): boolean => {
+  return networkMappings?.some((mapping: NetworkMapping) => {
+    const source = mapping[NetworkMapFieldId.SourceNetwork];
+    return isSameSourceNetwork(source, usedNetwork);
+  });
 };

--- a/src/networkMaps/create/fields/InventorySourceNetworkField.tsx
+++ b/src/networkMaps/create/fields/InventorySourceNetworkField.tsx
@@ -13,6 +13,15 @@ import type { MappingValue } from '@utils/types';
 
 import type { CreateNetworkMapFormData } from '../types';
 
+/**
+ * Displays a flat list of source networks from provider inventory.
+ *
+ * NOTE: This component does NOT perform Hyper-V VLAN disambiguation because it
+ * operates at the provider inventory level without VM context. Per-VM VLAN
+ * conflicts (multiple NICs on the same switch with different VLANs) are only
+ * detected in the plan wizard flow where selected VMs are known.
+ * See getHypervVlanQualifiedNetworks() in plans/create/steps/network-map/utils.ts.
+ */
 type InventorySourceNetworkFieldProps = {
   fieldId: string;
   sourceNetworks: InventoryNetwork[];

--- a/src/networkMaps/create/utils/buildNetworkMappings.ts
+++ b/src/networkMaps/create/utils/buildNetworkMappings.ts
@@ -13,6 +13,8 @@ import { IgnoreNetwork } from '@utils/mappings/constants';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 import type { MappingValue } from '@utils/types';
 
+type NetworkMapSource = V1beta1NetworkMapSpecMapSource & { vlan?: string };
+
 const getDestination = (targetNetwork: MappingValue): V1beta1NetworkMapSpecMapDestination => {
   if (targetNetwork.name === DEFAULT_NETWORK) {
     return { type: POD };
@@ -68,12 +70,14 @@ export const buildNetworkMappings = (
     }
 
     if (!isOpenShiftProvider) {
+      const source: NetworkMapSource = {
+        id: sourceNetwork.id,
+        name: sourceNetwork.name,
+        ...(sourceNetwork.vlan ? { vlan: sourceNetwork.vlan } : {}),
+      };
       const baseMapping: V1beta1NetworkMapSpecMap = {
         destination,
-        source: {
-          id: sourceNetwork.id,
-          name: sourceNetwork.name,
-        },
+        source,
       };
       acc.push(baseMapping);
     }
@@ -128,12 +132,14 @@ export const getMappingValues = (
   return specMapping.map((mapping) => {
     const sourceNet = mapping.source;
     const destNet = mapping.destination;
+    const { vlan } = sourceNet as NetworkMapSource;
 
     const sourceNetwork: MappingValue = {
       id: isOpenShiftProvider
         ? (sourceNetworks.find((net) => net.name === sourceNet.name)?.id ?? '')
         : (sourceNet.id ?? ''),
       name: getSourceNetName(sourceNet, isOpenShiftProvider),
+      ...(vlan ? { vlan } : {}),
     };
 
     const targetNetwork: MappingValue = {

--- a/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
@@ -3,6 +3,7 @@ import { useFieldArray } from 'react-hook-form';
 
 import FieldBuilderTable from '@components/FieldBuilderTable/FieldBuilderTable';
 import TargetNetworkField from '@components/mappings/network-mappings/TargetNetworkField';
+import { isSameSourceNetwork } from '@components/mappings/network-mappings/utils/utils';
 import type { OVirtNicProfile } from '@forklift-ui/types';
 import { useForkliftTranslation } from '@utils/i18n';
 import {
@@ -87,8 +88,8 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
         onClick: () => {
           const missingNetwork = usedSourceNetworks.find(
             (sourceNetwork) =>
-              !netMappingFields.find(
-                (netMapping) => netMapping.sourceNetwork.id === sourceNetwork.id,
+              !netMappingFields.find((netMapping) =>
+                isSameSourceNetwork(netMapping.sourceNetwork, sourceNetwork),
               ),
           );
 
@@ -105,16 +106,16 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
             return true;
           }
           return Boolean(
-            usedSourceNetworks.find(
-              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            usedSourceNetworks.find((network) =>
+              isSameSourceNetwork(network, netMappingFields[index].sourceNetwork),
             ),
           );
         },
         onClick: (index) => {
           if (
             netMappingFields.length > 1 &&
-            !usedSourceNetworks.find(
-              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            !usedSourceNetworks.find((network) =>
+              isSameSourceNetwork(network, netMappingFields[index].sourceNetwork),
             )
           ) {
             remove(index);
@@ -125,8 +126,8 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
             return t('At least one network mapping must be provided.');
           }
           if (
-            usedSourceNetworks.find(
-              (network) => network.id === netMappingFields[index].sourceNetwork.id,
+            usedSourceNetworks.find((network) =>
+              isSameSourceNetwork(network, netMappingFields[index].sourceNetwork),
             )
           ) {
             return t('All networks detected on the selected VMs require a mapping.');

--- a/src/plans/create/steps/network-map/__tests__/vlanUtils.test.ts
+++ b/src/plans/create/steps/network-map/__tests__/vlanUtils.test.ts
@@ -1,0 +1,295 @@
+import {
+  buildNetworkMappings,
+  getMappingValues,
+} from 'src/networkMaps/create/utils/buildNetworkMappings';
+
+import { NetworkMapFieldId } from '@utils/mappings/networkMap';
+import { PROVIDER_TYPES } from '@utils/providers/constants';
+
+import {
+  getHypervVlanQualifiedNetworks,
+  getSourceNetworkValues,
+  validateNetworkMap,
+} from '../utils';
+
+const makeHypervVm = (name: string, nics: { networkId: string; vlanId?: number }[]) =>
+  ({
+    name,
+    providerType: PROVIDER_TYPES.hyperv,
+    nics: nics.map((nic, idx) => ({
+      name: `nic-${idx}`,
+      mac: `00:00:00:00:00:0${idx}`,
+      deviceIndex: idx,
+      network: { kind: 'Network', id: nic.networkId },
+      vlanId: nic.vlanId ?? 0,
+    })),
+  }) as never;
+
+const networks = [
+  { id: 'net-a', name: 'Lab-External' },
+  { id: 'net-b', name: 'Default Switch' },
+] as never[];
+
+describe('getHypervVlanQualifiedNetworks', () => {
+  it('returns empty when no VMs have VLAN conflicts', () => {
+    const vms = [makeHypervVm('vm1', [{ networkId: 'net-a' }, { networkId: 'net-b' }])];
+    expect(getHypervVlanQualifiedNetworks(vms, networks)).toEqual([]);
+  });
+
+  it('returns empty when single NIC per network even with VLAN set', () => {
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-b', vlanId: 200 },
+      ]),
+    ];
+    expect(getHypervVlanQualifiedNetworks(vms, networks)).toEqual([]);
+  });
+
+  it('returns VLAN-qualified entries when multiple NICs share same network with different VLANs', () => {
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 200 },
+      ]),
+    ];
+    const result = getHypervVlanQualifiedNetworks(vms, networks);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      id: 'net-a',
+      name: 'Lab-External (VLAN 100)',
+      vlan: '100',
+    });
+    expect(result).toContainEqual({
+      id: 'net-a',
+      name: 'Lab-External (VLAN 200)',
+      vlan: '200',
+    });
+  });
+
+  it('handles mixed tagged/untagged NICs on same network', () => {
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 0 },
+      ]),
+    ];
+    const result = getHypervVlanQualifiedNetworks(vms, networks);
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual({
+      id: 'net-a',
+      name: 'Lab-External (VLAN 100)',
+      vlan: '100',
+    });
+    expect(result).toContainEqual({
+      id: 'net-a',
+      name: 'Lab-External (Untagged)',
+      vlan: '0',
+    });
+  });
+
+  it('does not duplicate entries across multiple VMs', () => {
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 200 },
+      ]),
+      makeHypervVm('vm2', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 200 },
+      ]),
+    ];
+    const result = getHypervVlanQualifiedNetworks(vms, networks);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty when multiple NICs share same network with the SAME vlan', () => {
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 100 },
+      ]),
+    ];
+    expect(getHypervVlanQualifiedNetworks(vms, networks)).toEqual([]);
+  });
+
+  it('ignores non-Hyper-V VMs', () => {
+    const vms = [
+      {
+        name: 'vsphere-vm',
+        providerType: PROVIDER_TYPES.vsphere,
+        nics: [
+          { network: { id: 'net-a' }, vlanId: 100 },
+          { network: { id: 'net-a' }, vlanId: 200 },
+        ],
+      } as never,
+    ];
+    expect(getHypervVlanQualifiedNetworks(vms, networks)).toEqual([]);
+  });
+});
+
+describe('getSourceNetworkValues', () => {
+  it('excludes plain network from used/other when VLAN-qualified entries exist', () => {
+    const availableNetworks = [
+      { id: 'net-a', name: 'Lab-External' },
+      { id: 'net-b', name: 'Default Switch' },
+    ] as never[];
+
+    const vms = [
+      makeHypervVm('vm1', [
+        { networkId: 'net-a', vlanId: 100 },
+        { networkId: 'net-a', vlanId: 200 },
+        { networkId: 'net-b' },
+      ]),
+    ];
+
+    const result = getSourceNetworkValues(availableNetworks, vms, []);
+
+    // net-a should NOT appear in used/other as a plain entry
+    const plainNetA = [...result.used, ...result.other].filter(
+      (entry) => entry.id === 'net-a' && !entry.vlan,
+    );
+    expect(plainNetA).toHaveLength(0);
+
+    // VLAN-qualified entries for net-a should be in 'used'
+    const vlanEntries = result.used.filter((entry) => entry.id === 'net-a' && entry.vlan);
+    expect(vlanEntries).toHaveLength(2);
+    expect(
+      vlanEntries.map((entry) => entry.vlan).sort((a, b) => (a ?? '').localeCompare(b ?? '')),
+    ).toEqual(['100', '200']);
+
+    // net-b should still appear as a plain entry (in used or other)
+    const netB = [...result.used, ...result.other].find((entry) => entry.id === 'net-b');
+    expect(netB).toBeDefined();
+    expect(netB?.vlan).toBeUndefined();
+  });
+});
+
+describe('validateNetworkMap with VLAN-qualified entries', () => {
+  it('returns undefined when all VLAN-qualified networks are mapped', () => {
+    const usedSourceNetworks = [
+      { id: 'net-a', name: 'Lab-External (VLAN 100)', vlan: '100' },
+      { id: 'net-a', name: 'Lab-External (VLAN 200)', vlan: '200' },
+      { id: 'net-b', name: 'Default Switch' },
+    ];
+    const values = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: {
+          id: 'net-a',
+          name: 'Lab-External (VLAN 100)',
+          vlan: '100',
+        },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'ns1', name: 'ns1/nad-a' },
+      },
+      {
+        [NetworkMapFieldId.SourceNetwork]: {
+          id: 'net-a',
+          name: 'Lab-External (VLAN 200)',
+          vlan: '200',
+        },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'ns1', name: 'ns1/nad-b' },
+      },
+      {
+        [NetworkMapFieldId.SourceNetwork]: { id: 'net-b', name: 'Default Switch' },
+        [NetworkMapFieldId.TargetNetwork]: { id: '', name: 'Pod Networking' },
+      },
+    ];
+
+    const result = validateNetworkMap({
+      values,
+      usedSourceNetworks,
+      vms: {},
+      oVirtNicProfiles: [],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('returns error when a VLAN-qualified network is not mapped', () => {
+    const usedSourceNetworks = [
+      { id: 'net-a', name: 'Lab-External (VLAN 100)', vlan: '100' },
+      { id: 'net-a', name: 'Lab-External (VLAN 200)', vlan: '200' },
+    ];
+    const values = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: {
+          id: 'net-a',
+          name: 'Lab-External (VLAN 100)',
+          vlan: '100',
+        },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'ns1', name: 'ns1/nad-a' },
+      },
+    ];
+
+    const result = validateNetworkMap({
+      values,
+      usedSourceNetworks,
+      vms: {},
+      oVirtNicProfiles: [],
+    });
+    expect(result).toBeDefined();
+  });
+});
+
+describe('VLAN round-trip: form values → CR spec → form values', () => {
+  it('preserves vlan field through buildNetworkMappings → getMappingValues', () => {
+    const sourceProvider = { spec: { type: PROVIDER_TYPES.hyperv } } as never;
+    const mappings = [
+      {
+        [NetworkMapFieldId.SourceNetwork]: {
+          id: 'net-a',
+          name: 'Lab-External (VLAN 100)',
+          vlan: '100',
+        },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'ns1', name: 'ns1/nad-a' },
+      },
+      {
+        [NetworkMapFieldId.SourceNetwork]: {
+          id: 'net-a',
+          name: 'Lab-External (VLAN 200)',
+          vlan: '200',
+        },
+        [NetworkMapFieldId.TargetNetwork]: { id: 'ns1', name: 'ns1/nad-b' },
+      },
+      {
+        [NetworkMapFieldId.SourceNetwork]: { id: 'net-b', name: 'Default Switch' },
+        [NetworkMapFieldId.TargetNetwork]: { id: '', name: 'Pod Networking' },
+      },
+    ];
+
+    // Form → CR spec
+    const specMappings = buildNetworkMappings(mappings, sourceProvider);
+
+    // Verify vlan is in the CR spec
+    const vlanEntries = specMappings.filter((entry) => (entry.source as { vlan?: string }).vlan);
+    expect(vlanEntries).toHaveLength(2);
+
+    // CR spec → Form values (round-trip back)
+    const destinationNetworks = [
+      { name: 'nad-a', namespace: 'ns1', uid: 'uid-a' },
+      { name: 'nad-b', namespace: 'ns1', uid: 'uid-b' },
+    ] as never[];
+    const sourceNetworks = [
+      { id: 'net-a', name: 'Lab-External' },
+      { id: 'net-b', name: 'Default Switch' },
+    ] as never[];
+
+    const roundTripped = getMappingValues(
+      specMappings,
+      sourceProvider,
+      sourceNetworks,
+      destinationNetworks,
+    );
+
+    // Verify vlan survived the round-trip
+    const vlan100 = roundTripped.find((mapping) => mapping.sourceNetwork.vlan === '100');
+    const vlan200 = roundTripped.find((mapping) => mapping.sourceNetwork.vlan === '200');
+    const noVlan = roundTripped.find((mapping) => mapping.sourceNetwork.id === 'net-b');
+
+    expect(vlan100).toBeDefined();
+    expect(vlan100?.sourceNetwork.id).toBe('net-a');
+    expect(vlan200).toBeDefined();
+    expect(vlan200?.sourceNetwork.id).toBe('net-a');
+    expect(noVlan).toBeDefined();
+    expect(noVlan?.sourceNetwork.vlan).toBeUndefined();
+  });
+});

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -155,6 +155,76 @@ const getNetworksUsedByProviderVms = (
   return Array.from(networkIdSet);
 };
 
+type HypervNic = { network?: { id?: string }; vlanId?: number };
+type HypervVmWithNics = ProviderVirtualMachine & { nics?: HypervNic[] };
+
+const collectDistinctVlansByNetwork = (nics: HypervNic[]): Map<string, Set<number>> => {
+  const vlansByNetwork = new Map<string, Set<number>>();
+  for (const nic of nics) {
+    const netId = nic.network?.id;
+    if (netId) {
+      if (!vlansByNetwork.has(netId)) vlansByNetwork.set(netId, new Set<number>());
+      vlansByNetwork.get(netId)!.add(nic.vlanId ?? 0);
+    }
+  }
+  return vlansByNetwork;
+};
+
+const upsertVlanEntry = (
+  vlanEntries: Map<string, MappingValue>,
+  networkId: string,
+  networkName: string,
+  vlanId: number,
+): void => {
+  const key = vlanId === 0 ? `${networkId}/untagged` : `${networkId}/${vlanId}`;
+  if (vlanEntries.has(key)) return;
+  vlanEntries.set(
+    key,
+    vlanId === 0
+      ? { id: networkId, name: `${networkName} (Untagged)`, vlan: '0' }
+      : { id: networkId, name: `${networkName} (VLAN ${vlanId})`, vlan: String(vlanId) },
+  );
+};
+
+/**
+ * For Hyper-V VMs, detects NICs that share the same network but have different VLANs.
+ * Returns VLAN-qualified MappingValues for those cases.
+ *
+ * Disambiguation is scoped to a single VM: only when one VM has multiple NICs on
+ * the same network with distinct VLAN IDs are VLAN-qualified entries generated.
+ * Cross-VM differences (each VM has a single NIC per network but with different
+ * VLANs) do not create mapping conflicts and are handled by the plain network entry.
+ */
+export const getHypervVlanQualifiedNetworks = (
+  vms: ProviderVirtualMachine[],
+  availableSourceNetworks: (ProviderNetwork | OpenShiftNetworkAttachmentDefinition)[],
+): MappingValue[] => {
+  const networkNameById = new Map(availableSourceNetworks.map((net) => [net.id, net.name]));
+  const vlanEntries = new Map<string, MappingValue>();
+
+  const hypervVms = vms.filter(
+    (vm): vm is HypervVmWithNics =>
+      vm.providerType === PROVIDER_TYPES.hyperv && Boolean((vm as HypervVmWithNics).nics),
+  );
+
+  for (const vm of hypervVms) {
+    const nics = vm.nics ?? [];
+    const vlansByNetwork = collectDistinctVlansByNetwork(nics);
+
+    const conflictNics = nics.filter(
+      (nic) => nic.network?.id && (vlansByNetwork.get(nic.network.id)?.size ?? 0) > 1,
+    );
+
+    for (const nic of conflictNics) {
+      const networkId = nic.network!.id!;
+      const networkName = networkNameById.get(networkId) ?? networkId;
+      upsertVlanEntry(vlanEntries, networkId, networkName, nic.vlanId ?? 0);
+    }
+  }
+
+  return Array.from(vlanEntries.values());
+};
+
 /**
  * Categorizes available source networks into 'used' and 'other' based on VM usage
  * This helps prioritize networks that need mapping in the UI
@@ -168,21 +238,31 @@ export const getSourceNetworkValues = (
     getNetworksUsedByProviderVms(vms, nicProfiles, availableSourceNetworks),
   );
 
+  // For Hyper-V, detect VLAN conflicts and generate VLAN-qualified entries
+  const vlanQualified = getHypervVlanQualifiedNetworks(vms, availableSourceNetworks);
+  const networksWithVlanConflict = new Set(vlanQualified.map((entry) => entry.id));
+
   const used: MappingValue[] = [];
   const other: MappingValue[] = [];
 
   for (const network of availableSourceNetworks) {
-    const mappingValue = {
-      id: network.id,
-      name: network.name === DEFAULT_NETWORK ? DEFAULT_NETWORK : getMapResourceLabel(network),
-    };
-
-    if (usedNetworkIds.has(mappingValue.id) || usedNetworkIds.has(mappingValue.name)) {
-      used.push(mappingValue);
+    if (networksWithVlanConflict.has(network.id)) {
+      // Network replaced by VLAN-qualified entries below
     } else {
-      other.push(mappingValue);
+      const mappingValue = {
+        id: network.id,
+        name: network.name === DEFAULT_NETWORK ? DEFAULT_NETWORK : getMapResourceLabel(network),
+      };
+
+      if (usedNetworkIds.has(mappingValue.id) || usedNetworkIds.has(mappingValue.name)) {
+        used.push(mappingValue);
+      } else {
+        other.push(mappingValue);
+      }
     }
   }
+
+  used.push(...vlanQualified);
 
   return { other, used };
 };

--- a/src/plans/create/utils/createNetworkMap.ts
+++ b/src/plans/create/utils/createNetworkMap.ts
@@ -44,6 +44,7 @@ const getSource = (sourceNetwork: MappingValue, sourceProvider?: V1beta1Provider
     name: sourceNetwork.name,
     // Set type to 'multus' only for OpenShift source providers
     type: sourceProvider?.spec?.type === PROVIDER_TYPES.openshift ? MULTUS : undefined,
+    ...(sourceNetwork.vlan ? { vlan: sourceNetwork.vlan } : {}),
   };
 };
 

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/components/PlanNetworkMapFieldsTable.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/components/PlanNetworkMapFieldsTable.tsx
@@ -7,6 +7,7 @@ import { hasPodNetworkMappings } from 'src/plans/create/utils/hasMultiplePodNetw
 
 import FieldBuilderTable from '@components/FieldBuilderTable/FieldBuilderTable';
 import TargetNetworkField from '@components/mappings/network-mappings/TargetNetworkField';
+import { isSameSourceNetwork } from '@components/mappings/network-mappings/utils/utils';
 import type { OVirtNicProfile, ProviderVirtualMachine } from '@forklift-ui/types';
 import { NetworkMapFieldId } from '@utils/crds/maps/types';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -107,8 +108,8 @@ const PlanNetworkMapFieldsTable: FC<PlanNetworkMapFieldsTableProps> = ({
         onClick: async () => {
           const missingNetwork = usedSourceNetworks.find(
             (sourceNetwork) =>
-              !networkMappingFields.some(
-                (netMapping) => netMapping.sourceNetwork.id === sourceNetwork.id,
+              !networkMappingFields.some((netMapping) =>
+                isSameSourceNetwork(netMapping.sourceNetwork, sourceNetwork),
               ),
           );
 
@@ -128,15 +129,15 @@ const PlanNetworkMapFieldsTable: FC<PlanNetworkMapFieldsTableProps> = ({
           if (networkMappingFields.length <= 1) {
             return true;
           }
-          return usedSourceNetworks.some(
-            (network) => network.id === networkMappingFields[index].sourceNetwork.id,
+          return usedSourceNetworks.some((network) =>
+            isSameSourceNetwork(network, networkMappingFields[index].sourceNetwork),
           );
         },
         onClick: (index) => {
           if (
             networkMappingFields.length > 1 &&
-            !usedSourceNetworks.some(
-              (network) => network.id === networkMappingFields[index].sourceNetwork.id,
+            !usedSourceNetworks.some((network) =>
+              isSameSourceNetwork(network, networkMappingFields[index].sourceNetwork),
             )
           ) {
             remove(index);
@@ -147,8 +148,8 @@ const PlanNetworkMapFieldsTable: FC<PlanNetworkMapFieldsTableProps> = ({
             return t('At least one network mapping must be provided.');
           }
           if (
-            usedSourceNetworks.some(
-              (network) => network.id === networkMappingFields[index].sourceNetwork.id,
+            usedSourceNetworks.some((network) =>
+              isSameSourceNetwork(network, networkMappingFields[index].sourceNetwork),
             )
           ) {
             return t('All networks detected on the selected VMs require a mapping.');

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -29,7 +29,7 @@ export type VmFeatures = {
 
 export type FeatureName = (typeof FEATURE_NAMES)[keyof typeof FEATURE_NAMES];
 
-export type MappingValue = { id?: string; name: string };
+export type MappingValue = { id?: string; name: string; vlan?: string };
 
 /**
  * Type for the return value of access review hooks.


### PR DESCRIPTION
When a Hyper-V VM has multiple NICs on the same virtual switch with different VLANs, the UI now shows them as distinct selectable entries in the source network dropdown (e.g., "Lab-External (VLAN 100)").

- Add isSameSourceNetwork() helper for VLAN-aware matching and use it in NetworkMapFieldTable and PlanNetworkMapFieldsTable for add/remove/ disable logic.
- Add getHypervVlanQualifiedNetworks() to detect VLAN conflicts within a VM and generate qualified MappingValue entries including "Untagged" for vlanId=0 NICs coexisting with tagged NICs.
- Propagate vlan field through buildNetworkMappings and createNetworkMap so the NetworkMap CR source reference carries the VLAN qualifier.
- Add unit tests for both isSameSourceNetwork and VLAN qualification.

Ref: https://redhat.atlassian.net/browse/MTV-5868
Resolves: MTV-5868

<img width="725" height="483" alt="image" src="https://github.com/user-attachments/assets/3e9ece30-a6d0-47ec-b00c-6e4a8c7f96f6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network mapping with VLAN support to properly disambiguate Hyper-V scenarios where virtual machines have multiple network adapters on the same network with different VLAN IDs.
  * Network mappings now preserve and validate VLAN information throughout the mapping workflow.

* **Tests**
  * Added comprehensive test coverage for VLAN detection utilities and network mapping validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->