### PR TITLE
chore: batch learnings from recent merged PRs

### DIFF
--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -28,6 +28,32 @@ import Select from '@components/common/Select';
 // NOT: import { Select } from '@patternfly/react-core';
 ```
 
+### Use `PF_LABEL_STATUS` for Status Props
+Use the shared constants instead of string literals for PatternFly `status` props:
+```typescript
+import { PF_LABEL_STATUS, type PfLabelStatus } from '@utils/constants';
+
+// ✅ Good
+<Label status={PF_LABEL_STATUS.DANGER}>Error</Label>
+<Icon status={PF_LABEL_STATUS.WARNING}>...</Icon>
+
+// ❌ Bad
+<Label status="danger">Error</Label>
+```
+
+### Use `STATUS_ICONS` for Status Icons
+Use the shared status icon map instead of manually wrapping icons with hardcoded colors:
+```typescript
+import { STATUS_ICONS } from '@components/status/statusIcons';
+
+// ✅ Good - uses PF6 Icon status prop, respects theming
+{STATUS_ICONS.danger}
+{STATUS_ICONS.warning}
+
+// ❌ Bad - hardcoded hex colors break in dark mode
+<ExclamationCircleIcon color="#C9190B" />
+```
+
 ### Common PatternFly Patterns
 ```typescript
 import {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -668,6 +668,20 @@ const [data, loaded, error] = useK8sWatchResource<Resource>({
 });
 ```
 
+### Actions Dropdown Convention
+Action dropdowns use `isDetailsPage` (not `isKebab`) to control behavior by context:
+- **List page** (default): kebab icon, "Edit" navigates to resource, "Delete"
+- **Details page** (`isDetailsPage`): "Actions" button, "Edit YAML" navigates to YAML tab, "Delete"
+
+### Build-Time Feature Hiding
+When a UI component is ready but the backend feature isn't, hide it at build time rather than deleting the code:
+1. Keep the component file intact
+2. Remove the import and JSX usage from the parent component
+3. Add the orphaned file to `knip.config.ts` `ignore` with a comment linking to the upstream issue
+4. Re-enable when the backend lands
+
+This avoids re-implementation work and keeps knip from flagging the file as unused.
+
 ---
 
 ## Dev-Helper Skill


### PR DESCRIPTION
## Summary

Rule and documentation updates based on learnings from 16 merged PRs in the last 30 days.

### New patterns documented

- **`PF_LABEL_STATUS` constants** (from PR #2443): Use shared constants instead of string literals for PatternFly `status` props on Label, Icon, EmptyState
- **`STATUS_ICONS` shared map** (from PR #2403): Use centralized status icon rendering with PF6 `Icon status` prop instead of hardcoded hex colors
- **Actions dropdown `isDetailsPage`** (from PR #2404): Semantic prop name convention for list vs details page action behavior
- **Build-time feature hiding** (from PR #2470): Pattern for hiding UI when backend isn't ready -- keep file, remove import, add to knip ignore

### Files changed

- `AGENTS.md` -- Added actions dropdown convention and build-time feature hiding pattern
- `.cursor/rules/react-components.mdc` -- Added PF_LABEL_STATUS and STATUS_ICONS usage guidance

### PRs reviewed (no additional learnings needed)

#2428, #2435, #2437, #2438, #2439, #2442, #2445, #2448, #2454, #2462, #2466, #2479

Resolves: None

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with conventions for component implementations and feature management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->