### PR TITLE
Resolves: MTV-5827 | Fix ambiguous Dell/EMC vendor suggestions in storage offload

### DIFF
--- a/src/storageMaps/create/utils/__tests__/getStorageMappingValues.test.ts
+++ b/src/storageMaps/create/utils/__tests__/getStorageMappingValues.test.ts
@@ -1,0 +1,119 @@
+import type {
+  V1beta1Provider,
+  V1beta1StorageMapSpecMap,
+  V1beta1StorageMapSpecMapOffloadPluginVsphereXcopyConfig,
+} from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+import type { InventoryStorage } from '@utils/hooks/useStorages';
+import { PROVIDER_TYPES } from '@utils/providers/constants';
+import { StorageMapFieldId } from '@utils/storage/types';
+
+import { getStorageMappingValues } from '../buildStorageMappings';
+
+const makeProvider = (type: string): V1beta1Provider =>
+  ({ spec: { type } }) as unknown as V1beta1Provider;
+
+const makeSpecMapping = (
+  sourceId: string,
+  targetStorageClass: string,
+  offload?: V1beta1StorageMapSpecMapOffloadPluginVsphereXcopyConfig,
+): V1beta1StorageMapSpecMap => {
+  const mapping: V1beta1StorageMapSpecMap = {
+    destination: { storageClass: targetStorageClass },
+    source: { id: sourceId },
+  };
+
+  if (offload) {
+    mapping.offloadPlugin = {
+      vsphereXcopyConfig: offload,
+    };
+  }
+
+  return mapping;
+};
+
+const emptySourceStorages = new Map<string, InventoryStorage>();
+
+describe('getStorageMappingValues', () => {
+  describe('offload fields always present', () => {
+    it('includes empty offload fields when no offloadPlugin in spec', () => {
+      const vsphereProvider = makeProvider(PROVIDER_TYPES.vsphere);
+      const specMappings = [makeSpecMapping('ds-1', 'ceph-rbd')];
+
+      const result = getStorageMappingValues(specMappings, vsphereProvider, emptySourceStorages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0][StorageMapFieldId.OffloadPlugin]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageSecret]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageProduct]).toBe('');
+    });
+
+    it('includes populated offload fields when offloadPlugin exists in spec', () => {
+      const vsphereProvider = makeProvider(PROVIDER_TYPES.vsphere);
+      const specMappings = [
+        makeSpecMapping('ds-1', 'dell-powermax-csi', {
+          secretRef: 'my-secret',
+          storageVendorProduct: 'powermax',
+        }),
+      ];
+
+      const result = getStorageMappingValues(specMappings, vsphereProvider, emptySourceStorages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0][StorageMapFieldId.OffloadPlugin]).toBe('vsphereXcopyConfig');
+      expect(result[0][StorageMapFieldId.StorageSecret]).toBe('my-secret');
+      expect(result[0][StorageMapFieldId.StorageProduct]).toBe('powermax');
+    });
+
+    it('includes empty offload fields for non-vSphere providers', () => {
+      const ovirtProvider = makeProvider(PROVIDER_TYPES.ovirt);
+      const specMappings = [makeSpecMapping('sd-1', 'ceph-rbd')];
+
+      const result = getStorageMappingValues(specMappings, ovirtProvider, emptySourceStorages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0][StorageMapFieldId.OffloadPlugin]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageSecret]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageProduct]).toBe('');
+    });
+
+    it('includes empty offload fields for OpenStack providers', () => {
+      const openstackProvider = makeProvider(PROVIDER_TYPES.openstack);
+      const specMappings = [makeSpecMapping('vol-1', 'standard-csi')];
+
+      const result = getStorageMappingValues(specMappings, openstackProvider, emptySourceStorages);
+
+      expect(result).toHaveLength(1);
+      expect(result[0][StorageMapFieldId.OffloadPlugin]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageSecret]).toBe('');
+      expect(result[0][StorageMapFieldId.StorageProduct]).toBe('');
+    });
+  });
+
+  describe('isDirty compatibility', () => {
+    it('returns consistent shape regardless of offload presence', () => {
+      const provider = makeProvider(PROVIDER_TYPES.vsphere);
+      const withOffload = makeSpecMapping('ds-1', 'sc-1', {
+        secretRef: 's',
+        storageVendorProduct: 'ontap',
+      });
+      const withoutOffload = makeSpecMapping('ds-2', 'sc-2');
+
+      const results = getStorageMappingValues(
+        [withOffload, withoutOffload],
+        provider,
+        emptySourceStorages,
+      );
+
+      const keysWithOffload = Object.keys(results[0]).sort();
+      const keysWithoutOffload = Object.keys(results[1]).sort();
+
+      expect(keysWithOffload).toEqual(keysWithoutOffload);
+    });
+  });
+
+  it('returns empty array when specMappings is undefined', () => {
+    const provider = makeProvider(PROVIDER_TYPES.vsphere);
+    expect(getStorageMappingValues(undefined, provider, emptySourceStorages)).toEqual([]);
+  });
+});

--- a/src/storageMaps/create/utils/buildStorageMappings.ts
+++ b/src/storageMaps/create/utils/buildStorageMappings.ts
@@ -168,21 +168,13 @@ export const getStorageMappingValues = (
       name: destination.storageClass,
     };
 
-    const storageMapping: StorageMapping = {
+    return {
+      [StorageMapFieldId.OffloadPlugin]: offloadPlugin ? OffloadPlugin.VSphereXcopyConfig : '',
       [StorageMapFieldId.SourceStorage]: sourceStorage,
+      [StorageMapFieldId.StorageProduct]:
+        offloadPlugin?.vsphereXcopyConfig?.storageVendorProduct ?? '',
+      [StorageMapFieldId.StorageSecret]: offloadPlugin?.vsphereXcopyConfig?.secretRef ?? '',
       [StorageMapFieldId.TargetStorage]: targetStorage,
     };
-
-    if (offloadPlugin) {
-      storageMapping[StorageMapFieldId.OffloadPlugin] = offloadPlugin
-        ? OffloadPlugin.VSphereXcopyConfig
-        : '';
-      storageMapping[StorageMapFieldId.StorageSecret] =
-        offloadPlugin?.vsphereXcopyConfig?.secretRef ?? '';
-      storageMapping[StorageMapFieldId.StorageProduct] =
-        offloadPlugin?.vsphereXcopyConfig?.storageVendorProduct ?? '';
-    }
-
-    return storageMapping;
   });
 };

--- a/src/storageMaps/utils/__tests__/offloadMatchUtils.test.ts
+++ b/src/storageMaps/utils/__tests__/offloadMatchUtils.test.ts
@@ -56,8 +56,8 @@ describe('deriveSuggestedProduct', () => {
     expect(deriveSuggestedProduct(Ontap, Ontap)).toBe(Ontap);
   });
 
-  it('returns datastoreVendor when both defined but differ', () => {
-    expect(deriveSuggestedProduct(Ontap, PureFlashArray)).toBe(Ontap);
+  it('returns storageClassVendor when both defined but differ', () => {
+    expect(deriveSuggestedProduct(Ontap, PureFlashArray)).toBe(PureFlashArray);
   });
 
   it('returns datastoreVendor when only it is defined', () => {

--- a/src/storageMaps/utils/__tests__/vendorLookupTables.test.ts
+++ b/src/storageMaps/utils/__tests__/vendorLookupTables.test.ts
@@ -13,10 +13,6 @@ describe('resolveProductFromScsiVendor', () => {
   it.each([
     ['PURE', StorageVendorProduct.PureFlashArray],
     ['NETAPP', StorageVendorProduct.Ontap],
-    ['DGC', StorageVendorProduct.PowerFlex],
-    ['DellEMC', StorageVendorProduct.PowerStore],
-    ['DELL', StorageVendorProduct.PowerStore],
-    ['EMC', StorageVendorProduct.PowerMax],
     ['IBM', StorageVendorProduct.FlashSystem],
     ['HITACHI', StorageVendorProduct.Vantara],
     ['3PARdata', StorageVendorProduct.Primera3Par],
@@ -25,6 +21,13 @@ describe('resolveProductFromScsiVendor', () => {
   ])('resolves "%s" to %s', (vendor, expected) => {
     expect(resolveProductFromScsiVendor(vendor)).toBe(expected);
   });
+
+  it.each(['DGC', 'DellEMC', 'DELL', 'EMC'])(
+    'returns undefined for ambiguous Dell/EMC vendor "%s"',
+    (vendor) => {
+      expect(resolveProductFromScsiVendor(vendor)).toBeUndefined();
+    },
+  );
 
   it('handles case-insensitive matching', () => {
     expect(resolveProductFromScsiVendor('pure')).toBe(StorageVendorProduct.PureFlashArray);
@@ -92,7 +95,7 @@ describe('resolveProductFromDatastore', () => {
   const hostScsiDisks = [
     { canonicalName: 'naa.600508b400105e834000200000490000', vendor: 'IBM' },
     { canonicalName: 'naa.624a9370aef5214a38ee4fa500011234', vendor: 'PURE' },
-    { canonicalName: 'naa.60060160b1234f00abcd1234abcd1234', vendor: 'DGC' },
+    { canonicalName: 'naa.60060160b1234f00abcd1234abcd1234', vendor: 'NETAPP' },
   ];
 
   it('resolves vendor from matching backing device', () => {
@@ -167,15 +170,30 @@ describe('resolveProductFromDatastoreName', () => {
     ['ibm_flashsystem_lun3', StorageVendorProduct.FlashSystem],
     ['hpe-primera-vol1', StorageVendorProduct.Primera3Par],
     ['infinidat-prod', StorageVendorProduct.Infinibox],
-    ['Dell-PowerStore-01', StorageVendorProduct.PowerStore],
   ])('resolves "%s" to %s', (name, expected) => {
     expect(resolveProductFromDatastoreName(name)).toBe(expected);
   });
 
-  it('prefers longer vendor key when names overlap', () => {
+  it.each([
+    ['Dell-PowerStore-01', StorageVendorProduct.PowerStore],
+    ['eco-powermax-ds1', StorageVendorProduct.PowerMax],
+    ['eco-dellpf-powerflex', StorageVendorProduct.PowerFlex],
+  ])('resolves product-specific Dell name "%s" to %s', (name, expected) => {
+    expect(resolveProductFromDatastoreName(name)).toBe(expected);
+  });
+
+  it('prefers product-specific pattern over generic vendor key', () => {
     expect(resolveProductFromDatastoreName('dellemc-powermax-lun')).toBe(
-      StorageVendorProduct.PowerStore,
+      StorageVendorProduct.PowerMax,
     );
+  });
+
+  it('returns undefined for ambiguous Dell/EMC names without product hint', () => {
+    expect(resolveProductFromDatastoreName('dell-storage-01')).toBeUndefined();
+    expect(resolveProductFromDatastoreName('emc-lun-05')).toBeUndefined();
+  });
+
+  it('still resolves unambiguous vendors in names', () => {
     expect(resolveProductFromDatastoreName('infinidat-ds01')).toBe(StorageVendorProduct.Infinibox);
   });
 

--- a/src/storageMaps/utils/offloadMatchUtils.ts
+++ b/src/storageMaps/utils/offloadMatchUtils.ts
@@ -28,5 +28,6 @@ export const deriveSuggestedProduct = (
     return datastoreVendor;
   }
 
-  return datastoreVendor ?? storageClassVendor;
+  // CSI provisioner is unambiguous; SCSI/name-based detection may not be (Dell/EMC)
+  return storageClassVendor ?? datastoreVendor;
 };

--- a/src/storageMaps/utils/vendorLookupTables.ts
+++ b/src/storageMaps/utils/vendorLookupTables.ts
@@ -3,18 +3,12 @@ import type { OpenShiftStorageClass, VSphereDataStore } from '@forklift-ui/types
 import { StorageVendorProduct } from './types';
 
 /**
- * T10 SCSI Vendor ID -> StorageVendorProduct mapping.
- * Source: https://www.t10.org/lists/vid-alph.htm
- *
- * These are hardware-level identifiers reported by vSphere HostScsiDisk.Vendor.
- * The Forklift backend trims whitespace before returning them.
+ * Dell/EMC IDs (dell, dellemc, dgc, emc) are intentionally excluded —
+ * Dell produces PowerStore, PowerMax, AND PowerFlex and the SCSI vendor
+ * string alone cannot distinguish between them. Use CSI provisioner instead.
  */
 const SCSI_VENDOR_TO_PRODUCT: Record<string, StorageVendorProduct> = {
   '3pardata': StorageVendorProduct.Primera3Par,
-  dell: StorageVendorProduct.PowerStore,
-  dellemc: StorageVendorProduct.PowerStore,
-  dgc: StorageVendorProduct.PowerFlex,
-  emc: StorageVendorProduct.PowerMax,
   hitachi: StorageVendorProduct.Vantara,
   hpe: StorageVendorProduct.Primera3Par,
   ibm: StorageVendorProduct.FlashSystem,
@@ -23,12 +17,12 @@ const SCSI_VENDOR_TO_PRODUCT: Record<string, StorageVendorProduct> = {
   pure: StorageVendorProduct.PureFlashArray,
 };
 
-/**
- * CSI provisioner string -> StorageVendorProduct mapping.
- * Source: https://kubernetes-csi.github.io/docs/drivers.html
- *
- * Entries are matched via substring inclusion against the StorageClass provisioner.
- */
+const DATASTORE_NAME_PRODUCT_PATTERNS: [string, StorageVendorProduct][] = [
+  ['powerflex', StorageVendorProduct.PowerFlex],
+  ['powermax', StorageVendorProduct.PowerMax],
+  ['powerstore', StorageVendorProduct.PowerStore],
+];
+
 const CSI_PROVISIONER_ENTRIES: [string, StorageVendorProduct][] = [
   ['block.csi.ibm.com', StorageVendorProduct.FlashSystem],
   ['csi-powermax.dellemc.com', StorageVendorProduct.PowerMax],
@@ -82,13 +76,6 @@ export const resolveProductFromStorageClass = (
   return resolveProductFromCsiProvisioner(provisioner);
 };
 
-/**
- * Heuristic fallback: checks if the datastore name contains a known vendor keyword.
- * Used when backingDevicesNames is not available (vVol, NFS datastores).
- *
- * Entries are sorted by key length descending so longer, more-specific keys
- * (e.g. "dellemc") match before shorter prefixes (e.g. "dell", "emc").
- */
 export const resolveProductFromDatastoreName = (
   name: string | undefined,
 ): StorageVendorProduct | undefined => {
@@ -98,11 +85,13 @@ export const resolveProductFromDatastoreName = (
 
   const normalized = name.toLowerCase();
 
-  const sortedEntries = Object.entries(SCSI_VENDOR_TO_PRODUCT).sort(
-    ([a], [b]) => b.length - a.length,
-  );
+  for (const [pattern, product] of DATASTORE_NAME_PRODUCT_PATTERNS) {
+    if (normalized.includes(pattern)) {
+      return product;
+    }
+  }
 
-  for (const [vendorKey, product] of sortedEntries) {
+  for (const [vendorKey, product] of Object.entries(SCSI_VENDOR_TO_PRODUCT)) {
     if (normalized.includes(vendorKey)) {
       return product;
     }
@@ -111,11 +100,6 @@ export const resolveProductFromDatastoreName = (
   return undefined;
 };
 
-/**
- * Resolves the StorageVendorProduct for a datastore by:
- * 1. Correlating backingDevicesNames with Host SCSI disk canonical names (VMFS)
- * 2. Falling back to a name-based heuristic (vVol, NFS)
- */
 export const resolveProductFromDatastore = (
   datastore: DatastoreWithBacking | undefined,
   hostScsiDisks: HostScsiDisk[],

--- a/src/utils/hooks/useStorages.ts
+++ b/src/utils/hooks/useStorages.ts
@@ -34,7 +34,7 @@ const subPath: Record<string, string> = {
   [PROVIDER_TYPES.openstack]: 'volumetypes',
   [PROVIDER_TYPES.ova]: 'storages?detail=1',
   [PROVIDER_TYPES.ovirt]: 'storagedomains',
-  [PROVIDER_TYPES.vsphere]: 'datastores',
+  [PROVIDER_TYPES.vsphere]: 'datastores?detail=1',
 };
 
 export type InventoryStorage =


### PR DESCRIPTION
## Links

- [MTV-5827](https://issues.redhat.com/browse/MTV-5827)

## Description

Fixes incorrect vendor product suggestions in storage map offload configuration for Dell/EMC storage, and a `isDirty` tracking issue that could prevent saving offload changes.

### Fix 1: Ambiguous vendor suggestions

**Root cause:** The SCSI vendor lookup table mapped ambiguous Dell/EMC identifiers (`DELL`, `DellEMC`, `DGC`, `EMC`) to a single specific product, but Dell manufactures three different products (PowerStore, PowerMax, PowerFlex). The suggestion priority also preferred the inaccurate SCSI signal over the authoritative CSI provisioner.

**Changes:**
- Remove ambiguous Dell/EMC entries from `SCSI_VENDOR_TO_PRODUCT` table (unambiguous vendors like IBM, NetApp, Pure are unchanged)
- Add product-specific name patterns (`powerstore`, `powermax`, `powerflex`) for datastore name heuristic
- Invert `deriveSuggestedProduct` to prefer CSI provisioner over SCSI/name-based vendor detection

### Fix 2: isDirty not tracking offload field changes

**Root cause:** `getStorageMappingValues` omitted offload fields (`offloadPlugin`, `storageSecret`, `storageProduct`) from `defaultValues` when the existing storage map had no offload config. This caused react-hook-form's `isDirty` to not detect when users added offload configuration, keeping the Save button disabled.

**Change:** Always include offload fields in the mapping (defaulting to empty strings when absent), matching the pattern already used by `transformStorageMapToFormValues`.

### Fix 3: Enable SCSI-based vendor detection

**Root cause:** vSphere datastores were fetched at `detail=0` which does not include `backingDevicesNames`. Without this field, the SCSI-based vendor detection via `useDatastoreVendor` could not run for VMFS datastores.

**Change:** Fetch vSphere datastores at `detail=1` to include `backingDevicesNames`.

## Demo

<!-- Screenshots will be added -->

## CC://

Made with Cursor

[MTV-5827]: https://redhat.atlassian.net/browse/MTV-5827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ