### PR TITLE
Resolves: MTV-5759 | QE: Cover Overview – Health tab

### DIFF
--- a/src/overview/tabs/Health/cards/ConditionsCard.tsx
+++ b/src/overview/tabs/Health/cards/ConditionsCard.tsx
@@ -18,7 +18,7 @@ const ConditionsCard: FC<ConditionsCardProps> = ({ obj }) => {
     | undefined;
 
   return (
-    <Card className="pf-m-full-height">
+    <Card className="pf-m-full-height" data-testid="health-conditions-card">
       <CardTitle className="forklift-title">{t('Conditions')}</CardTitle>
       <CardBody>
         {status?.conditions && <ConditionsSection conditions={status.conditions} />}

--- a/src/overview/tabs/Health/cards/Controller/ControllerCard.tsx
+++ b/src/overview/tabs/Health/cards/Controller/ControllerCard.tsx
@@ -28,7 +28,7 @@ const ControllerCard: FC<ControllerCardProps> = ({ limit, obj }) => {
   });
 
   return (
-    <Card className="pf-m-full-height">
+    <Card className="pf-m-full-height" data-testid="health-controller-card">
       <CardHeader
         actions={{
           actions: limit ? <Link to={'health'}>View all</Link> : null,

--- a/testing/playwright/e2e/downstream/overview-page.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-page.spec.ts
@@ -13,6 +13,30 @@ import { ResourceManager } from '../../utils/resource-manager/ResourceManager';
 import { V2_11_0, V2_12_0 } from '../../utils/version/constants';
 import { isVersionAtLeast, requireVersion } from '../../utils/version/version';
 
+test.describe('Overview Page - Health Tab', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_11_0);
+
+  test('should navigate to Health tab and verify status cards render', async ({ page }) => {
+    const overviewPage = new OverviewPage(page);
+
+    await test.step('Navigate to the Overview page', async () => {
+      await overviewPage.navigateDirectly();
+    });
+
+    await test.step('Navigate to the Health tab', async () => {
+      await overviewPage.healthTab.navigateToHealthTab();
+    });
+
+    await test.step('Verify the Health tab is selected and URL contains /health', async () => {
+      await overviewPage.healthTab.verifyHealthTabSelected();
+    });
+
+    await test.step('Verify Health and Conditions cards render with expected content', async () => {
+      await overviewPage.healthTab.verifyCardsRender();
+    });
+  });
+});
+
 test.describe(
   'Overview Page - Settings',
   {

--- a/testing/playwright/page-objects/OverviewPage/OverviewPage.ts
+++ b/testing/playwright/page-objects/OverviewPage/OverviewPage.ts
@@ -4,6 +4,7 @@ import { NavigationHelper } from '../../utils/NavigationHelper';
 import { LearningExperienceDrawer } from '../LearningExperienceDrawer';
 
 import { ThroughputCard } from './components/ThroughputCard';
+import { HealthTab } from './tabs/HealthTab';
 import { SettingsTab } from './tabs/SettingsTab';
 
 export type { TopicConfig } from '../LearningExperienceDrawer';
@@ -11,6 +12,7 @@ export type { TopicConfig } from '../LearningExperienceDrawer';
 export class OverviewPage {
   private readonly navigation: NavigationHelper;
   private readonly page: Page;
+  public readonly healthTab: HealthTab;
   public readonly learningExperience: LearningExperienceDrawer;
   public readonly networkThroughputCard: ThroughputCard;
   public readonly settingsTab: SettingsTab;
@@ -19,6 +21,7 @@ export class OverviewPage {
   constructor(page: Page) {
     this.page = page;
     this.navigation = new NavigationHelper(page);
+    this.healthTab = new HealthTab(page);
     this.learningExperience = new LearningExperienceDrawer(page);
     this.networkThroughputCard = new ThroughputCard(page, 'Network throughput');
     this.settingsTab = new SettingsTab(page);

--- a/testing/playwright/page-objects/OverviewPage/tabs/HealthTab.ts
+++ b/testing/playwright/page-objects/OverviewPage/tabs/HealthTab.ts
@@ -33,6 +33,6 @@ export class HealthTab {
 
   async verifyHealthTabSelected(): Promise<void> {
     await expect(this.tab).toHaveAttribute('aria-selected', 'true');
-    await expect(this.page).toHaveURL(/\/health/);
+    await expect(this.page).toHaveURL(/\/health(?:\?|$)/);
   }
 }

--- a/testing/playwright/page-objects/OverviewPage/tabs/HealthTab.ts
+++ b/testing/playwright/page-objects/OverviewPage/tabs/HealthTab.ts
@@ -1,0 +1,38 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export class HealthTab {
+  protected readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  get conditionsCard(): Locator {
+    return this.page.getByTestId('health-conditions-card');
+  }
+
+  get controllerCard(): Locator {
+    return this.page.getByTestId('health-controller-card');
+  }
+
+  async navigateToHealthTab(): Promise<void> {
+    await this.tab.click();
+    await expect(this.controllerCard).toBeVisible();
+  }
+
+  get tab(): Locator {
+    return this.page.getByRole('tab', { name: 'Health', exact: true });
+  }
+
+  async verifyCardsRender(): Promise<void> {
+    await expect(this.controllerCard.getByRole('columnheader', { name: 'Pod' })).toBeVisible();
+    await expect(this.controllerCard.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+    await expect(this.conditionsCard).toBeVisible();
+    await expect(this.conditionsCard.getByRole('columnheader', { name: 'Type' })).toBeVisible();
+  }
+
+  async verifyHealthTabSelected(): Promise<void> {
+    await expect(this.tab).toHaveAttribute('aria-selected', 'true');
+    await expect(this.page).toHaveURL(/\/health/);
+  }
+}


### PR DESCRIPTION
## 📝 Links

* MTV-5759
* Stacks on top of #2485 (MTV-5758) — merge that first; this PR's meaningful diff is the single commit `test(e2e): cover Overview – Health tab`

## 📝 Description

Adds Playwright E2E coverage for the **Health tab** on the Overview page, verifying that both status cards render correctly.

* Add `data-testid` attributes (`health-controller-card`, `health-conditions-card`) to `ControllerCard` and `ConditionsCard` for stable test selectors
* New `HealthTab` page object (`testing/playwright/page-objects/OverviewPage/tabs/HealthTab.ts`) with:
  - `tab`, `controllerCard`, `conditionsCard` locators
  - `navigateToHealthTab()`, `verifyHealthTabSelected()`, `verifyCardsRender()` methods
* Wire `healthTab` into `OverviewPage`
* New test describe block **"Overview Page - Health Tab"** prepended to `overview-page.spec.ts` — stays well within the 300-line limit; follows the file-per-feature convention already established there

The single test covers:
- Tab navigation (click Health tab → controller card visible)
- URL assertion (`/health`)
- Tab selected state (`aria-selected="true"`)
- `ControllerCard` structure: `Pod` + `Status` column headers visible in the pods table
- `ConditionsCard` structure: `Type` column header visible in the conditions table

## 🎥 Demo

## 📝 CC://

Made with Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the Overview page’s Health tab, including navigation, tab selection, URL behavior, and content checks.
  * Introduced dedicated page-object support for the Health tab to improve reliability of UI interactions.
* **Tests**
  * Added validation for the Health and Conditions cards to confirm key table headings display as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->