### PR TITLE
Resolves: MTV-5904 | Enhance backport workflow with Jira ticket cloning

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -139,6 +139,228 @@ jobs:
           echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
           echo "pr_merged=$pr_merged" >> $GITHUB_OUTPUT
 
+      - name: Extract Jira ticket from original PR
+        id: extract_ticket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.parse_comment.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          repo="${{ github.repository }}"
+          ticket_key=""
+          skip_reason=""
+
+          echo "🔍 Extracting Jira ticket from PR #$PR_NUMBER..."
+
+          # Fetch commits from the PR
+          commits_data=$(curl -sSf \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ github.api_url }}/repos/${repo}/pulls/${PR_NUMBER}/commits?per_page=100")
+
+          # Search commit messages for "Resolves:" line
+          resolves_line=""
+          while IFS= read -r msg; do
+            if [[ -n "$msg" ]]; then
+              resolves_line="$msg"
+              break
+            fi
+          done < <(echo "$commits_data" | jq -r '.[].commit.message' | grep -i "^Resolves:" | head -1)
+
+          if [[ -n "$resolves_line" ]]; then
+            # Check for "Resolves: None" (case-insensitive)
+            if echo "$resolves_line" | grep -iq "^Resolves:[[:space:]]*none$"; then
+              echo "ℹ️ Original PR has 'Resolves: None' - no ticket attached"
+              skip_reason="no_ticket_attached"
+            else
+              # Extract MTV-XXXX pattern (take the first one)
+              ticket_key=$(echo "$resolves_line" | grep -oE "MTV-[0-9]+" | head -1 || true)
+              if [[ -z "$ticket_key" ]]; then
+                echo "⚠️ Found Resolves line but no MTV ticket: $resolves_line"
+                skip_reason="ticket_not_found"
+              else
+                echo "✅ Found ticket: $ticket_key"
+              fi
+            fi
+          else
+            # Fallback: check PR title for MTV-XXXX
+            pr_title="${{ steps.verify_refs.outputs.pr_title }}"
+            ticket_key=$(echo "$pr_title" | grep -oE "MTV-[0-9]+" | head -1 || true)
+            if [[ -n "$ticket_key" ]]; then
+              echo "✅ Found ticket in PR title: $ticket_key"
+            else
+              echo "⚠️ Cannot find an MTV ticket in commits or PR title"
+              skip_reason="ticket_not_found"
+            fi
+          fi
+
+          echo "ticket_key=$ticket_key" >> $GITHUB_OUTPUT
+          echo "skip_reason=$skip_reason" >> $GITHUB_OUTPUT
+
+      - name: Post ticket skip comment
+        if: steps.extract_ticket.outputs.skip_reason != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const skipReason = '${{ steps.extract_ticket.outputs.skip_reason }}';
+
+            let body;
+            if (skipReason === 'no_ticket_attached') {
+              body = `ℹ️ **Jira Clone Skipped**\n\nBackport parent has no ticket attached to it (\`Resolves: None\`). Skipping clone.`;
+            } else {
+              body = `⚠️ **Jira Clone Skipped**\n\nCannot find an MTV ticket in the original PR. Skipping clone.\nPlease locate the ticket manually and link it to the backport PR.`;
+            }
+
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+      - name: Clone Jira ticket for backport
+        id: clone_ticket
+        if: steps.extract_ticket.outputs.ticket_key != '' && steps.parse_comment.outputs.dry_run == 'false'
+        env:
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          TICKET_KEY: ${{ steps.extract_ticket.outputs.ticket_key }}
+          BRANCH_NAME: ${{ steps.parse_comment.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+
+          JIRA_BASE="https://redhat.atlassian.net"
+          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64)"
+
+          jira_get() {
+            curl -sSf -H "$AUTH_HEADER" -H "Content-Type: application/json" "$1"
+          }
+
+          jira_post() {
+            curl -sSf -X POST -H "$AUTH_HEADER" -H "Content-Type: application/json" -d "$2" "$1"
+          }
+
+          echo "🔍 Checking for existing clone of $TICKET_KEY for branch $BRANCH_NAME..."
+
+          # Fetch the original ticket with issue links
+          original_data=$(jira_get "${JIRA_BASE}/rest/api/3/issue/${TICKET_KEY}?fields=issuelinks,summary,description,components,priority,issuetype")
+
+          # Check for existing clone: look for "Cloners" link with matching backport prefix
+          existing_clone=""
+          existing_clone=$(echo "$original_data" | jq -r --arg prefix "[Backport ${BRANCH_NAME}]" '
+            .fields.issuelinks[]?
+            | select(.type.name == "Cloners")
+            | select(.inwardIssue != null)
+            | select(.inwardIssue.fields.summary | startswith($prefix))
+            | .inwardIssue.key
+          ' | head -1 || true)
+
+          if [[ -n "$existing_clone" ]]; then
+            echo "✅ Found existing clone: $existing_clone (reusing)"
+            echo "clone_key=$existing_clone" >> $GITHUB_OUTPUT
+            echo "clone_existed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "📝 No existing clone found. Creating new clone..."
+
+          # Extract fields from original
+          original_summary=$(echo "$original_data" | jq -r '.fields.summary')
+          original_components=$(echo "$original_data" | jq -c '[.fields.components[]? | {id: .id}]')
+          original_priority=$(echo "$original_data" | jq -r '.fields.priority.id')
+          original_issuetype=$(echo "$original_data" | jq -r '.fields.issuetype.id')
+
+          # Read fix version from build/release.conf on target branch
+          fix_version_id=""
+          cpe_version=""
+          if release_conf=$(git show "origin/${BRANCH_NAME}:build/release.conf" 2>/dev/null); then
+            cpe_version=$(echo "$release_conf" | grep "^CPE=" | cut -d= -f2)
+            echo "  - CPE version from release.conf: $cpe_version"
+
+            if [[ -n "$cpe_version" ]]; then
+              # Query Jira for matching fix version
+              versions_data=$(jira_get "${JIRA_BASE}/rest/api/3/project/MTV/versions")
+              fix_version_id=$(echo "$versions_data" | jq -r --arg cpe "$cpe_version" '
+                .[] | select(.name | contains($cpe)) | .id
+              ' | head -1 || true)
+
+              if [[ -n "$fix_version_id" ]]; then
+                echo "  - Matched fix version ID: $fix_version_id"
+              else
+                echo "  ⚠️ No fix version matching '$cpe_version' found in MTV project"
+              fi
+            fi
+          else
+            echo "  ⚠️ Could not read build/release.conf from branch $BRANCH_NAME"
+          fi
+
+          # Build the clone description in ADF format
+          clone_summary="[Backport ${BRANCH_NAME}] ${original_summary}"
+          description_adf=$(jq -n --arg key "$TICKET_KEY" --arg base "$JIRA_BASE" '{
+            version: 1,
+            type: "doc",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", text: "Backport of " },
+                  {
+                    type: "inlineCard",
+                    attrs: { url: ($base + "/browse/" + $key) }
+                  }
+                ]
+              }
+            ]
+          }')
+
+          # Build create payload
+          create_payload=$(jq -n \
+            --arg summary "$clone_summary" \
+            --argjson desc "$description_adf" \
+            --argjson components "$original_components" \
+            --arg priority_id "$original_priority" \
+            --arg issuetype_id "$original_issuetype" \
+            --arg fix_version_id "$fix_version_id" \
+            '{
+              fields: {
+                project: { key: "MTV" },
+                summary: $summary,
+                description: $desc,
+                components: $components,
+                priority: { id: $priority_id },
+                issuetype: { id: $issuetype_id }
+              }
+            }
+            | if $fix_version_id != "" then .fields.fixVersions = [{ id: $fix_version_id }] else . end
+            ')
+
+          # Create the clone
+          echo "📝 Creating Jira ticket..."
+          clone_response=$(jira_post "${JIRA_BASE}/rest/api/3/issue" "$create_payload")
+          clone_key=$(echo "$clone_response" | jq -r '.key')
+
+          if [[ -z "$clone_key" || "$clone_key" == "null" ]]; then
+            echo "::warning::Failed to create Jira clone. Response: $clone_response"
+            echo "clone_key=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "✅ Created clone: $clone_key"
+
+          # Create Cloners link (original is cloned by clone)
+          link_payload=$(jq -n --arg clone "$clone_key" --arg original "$TICKET_KEY" '{
+            type: { name: "Cloners" },
+            inwardIssue: { key: $clone },
+            outwardIssue: { key: $original }
+          }')
+
+          if ! jira_post "${JIRA_BASE}/rest/api/3/issueLink" "$link_payload" >/dev/null 2>&1; then
+            echo "::warning::Failed to create Cloners link between $clone_key and $TICKET_KEY"
+          else
+            echo "✅ Created Cloners link: $clone_key → $TICKET_KEY"
+          fi
+
+          echo "clone_key=$clone_key" >> $GITHUB_OUTPUT
+          echo "clone_existed=false" >> $GITHUB_OUTPUT
+
       - name: Post status comment (start)
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -147,11 +369,17 @@ jobs:
             const issue_number = context.issue.number;
             const branch = '${{ steps.parse_comment.outputs.branch_name }}';
             const dryRun = '${{ steps.parse_comment.outputs.dry_run }}' === 'true';
+            const cloneKey = '${{ steps.clone_ticket.outputs.clone_key }}';
+
+            let jiraInfo = '';
+            if (cloneKey) {
+              jiraInfo = `\n🎫 Jira clone: [${cloneKey}](https://redhat.atlassian.net/browse/${cloneKey})`;
+            }
 
             const body = `🔄 **Backport Status**
 
             Starting backport of PR #${{ steps.parse_comment.outputs.pr_number }} to \`${branch}\`
-            ${dryRun ? '🧪 **Dry run mode** - No actual changes will be made' : '🚀 **Live mode** - Changes will be applied'}
+            ${dryRun ? '🧪 **Dry run mode** - No actual changes will be made' : '🚀 **Live mode** - Changes will be applied'}${jiraInfo}
 
             [View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
 
@@ -168,6 +396,8 @@ jobs:
           no-squash: true
           auth: ${{ secrets.GITHUB_TOKEN }}
           dry-run: ${{ steps.parse_comment.outputs.dry_run }}
+          title: "${{ steps.clone_ticket.outputs.clone_key && format('Resolves: {0} | ', steps.clone_ticket.outputs.clone_key) || '' }}[Backport ${{ steps.parse_comment.outputs.branch_name }}] ${{ steps.verify_refs.outputs.pr_title }}"
+          body: "Backport of #${{ steps.parse_comment.outputs.pr_number }} to `${{ steps.parse_comment.outputs.branch_name }}`\n\n${{ steps.clone_ticket.outputs.clone_key && format('Resolves: {0}\nOriginal ticket: {1}', steps.clone_ticket.outputs.clone_key, steps.extract_ticket.outputs.ticket_key) || '' }}"
 
       - name: Post success comment
         if: success()
@@ -178,6 +408,7 @@ jobs:
             const issue_number = context.issue.number;
             const branch = '${{ steps.parse_comment.outputs.branch_name }}';
             const dryRun = '${{ steps.parse_comment.outputs.dry_run }}' === 'true';
+            const cloneKey = '${{ steps.clone_ticket.outputs.clone_key }}';
 
             let body;
             if (dryRun) {
@@ -188,16 +419,21 @@ jobs:
               To perform the actual backport, run:
               \`/backport ${branch}\` (without --dry-run flag)`;
             } else {
+              let jiraInfo = '';
+              if (cloneKey) {
+                jiraInfo = `\n🎫 Jira clone: [${cloneKey}](https://redhat.atlassian.net/browse/${cloneKey})`;
+              }
               body = `✅ **Backport Completed Successfully**
 
               PR #${{ steps.parse_comment.outputs.pr_number }} has been successfully backported to \`${branch}\`.
 
-              A new pull request should have been created with the backported changes.`;
+              A new pull request should have been created with the backported changes.${jiraInfo}`;
             }
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
 
       - name: Label new backport PR (skip on dry run)
+        id: label_pr
         if: success() && steps.parse_comment.outputs.dry_run == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -209,7 +445,6 @@ jobs:
 
             // Heuristic: find the most recent open PR to the target branch
             // that looks like a backport of the original PR.
-            // We check title/body for the original PR number or title.
             const openPRs = await github.paginate(github.rest.pulls.list, {
               owner, repo, state: 'open', base: branch, per_page: 100
             });
@@ -234,6 +469,7 @@ jobs:
 
             if (!candidates.length) {
               core.info('No candidate backport PR found to label (yet).');
+              core.setOutput('backport_pr_url', '');
               return;
             }
 
@@ -256,6 +492,58 @@ jobs:
             });
 
             core.info(`Applied label '${label}' to PR #${pr.number}`);
+            core.setOutput('backport_pr_url', pr.html_url);
+
+      - name: Update cloned Jira ticket (POST + PR link)
+        if: success() && steps.clone_ticket.outputs.clone_key != '' && steps.parse_comment.outputs.dry_run == 'false'
+        env:
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          CLONE_KEY: ${{ steps.clone_ticket.outputs.clone_key }}
+          BACKPORT_PR_URL: ${{ steps.label_pr.outputs.backport_pr_url }}
+        run: |
+          set -euo pipefail
+
+          JIRA_BASE="https://redhat.atlassian.net"
+          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64)"
+
+          jira_get() {
+            curl -sSf -H "$AUTH_HEADER" -H "Content-Type: application/json" "$1"
+          }
+
+          jira_put() {
+            curl -sSf -X PUT -H "$AUTH_HEADER" -H "Content-Type: application/json" -d "$2" "$1"
+          }
+
+          jira_post() {
+            curl -sSf -X POST -H "$AUTH_HEADER" -H "Content-Type: application/json" -d "$2" "$1"
+          }
+
+          # Set "Git Pull Request" field if we found the backport PR URL
+          if [[ -n "$BACKPORT_PR_URL" ]]; then
+            echo "🔗 Setting PR link on $CLONE_KEY: $BACKPORT_PR_URL"
+            pr_payload=$(jq -n --arg url "$BACKPORT_PR_URL" '{fields: {customfield_10875: $url}}')
+            if ! jira_put "${JIRA_BASE}/rest/api/3/issue/${CLONE_KEY}" "$pr_payload" 2>/dev/null; then
+              echo "::warning::Failed to set PR link on $CLONE_KEY"
+            fi
+          fi
+
+          # Transition to POST
+          echo "🔄 Transitioning $CLONE_KEY to POST..."
+          transitions_data=$(jira_get "${JIRA_BASE}/rest/api/3/issue/${CLONE_KEY}/transitions")
+          post_id=$(echo "$transitions_data" | jq -r '.transitions[] | select(.name == "POST" or .to.name == "POST") | .id' | head -1)
+
+          if [[ -n "$post_id" && "$post_id" != "null" ]]; then
+            transition_payload=$(jq -n --arg id "$post_id" '{transition: {id: $id}}')
+            if jira_post "${JIRA_BASE}/rest/api/3/issue/${CLONE_KEY}/transitions" "$transition_payload" 2>/dev/null; then
+              echo "✅ Transitioned $CLONE_KEY to POST"
+            else
+              echo "::warning::Failed to transition $CLONE_KEY to POST"
+            fi
+          else
+            echo "::warning::POST transition not available for $CLONE_KEY. Available transitions:"
+            echo "$transitions_data" | jq -r '.transitions[] | "  - \(.name) (id: \(.id))"'
+          fi
 
       - name: Post failure comment
         if: failure()
@@ -265,22 +553,48 @@ jobs:
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const branch = '${{ steps.parse_comment.outputs.branch_name || 'unknown' }}';
+            const prNumber = '${{ steps.parse_comment.outputs.pr_number || github.event.issue.number }}';
+            const cloneKey = '${{ steps.clone_ticket.outputs.clone_key }}';
+            const ticketKey = '${{ steps.extract_ticket.outputs.ticket_key }}';
+
+            // Fetch commit SHAs from the original PR for pastable commands
+            let commitShas = '';
+            try {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner, repo, pull_number: parseInt(prNumber, 10), per_page: 100
+              });
+              commitShas = commits.map(c => c.sha.substring(0, 12)).join(' ');
+            } catch {
+              commitShas = '<commit-sha(s)>';
+            }
+
+            const resolvedTicket = cloneKey || ticketKey || 'MTV-XXXX';
+            const prTitle = `${{ steps.verify_refs.outputs.pr_title || 'Original PR title' }}`;
 
             const body = `❌ **Backport Failed**
 
-            The backport of PR #${{ steps.parse_comment.outputs.pr_number || github.event.issue.number }} to \`${branch}\` failed.
+            The backport of PR #${prNumber} to \`${branch}\` failed.
 
             Common causes:
             - Merge conflicts that require manual resolution
             - Target branch doesn't exist
             - Invalid branch name format (must be release-X.Y or release-X.Y.Z)
-            - Invalid PR number
 
             Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
 
-            **Usage Examples:**
-            - \`/backport release-2.9\` - Live backport
-            - \`/backport release-2.9.3\` - Live backport to a patch branch
-            - \`/backport release-2.5 --dry-run\` - Test backport without changes`;
+            ---
+
+            **Manual resolution steps:**
+
+            \`\`\`bash
+            git fetch origin
+            git checkout -b backport-${prNumber}-to-${branch} origin/${branch}
+            git cherry-pick -x ${commitShas}
+            # Resolve any conflicts, then:
+            git add .
+            git commit
+            git push origin backport-${prNumber}-to-${branch}
+            gh pr create --base ${branch} --title "Resolves: ${resolvedTicket} | [Backport ${branch}] ${prTitle}"
+            \`\`\``;
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -219,6 +219,7 @@ jobs:
       - name: Clone Jira ticket for backport
         id: clone_ticket
         if: steps.extract_ticket.outputs.ticket_key != '' && steps.parse_comment.outputs.dry_run == 'false'
+        continue-on-error: true
         env:
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
@@ -228,7 +229,7 @@ jobs:
           set -euo pipefail
 
           JIRA_BASE="https://redhat.atlassian.net"
-          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64)"
+          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64 -w 0)"
 
           jira_get() {
             curl -sSf -H "$AUTH_HEADER" -H "Content-Type: application/json" "$1"
@@ -279,7 +280,7 @@ jobs:
               # Query Jira for matching fix version
               versions_data=$(jira_get "${JIRA_BASE}/rest/api/3/project/MTV/versions")
               fix_version_id=$(echo "$versions_data" | jq -r --arg cpe "$cpe_version" '
-                .[] | select(.name | contains($cpe)) | .id
+                .[] | select(.name | contains($cpe)) | select(.released == false) | .id
               ' | head -1 || true)
 
               if [[ -n "$fix_version_id" ]]; then
@@ -496,6 +497,7 @@ jobs:
 
       - name: Update cloned Jira ticket (POST + PR link)
         if: success() && steps.clone_ticket.outputs.clone_key != '' && steps.parse_comment.outputs.dry_run == 'false'
+        continue-on-error: true
         env:
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
@@ -505,7 +507,7 @@ jobs:
           set -euo pipefail
 
           JIRA_BASE="https://redhat.atlassian.net"
-          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64)"
+          AUTH_HEADER="Authorization: Basic $(echo -n "${JIRA_EMAIL}:${JIRA_API_TOKEN}" | base64 -w 0)"
 
           jira_get() {
             curl -sSf -H "$AUTH_HEADER" -H "Content-Type: application/json" "$1"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -274,15 +274,18 @@ jobs:
           fix_version_id=""
           cpe_version=""
           if release_conf=$(git show "origin/${BRANCH_NAME}:build/release.conf" 2>/dev/null); then
-            cpe_version=$(echo "$release_conf" | grep "^CPE=" | cut -d= -f2)
+            cpe_version=$(echo "$release_conf" | awk -F= '$1 == "CPE" {print $2; exit}')
             echo "  - CPE version from release.conf: $cpe_version"
 
             if [[ -n "$cpe_version" ]]; then
               # Query Jira for matching fix version
-              versions_data=$(jira_get "${JIRA_BASE}/rest/api/3/project/MTV/versions")
-              fix_version_id=$(echo "$versions_data" | jq -r --arg cpe "$cpe_version" '
-                .[] | select(.name | contains($cpe)) | select(.released == false) | .id
-              ' | head -1 || true)
+              if versions_data=$(jira_get "${JIRA_BASE}/rest/api/3/project/MTV/versions"); then
+                fix_version_id=$(echo "$versions_data" | jq -r --arg cpe "$cpe_version" '
+                  .[] | select(.name | contains($cpe)) | select(.released == false) | .id
+                ' | head -1 || true)
+              else
+                echo "  ⚠️ Could not fetch MTV fix versions; creating clone without fixVersion"
+              fi
 
               if [[ -n "$fix_version_id" ]]; then
                 echo "  - Matched fix version ID: $fix_version_id"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -144,6 +144,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.parse_comment.outputs.pr_number }}
+          PR_TITLE: ${{ steps.verify_refs.outputs.pr_title }}
         run: |
           set -euo pipefail
 
@@ -185,7 +186,7 @@ jobs:
             fi
           else
             # Fallback: check PR title for MTV-XXXX
-            pr_title="${{ steps.verify_refs.outputs.pr_title }}"
+            pr_title="$PR_TITLE"
             ticket_key=$(echo "$pr_title" | grep -oE "MTV-[0-9]+" | head -1 || true)
             if [[ -n "$ticket_key" ]]; then
               echo "✅ Found ticket in PR title: $ticket_key"
@@ -437,12 +438,14 @@ jobs:
         id: label_pr
         if: success() && steps.parse_comment.outputs.dry_run == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_TITLE: ${{ steps.verify_refs.outputs.pr_title }}
         with:
           script: |
             const { owner, repo } = context.repo;
             const branch = '${{ steps.parse_comment.outputs.branch_name }}';
             const originalNumber = parseInt('${{ steps.parse_comment.outputs.pr_number }}', 10);
-            const originalTitle = `${{ toJSON(steps.verify_refs.outputs.pr_title) }}`;
+            const originalTitle = process.env.PR_TITLE;
 
             // Heuristic: find the most recent open PR to the target branch
             // that looks like a backport of the original PR.
@@ -550,6 +553,8 @@ jobs:
       - name: Post failure comment
         if: failure()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_TITLE: ${{ steps.verify_refs.outputs.pr_title || 'Original PR title' }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -571,7 +576,7 @@ jobs:
             }
 
             const resolvedTicket = cloneKey || ticketKey || 'MTV-XXXX';
-            const prTitle = `${{ steps.verify_refs.outputs.pr_title || 'Original PR title' }}`;
+            const prTitle = process.env.PR_TITLE;
 
             const body = `❌ **Backport Failed**
 
@@ -594,7 +599,7 @@ jobs:
             git cherry-pick -x ${commitShas}
             # Resolve any conflicts, then:
             git add .
-            git commit
+            git cherry-pick --continue
             git push origin backport-${prNumber}-to-${branch}
             gh pr create --base ${branch} --title "Resolves: ${resolvedTicket} | [Backport ${branch}] ${prTitle}"
             \`\`\``;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Development happens on `main`. Release branches follow the pattern `release-X.Y`
 
 - **Feature branches**: fork from `main`, open a PR against `main`
 - **Release branches**: cut from `main` when a release stabilizes
-- **Backports**: after a PR merges to `main`, comment `/backport release-X.Y` on the PR to create a cherry-pick PR to that release branch. `/cherrypick` and `/cherry-pick` also work. Add `--dry-run` to test first.
+- **Backports**: after a PR merges to `main`, comment `/backport release-X.Y` on the PR to create a cherry-pick PR to that release branch. `/cherrypick` and `/cherry-pick` also work. Add `--dry-run` to test first. The backport workflow also clones the associated Jira ticket (if any) and links it to the backport PR -- see [Repository Secrets](#repository-secrets) below.
 
 ## Pull Request Process
 
@@ -142,3 +142,16 @@ npm run lint:fix    # auto-fix
 - **Jira project**: MTV (tickets are `MTV-XXXX`)
 - **Repository**: [kubev2v/forklift-console-plugin](https://github.com/kubev2v/forklift-console-plugin)
 - **Forklift ecosystem**: [kubev2v/forklift](https://github.com/kubev2v/forklift) (operator and controllers)
+
+## Repository Secrets
+
+The backport workflow requires Jira API access to clone tickets. Two secrets must be configured in repository settings (Settings > Secrets and variables > Actions):
+
+| Secret | Description |
+|--------|-------------|
+| `JIRA_EMAIL` | Jira account email (personal or service account) |
+| `JIRA_API_TOKEN` | API token for that account ([generate here](https://id.atlassian.com/manage-profile/security/api-tokens)) |
+
+These are used by the backport workflow to create cloned Jira tickets for backport PRs. The workflow code is credential-agnostic -- when a shared service account becomes available, update the secret values without changing any workflow logic.
+
+If these secrets are not configured, the backport still works but skips the Jira integration (ticket cloning, linking, and status transitions).


### PR DESCRIPTION
## Summary

- Adds Jira integration to the `/backport` workflow: clones the original ticket with `[Backport release-X.Y]` prefix, links it via Cloners, sets fix version from `build/release.conf`, and transitions to POST after the backport PR is created
- Handles edge cases gracefully: `Resolves: None` (skip), missing ticket (warn), existing clone (reuse), Jira API failures (non-blocking)
- Enhances the failure comment with pastable manual cherry-pick and PR creation commands

## Links

- [MTV-5904](https://redhat.atlassian.net/browse/MTV-5904)

## Test plan

- [x] Add `JIRA_EMAIL` and `JIRA_API_TOKEN` repository secrets (already done)
- [ ] Merge to `main` (required for `issue_comment` trigger)
- [ ] Run `/backport release-2.12 --dry-run` on the PR for MTV-5314 or MTV-5635
- [ ] Run `/backport release-2.12` live and verify Jira clone, link, POST status
- [ ] Re-run `/backport release-2.12` on same PR to verify idempotency (reuses clone)
- [ ] Test failure scenario to verify pastable manual commands in comment


Made with [Cursor](https://cursor.com)

[MTV-5904]: https://redhat.atlassian.net/browse/MTV-5904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backport PRs now link to a cloned Jira ticket when available, with updated PR titles, bodies, and Backport Status comments.
  * The workflow can create or reuse an existing Jira clone, label new backport PRs, and (when live) sync the cloned Jira issue with the backport PR link and advance its workflow state.

* **Bug Fixes**
  * Improved ticket detection and clearer messaging when no Jira ticket is found, including more detailed failure guidance for manual recovery.

* **Documentation**
  * Updated backport instructions to describe Jira cloning/linking and added a “Repository Secrets” section for `JIRA_EMAIL` and `JIRA_API_TOKEN`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->