### PR TITLE
Resolves: MTV-5830 | Fix pre-hook job template selection in plan wizard

### DIFF
--- a/src/plans/create/steps/migration-hooks/components/JobTemplateAssignment.tsx
+++ b/src/plans/create/steps/migration-hooks/components/JobTemplateAssignment.tsx
@@ -3,7 +3,6 @@ import { Controller } from 'react-hook-form';
 
 import TypeaheadSelect from '@components/common/TypeaheadSelect/TypeaheadSelect';
 import { FormGroup, FormSection } from '@patternfly/react-core';
-import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
 import type { AapJobTemplate } from '@utils/types/aap';
 
@@ -58,7 +57,8 @@ const JobTemplateAssignment: FC<JobTemplateAssignmentProps> = ({ jobTemplates })
               options={preHookOptions}
               value={field.value}
               onChange={(selected) => {
-                const numericValue = isEmpty(selected as string) ? Number(selected) : undefined;
+                const numericValue =
+                  selected !== undefined && selected !== '' ? Number(selected) : undefined;
                 field.onChange(numericValue);
                 setValue(
                   AapFormFieldId.AapPreHookJobTemplateName,


### PR DESCRIPTION
## Summary
- Fixed inverted conditional in pre-hook `onChange` handler that discarded user selections
- The `isEmpty(selected)` check evaluated to `false` for non-empty strings, causing the value to always be `undefined`
- Replaced with the same explicit check used by the working post-hook handler

## Test plan
- [x] Navigate to plan wizard → Hooks step → select AAP
- [x] Verify pre-hook dropdown shows job templates
- [x] Select a pre-hook template → value is retained (was discarded before fix)
- [x] Select a post-hook template → value is retained (worked before)
- [x] Mutual exclusion: template selected as pre-hook is not available in post-hook dropdown and vice versa

Resolves: MTV-5830

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of job template assignment input so empty or unselected values are processed more reliably.
  * Reduced the chance of incorrect numeric conversion when selecting a job template, by using a more explicit empty-check before converting the selected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->