### PR TITLE
Resolves: MTV-5927 | fix(e2e): replace hardcoded hostpath-csi-basic with dynamic storage target selection

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
@@ -2,12 +2,7 @@ import { expect } from '@playwright/test';
 
 import { sharedProviderFixtures as test } from '../../../fixtures/resourceFixtures';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
-import {
-  NetworkTargets,
-  SourceNetworks,
-  SourceStorages,
-  StorageClasses,
-} from '../../../types/test-data';
+import { NetworkTargets, SourceNetworks, SourceStorages } from '../../../types/test-data';
 import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
@@ -94,11 +89,12 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
     });
 
     let originalStorageTarget = '';
+    let alternateStorageTarget = '';
 
     await test.step('Edit storage mapping: modify, revert, and verify cancellation', async () => {
       const modal = await planDetailsPage.mappingsTab.openStorageMapEditModal();
       originalStorageTarget = await modal.getTargetStorageAtIndex(0);
-      await modal.selectTargetStorageAtIndex(0, StorageClasses.HOSTPATH_BASIC);
+      alternateStorageTarget = await modal.selectDifferentTargetAtIndex(0);
       await modal.verifySaveButtonEnabled();
       await modal.save();
 
@@ -114,7 +110,7 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
       const revertedTarget = await modalAfterRevert.getTargetStorageAtIndex(0);
       expect(revertedTarget).toContain(originalStorageTarget.split(' ')[0]);
 
-      await modalAfterRevert.selectTargetStorageAtIndex(0, StorageClasses.HOSTPATH_BASIC);
+      await modalAfterRevert.selectTargetStorageAtIndex(0, alternateStorageTarget);
       await modalAfterRevert.cancel();
 
       const modalAfterCancel = await planDetailsPage.mappingsTab.openStorageMapEditModal();
@@ -158,7 +154,6 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
     });
 
     const addedStorageSource = SourceStorages.MTV_NFS_US_V8;
-    const addedStorageTarget = StorageClasses.HOSTPATH_BASIC;
 
     await test.step('Add and remove storage mapping', async () => {
       const modal = await planDetailsPage.mappingsTab.openStorageMapEditModal();
@@ -167,7 +162,7 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
       const newRowIndex = await modal.addMapping();
       expect(newRowIndex).toBe(initialCount);
       await modal.selectSourceStorageAtIndex(newRowIndex, addedStorageSource);
-      await modal.selectTargetStorageAtIndex(newRowIndex, addedStorageTarget);
+      await modal.selectFirstAvailableTargetAtIndex(newRowIndex);
       await modal.verifySaveButtonEnabled();
       await modal.save();
 

--- a/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
@@ -100,7 +100,7 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
 
       const modalAfterSave = await planDetailsPage.mappingsTab.openStorageMapEditModal();
       const currentTarget = await modalAfterSave.getTargetStorageAtIndex(0);
-      expect(currentTarget).toBeTruthy();
+      expect(currentTarget).toContain(alternateStorageTarget.split(' ')[0]);
 
       await modalAfterSave.selectTargetStorageAtIndex(0, originalStorageTarget);
       await modalAfterSave.verifySaveButtonEnabled();

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
@@ -129,26 +129,33 @@ export abstract class BaseMappingEditModal extends BaseModal {
     const currentTarget = await this.getTargetAtIndex(index);
     const targetSelect = this.targetSelectLocator(index);
 
-    await this.page.waitForTimeout(FORM_SETTLE_MS);
-    await targetSelect.click();
-    await expect(targetSelect).toHaveAttribute('aria-expanded', 'true');
-    const listbox = this.page.locator('[role="listbox"]:visible').last();
-    await expect(listbox).toBeVisible();
+    for (let attempt = 0; attempt < MAX_DROPDOWN_ATTEMPTS; attempt += 1) {
+      try {
+        const listbox = await this.openDropdown(targetSelect);
+        const options = listbox.locator('[role="option"]:enabled');
+        const count = await options.count();
 
-    const options = listbox.locator('[role="option"]:enabled');
-    const count = await options.count();
+        for (let i = 0; i < count; i += 1) {
+          const option = options.nth(i);
+          const optionText = ((await option.textContent()) ?? '').trim();
+          if (optionText !== currentTarget) {
+            await option.click({ timeout: OPTION_CLICK_TIMEOUT_MS });
+            await expect(targetSelect).toContainText(optionText);
+            return optionText;
+          }
+        }
 
-    for (let i = 0; i < count; i += 1) {
-      const optionText = ((await options.nth(i).textContent()) ?? '').trim();
-      if (optionText !== currentTarget) {
-        await options.nth(i).click({ timeout: OPTION_CLICK_TIMEOUT_MS });
-        return this.getTargetAtIndex(index);
+        throw new Error(
+          `selectDifferentTargetAtIndex: no alternative option found at row ${index} (current: "${currentTarget}")`,
+        );
+      } catch (err) {
+        if (attempt === MAX_DROPDOWN_ATTEMPTS - 1) {
+          throw err;
+        }
       }
     }
 
-    throw new Error(
-      `selectDifferentTargetAtIndex: no alternative option found at row ${index} (current: "${currentTarget}")`,
-    );
+    throw new Error(`selectDifferentTargetAtIndex: exhausted all attempts at row ${index}`);
   }
 
   async selectFirstAvailableSourceAtIndex(index: number): Promise<string> {

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/BaseMappingEditModal.ts
@@ -128,10 +128,27 @@ export abstract class BaseMappingEditModal extends BaseModal {
   async selectDifferentTargetAtIndex(index: number): Promise<string> {
     const currentTarget = await this.getTargetAtIndex(index);
     const targetSelect = this.targetSelectLocator(index);
-    await this.expandAndSelectNth(targetSelect, 1);
-    const newValue = await this.getTargetAtIndex(index);
-    expect(newValue).not.toBe(currentTarget);
-    return newValue;
+
+    await this.page.waitForTimeout(FORM_SETTLE_MS);
+    await targetSelect.click();
+    await expect(targetSelect).toHaveAttribute('aria-expanded', 'true');
+    const listbox = this.page.locator('[role="listbox"]:visible').last();
+    await expect(listbox).toBeVisible();
+
+    const options = listbox.locator('[role="option"]:enabled');
+    const count = await options.count();
+
+    for (let i = 0; i < count; i += 1) {
+      const optionText = ((await options.nth(i).textContent()) ?? '').trim();
+      if (optionText !== currentTarget) {
+        await options.nth(i).click({ timeout: OPTION_CLICK_TIMEOUT_MS });
+        return this.getTargetAtIndex(index);
+      }
+    }
+
+    throw new Error(
+      `selectDifferentTargetAtIndex: no alternative option found at row ${index} (current: "${currentTarget}")`,
+    );
   }
 
   async selectFirstAvailableSourceAtIndex(index: number): Promise<string> {


### PR DESCRIPTION
## 📝 Links

[MTV-5927](https://redhat.atlassian.net/browse/MTV-5927)

## 📝 Description

The `plan-mappings-edit` E2E spec was selecting a hardcoded storage class (`hostpath-csi-basic`) that does not exist on all test clusters, causing the test to fail with _"Failed to select after 3 attempts"_ on any environment without that class.

- **`plan-mappings-edit.spec.ts`**: replace `StorageClasses.HOSTPATH_BASIC` with dynamic calls to `selectDifferentTargetAtIndex()` and `selectFirstAvailableTargetAtIndex()`, making the test cluster-agnostic
- **`BaseMappingEditModal`**: improve `selectDifferentTargetAtIndex()` to scan all available dropdown options and pick the first one that genuinely differs from the current selection, instead of blindly picking `nth(1)` (which could be the same value when only one option is available or when `nth(1)` happened to equal the current selection)

## 🎥 Demo

No UI change — test-only fix.

## 📝 CC://

Resolves: MTV-5927

[MTV-5927]: https://redhat.atlassian.net/browse/MTV-5927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ