### PR TITLE
Resolves: MTV-5905 | Fix suggest-backport workflow: use pull_request_target for secret access

### DIFF
--- a/.github/workflows/suggest-backport.yml
+++ b/.github/workflows/suggest-backport.yml
@@ -1,6 +1,6 @@
 name: Suggest Backport
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
## Summary

- Switch suggest-backport workflow from `pull_request` to `pull_request_target` trigger so repository secrets (`JIRA_EMAIL`, `JIRA_API_TOKEN`) are available for PRs from forks

## Root Cause

The `pull_request` trigger does not expose repository secrets to workflows when the PR comes from a fork. Since all PRs in this project come from forks, the Jira credentials were always empty, causing the Jira API call to fail with `404` and the severity check step to exit early (masked by `continue-on-error: true`).

## Why this is safe

`pull_request_target` runs in the context of the base repository (not the PR head). This workflow only:
- Reads PR metadata (commits, title)
- Calls Jira REST API with repository secrets
- Calls GitHub API to post a comment
- Runs a dry-run backport (read-only cherry-pick)

It does **not** checkout or execute any code from the PR branch.

## Links

- [MTV-5905](https://redhat.atlassian.net/browse/MTV-5905)

## Test plan

- [ ] Merge this PR, then merge another PR with a high-severity Bug ticket (e.g., MTV-5920 level)
- [ ] Verify the suggest-backport comment appears with dry-run result


Made with [Cursor](https://cursor.com)

[MTV-5905]: https://redhat.atlassian.net/browse/MTV-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ