### PR TITLE
Resolves: MT-5499 | Remove total alerts count

### DIFF
--- a/src/overview/tabs/Overview/components/MigrationAlertsCard/MigrationAlertsCard.tsx
+++ b/src/overview/tabs/Overview/components/MigrationAlertsCard/MigrationAlertsCard.tsx
@@ -41,8 +41,6 @@ const MigrationAlertsCard: FC = () => {
     [alerts],
   );
 
-  const totalCount = alerts.length;
-
   const renderAlertList = (): JSX.Element => {
     if (!loaded) {
       return (
@@ -83,10 +81,7 @@ const MigrationAlertsCard: FC = () => {
           hasNoOffset: false,
         }}
       >
-        <CardTitle className="migration-alerts-card__title">
-          {t('Migration plan alerts')}
-          <span className="migration-alerts-card__total-count">{totalCount}</span>
-        </CardTitle>
+        <CardTitle className="migration-alerts-card__title">{t('Migration plan alerts')}</CardTitle>
       </CardHeader>
 
       <CardBody className="migration-alerts-card__summary">

--- a/src/overview/tabs/Overview/components/MigrationAlertsCard/__tests__/MigrationAlertsCard.test.tsx
+++ b/src/overview/tabs/Overview/components/MigrationAlertsCard/__tests__/MigrationAlertsCard.test.tsx
@@ -87,7 +87,7 @@ describe('MigrationAlertsCard', () => {
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
-  it('renders card title with total count', () => {
+  it('renders card title', () => {
     mockUseMigrationAlerts.mockReturnValue({
       alerts: [failedAlert, succeededAlert],
       error: undefined,
@@ -97,11 +97,6 @@ describe('MigrationAlertsCard', () => {
     renderCard();
 
     expect(screen.getByText('Migration plan alerts')).toBeInTheDocument();
-    expect(
-      screen
-        .getByTestId('migration-alerts-card')
-        .querySelector('.migration-alerts-card__total-count')?.textContent,
-    ).toBe('2');
   });
 
   it('shows summary section with failed and succeeded counts', () => {


### PR DESCRIPTION
## 📝 Links

https://redhat.atlassian.net/browse/MTV-5499

## 📝 Description

Remove total count of alerts from card header

## 🎥 Demo

<!---
> Please add a video or an image of the behavior/changes
-->

## 📝 CC://

<!---
> @tag as needed
-->

---

<details>
<summary>Merge automation commands</summary>

| Command | Description |
|---------|-------------|
| `/lgtm` or `/approve` | Add the `approved` label — PR will auto-merge when all checks pass |
| `/retest` | Re-trigger **Konflux** pipelines (handled by Pipelines as Code) |
| `/retest-gh` | Re-run **failed** GitHub Actions jobs |
| `/retest-gh-all` | Re-run **all** GitHub Actions workflows from scratch |
| `/retest-all` | Re-run failed GitHub Actions jobs **+** Konflux pipelines |
| `/hold` | Prevent auto-merge even if approved and checks pass |
| `/unhold` | Remove the hold and allow auto-merge again |

Submitting a **GitHub review approval** (Approve) also adds the `approved` label.

When checks fail on an approved PR, the bot automatically retries failed GitHub Actions up to **3 times**.
Konflux pipeline failures require a manual `/retest` to re-trigger.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the numeric total count from the migration alerts card header; the card now focuses on showing the alert list.
  * Loading and empty states remain unchanged.

* **Tests**
  * Updated the migration alerts card test to validate only the presence of “Migration plan alerts” when alerts are available, without checking the removed total-count text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->