### PR TITLE
Resolves: MTV-5569 | Fix Inspect VMs Select All to exclude active inspections

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -1447,6 +1447,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "This secret must be created in your project beforehand, typically using details provided by your storage administrator.",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "Tips and tricks",
   "To create a network mapping:": "To create a network mapping:",
   "To create a storage mapping:": "To create a storage mapping:",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -1457,6 +1457,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "Este recurso lo administra <2></2> y cualquier modificación podrá sobrescribirse. Edite el recurso de gestión para conservar los cambios.",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "Este secreto debe crearse en su proyecto de antemano, generalmente utilizando detalles proporcionados por su administrador de almacenamiento.",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "Esto acelera significativamente el proceso de migración y libera recursos de red y de host, ya que alivia la necesidad de extraer datos a través del host de origen.",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "Consejos y trucos",
   "To create a network mapping:": "Para crear una asociación de red:",
   "To create a storage mapping:": "Para crear una asociación de almacenamiento:",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -1457,6 +1457,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "Cette ressource est gérée par <2></2> et toute modification peut être remplacée. Modifiez la ressource de gestion pour conserver les modifications.",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "Ce secret doit être créé au préalable dans votre projet, généralement à l'aide des informations fournies par votre administrateur de stockage.",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "Cela accélère considérablement le processus de migration et libère des ressources réseau et hôte en évitant la nécessité de faire transiter les données par l'hôte source.",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "Conseils et astuces",
   "To create a network mapping:": "Pour créer un mappage réseau\u00a0:",
   "To create a storage mapping:": "Pour créer un mappage de stockage\u00a0:",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -1444,6 +1444,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "このリソースは <2></2> によって管理されており、変更が上書きされる可能性があります。変更を保持するには、管理元のリソースを編集してください。",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "このシークレットは、通常はストレージ管理者から提供された詳細情報を使用して、事前にプロジェクト内に作成する必要があります。",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "これにより、ソースホストを介してデータを取得する必要がなくなるため、移行プロセスが大幅に高速化され、ネットワークとホストのリソースが解放されます。",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "ヒントとコツ",
   "To create a network mapping:": "ネットワークマッピングを作成するには:",
   "To create a storage mapping:": "ストレージマッピングを作成するには:",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -1444,6 +1444,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "이 리소스는<2></2>에 의해 관리되며 모든 수정 사항을 덮어쓸 수 있습니다. 관리 리소스를 편집하여 변경 사항을 보존하십시오.",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "이 시크릿은 일반적으로 스토리지 관리자가 제공하는 정보를 사용하여 프로젝트에서 미리 생성해야 합니다.",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "이로 인해 마이그레이션 프로세스 속도가 크게 향상되고 소스 호스트를 통해 데이터를 가져올 필요가 없어 네트워크 및 호스트 리소스를 확보할 수 있습니다.",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "팁 및 요령",
   "To create a network mapping:": "네트워크 매핑을 생성하려면 다음 단계를 따르세요:",
   "To create a storage mapping:": "스토리지 매핑을 생성하려면 다음 단계를 따르세요.",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -1444,6 +1444,7 @@
   "This resource is managed by <2></2> and any modifications might be overwritten. Edit the managing resource to preserve changes.": "该资源由<2></2>管理，对它做的任何更改都可能会被覆盖。编辑管理资源以保留更改。",
   "This secret must be created in your project beforehand, typically using details provided by your storage administrator.": "此 secret 必须事先在项目中创建，通常使用您的存储管理员提供的详细信息。",
   "This significantly speeds up the migration process and frees up network and host resources by avoiding the need to pull data through the source host.": "这将不需要通过源主机拉取数据，因此可以显著地加快迁移、释放网络以及主机资源的速度。",
+  "This VM is already being inspected.": "This VM is already being inspected.",
   "Tips and tricks": "提示和技巧",
   "To create a network mapping:": "创建网络映射：",
   "To create a storage mapping:": "创建存储映射：",

--- a/src/components/InspectVirtualMachines/InspectionVmTable.tsx
+++ b/src/components/InspectVirtualMachines/InspectionVmTable.tsx
@@ -1,6 +1,7 @@
 import { type FC, useCallback, useMemo, useState } from 'react';
 import { loadUserSettings } from 'src/components/common/Page/userSettings';
 import { StandardPageWithSelection } from 'src/components/page/StandardPageWithSelection';
+import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { DISK_ENCRYPTION_TYPE } from '@utils/crds/conversion/constants';
 import { isEmpty } from '@utils/helpers';
@@ -41,6 +42,7 @@ const InspectionVmTable: FC<InspectionVmTableProps> = ({
   vmOverrides = {},
   vmRows,
 }) => {
+  const { t } = useForkliftTranslation();
   const userSettings = useMemo(() => loadUserSettings({ pageId: INSPECTION_VM_TABLE_ID }), []);
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
 
@@ -68,6 +70,12 @@ const InspectionVmTable: FC<InspectionVmTableProps> = ({
     [isProviderFlow, vmOverrides, onVmOverrideChange],
   );
 
+  const getSelectDisabledReason = useCallback(
+    (item: InspectionVmRowData): string | undefined =>
+      item.isActive ? t('This VM is already being inspected.') : undefined,
+    [t],
+  );
+
   return (
     <StandardPageWithSelection<InspectionVmRowData>
       dataSource={[enrichedRows, !isLoading, null]}
@@ -76,6 +84,7 @@ const InspectionVmTable: FC<InspectionVmTableProps> = ({
       userSettings={userSettings}
       toId={toId}
       canSelect={canSelect}
+      getSelectDisabledReason={getSelectDisabledReason}
       onSelect={onSelect}
       selectedIds={selectedIds}
       {...(isProviderFlow && {

--- a/src/components/page/StandardPageInner.tsx
+++ b/src/components/page/StandardPageInner.tsx
@@ -28,6 +28,7 @@ const StandardPageInner = <T,>({
   activeSort,
   addButton,
   alerts,
+  canSelect,
   cell,
   className,
   compareFn,
@@ -110,11 +111,17 @@ const StandardPageInner = <T,>({
   );
 
   const dataIds = useMemo(
-    () => finalFilteredData?.map((data) => toId?.(data) ?? ''),
-    [finalFilteredData, toId],
+    () =>
+      finalFilteredData
+        ?.filter((item) => canSelect?.(item) ?? true)
+        .map((data) => toId?.(data) ?? ''),
+    [finalFilteredData, toId, canSelect],
   );
 
-  const pageDataIds = useMemo(() => pageData?.map((data) => toId?.(data) ?? ''), [pageData, toId]);
+  const pageDataIds = useMemo(
+    () => pageData?.filter((item) => canSelect?.(item) ?? true).map((data) => toId?.(data) ?? ''),
+    [pageData, toId, canSelect],
+  );
 
   const renderedGlobalActions = useMemo(
     () =>

--- a/src/components/page/StandardPageWithSelection.tsx
+++ b/src/components/page/StandardPageWithSelection.tsx
@@ -25,6 +25,7 @@ type StandardPageWithSelectionProps<T> = ComponentProps<typeof StandardPage<T>> 
         toId: (item: T) => string;
         selectedIds: string[];
         canSelect?: (item: T) => boolean;
+        getSelectDisabledReason?: (item: T) => string | undefined;
         onExpand?: (expandedIds: string[]) => void;
         expandedIds?: string[];
       }
@@ -34,6 +35,7 @@ type StandardPageWithSelectionProps<T> = ComponentProps<typeof StandardPage<T>> 
         toId: (item: T) => string;
         selectedIds?: never;
         canSelect?: never;
+        getSelectDisabledReason?: never;
         onExpand: (expandedIds: string[]) => void;
         expandedIds: string[];
       }
@@ -43,6 +45,7 @@ type StandardPageWithSelectionProps<T> = ComponentProps<typeof StandardPage<T>> 
         toId?: never;
         selectedIds?: never;
         canSelect?: never;
+        getSelectDisabledReason?: never;
         onExpand?: never;
         expandedIds?: never;
       }
@@ -54,6 +57,7 @@ export const StandardPageWithSelection = <T,>(props: StandardPageWithSelectionPr
     cell,
     expanded,
     expandedIds,
+    getSelectDisabledReason,
     GlobalActionToolbarItems,
     header,
     onExpand,
@@ -85,6 +89,7 @@ export const StandardPageWithSelection = <T,>(props: StandardPageWithSelectionPr
       canSelect,
       cell,
       expandedIds: internalExpandedIds,
+      getSelectDisabledReason,
       selectedIds: internalSelectedIds,
       toggleExpandFor,
       toggleSelectFor,
@@ -92,14 +97,15 @@ export const StandardPageWithSelection = <T,>(props: StandardPageWithSelectionPr
     });
     return withTr(RowWithSelection, expanded);
   }, [
+    canSelect,
     cell,
     expanded,
+    getSelectDisabledReason,
     internalExpandedIds,
     internalSelectedIds,
     toggleExpandFor,
     toggleSelectFor,
     toId,
-    canSelect,
   ]);
 
   const finalHeader = useMemo(() => {
@@ -140,6 +146,7 @@ export const StandardPageWithSelection = <T,>(props: StandardPageWithSelectionPr
     <StandardPage
       {...rest}
       pageRef={pageRef}
+      canSelect={canSelect}
       expandedIds={internalExpandedIds}
       selectedIds={internalSelectedIds}
       onSelect={onSelectCallback}

--- a/src/components/page/__tests__/StandardPageWithSelection.test.tsx
+++ b/src/components/page/__tests__/StandardPageWithSelection.test.tsx
@@ -266,5 +266,51 @@ describe('StandardPageWithSelection', () => {
       expect(checkboxes[2]).toBeDisabled(); // Item 2 - should be disabled
       expect(checkboxes[3]).not.toBeDisabled(); // Item 3
     });
+
+    it('should only select eligible items when Select All is used', async () => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+      const canSelect = (item: { id: string }) => item.id !== '2';
+
+      renderWithRouter(
+        <StandardPageWithSelection
+          dataSource={[mockData, true, null]}
+          fieldsMetadata={fieldsMetadata}
+          namespace="test-ns"
+          toId={toId}
+          onSelect={onSelect}
+          selectedIds={[]}
+          canSelect={canSelect}
+        />,
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      await user.click(checkboxes[0]); // Header checkbox — select page
+
+      expect(onSelect).toHaveBeenCalledWith(['1', '3']);
+    });
+
+    it('should not include non-selectable items when deselecting all', async () => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+      const canSelect = (item: { id: string }) => item.id !== '2';
+
+      renderWithRouter(
+        <StandardPageWithSelection
+          dataSource={[mockData, true, null]}
+          fieldsMetadata={fieldsMetadata}
+          namespace="test-ns"
+          toId={toId}
+          onSelect={onSelect}
+          selectedIds={['1', '3']}
+          canSelect={canSelect}
+        />,
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      await user.click(checkboxes[0]); // Header checkbox — deselect all
+
+      expect(onSelect).toHaveBeenCalledWith([]);
+    });
   });
 });

--- a/src/components/page/utils/createRowWithSelection.tsx
+++ b/src/components/page/utils/createRowWithSelection.tsx
@@ -1,6 +1,8 @@
 import type { FC } from 'react';
 
+import { Tooltip } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
+import { isEmpty } from '@utils/helpers';
 
 import type { RowProps } from '../../common/TableView/types';
 
@@ -9,23 +11,40 @@ export const createRowWithSelection = <T,>({
   canSelect,
   cell: CellComponent,
   expandedIds,
+  getSelectDisabledReason,
   selectedIds,
   toggleExpandFor,
   toggleSelectFor,
   toId,
 }: {
+  canSelect?: (item: T) => boolean;
   cell?: FC<RowProps<T>>;
   expandedIds?: string[];
+  getSelectDisabledReason?: (item: T) => string | undefined;
   selectedIds?: string[];
   toggleExpandFor: (items: T[]) => void;
   toggleSelectFor: (items: T[]) => void;
   toId?: (item: T) => string;
-  canSelect?: (item: T) => boolean;
 }) => {
   const RowWithSelection = (props: RowProps<T>) => {
     const itemId = toId?.(props.resourceData) ?? '';
     const isExpanded = expandedIds?.includes(itemId) ?? false;
     const isSelected = selectedIds?.includes(itemId) ?? false;
+    const isDisabled = !canSelect?.(props.resourceData);
+    const disabledReason = isDisabled ? getSelectDisabledReason?.(props.resourceData) : undefined;
+
+    const selectTd = isEmpty(selectedIds) ? undefined : (
+      <Td
+        select={{
+          isDisabled,
+          isSelected,
+          onSelect: () => {
+            toggleSelectFor([props.resourceData]);
+          },
+          rowIndex: props.resourceIndex,
+        }}
+      />
+    );
 
     return (
       <>
@@ -40,18 +59,8 @@ export const createRowWithSelection = <T,>({
             }}
           />
         )}
-        {selectedIds !== undefined && (
-          <Td
-            select={{
-              isDisabled: !canSelect?.(props.resourceData),
-              isSelected,
-              onSelect: () => {
-                toggleSelectFor([props.resourceData]);
-              },
-              rowIndex: props.resourceIndex,
-            }}
-          />
-        )}
+        {selectTd &&
+          (disabledReason ? <Tooltip content={disabledReason}>{selectTd}</Tooltip> : selectTd)}
         {CellComponent && <CellComponent {...props} />}
       </>
     );

--- a/src/components/page/utils/createRowWithSelection.tsx
+++ b/src/components/page/utils/createRowWithSelection.tsx
@@ -1,8 +1,7 @@
-import type { FC } from 'react';
+import { type FC, useRef } from 'react';
 
 import { Tooltip } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
-import { isEmpty } from '@utils/helpers';
 
 import type { RowProps } from '../../common/TableView/types';
 
@@ -30,21 +29,9 @@ export const createRowWithSelection = <T,>({
     const itemId = toId?.(props.resourceData) ?? '';
     const isExpanded = expandedIds?.includes(itemId) ?? false;
     const isSelected = selectedIds?.includes(itemId) ?? false;
-    const isDisabled = !canSelect?.(props.resourceData);
+    const isDisabled = !(canSelect?.(props.resourceData) ?? true);
     const disabledReason = isDisabled ? getSelectDisabledReason?.(props.resourceData) : undefined;
-
-    const selectTd = isEmpty(selectedIds) ? undefined : (
-      <Td
-        select={{
-          isDisabled,
-          isSelected,
-          onSelect: () => {
-            toggleSelectFor([props.resourceData]);
-          },
-          rowIndex: props.resourceIndex,
-        }}
-      />
-    );
+    const selectRef = useRef<HTMLTableCellElement>(null);
 
     return (
       <>
@@ -59,8 +46,20 @@ export const createRowWithSelection = <T,>({
             }}
           />
         )}
-        {selectTd &&
-          (disabledReason ? <Tooltip content={disabledReason}>{selectTd}</Tooltip> : selectTd)}
+        {selectedIds !== undefined && (
+          <Td
+            ref={selectRef}
+            select={{
+              isDisabled,
+              isSelected,
+              onSelect: () => {
+                toggleSelectFor([props.resourceData]);
+              },
+              rowIndex: props.resourceIndex,
+            }}
+          />
+        )}
+        {disabledReason && <Tooltip triggerRef={selectRef} content={disabledReason} />}
         {CellComponent && <CellComponent {...props} />}
       </>
     );

--- a/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
@@ -6,6 +6,7 @@ import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetai
 import { NetworkTargets, type PlanTestData, SourceNetworks } from '../../../types/test-data';
 import {
   ACTIVE_OR_COMPLETED_STATUSES,
+  ACTIVE_STATUSES,
   COMPLETED_STATUSES,
   inspectionStatusDisplayToFilterId,
   isCompletedInspectionStatus,
@@ -14,15 +15,22 @@ import { requireVddk } from '../../../utils/requireVddk';
 import { V2_12_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
-// Deep inspection creates vSphere snapshots — keep mtv-func-win2022 isolated here to avoid
-// VMHasSnapshots conflicts with other suites (migration-happy-path, plan-migration-type).
+// Deep inspection creates vSphere snapshots — only inspect mtv-func-win2022 here.
+// mtv-func-rhel9 is a Select All peer and must never be submitted for inspection
+// (avoids VMHasSnapshots conflicts with migration-happy-path / plan-migration-type).
+const INSPECTED_VM = 'mtv-func-win2022';
+const SELECT_ALL_PEER_VM = 'mtv-func-rhel9';
+
 const test = sharedProviderFixtures.extend<{ testPlan: Awaited<ReturnType<typeof createPlan>> }>({
   testPlan: async ({ page, resourceManager, testProvider }, setValue) => {
     if (!testProvider) throw new Error('testPlan fixture requires testProvider');
     const plan = await createPlan(page, resourceManager, {
       sourceProvider: testProvider,
       customPlanData: {
-        virtualMachines: [{ folder: 'vm', sourceName: 'mtv-func-win2022' }],
+        virtualMachines: [
+          { folder: 'vm', sourceName: INSPECTED_VM },
+          { folder: 'vm', sourceName: SELECT_ALL_PEER_VM },
+        ],
         // mtv-func-win2022 has 2 NICs; explicit mappings avoid the duplicate-Default-Network validation error.
         networkMap: {
           mappings: [
@@ -43,6 +51,7 @@ type SetupResult = {
   namespace: string;
   planDetailsPage: PlanDetailsPage;
   planName: string;
+  secondVmName: string;
 };
 
 const setupPlanDetailsPage = async (
@@ -53,13 +62,16 @@ const setupPlanDetailsPage = async (
   const planDetailsPage = new PlanDetailsPage(page);
   const { name: planName, namespace } = testPlan.metadata;
   const firstVmName = testPlan.testData.virtualMachines?.[0]?.sourceName;
-  if (!firstVmName) throw new Error('No source VM found in plan test data');
+  const secondVmName = testPlan.testData.virtualMachines?.[1]?.sourceName;
+  if (!firstVmName || !secondVmName) {
+    throw new Error('Expected two source VMs in plan test data');
+  }
 
   await planDetailsPage.navigate(planName, namespace);
   await planDetailsPage.verifyPlanTitle(planName);
   await planDetailsPage.virtualMachinesTab.navigateToVirtualMachinesTab();
 
-  return { firstVmName, namespace, planDetailsPage, planName };
+  return { firstVmName, namespace, planDetailsPage, planName, secondVmName };
 };
 
 test.describe('Plan Deep Inspection', { tag: '@downstream' }, () => {
@@ -246,6 +258,49 @@ test.describe('Plan Deep Inspection', { tag: '@downstream' }, () => {
     });
   });
 
+  test('should exclude VMs with active inspections from Select All', async ({
+    page,
+    testPlan,
+    testProvider: _testProvider,
+  }) => {
+    const { firstVmName, planDetailsPage, secondVmName } = await setupPlanDetailsPage(
+      page,
+      testPlan,
+    );
+    const activeVmRow = planDetailsPage.virtualMachinesTab.getVmRow(firstVmName);
+
+    await test.step('ensure first VM has an active inspection', async () => {
+      const status = await planDetailsPage.virtualMachinesTab.getVmInspectionStatus(firstVmName);
+      if (!ACTIVE_STATUSES.test(status)) {
+        const inspectModal = await planDetailsPage.openInspectModal();
+        await inspectModal.selectVmByName(firstVmName);
+        await inspectModal.clickInspect();
+      }
+      await expect(activeVmRow.getByText(ACTIVE_STATUSES)).toBeVisible({ timeout: 30_000 });
+    });
+
+    await test.step('Select All includes only eligible VMs', async () => {
+      const inspectModal = await planDetailsPage.openInspectModal();
+      await inspectModal.waitForVmTableLoaded();
+
+      expect(await inspectModal.getVmRowCount()).toBe(2);
+      expect(await inspectModal.isVmCheckboxDisabled(firstVmName)).toBe(true);
+      expect(await inspectModal.isVmCheckboxDisabled(secondVmName)).toBe(false);
+
+      await inspectModal.selectAllVms();
+
+      const eligibleCount = await inspectModal.getEligibleVmCount();
+      expect(eligibleCount).toBe(1);
+      const buttonText = await inspectModal.getConfirmButtonText();
+      expect(buttonText).toContain(`Inspect ${eligibleCount} VM`);
+
+      expect(await inspectModal.isVmCheckboxChecked(firstVmName)).toBe(false);
+      expect(await inspectModal.isVmCheckboxChecked(secondVmName)).toBe(true);
+
+      await inspectModal.close();
+    });
+  });
+
   test('should select all VMs and update confirm button text', async ({
     page,
     testPlan,
@@ -253,13 +308,15 @@ test.describe('Plan Deep Inspection', { tag: '@downstream' }, () => {
   }) => {
     const { planDetailsPage } = await setupPlanDetailsPage(page, testPlan);
 
-    await test.step('open modal and select all VMs', async () => {
+    await test.step('open modal and select all eligible VMs', async () => {
       const inspectModal = await planDetailsPage.openInspectModal();
+      await inspectModal.waitForVmTableLoaded();
       await inspectModal.selectAllVms();
 
-      const vmCount = await inspectModal.getVmRowCount();
+      const eligibleCount = await inspectModal.getEligibleVmCount();
+      expect(eligibleCount).toBeGreaterThan(0);
       const buttonText = await inspectModal.getConfirmButtonText();
-      expect(buttonText).toContain(`Inspect ${vmCount} VM`);
+      expect(buttonText).toContain(`Inspect ${eligibleCount} VM`);
       await inspectModal.close();
     });
   });

--- a/testing/playwright/page-objects/InspectVirtualMachinesModal.ts
+++ b/testing/playwright/page-objects/InspectVirtualMachinesModal.ts
@@ -7,6 +7,15 @@ export class InspectVirtualMachinesModal {
     this.page = page;
   }
 
+  private vmCheckbox(vmName: string): Locator {
+    const row = this.vmTable.getByRole('row', { exact: false, name: vmName });
+    return row.getByRole('checkbox');
+  }
+
+  private get vmTableBodyRows(): Locator {
+    return this.vmTable.getByRole('rowgroup').nth(1).getByRole('row');
+  }
+
   get cancelButton(): Locator {
     return this.page.getByTestId('modal-cancel-button');
   }
@@ -28,6 +37,21 @@ export class InspectVirtualMachinesModal {
     return (await this.confirmButton.textContent()) ?? '';
   }
 
+  async getEligibleVmCount(): Promise<number> {
+    const rows = this.vmTableBodyRows;
+    const rowCount = await rows.count();
+    let eligibleCount = 0;
+
+    for (let i = 0; i < rowCount; i += 1) {
+      const checkbox = rows.nth(i).getByRole('checkbox');
+      if (!(await checkbox.isDisabled())) {
+        eligibleCount += 1;
+      }
+    }
+
+    return eligibleCount;
+  }
+
   async getVmInspectionStatus(vmName: string): Promise<string> {
     const row = this.vmTable.getByRole('row', { exact: false, name: vmName });
     const statusCell = row.getByRole('gridcell').last();
@@ -35,12 +59,19 @@ export class InspectVirtualMachinesModal {
   }
 
   async getVmRowCount(): Promise<number> {
-    const body = this.vmTable.getByRole('rowgroup').nth(1);
-    return body.getByRole('row').count();
+    return this.vmTableBodyRows.count();
   }
 
   async isConfirmDisabled(): Promise<boolean> {
     return this.confirmButton.isDisabled();
+  }
+
+  async isVmCheckboxChecked(vmName: string): Promise<boolean> {
+    return this.vmCheckbox(vmName).isChecked();
+  }
+
+  async isVmCheckboxDisabled(vmName: string): Promise<boolean> {
+    return this.vmCheckbox(vmName).isDisabled();
   }
 
   get modal(): Locator {
@@ -57,7 +88,7 @@ export class InspectVirtualMachinesModal {
    * Useful when the test does not know VM names upfront (e.g. dynamically created plans).
    */
   async selectFirstEligibleVm(): Promise<string> {
-    const rows = this.vmTable.getByRole('rowgroup').nth(1).getByRole('row');
+    const rows = this.vmTableBodyRows;
     const rowCount = await rows.count();
 
     for (let i = 0; i < rowCount; i += 1) {
@@ -74,8 +105,7 @@ export class InspectVirtualMachinesModal {
   }
 
   async selectVmByName(vmName: string): Promise<void> {
-    const row = this.vmTable.getByRole('row', { exact: false, name: vmName });
-    await row.getByRole('checkbox').check();
+    await this.vmCheckbox(vmName).check();
   }
 
   get techPreviewLabel(): Locator {
@@ -92,6 +122,6 @@ export class InspectVirtualMachinesModal {
 
   async waitForVmTableLoaded(): Promise<void> {
     await expect(this.vmTable).toBeVisible();
-    await expect(this.vmTable.locator('tbody tr').first()).toBeVisible({ timeout: 30_000 });
+    await expect(this.vmTableBodyRows.first()).toBeVisible({ timeout: 30_000 });
   }
 }

--- a/testing/playwright/utils/inspection-status.ts
+++ b/testing/playwright/utils/inspection-status.ts
@@ -15,6 +15,9 @@ export const INSPECTION_STATUS_LABEL = {
 /** Terminal inspection statuses shown in the VMs table. */
 export const COMPLETED_STATUSES = /Inspection passed|Issues found|Inspection error|Canceled/;
 
+/** Pending or Running — VM checkbox is disabled / excluded from Select All. */
+export const ACTIVE_STATUSES = /Pending|Running/;
+
 /** Running or any terminal status except Canceled. */
 export const ACTIVE_OR_COMPLETED_STATUSES =
   /Running|Inspection passed|Issues found|Inspection error/;


### PR DESCRIPTION
## Links

- [MTV-5569](https://redhat.atlassian.net/browse/MTV-5569)

## Description

Fix Inspect VMs "Select All" to exclude VMs with already-running inspections.

- Forward `canSelect` from `StandardPageWithSelection` into `StandardPageInner` so bulk `dataIds` / `pageDataIds` are filtered by selectability
- Add `getSelectDisabledReason` to `createRowWithSelection` for tooltip on disabled checkboxes
- Wire tooltip "This VM is already being inspected." in `InspectionVmTable`
- Add unit tests verifying Select All with `canSelect` only selects eligible items

This is a shared-layer fix — any future table using `canSelect` with `StandardPageWithSelection` will get correct bulk select behavior.

## Demo

<!-- Cluster is redeploying MTV; visual demo will be added once available -->

## CC://

Made with Cursor


[MTV-5569]: https://redhat.atlassian.net/browse/MTV-5569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized, explanatory disable reason for VMs that are already being inspected (shown via tooltip).
* **Bug Fixes**
  * “Select All” / “Deselect All” now target only eligible VMs, excluding those with active inspections.
  * Eligible counts and bulk actions no longer include disabled VMs.
* **Localization**
  * Added the “This VM is already being inspected.” message to EN/ES/FR/JA/KO/ZH (some non-EN locales currently fall back to English text).
* **Tests**
  * Updated component tests and Playwright end-to-end coverage for eligible-selection checkbox and confirm-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->