### PR TITLE
Resolves: MTV-5762 | QE: Add delete step to Network Map create test

### DIFF
--- a/testing/playwright/e2e/downstream/network-maps/network-map-create.spec.ts
+++ b/testing/playwright/e2e/downstream/network-maps/network-map-create.spec.ts
@@ -96,5 +96,13 @@ test.describe('Network Maps', { tag: '@downstream' }, () => {
         { sourceNetwork: 'Mgmt Network', targetNetwork: 'Ignore network' },
       ],
     });
+
+    // Delete the network map via the Actions menu and verify it redirects back to the list,
+    // with the deleted map no longer present
+    await networkMapDetailsPage.deleteMap(newMapName);
+    await expect(page).toHaveURL(
+      new RegExp(`/k8s/ns/${MTV_NAMESPACE}/forklift\\.konveyor\\.io~v1beta1~NetworkMap$`),
+    );
+    await expect(page.getByRole('link', { name: newMapName, exact: true })).not.toBeVisible();
   });
 });

--- a/testing/playwright/e2e/downstream/network-maps/network-map-create.spec.ts
+++ b/testing/playwright/e2e/downstream/network-maps/network-map-create.spec.ts
@@ -97,8 +97,6 @@ test.describe('Network Maps', { tag: '@downstream' }, () => {
       ],
     });
 
-    // Delete the network map via the Actions menu and verify it redirects back to the list,
-    // with the deleted map no longer present
     await networkMapDetailsPage.deleteMap(newMapName);
     await expect(page).toHaveURL(
       new RegExp(`/k8s/ns/${MTV_NAMESPACE}/forklift\\.konveyor\\.io~v1beta1~NetworkMap$`),

--- a/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
+++ b/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
@@ -63,11 +63,7 @@ export abstract class BaseMapDetailsPage {
     return this.page.getByTestId(this.config.editButtonTestId);
   }
 
-  /**
-   * Deletes the map via the details page "Actions" menu, confirming in the shared DeleteModal.
-   * Mirrors the app's own delete code path (NetworkMapActionsDropdownItems /
-   * StorageMapActionsDropdownItems), which both launch the same generic DeleteModal component.
-   */
+  /** Deletes the map via the details page Actions menu, confirming in the shared DeleteModal. */
   async deleteMap(mapName: string): Promise<void> {
     await this.verifyOnDetailsPage();
     await this.actionsMenuToggleLocator().click();

--- a/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
+++ b/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
@@ -6,6 +6,8 @@ import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 import { isEmpty } from '../../utils/utils';
 import { YamlEditorPage } from '../YamlEditorPage';
 
+import { DeleteResourceModal } from './DeleteResourceModal';
+
 /**
  * Configuration for a map details page.
  */
@@ -43,16 +45,37 @@ export abstract class BaseMapDetailsPage {
   protected readonly navigationHelper: NavigationHelper;
   protected readonly page: Page;
 
+  private readonly deleteModal: DeleteResourceModal;
   private readonly yamlEditor: YamlEditorPage;
 
   constructor(page: Page) {
     this.page = page;
     this.navigationHelper = new NavigationHelper(page);
     this.yamlEditor = new YamlEditorPage(page);
+    this.deleteModal = new DeleteResourceModal(page);
+  }
+
+  protected actionsMenuToggleLocator(): Locator {
+    return this.page.getByRole('button', { name: 'Actions', exact: true });
   }
 
   protected editButtonLocator(): Locator {
     return this.page.getByTestId(this.config.editButtonTestId);
+  }
+
+  /**
+   * Deletes the map via the details page "Actions" menu, confirming in the shared DeleteModal.
+   * Mirrors the app's own delete code path (NetworkMapActionsDropdownItems /
+   * StorageMapActionsDropdownItems), which both launch the same generic DeleteModal component.
+   */
+  async deleteMap(mapName: string): Promise<void> {
+    await this.verifyOnDetailsPage();
+    await this.actionsMenuToggleLocator().click();
+    await this.page
+      .getByRole('menuitem', { name: `Delete ${this.config.mapTypeDisplay.toLowerCase()}` })
+      .click();
+    await this.deleteModal.verifyOpen(mapName);
+    await this.deleteModal.confirm();
   }
 
   protected detailsHeadingLocator(): Locator {

--- a/testing/playwright/page-objects/common/DeleteResourceModal.ts
+++ b/testing/playwright/page-objects/common/DeleteResourceModal.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Wraps the generic `DeleteModal` component (src/components/modals/DeleteModal/DeleteModal.tsx),
+ * shared by the Provider, NetworkMap, and StorageMap delete actions.
+ *
+ * Unlike `BaseModal`-based modals (which use `ModalForm` and expose `modal-confirm-button` /
+ * `modal-cancel-button` test-ids), this modal's buttons carry no test-ids, so it locates them
+ * by role/name scoped to the dialog.
+ */
+export class DeleteResourceModal {
+  private readonly dialog: Locator;
+
+  constructor(page: Page) {
+    this.dialog = page.getByRole('dialog');
+  }
+
+  async cancel(): Promise<void> {
+    await this.dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await this.waitForModalToClose();
+  }
+
+  async confirm(): Promise<void> {
+    await this.dialog.getByRole('button', { name: 'Delete', exact: true }).click();
+    await this.waitForModalToClose();
+  }
+
+  async verifyOpen(resourceName: string): Promise<void> {
+    await expect(this.dialog).toBeVisible();
+    await expect(this.dialog).toContainText(resourceName);
+  }
+
+  async waitForModalToClose(): Promise<void> {
+    await expect(this.dialog).not.toBeVisible();
+  }
+}

--- a/testing/playwright/page-objects/common/DeleteResourceModal.ts
+++ b/testing/playwright/page-objects/common/DeleteResourceModal.ts
@@ -1,12 +1,8 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
- * Wraps the generic `DeleteModal` component (src/components/modals/DeleteModal/DeleteModal.tsx),
- * shared by the Provider, NetworkMap, and StorageMap delete actions.
- *
- * Unlike `BaseModal`-based modals (which use `ModalForm` and expose `modal-confirm-button` /
- * `modal-cancel-button` test-ids), this modal's buttons carry no test-ids, so it locates them
- * by role/name scoped to the dialog.
+ * Wraps the generic `DeleteModal` component, shared by Provider/NetworkMap/StorageMap delete.
+ * Its buttons carry no test-ids, so they're located by role/name within the dialog.
  */
 export class DeleteResourceModal {
   private readonly dialog: Locator;


### PR DESCRIPTION
## Summary
- Extends the network map create E2E test (`network-map-create.spec.ts`) to delete the network map via the details page "Actions" menu after creation, verifying the redirect back to the list and that the map is no longer present.
- Adds a shared `DeleteResourceModal` page object and a `deleteMap()` helper on `BaseMapDetailsPage`, so the delete flow is reused (not duplicated) by the upcoming Storage Map delete test (MTV-5763), which shares the same details-page base class.

## Test plan
- [x] Ran `network-map-create.spec.ts` against a live console/cluster; the test passes, including the new delete step.
- [x] Verified via `oc get networkmap` that the deleted map is actually removed from the cluster (not just hidden in the UI).
- [x] Linted the changed files with no errors.

Resolves: MTV-5762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added map deletion from the map details page via the “Actions” menu.
  * Introduced a reusable delete confirmation dialog flow for shared delete actions.

* **Tests**
  * Expanded end-to-end coverage to confirm deletion, verify navigation back to the NetworkMap list, and ensure the deleted map no longer appears in the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->