### PR TITLE
Resolves: MTV-5763 | QE: Add delete step to Storage Map create test

### DIFF
--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -176,6 +176,16 @@ test.describe(
 
         await modal.cancel();
       });
+
+      await test.step('Delete storage map and verify it is removed from the list', async () => {
+        await detailsPage.deleteMap(storageMapName);
+        await expect(page).toHaveURL(
+          new RegExp(`/k8s/ns/${MTV_NAMESPACE}/forklift\\.konveyor\\.io~v1beta1~StorageMap$`),
+        );
+        await expect(
+          page.getByRole('link', { name: storageMapName, exact: true }),
+        ).not.toBeVisible();
+      });
     });
 
     test('should hide offload options for non-vSphere providers', async ({

--- a/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
+++ b/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
@@ -63,11 +63,7 @@ export abstract class BaseMapDetailsPage {
     return this.page.getByTestId(this.config.editButtonTestId);
   }
 
-  /**
-   * Deletes the map via the details page "Actions" menu, confirming in the shared DeleteModal.
-   * Mirrors the app's own delete code path (NetworkMapActionsDropdownItems /
-   * StorageMapActionsDropdownItems), which both launch the same generic DeleteModal component.
-   */
+  /** Deletes the map via the details page Actions menu, confirming in the shared DeleteModal. */
   async deleteMap(mapName: string): Promise<void> {
     await this.verifyOnDetailsPage();
     await this.actionsMenuToggleLocator().click();

--- a/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
+++ b/testing/playwright/page-objects/common/BaseMapDetailsPage.ts
@@ -6,6 +6,8 @@ import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 import { isEmpty } from '../../utils/utils';
 import { YamlEditorPage } from '../YamlEditorPage';
 
+import { DeleteResourceModal } from './DeleteResourceModal';
+
 /**
  * Configuration for a map details page.
  */
@@ -43,16 +45,37 @@ export abstract class BaseMapDetailsPage {
   protected readonly navigationHelper: NavigationHelper;
   protected readonly page: Page;
 
+  private readonly deleteModal: DeleteResourceModal;
   private readonly yamlEditor: YamlEditorPage;
 
   constructor(page: Page) {
     this.page = page;
     this.navigationHelper = new NavigationHelper(page);
     this.yamlEditor = new YamlEditorPage(page);
+    this.deleteModal = new DeleteResourceModal(page);
+  }
+
+  protected actionsMenuToggleLocator(): Locator {
+    return this.page.getByRole('button', { name: 'Actions', exact: true });
   }
 
   protected editButtonLocator(): Locator {
     return this.page.getByTestId(this.config.editButtonTestId);
+  }
+
+  /**
+   * Deletes the map via the details page "Actions" menu, confirming in the shared DeleteModal.
+   * Mirrors the app's own delete code path (NetworkMapActionsDropdownItems /
+   * StorageMapActionsDropdownItems), which both launch the same generic DeleteModal component.
+   */
+  async deleteMap(mapName: string): Promise<void> {
+    await this.verifyOnDetailsPage();
+    await this.actionsMenuToggleLocator().click();
+    await this.page
+      .getByRole('menuitem', { name: `Delete ${this.config.mapTypeDisplay.toLowerCase()}` })
+      .click();
+    await this.deleteModal.verifyOpen(mapName);
+    await this.deleteModal.confirm();
   }
 
   protected detailsHeadingLocator(): Locator {

--- a/testing/playwright/page-objects/common/DeleteResourceModal.ts
+++ b/testing/playwright/page-objects/common/DeleteResourceModal.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Wraps the generic `DeleteModal` component (src/components/modals/DeleteModal/DeleteModal.tsx),
+ * shared by the Provider, NetworkMap, and StorageMap delete actions.
+ *
+ * Unlike `BaseModal`-based modals (which use `ModalForm` and expose `modal-confirm-button` /
+ * `modal-cancel-button` test-ids), this modal's buttons carry no test-ids, so it locates them
+ * by role/name scoped to the dialog.
+ */
+export class DeleteResourceModal {
+  private readonly dialog: Locator;
+
+  constructor(page: Page) {
+    this.dialog = page.getByRole('dialog');
+  }
+
+  async cancel(): Promise<void> {
+    await this.dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await this.waitForModalToClose();
+  }
+
+  async confirm(): Promise<void> {
+    await this.dialog.getByRole('button', { name: 'Delete', exact: true }).click();
+    await this.waitForModalToClose();
+  }
+
+  async verifyOpen(resourceName: string): Promise<void> {
+    await expect(this.dialog).toBeVisible();
+    await expect(this.dialog).toContainText(resourceName);
+  }
+
+  async waitForModalToClose(): Promise<void> {
+    await expect(this.dialog).not.toBeVisible();
+  }
+}

--- a/testing/playwright/page-objects/common/DeleteResourceModal.ts
+++ b/testing/playwright/page-objects/common/DeleteResourceModal.ts
@@ -1,12 +1,8 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
 /**
- * Wraps the generic `DeleteModal` component (src/components/modals/DeleteModal/DeleteModal.tsx),
- * shared by the Provider, NetworkMap, and StorageMap delete actions.
- *
- * Unlike `BaseModal`-based modals (which use `ModalForm` and expose `modal-confirm-button` /
- * `modal-cancel-button` test-ids), this modal's buttons carry no test-ids, so it locates them
- * by role/name scoped to the dialog.
+ * Wraps the generic `DeleteModal` component, shared by Provider/NetworkMap/StorageMap delete.
+ * Its buttons carry no test-ids, so they're located by role/name within the dialog.
  */
 export class DeleteResourceModal {
   private readonly dialog: Locator;


### PR DESCRIPTION
## Summary
- Extends the storage map offload create E2E test (`create-storage-map-offload.spec.ts`) to delete the storage map via the details page "Actions" menu after the create/edit/verify flow, checking the redirect back to the list and that the map is no longer present.
- Same pattern as MTV-5762 (network map delete), reusing the shared `deleteMap()` helper on `BaseMapDetailsPage` added there — no new test infrastructure needed.

## Test plan
- [x] Manually verified the underlying delete flow (Actions → "Delete storage map" → confirm in the shared `DeleteModal` → redirect to list) against a live console/cluster using a minimal `StorageMap` resource, confirming via `oc get storagemap` that the resource is actually removed from the cluster.
- [x] Automated run of the full spec file was blocked locally by an unrelated pre-existing limitation: the test's earlier steps create a `Secret` via a REST call that requires an authenticated browser session, which isn't available in this off-cluster/auth-disabled local dev setup. This is independent of the new delete step and also affects the file's existing (pre-change) test content.
- [x] Linted the changed file with no errors.

Depends on: #2510 (MTV-5762), which introduces the shared `deleteMap()` helper this PR reuses.

Resolves: MTV-5763