### PR TITLE
Resolves: MTV-5764 | QE: Add delete coverage for Plans

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-details-page.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-details-page.spec.ts
@@ -19,6 +19,25 @@ test.describe('Plan Details Navigation', { tag: '@downstream' }, () => {
   });
 });
 
+test.describe('Plan Details - Delete', { tag: '@downstream' }, () => {
+  requireVersion(test, V2_10_5);
+
+  test('should delete the plan from the details page and return to the list', async ({
+    page,
+    testPlan,
+    testProvider: _testProvider,
+  }) => {
+    const { namespace, planDetailsPage, planName } = await setupPlanDetailsPage(page, testPlan);
+
+    await planDetailsPage.deletePlan();
+
+    await expect(page).toHaveURL(
+      new RegExp(`/k8s/ns/${namespace}/forklift\\.konveyor\\.io~v1beta1~Plan$`),
+    );
+    await expect(page.getByRole('link', { name: planName, exact: true })).not.toBeVisible();
+  });
+});
+
 test.describe('Plan Details - VM Rename Validation', { tag: '@downstream' }, () => {
   requireVersion(test, V2_11_0);
 

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -77,6 +77,20 @@ export class PlanDetailsPage {
     return this.page.getByTestId('plan-critical-alert');
   }
 
+  /**
+   * Deletes the plan via the details page "Actions" menu, confirming in the plan-specific
+   * PlanDeleteModal (src/plans/actions/components/PlanDeleteModal.tsx).
+   */
+  async deletePlan(): Promise<void> {
+    await this.page.getByTestId('plan-actions-dropdown-button').click();
+    await this.page.getByRole('menuitem', { name: 'Delete', exact: true }).click();
+
+    const deleteModal = this.page.getByRole('dialog', { name: 'Delete plan' });
+    await expect(deleteModal).toBeVisible();
+    await deleteModal.getByTestId('modal-confirm-button').click();
+    await expect(deleteModal).not.toBeVisible();
+  }
+
   async duplicatePlan(newPlanName: string, namespace: string): Promise<void> {
     await this.page.getByTestId('plan-actions-dropdown-button').click();
     const duplicateItem = this.page.getByRole('menuitem', { name: 'Duplicate' });

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -77,10 +77,7 @@ export class PlanDetailsPage {
     return this.page.getByTestId('plan-critical-alert');
   }
 
-  /**
-   * Deletes the plan via the details page "Actions" menu, confirming in the plan-specific
-   * PlanDeleteModal (src/plans/actions/components/PlanDeleteModal.tsx).
-   */
+  /** Deletes the plan via the details page Actions menu, confirming in the plan-specific PlanDeleteModal. */
   async deletePlan(): Promise<void> {
     await this.page.getByTestId('plan-actions-dropdown-button').click();
     await this.page.getByRole('menuitem', { name: 'Delete', exact: true }).click();


### PR DESCRIPTION
## Summary
- Adds a single new test to `plan-details-page.spec.ts` that deletes a plan from the details page **Actions** menu (`PlanActionsDropdown` → `PlanDeleteModal`) and verifies the plan disappears from the Plans list, matching the pattern already covered for `Delete network map`/`Delete storage map` (MTV-5762/MTV-5763).
- Adds a `deletePlan()` helper to `PlanDetailsPage` page object, reusing the existing `plan-actions-dropdown-button` test-id and `modal-confirm-button` convention already used by `clickActionsMenuAndStart()` / `duplicatePlan()` in the same file.
- One test is sufficient for coverage since delete behavior is identical regardless of which plan-feature describe block created the plan — no need to duplicate this across the file's other test blocks.

## Test plan
- [x] Verified locally against a real cluster (local console + local plugin dev server) that a real plan created via the `testPlan`/`testProvider` fixtures can be deleted via **Actions → Delete**, redirects to the Plans list, and the deleted plan is no longer listed.
- [x] `npx eslint` clean on both changed files.
- [ ] CI Playwright run (downstream, `@downstream` tag).

Resolves: MTV-5764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for deleting a plan.
  * Verifies confirmation completes successfully, navigation returns to the Plans list, and the deleted plan is no longer visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->