### PR TITLE
Resolves: MTV-5491 | Fix provider inventory data loss when individual fetch fails

### DIFF
--- a/src/providers/list/utils/__tests__/getProvidersInventoryByNamespace.test.ts
+++ b/src/providers/list/utils/__tests__/getProvidersInventoryByNamespace.test.ts
@@ -1,0 +1,126 @@
+import type { ProviderInventory, V1beta1Provider } from '@forklift-ui/types';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+
+import { getProvidersInventoryByNamespace } from '../getProvidersInventoryByNamespace';
+
+const mockConsoleFetchJSON = jest.fn();
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  consoleFetchJSON: jest.fn((...args) => mockConsoleFetchJSON(...args)),
+}));
+
+const mockK8sGetProvidersByNamespace = jest.fn();
+jest.mock('../../utils/k8sGetProvidersByNamespace', () => ({
+  k8sGetProvidersByNamespace: jest.fn((...args) => mockK8sGetProvidersByNamespace(...args)),
+}));
+
+const makeProvider = (name: string, type: string, uid: string): V1beta1Provider =>
+  ({
+    metadata: { name, namespace: 'test-ns', uid },
+    spec: { type },
+    status: { phase: 'Ready' },
+  }) as unknown as V1beta1Provider;
+
+const makeInventoryResponse = (type: string, uid: string): ProviderInventory & { type: string } =>
+  ({
+    name: `provider-${uid}`,
+    networkCount: 2,
+    type,
+    uid,
+    vmCount: 5,
+  }) as unknown as ProviderInventory & { type: string };
+
+describe('getProvidersInventoryByNamespace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns inventory for all successful providers', async () => {
+    const providers = [
+      makeProvider('ec2-1', 'ec2', 'uid-1'),
+      makeProvider('ec2-2', 'ec2', 'uid-2'),
+    ];
+
+    mockK8sGetProvidersByNamespace.mockResolvedValue(providers);
+    mockConsoleFetchJSON
+      .mockResolvedValueOnce(makeInventoryResponse('ec2', 'uid-1'))
+      .mockResolvedValueOnce(makeInventoryResponse('ec2', 'uid-2'));
+
+    const result = await getProvidersInventoryByNamespace('test-ns');
+
+    const extended = result as Record<string, ProviderInventory[]>;
+    expect(extended.ec2).toHaveLength(2);
+    expect(extended.ec2[0].uid).toBe('uid-1');
+    expect(extended.ec2[1].uid).toBe('uid-2');
+  });
+
+  it('returns partial results when one provider fetch fails', async () => {
+    const providers = [
+      makeProvider('ec2-1', 'ec2', 'uid-1'),
+      makeProvider('ec2-2', 'ec2', 'uid-2'),
+    ];
+
+    mockK8sGetProvidersByNamespace.mockResolvedValue(providers);
+    mockConsoleFetchJSON
+      .mockResolvedValueOnce(makeInventoryResponse('ec2', 'uid-1'))
+      .mockRejectedValueOnce(new Error('Inventory not ready'));
+
+    const result = await getProvidersInventoryByNamespace('test-ns');
+
+    const extended = result as Record<string, ProviderInventory[]>;
+    expect(extended.ec2).toHaveLength(1);
+    expect(extended.ec2[0].uid).toBe('uid-1');
+  });
+
+  it('returns empty inventory when all provider fetches fail', async () => {
+    const providers = [
+      makeProvider('ec2-1', 'ec2', 'uid-1'),
+      makeProvider('ec2-2', 'ec2', 'uid-2'),
+    ];
+
+    mockK8sGetProvidersByNamespace.mockResolvedValue(providers);
+    mockConsoleFetchJSON
+      .mockRejectedValueOnce(new Error('Not found'))
+      .mockRejectedValueOnce(new Error('Not found'));
+
+    const result = await getProvidersInventoryByNamespace('test-ns');
+
+    expect(result).toEqual({});
+  });
+
+  it('filters out non-Ready providers', async () => {
+    const providers = [
+      makeProvider('ec2-ready', 'ec2', 'uid-1'),
+      {
+        ...makeProvider('ec2-staging', 'ec2', 'uid-2'),
+        status: { phase: 'Staging' },
+      } as unknown as V1beta1Provider,
+    ];
+
+    mockK8sGetProvidersByNamespace.mockResolvedValue(providers);
+    mockConsoleFetchJSON.mockResolvedValueOnce(makeInventoryResponse('ec2', 'uid-1'));
+
+    const result = await getProvidersInventoryByNamespace('test-ns');
+
+    expect(mockConsoleFetchJSON).toHaveBeenCalledTimes(1);
+    const extended = result as Record<string, ProviderInventory[]>;
+    expect(extended.ec2).toHaveLength(1);
+  });
+
+  it('handles mixed provider types correctly', async () => {
+    const providers = [
+      makeProvider('vsphere-1', 'vsphere', 'uid-vs'),
+      makeProvider('ec2-1', 'ec2', 'uid-ec2'),
+    ];
+
+    mockK8sGetProvidersByNamespace.mockResolvedValue(providers);
+    mockConsoleFetchJSON
+      .mockResolvedValueOnce(makeInventoryResponse('vsphere', 'uid-vs'))
+      .mockResolvedValueOnce(makeInventoryResponse('ec2', 'uid-ec2'));
+
+    const result = await getProvidersInventoryByNamespace('test-ns');
+
+    expect(result?.vsphere).toHaveLength(1);
+    const extended = result as Record<string, ProviderInventory[]>;
+    expect(extended.ec2).toHaveLength(1);
+  });
+});

--- a/src/providers/list/utils/getProvidersInventoryByNamespace.tsx
+++ b/src/providers/list/utils/getProvidersInventoryByNamespace.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/promise-function-async */
 import type {
   HypervProvider,
   OpenshiftProvider,
@@ -16,6 +15,39 @@ import { PROVIDER_TYPES } from '@utils/providers/constants';
 
 import { k8sGetProvidersByNamespace } from '../utils/k8sGetProvidersByNamespace';
 
+const addProviderToInventory = (
+  newInventory: ProvidersInventoryList,
+  provider: ProviderInventory & { type: string },
+): void => {
+  switch (provider.type) {
+    case PROVIDER_TYPES.openshift:
+      newInventory.openshift = [...(newInventory.openshift ?? []), provider as OpenshiftProvider];
+      break;
+    case PROVIDER_TYPES.openstack:
+      newInventory.openstack = [...(newInventory.openstack ?? []), provider as OpenstackProvider];
+      break;
+    case PROVIDER_TYPES.ovirt:
+      newInventory.ovirt = [...(newInventory.ovirt ?? []), provider as OVirtProvider];
+      break;
+    case PROVIDER_TYPES.vsphere:
+      newInventory.vsphere = [...(newInventory.vsphere ?? []), provider as VSphereProvider];
+      break;
+    case PROVIDER_TYPES.ova:
+      newInventory.ova = [...(newInventory.ova ?? []), provider as OvaProvider];
+      break;
+    case PROVIDER_TYPES.hyperv:
+      newInventory.hyperv = [...(newInventory.hyperv ?? []), provider as HypervProvider];
+      break;
+    case PROVIDER_TYPES.ec2: {
+      const extended = newInventory as ProvidersInventoryList & Record<string, ProviderInventory[]>;
+      extended.ec2 = [...(extended.ec2 ?? []), provider];
+      break;
+    }
+    default:
+      break;
+  }
+};
+
 export const getProvidersInventoryByNamespace = async (
   currNamespace: string | undefined,
 ): Promise<ProvidersInventoryList | null> => {
@@ -25,77 +57,25 @@ export const getProvidersInventoryByNamespace = async (
     (provider: V1beta1Provider) => provider?.status?.phase === 'Ready',
   );
 
-  const inventoryProviderURL = (provider: V1beta1Provider) =>
+  const inventoryProviderURL = (provider: V1beta1Provider): string =>
     `providers/${provider?.spec?.type}/${provider?.metadata?.uid}`;
 
-  const inventoryReadyProviders = () => {
-    return Promise.all(
-      readyProviders.map((provider) => {
-        return consoleFetchJSON(getInventoryApiUrl(inventoryProviderURL(provider))) as Promise<
+  const results = await Promise.allSettled(
+    readyProviders.map(
+      async (provider) =>
+        consoleFetchJSON(getInventoryApiUrl(inventoryProviderURL(provider))) as Promise<
           (ProviderInventory & { type: string }) | null
-        >;
-      }),
-    )
-      .then((newInventoryProviders) => {
-        const newInventory: ProvidersInventoryList = {};
+        >,
+    ),
+  );
 
-        newInventoryProviders.forEach((newInventoryProvider) => {
-          if (newInventoryProvider?.type) {
-            switch (newInventoryProvider.type) {
-              case PROVIDER_TYPES.openshift:
-                newInventory.openshift = [
-                  ...(newInventory.openshift ?? []),
-                  newInventoryProvider as OpenshiftProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.openstack:
-                newInventory.openstack = [
-                  ...(newInventory.openstack ?? []),
-                  newInventoryProvider as OpenstackProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.ovirt:
-                newInventory.ovirt = [
-                  ...(newInventory.ovirt ?? []),
-                  newInventoryProvider as OVirtProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.vsphere:
-                newInventory.vsphere = [
-                  ...(newInventory.vsphere ?? []),
-                  newInventoryProvider as VSphereProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.ova:
-                newInventory.ova = [
-                  ...(newInventory.ova ?? []),
-                  newInventoryProvider as OvaProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.hyperv:
-                newInventory.hyperv = [
-                  ...(newInventory.hyperv ?? []),
-                  newInventoryProvider as HypervProvider,
-                ];
-                break;
-              case PROVIDER_TYPES.ec2: {
-                const extended = newInventory as ProvidersInventoryList &
-                  Record<string, ProviderInventory[]>;
-                extended.ec2 = [...(extended.ec2 ?? []), newInventoryProvider];
-                break;
-              }
-              default:
-                break;
-            }
-          }
-        });
+  const newInventory: ProvidersInventoryList = {};
 
-        return newInventory;
-      })
-      .catch(() => {
-        return null;
-      });
-  };
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value?.type) {
+      addProviderToInventory(newInventory, result.value);
+    }
+  }
 
-  return inventoryReadyProviders();
+  return newInventory;
 };


### PR DESCRIPTION
## Summary

- Replace `Promise.all` with `Promise.allSettled` in `getProvidersInventoryByNamespace` so individual provider inventory fetch failures don't wipe all other providers' inventory data
- Extract the switch logic into a reusable `addProviderToInventory` helper
- Add unit tests covering partial failure, full failure, provider filtering, and mixed types

## Problem

When `canList` is false (user in a non-default namespace without cluster-wide list permissions), creating a new EC2 provider whose inventory hasn't been collected yet caused ALL providers' inventory to disappear from the list. This is because `Promise.all` rejects on the first failure, the `.catch()` returns `null`, and the UI loses all inventory data.

## Root Cause

`getProvidersInventoryByNamespace` used `Promise.all` to fetch inventory for all Ready providers in parallel. A single 404/error (e.g., from a newly-created provider not yet registered with the inventory service) caused the entire batch to fail.

## Fix

Use `Promise.allSettled` which never rejects. Only fulfilled results are processed into the inventory list. Failed providers are gracefully skipped, preserving other providers' data.

## Test plan

- [x] Unit tests: 5 new tests covering all failure scenarios
- [x] All existing provider tests pass (78/78)
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [ ] Manual: Create EC2 providers in a user-defined namespace and verify VM list consistency (requires ROSA cluster)

Resolves: MTV-5491

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider inventory results are now aggregated even when one or more provider inventory requests fail.
  * Providers that are not in the Ready state are excluded from inventory results.
  * Inventory remains correctly grouped across supported provider types, including EC2 providers.
  * Returns an empty inventory when no provider inventory requests succeed.

* **Tests**
  * Added coverage for successful, partial, and fully failed inventory retrieval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->