### PR TITLE
Resolves: MTV-5894 | Fix storage map edit modal missing offload options and vendor recommendations

### DIFF
--- a/src/storageMaps/details/components/StorageMapEdit.tsx
+++ b/src/storageMaps/details/components/StorageMapEdit.tsx
@@ -120,12 +120,13 @@ const StorageMapEdit: ModalComponent<StorageMapEditProps> = ({
         testId="edit-storage-map-modal"
       >
         <UpdateStorageMapFieldTable
-          targetStorages={targetStorages}
-          sourceStorages={allSourceStorages}
+          inventorySourceStorages={sourceStorages ?? []}
           isLoading={isLoading}
-          loadError={loadError}
           isVsphere={sourceProvider?.spec?.type === PROVIDER_TYPES.vsphere}
+          loadError={loadError}
           sourceProvider={sourceProvider}
+          sourceStorages={allSourceStorages}
+          targetStorages={targetStorages}
         />
         {error?.root && <FormErrorHelperText error={error.root} />}
       </ModalForm>

--- a/src/storageMaps/details/components/UpdateStorageMapFieldTable.tsx
+++ b/src/storageMaps/details/components/UpdateStorageMapFieldTable.tsx
@@ -7,6 +7,7 @@ import type { V1beta1Provider } from '@forklift-ui/types';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { FEATURE_NAMES } from '@utils/constants';
 import { useFeatureFlags } from '@utils/hooks/useFeatureFlags';
+import type { InventoryStorage } from '@utils/hooks/useStorages';
 import { useForkliftTranslation } from '@utils/i18n';
 import {
   StorageMapFieldId,
@@ -15,24 +16,27 @@ import {
 } from '@utils/storage/types';
 
 import AccessModeField from '../../components/AccessModeField';
-import OffloadStorageIndexedForm from '../../components/OffloadStorageIndexedForm/OffloadStorageIndexedForm';
+import OffloadStorageRow from '../../components/OffloadStorageIndexedForm/OffloadStorageRow';
 import SourceStorageField from '../../components/SourceStorageField';
 import TargetStorageField from '../../components/TargetStorageField';
+import TargetStorageWithSuggestion from '../../components/TargetStorageWithSuggestion';
 import { defaultStorageMapping, storageMapFieldLabels } from '../../utils/constants';
 import { getStorageMapFieldId } from '../../utils/getStorageMapFieldId';
 import type { UpdateMappingsFormData } from '../utils/types';
 import { validateUpdatedStorageMaps } from '../utils/utils';
 
 type UpdateStorageMapFieldTableProps = {
-  targetStorages: TargetStorage[];
-  sourceStorages: StorageMappingValue[];
+  inventorySourceStorages: InventoryStorage[];
   isLoading: boolean;
-  loadError: Error | null;
   isVsphere: boolean;
+  loadError: Error | null;
   sourceProvider: V1beta1Provider | undefined;
+  sourceStorages: StorageMappingValue[];
+  targetStorages: TargetStorage[];
 };
 
 const UpdateStorageMapFieldTable: FC<UpdateStorageMapFieldTableProps> = ({
+  inventorySourceStorages,
   isLoading,
   isVsphere,
   loadError,
@@ -43,6 +47,7 @@ const UpdateStorageMapFieldTable: FC<UpdateStorageMapFieldTableProps> = ({
   const { t } = useForkliftTranslation();
   const { isFeatureEnabled } = useFeatureFlags();
   const isCopyOffloadEnabled = isFeatureEnabled(FEATURE_NAMES.COPY_OFFLOAD);
+  const isVsphereOffload = isVsphere && isCopyOffloadEnabled;
   const {
     control,
     formState: { isSubmitting },
@@ -86,9 +91,14 @@ const UpdateStorageMapFieldTable: FC<UpdateStorageMapFieldTableProps> = ({
                 targetStorageFieldId={getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}
               />
             </StackItem>
-            {isVsphere && isCopyOffloadEnabled && (
+            {isVsphereOffload && (
               <StackItem>
-                <OffloadStorageIndexedForm index={index} sourceProvider={sourceProvider} />
+                <OffloadStorageRow
+                  index={index}
+                  sourceProvider={sourceProvider}
+                  sourceStorages={inventorySourceStorages}
+                  targetStorages={targetStorages}
+                />
               </StackItem>
             )}
           </Stack>
@@ -99,11 +109,21 @@ const UpdateStorageMapFieldTable: FC<UpdateStorageMapFieldTableProps> = ({
             storageMappings={storageMap}
             sourceStorages={sourceStorages}
           />,
-          <TargetStorageField
-            fieldId={getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}
-            targetStorages={targetStorages}
-            testId={`target-storage-${getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}`}
-          />,
+          isVsphereOffload ? (
+            <TargetStorageWithSuggestion
+              fieldId={getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}
+              index={index}
+              sourceStorages={inventorySourceStorages}
+              targetStorages={targetStorages}
+              testId={`target-storage-${getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}`}
+            />
+          ) : (
+            <TargetStorageField
+              fieldId={getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}
+              targetStorages={targetStorages}
+              testId={`target-storage-${getStorageMapFieldId(StorageMapFieldId.TargetStorage, index)}`}
+            />
+          ),
         ],
       }))}
       addButton={{


### PR DESCRIPTION
## Links

- [MTV-5894](https://issues.redhat.com/browse/MTV-5894)

## Description

The storage map edit modal on the details page was missing offload options and vendor recommendations that are present in:
- Storage map create form
- Plan creation wizard (storage step)
- Plan mappings tab (edit modal)

**Changes:**
- Replace `OffloadStorageIndexedForm` with `OffloadStorageRow` in `UpdateStorageMapFieldTable` to enable per-row vendor resolution (datastore vendor + target provisioner matching)
- Conditionally render `TargetStorageWithSuggestion` instead of plain `TargetStorageField` when vSphere copy offload is enabled, showing Recommended/Other storage class grouping
- Pass inventory source storages from `StorageMapEdit` to `UpdateStorageMapFieldTable` to supply both new components with the inventory data they need

## Demo

Code parity fix — the edit modal now includes the same offload and suggestion components as the create form and plan wizard.

## CC://

Made with Cursor


[MTV-5894]: https://redhat.atlassian.net/browse/MTV-5894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced storage map edit screens with additional source inventory storage context.
  - Updated vSphere offload UI to use a dedicated offload row and show suggested target storage options when applicable.

- **Bug Fixes**
  - Improved rendering logic for vSphere offload configurations by selecting the correct target storage input (suggestions vs. standard field) and keeping form behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->