### PR TITLE
Resolves: MTV-5875 | Fix start-console.sh silently exiting when Forklift routes are missing

### DIFF
--- a/ci/start-console.sh
+++ b/ci/start-console.sh
@@ -145,9 +145,25 @@ fi
 # Look for forklift routes
 if oc_available_loggedin && { [ -z "${INVENTORY_SERVER_HOST+x}" ] && [ -z "${SERVICES_API_SERVER_HOST+x}" ]; }; then
     routes=$(oc get routes -A -o template --template='{{range .items}}{{.spec.host}}{{"\n"}}{{end}}' 2>/dev/null || true)
-    INVENTORY_SERVER_HOST="https://$(echo "$routes" | grep forklift-inventory)"
-    SERVICES_API_SERVER_HOST="https://$(echo "$routes" | grep forklift-services)"
-    OVA_PROXY_SERVER_HOST="https://$(echo "$routes" | grep forklift-ova-proxy || true)"
+
+    inventory_route=$(echo "$routes" | grep forklift-inventory || true)
+    services_route=$(echo "$routes" | grep forklift-services || true)
+    ova_route=$(echo "$routes" | grep forklift-ova-proxy || true)
+
+    if [[ -z "$inventory_route" || -z "$services_route" ]]; then
+        echo "Error: Required Forklift routes not found on the cluster."
+        echo ""
+        [[ -z "$inventory_route" ]] && echo "  - Missing: forklift-inventory route"
+        [[ -z "$services_route" ]] && echo "  - Missing: forklift-services route"
+        echo ""
+        echo "Make sure Forklift is installed and the operator has finished reconciling."
+        echo "You can also set INVENTORY_SERVER_HOST and SERVICES_API_SERVER_HOST manually."
+        exit 1
+    fi
+
+    INVENTORY_SERVER_HOST="https://${inventory_route}"
+    SERVICES_API_SERVER_HOST="https://${services_route}"
+    OVA_PROXY_SERVER_HOST="https://${ova_route}"
 fi
 
 # Default API server hosts


### PR DESCRIPTION
## Links

- [MTV-5875](https://redhat.atlassian.net/browse/MTV-5875)

## Description

`npm run console` (which runs `ci/start-console.sh`) silently exits with code 1 when the target cluster has no Forklift routes, leaving the developer with no indication of what went wrong.

The script uses `set -euo pipefail`, and the `grep` calls for `forklift-inventory` and `forklift-services` routes (lines 148-149) were missing `|| true` guards. When `grep` finds no match it returns exit code 1, terminating the script immediately.

- Guard all three `grep` calls with `|| true` into intermediate variables
- Validate that the required routes (`forklift-inventory`, `forklift-services`) are present
- Print a clear error message listing which routes are missing and how to work around it
- Exit gracefully with a helpful message instead of silently failing

## Demo

<!-- CLI script fix — no UI changes -->

Run `npm run console` against a cluster without Forklift installed:

**Before:** Script silently exits with code 1, no output.

**After:**
```
Error: Required Forklift routes not found on the cluster.

  - Missing: forklift-inventory route
  - Missing: forklift-services route

Make sure Forklift is installed and the operator has finished reconciling.
You can also set INVENTORY_SERVER_HOST and SERVICES_API_SERVER_HOST manually.
```

## CC://

Made with Cursor


[MTV-5875]: https://redhat.atlassian.net/browse/MTV-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console startup route detection.
  * Added validation for required inventory and services routes, with clear errors when routes are unavailable.
  * Updated service host configuration to use consistent HTTPS URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->