### PR TITLE
Resolves: MTV-6114 | Make target availability zone required for EC2 provider

### DIFF
--- a/src/providers/create/fields/ec2/Ec2TargetSettingsFields.tsx
+++ b/src/providers/create/fields/ec2/Ec2TargetSettingsFields.tsx
@@ -45,7 +45,6 @@ const Ec2TargetSettingsFields: FC = () => {
         <div className="pf-v6-u-ml-lg">
           <ProviderFormTextInput
             fieldId={ProviderFormFieldId.Ec2TargetAz}
-            isRequired={false}
             label={t('Target availability zone')}
             helperText={t('Target availability zone for migrations. EBS volumes are AZ-specific.')}
             testId="ec2-target-az-input"


### PR DESCRIPTION
## Summary

When creating an EC2 provider with manual target settings (auto-detect unchecked), the "Target availability zone" field was optional. This allowed users to create providers that appeared ready but would fail at migration time with:

```
provider spec.settings.target-az is not configured, must specify target availability zone
```

This PR makes the field required (removes `isRequired={false}`), so the form blocks submission until the user provides a value.

**Related:** MTV-5256 / PR #2396 fixed the key naming (`targetAz` → `target-az`). This ticket addresses the field not being enforced as required.

## Test plan

- [ ] Create EC2 provider with auto-detect unchecked → verify target-az shows asterisk and blocks submission if empty
- [ ] Create EC2 provider with auto-detect checked → verify target-az field is hidden (unchanged behavior)
- [ ] Fill in target-az → verify form submits and `spec.settings.target-az` is set correctly

Resolves: MTV-6114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the conditional display of the target availability zone and target region fields when automatic detection is disabled.
  * Updated the availability zone input’s configuration by removing an unnecessary “not required” override, keeping the same on-screen behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->