### PR TITLE
Resolves: None | fix(e2e): assert aria-expanded after each accordion toggle click

### DIFF
--- a/testing/playwright/page-objects/LearningExperienceDrawer.ts
+++ b/testing/playwright/page-objects/LearningExperienceDrawer.ts
@@ -166,8 +166,12 @@ export class LearningExperienceDrawer {
 
       await toggleButton.scrollIntoViewIfNeeded();
       await expect(toggleButton).toBeVisible();
+
       await toggleButton.click();
+      await expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+
       await toggleButton.click();
+      await expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     }
   }
 


### PR DESCRIPTION
## 📝 Links

Noted while investigating [MTV-6166](https://redhat.atlassian.net/browse/MTV-6166) — not itself a fix for that ticket.

## 📝 Description

`testAccordionsStructure()` fired the expand and collapse clicks on each Learning Experience drawer accordion back-to-back with no intermediate assertion. If a click failed to register (e.g. a slow re-render), the test would still pass, masking real UI issues as a "flaky click" instead of surfacing them as an assertion failure.

- **`LearningExperienceDrawer.ts`**: assert on `aria-expanded` after each click so the toggle's actual state is verified instead of assumed

## 🎥 Demo

No UI change — test-only fix.

## 📝 CC://

Resolves: None

[MTV-6166]: https://redhat.atlassian.net/browse/MTV-6166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened accordion interaction checks by scrolling toggles into view, verifying visibility, and asserting the correct expanded (`aria-expanded=true`) and collapsed (`aria-expanded=false`) states across repeated clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->