### PR TITLE
Resolves: MTV-6168 | fix(e2e): fall back to console-address-derived cluster API URL

### DIFF
--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -82,7 +82,14 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
 
       await test.step('Set language via API then navigate to overview', async () => {
         await navigation.navigateToConsole();
-        await setConsoleLanguage(page, lang);
+        const configMapPatched = await setConsoleLanguage(page, lang);
+        expect(
+          configMapPatched,
+          'Language ConfigMap patch failed — the Console will not have switched language ' +
+            'server-side, so the translated-heading assertion below is expected to fail too. ' +
+            'Check the API PATCH error logged above (a 401 usually means the auth path used ' +
+            'by BaseResourceManager is broken, not that the translation is missing).',
+        ).toBe(true);
         await navigation.navigateToOverview();
         // Let the locale file finish loading. catch() is mandatory — K8s watch streams
         // prevent networkidle from ever firing on busy clusters.

--- a/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
+++ b/testing/playwright/e2e/downstream/i18n-smoke.spec.ts
@@ -85,10 +85,8 @@ test.describe('i18n — translations smoke test', { tag: '@downstream' }, () => 
         const configMapPatched = await setConsoleLanguage(page, lang);
         expect(
           configMapPatched,
-          'Language ConfigMap patch failed — the Console will not have switched language ' +
-            'server-side, so the translated-heading assertion below is expected to fail too. ' +
-            'Check the API PATCH error logged above (a 401 usually means the auth path used ' +
-            'by BaseResourceManager is broken, not that the translation is missing).',
+          'Language ConfigMap patch failed — check the API PATCH error logged above, not the ' +
+            'translated-heading assertion below.',
         ).toBe(true);
         await navigation.navigateToOverview();
         // Let the locale file finish loading. catch() is mandatory — K8s watch streams

--- a/testing/playwright/fixtures/helpers/languageHelpers.ts
+++ b/testing/playwright/fixtures/helpers/languageHelpers.ts
@@ -64,11 +64,8 @@ const setLocalStorageLanguage = async (page: Page, language: string): Promise<vo
  * After calling this, do a full `page.goto()` to a target page — the Console
  * will initialize in the requested language.
  *
- * Returns whether the ConfigMap patch succeeded. The localStorage write always
- * happens regardless (it's what makes auth-disabled clusters work), so this is
- * informational rather than something every caller needs to check — but tests
- * that rely on the ConfigMap actually being updated should assert on it instead
- * of only discovering the failure much later via an unrelated UI assertion.
+ * Returns whether the ConfigMap patch succeeded, so callers can assert on it
+ * directly instead of discovering the failure later via an unrelated UI check.
  */
 export const setConsoleLanguage = async (
   page: Page,

--- a/testing/playwright/fixtures/helpers/languageHelpers.ts
+++ b/testing/playwright/fixtures/helpers/languageHelpers.ts
@@ -63,13 +63,19 @@ const setLocalStorageLanguage = async (page: Page, language: string): Promise<vo
  *
  * After calling this, do a full `page.goto()` to a target page — the Console
  * will initialize in the requested language.
+ *
+ * Returns whether the ConfigMap patch succeeded. The localStorage write always
+ * happens regardless (it's what makes auth-disabled clusters work), so this is
+ * informational rather than something every caller needs to check — but tests
+ * that rely on the ConfigMap actually being updated should assert on it instead
+ * of only discovering the failure much later via an unrelated UI assertion.
  */
 export const setConsoleLanguage = async (
   page: Page,
   language: SupportedLanguage,
-): Promise<void> => {
+): Promise<boolean> => {
   await setLocalStorageLanguage(page, language);
-  await patchLanguageConfigMap(language);
+  return patchLanguageConfigMap(language);
 };
 
 /**

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -53,6 +53,32 @@ const OC_BINARY_LOCATIONS = ['/usr/local/bin/oc', '/usr/bin/oc', '/opt/homebrew/
 
 const findOcBinary = (): string | null => OC_BINARY_LOCATIONS.find(existsSync) ?? null;
 
+const DEFAULT_CLUSTER_API_PORT = '6443';
+const CONSOLE_ROUTE_HOST_PREFIX = 'console-openshift-console.apps.';
+
+/**
+ * Best-effort fallback for when the cookie-authenticated infrastructure lookup
+ * (`fetchClusterApiUrl`) fails: derives the cluster API server URL from the
+ * console's own address. Only works for OpenShift's default DNS layout, where
+ * the console route host is `console-openshift-console.apps.<cluster-domain>`
+ * and the API server is reachable at `api.<cluster-domain>:6443` — clusters
+ * with custom console routes will not match and this returns null.
+ */
+const deriveClusterApiUrlFromConsoleAddress = (): string | null => {
+  const consoleAddress = process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS;
+  if (!consoleAddress) return null;
+
+  try {
+    const { hostname } = new URL(consoleAddress);
+    if (!hostname.startsWith(CONSOLE_ROUTE_HOST_PREFIX)) return null;
+
+    const clusterDomain = hostname.slice(CONSOLE_ROUTE_HOST_PREFIX.length);
+    return `https://api.${clusterDomain}:${DEFAULT_CLUSTER_API_PORT}`;
+  } catch {
+    return null;
+  }
+};
+
 /**
  * Runs `oc login` to generate a kubeconfig at KUBECONFIG_FILE.
  * Writes KUBECONFIG_PATH into process.env so subsequent Node.js HTTP calls in
@@ -64,13 +90,28 @@ const findOcBinary = (): string | null => OC_BINARY_LOCATIONS.find(existsSync) ?
  *  - The `oc` binary is not available
  */
 const generateKubeconfig = async (username: string, password: string): Promise<void> => {
-  const clusterApiUrl =
-    process.env.CLUSTER_API_URL?.replace(/\/$/, '') ?? (await fetchClusterApiUrl());
+  let clusterApiUrl = process.env.CLUSTER_API_URL?.replace(/\/$/, '') ?? null;
+
+  if (!clusterApiUrl) {
+    clusterApiUrl = await fetchClusterApiUrl();
+
+    if (!clusterApiUrl) {
+      console.error(
+        '⚠️ Cookie-authenticated infrastructure lookup could not determine the cluster API ' +
+          'URL — falling back to deriving it from the console address.',
+      );
+      clusterApiUrl = deriveClusterApiUrlFromConsoleAddress();
+      if (clusterApiUrl) {
+        console.error(`📌 Derived cluster API URL from console address: ${clusterApiUrl}`);
+      }
+    }
+  }
 
   if (!clusterApiUrl) {
     console.error(
-      '⚠️ Could not determine cluster API URL — skipping kubeconfig generation. ' +
-        'Set CLUSTER_API_URL env var to enable kubeconfig-based auth.',
+      '⚠️ Could not determine cluster API URL by any method (infrastructure lookup and ' +
+        'console-address fallback both failed) — skipping kubeconfig generation. Set ' +
+        'CLUSTER_API_URL env var to enable kubeconfig-based auth.',
     );
     return;
   }


### PR DESCRIPTION
## 📝 Links

[MTV-6168](https://redhat.atlassian.net/browse/MTV-6168)

## 📝 Description

`global.setup.ts`'s `generateKubeconfig()` relied solely on a cookie-authenticated infrastructure lookup (`fetchClusterApiUrl()`) to find the cluster API server before running `oc login`. On clusters where that cookie-based console-proxy call is rejected (401), kubeconfig generation was silently skipped, forcing every `BaseResourceManager` call in the run onto the session-cookie fallback path — which fails the same way, breaking any test that depends on direct API helpers (NAD creation, ConfigMap patches, version auto-detection).

- **`global.setup.ts`**: when the infrastructure lookup fails, derive the API URL from the console's own address (default OpenShift DNS layout: `console-openshift-console.apps.<domain>` → `api.<domain>:6443`) so `oc login` still gets a chance to run; log clearly which lookup path succeeded so this class of failure is diagnosable from CI output instead of a single easy-to-miss warning
- **`languageHelpers.ts`**: `setConsoleLanguage()` now returns the ConfigMap-patch result instead of dropping it, so callers that need the write to have actually happened can check
- **`i18n-smoke.spec.ts`**: assert on that result instead of only failing later on the unrelated translated-heading assertion, which used to look like a translation bug rather than an auth failure

## 🎥 Demo

No UI change — test-only fix.

## 📝 CC://

Resolves: MTV-6168

[MTV-6168]: https://redhat.atlassian.net/browse/MTV-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ