### PR TITLE
Resolves: None | chore(e2e): use built-in printFailuresInline instead of a custom reporter

### DIFF
--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -13,9 +13,9 @@
       },
       "devDependencies": {
         "@kubernetes/client-node": "^1.4.0",
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^20.0.0",
-        "playwright": "^1.60.0",
+        "playwright": "^1.61.1",
         "typescript": "^5.8.2"
       }
     },
@@ -95,13 +95,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -753,13 +753,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/testing/package.json
+++ b/testing/package.json
@@ -17,9 +17,9 @@
   "description": "",
   "devDependencies": {
     "@kubernetes/client-node": "^1.4.0",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^20.0.0",
-    "playwright": "^1.60.0",
+    "playwright": "^1.61.1",
     "typescript": "^5.8.2"
   },
   "dependencies": {

--- a/testing/playwright.config.ts
+++ b/testing/playwright.config.ts
@@ -30,7 +30,9 @@ export default defineConfig({
   retries: process.env.GITHUB_ACTIONS ? 3 : 0,
 
   reporter: [
-    ['list'],
+    // printFailuresInline keeps failure causes visible even if a CI run is interrupted
+    // or times out mid-suite before the end-of-run report is written.
+    ['list', { printFailuresInline: true }],
     ['html', { open: 'never' }],
     ['junit', { outputFile: 'test-results/junit.xml' }],
   ],


### PR DESCRIPTION
## 📝 Links

None

## 📝 Description

Split from this PR: the alerts-card exact-match fix now lives in #2529, since it was an unrelated change bundled in by mistake.

Playwright's `list` reporter has natively supported printing failure details immediately after a failed test (instead of only at the end of the run) since v1.61.0, via the `printFailuresInline` option. Bumped `playwright`/`@playwright/test` from `1.60.0` to `1.61.1` and enabled it, rather than maintaining a hand-rolled reporter that reimplements the same behavior without upstream's retry/TTY/color-awareness. This keeps failure causes visible even if a CI run is interrupted mid-suite.

## 🎥 Demo

No UI change — test-only.

## 📝 CC://

Resolves: None