### PR TITLE
Resolves: None | fix(e2e): retry guided-tour dismissal to survive tour re-render race

### DIFF
--- a/testing/playwright/utils/timeouts.ts
+++ b/testing/playwright/utils/timeouts.ts
@@ -3,6 +3,10 @@ export const GUIDED_TOUR_VISIBLE_TIMEOUT_MS = 2_000;
 /** force:true bypasses animation-stability checks; keep timeout short. */
 export const GUIDED_TOUR_CLICK_TIMEOUT_MS = 3_000;
 export const GUIDED_TOUR_HIDDEN_TIMEOUT_MS = 3_000;
+/** Total attempts before giving up on dismissing the guided tour. */
+export const GUIDED_TOUR_MAX_ATTEMPTS = 3;
+/** Backoff between attempts, letting an in-flight tour re-render settle. */
+export const GUIDED_TOUR_RETRY_BACKOFF_MS = 500;
 
 /** Initial check before reloading when the dynamic plugin may not have registered its routes yet. */
 export const PAGE_LOAD_INITIAL_TIMEOUT_MS = 10_000;

--- a/testing/playwright/utils/utils.ts
+++ b/testing/playwright/utils/utils.ts
@@ -3,24 +3,41 @@ import { expect, type Locator, type Page } from '@playwright/test';
 import {
   GUIDED_TOUR_CLICK_TIMEOUT_MS,
   GUIDED_TOUR_HIDDEN_TIMEOUT_MS,
+  GUIDED_TOUR_MAX_ATTEMPTS,
+  GUIDED_TOUR_RETRY_BACKOFF_MS,
   GUIDED_TOUR_VISIBLE_TIMEOUT_MS,
 } from './timeouts';
 
+/**
+ * Dismisses the guided tour modal, retrying the click if the tour is still
+ * mid-transition when it fires. The "Skip tour" button can report visible via
+ * waitFor and still fail a forced click moments later — the tour re-renders
+ * its position during its entrance animation, briefly detaching/reattaching
+ * the button node. Retrying (rather than a longer single timeout) re-resolves
+ * the locator against the settled DOM instead of racing the same transition.
+ */
 export const disableGuidedTour = async (page: Page): Promise<void> => {
   // Use .first() to avoid strict-mode crashes if two skip buttons are briefly in the DOM.
   const skipButton = page.getByRole('button', { name: /skip tour/i }).first();
 
-  let isVisible = false;
-  try {
-    await skipButton.waitFor({ state: 'visible', timeout: GUIDED_TOUR_VISIBLE_TIMEOUT_MS });
-    isVisible = true;
-  } catch {
-    // Tour not present on this build — nothing to dismiss.
-  }
+  for (let attempt = 1; attempt <= GUIDED_TOUR_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await skipButton.waitFor({ state: 'visible', timeout: GUIDED_TOUR_VISIBLE_TIMEOUT_MS });
+    } catch {
+      // Tour not present on this build — nothing to dismiss.
+      return;
+    }
 
-  if (isVisible) {
-    await skipButton.click({ force: true, timeout: GUIDED_TOUR_CLICK_TIMEOUT_MS });
-    await skipButton.waitFor({ state: 'hidden', timeout: GUIDED_TOUR_HIDDEN_TIMEOUT_MS });
+    try {
+      await skipButton.click({ force: true, timeout: GUIDED_TOUR_CLICK_TIMEOUT_MS });
+      await skipButton.waitFor({ state: 'hidden', timeout: GUIDED_TOUR_HIDDEN_TIMEOUT_MS });
+      return;
+    } catch (error) {
+      if (attempt === GUIDED_TOUR_MAX_ATTEMPTS) {
+        throw error;
+      }
+      await page.waitForTimeout(GUIDED_TOUR_RETRY_BACKOFF_MS);
+    }
   }
 };
 


### PR DESCRIPTION
## 📝 Links

None

## 📝 Description

`disableGuidedTour()` intermittently failed global setup with a click timeout, even though the "Skip tour" button had just been confirmed visible:

```
❌ Login failed in global setup: locator.click: Timeout 3000ms exceeded.
Call log:
  - waiting for getByRole('button', { name: /skip tour/i }).first()
```

The tour modal re-renders its position during its entrance animation, briefly detaching/reattaching the button node. `waitFor('visible')` can resolve just before that happens, so the subsequent forced click races the same transition and times out.

Retries the click/hidden sequence up to 3 times with a short backoff instead of only lengthening the single-attempt timeout, so a fresh locator resolution is attempted against the settled DOM rather than repeatedly racing the same transition. Verified locally against a live cluster — reproduced the failure, applied the fix, then ran global setup 3x fresh with no further failures.

## 🎥 Demo

No UI change — test-only.

## 📝 CC://

Resolves: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guided-tour dismissal during transitions by retrying when necessary.
  * Reduced test interruptions caused by the tour appearing or remaining visible unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->