### PR TITLE
Resolves: None | fix(e2e): treat tour hidden state as success, not the click, in disableGuidedTour

### DIFF
--- a/testing/playwright/utils/utils.ts
+++ b/testing/playwright/utils/utils.ts
@@ -9,21 +9,12 @@ import {
 /**
  * Dismisses the guided tour modal.
  *
- * The console persists tour completion per-user server-side (the
- * `console.guidedTour` key in the user-settings ConfigMap). Once a prior test
- * run has dismissed the tour, that flag is `completed: true`, so on every
- * subsequent load the console optimistically mounts the tour modal before
- * its settings fetch resolves, then immediately unmounts it once it reads
- * `completed: true` back. Our own `waitFor('visible')` can catch that
- * optimistic render right before the unmount, so the click that follows can
- * fire into an element that's already being torn down — a deterministic
- * race once the flag is set, not occasional flakiness.
- *
- * The click itself is just a means to an end: what actually matters is that
- * the tour is gone before tests proceed. So a click failure isn't treated as
- * fatal on its own — we still assert the tour ends up hidden (whether we
- * dismissed it or the console's own settings sync did), and only fail if it
- * doesn't.
+ * Once the tour has been dismissed before (completion is persisted per-user
+ * server-side), the console briefly mounts the modal on every load before
+ * unmounting it once its settings fetch resolves. `waitFor('visible')` can
+ * catch that optimistic render right before teardown, so the click can race
+ * an element that's already disappearing. The click is a means to an end,
+ * not the success criterion — only the final `waitFor('hidden')` is.
  */
 export const disableGuidedTour = async (page: Page): Promise<void> => {
   // Use .first() to avoid strict-mode crashes if two skip buttons are briefly in the DOM.
@@ -39,9 +30,8 @@ export const disableGuidedTour = async (page: Page): Promise<void> => {
   try {
     await skipButton.click({ force: true, timeout: GUIDED_TOUR_CLICK_TIMEOUT_MS });
   } catch {
-    // Click may race the console's own dismissal once the tour is already
-    // marked completed server-side; fall through to the hidden-state check,
-    // which is the real success criterion.
+    // May race the console's own dismissal; the hidden-state check below is
+    // the real success criterion, so a click failure alone isn't fatal.
   }
   await skipButton.waitFor({ state: 'hidden', timeout: GUIDED_TOUR_HIDDEN_TIMEOUT_MS });
 };

--- a/testing/playwright/utils/utils.ts
+++ b/testing/playwright/utils/utils.ts
@@ -6,22 +6,44 @@ import {
   GUIDED_TOUR_VISIBLE_TIMEOUT_MS,
 } from './timeouts';
 
+/**
+ * Dismisses the guided tour modal.
+ *
+ * The console persists tour completion per-user server-side (the
+ * `console.guidedTour` key in the user-settings ConfigMap). Once a prior test
+ * run has dismissed the tour, that flag is `completed: true`, so on every
+ * subsequent load the console optimistically mounts the tour modal before
+ * its settings fetch resolves, then immediately unmounts it once it reads
+ * `completed: true` back. Our own `waitFor('visible')` can catch that
+ * optimistic render right before the unmount, so the click that follows can
+ * fire into an element that's already being torn down — a deterministic
+ * race once the flag is set, not occasional flakiness.
+ *
+ * The click itself is just a means to an end: what actually matters is that
+ * the tour is gone before tests proceed. So a click failure isn't treated as
+ * fatal on its own — we still assert the tour ends up hidden (whether we
+ * dismissed it or the console's own settings sync did), and only fail if it
+ * doesn't.
+ */
 export const disableGuidedTour = async (page: Page): Promise<void> => {
   // Use .first() to avoid strict-mode crashes if two skip buttons are briefly in the DOM.
   const skipButton = page.getByRole('button', { name: /skip tour/i }).first();
 
-  let isVisible = false;
   try {
     await skipButton.waitFor({ state: 'visible', timeout: GUIDED_TOUR_VISIBLE_TIMEOUT_MS });
-    isVisible = true;
   } catch {
     // Tour not present on this build — nothing to dismiss.
+    return;
   }
 
-  if (isVisible) {
+  try {
     await skipButton.click({ force: true, timeout: GUIDED_TOUR_CLICK_TIMEOUT_MS });
-    await skipButton.waitFor({ state: 'hidden', timeout: GUIDED_TOUR_HIDDEN_TIMEOUT_MS });
+  } catch {
+    // Click may race the console's own dismissal once the tour is already
+    // marked completed server-side; fall through to the hidden-state check,
+    // which is the real success criterion.
   }
+  await skipButton.waitFor({ state: 'hidden', timeout: GUIDED_TOUR_HIDDEN_TIMEOUT_MS });
 };
 
 // Dynamic plugin may not have registered its routes yet on first load; reload and retry once.


### PR DESCRIPTION
## 📝 Links

None

## 📝 Description

`disableGuidedTour()` in global setup started failing deterministically:

```
❌ Login failed in global setup: locator.click: Timeout 3000ms exceeded.
Call log:
  - waiting for getByRole('button', { name: /skip tour/i }).first()
```

The failure screenshot showed no tour modal at all — just the fully-loaded dashboard.

**Verified root cause**: the console persists tour completion per-user server-side via the `console.guidedTour` key in the `user-settings-<user>` ConfigMap. Confirmed on-cluster:

```
$ oc get configmap user-settings-kubeadmin -n openshift-console-user-settings \
    -o jsonpath='{.data.console\.guidedTour}'
{"admin":{"completed":true}}
```

Once that flag is `true` (set by *any* prior successful dismissal — including our own test runs, which is why this went from "not happening" to "happening every time"), the console optimistically mounts the tour modal on every page load before its settings fetch resolves, then immediately unmounts it once it reads `completed: true` back. `waitFor('visible')` can catch that optimistic render right before the async unmount, so the click that follows fires into an element that's already being torn down. Once the flag is set this is a deterministic race, not occasional flakiness.

**Fix**: the click is only a means to an end — what actually matters is that the tour ends up gone. Stop treating a click failure as fatal on its own; fall through to the existing `waitFor('hidden')` check (the real success criterion) and only fail if the tour is still blocking the page after that.

Verified locally against the live cluster with the flag confirmed `true`: ran global setup 3x fresh (cleared auth each time) — all 3 passed with no tour-related errors, versus 100% failure before the fix.

## 🎥 Demo

No UI change — test-only.

## 📝 CC://

Resolves: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved guided-tour handling in automated tests.
  * Added more reliable waiting for tour dismissal and graceful handling of concurrent or incomplete dismissals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->