### PR TITLE
Resolves: None | fix(e2e): use exact text match for alerts card summary counts

### DIFF
--- a/testing/playwright/e2e/downstream/overview-alerts-card.spec.ts
+++ b/testing/playwright/e2e/downstream/overview-alerts-card.spec.ts
@@ -26,8 +26,8 @@ test.describe(
 
       await test.step('verify summary counts are displayed', async () => {
         const alertsCard = page.getByTestId('migration-alerts-card');
-        await expect(alertsCard.getByText('Failed')).toBeVisible();
-        await expect(alertsCard.getByText('Succeeded')).toBeVisible();
+        await expect(alertsCard.getByText('Failed', { exact: true })).toBeVisible();
+        await expect(alertsCard.getByText('Succeeded', { exact: true })).toBeVisible();
       });
     });
 


### PR DESCRIPTION
## 📝 Links

None

## 📝 Description

Split out of #2526, which bundled two unrelated test-infra changes.

`getByText('Failed')` / `getByText('Succeeded')` without exact matching can also match longer strings containing those words elsewhere in the migration alerts card (e.g. `MigrationFailed`/`MigrationSucceeded` alert names), risking a strict-mode violation or a false match. Scoped both locators to an exact match — mirrors the same `exact: true` already used in this component's Jest unit test for the identical reason.

## 🎥 Demo

No UI change — test-only.

## 📝 CC://

Resolves: None