### PR TITLE
Resolves: MTV-6157 MTV-6158 MTV-6159 MTV-6160 | Fix CVE vulnerabilities for main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14237,15 +14237,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "node_modules/lint-staged": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
@@ -16868,6 +16859,25 @@
       "dependencies": {
         "linkify-it": "^2.0.3",
         "tlds": "^1.199.0"
+      }
+    },
+    "node_modules/react-linkify/node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/react-redux": {
@@ -19792,9 +19802,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT"
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
   "overrides": {
     "dompurify": ">=3.3.2",
     "electron-to-chromium": "1.5.387",
+    "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "monaco-editor": "^0.52.2",
     "node-forge": "^1.3.2",


### PR DESCRIPTION
## Links

> References: https://issues.redhat.com/browse/MTV-6157, https://issues.redhat.com/browse/MTV-6158, https://issues.redhat.com/browse/MTV-6159, https://issues.redhat.com/browse/MTV-6160

## Description

Fix CVE vulnerabilities in dependencies for the `main` branch.

**CVEs addressed:**
- CVE-2026-48801 (`linkify-it` 2.2.0 → 5.0.2 via override/resolution)

**Companion PRs:**
- main: https://github.com/kubev2v/forklift-console-plugin/pull/2531
- release-2.12: https://github.com/kubev2v/forklift-console-plugin/pull/2532
- release-2.11: https://github.com/kubev2v/forklift-console-plugin/pull/2533
- release-2.10: https://github.com/kubev2v/forklift-console-plugin/pull/2534
- release-2.9: https://github.com/kubev2v/forklift-console-plugin/pull/2535

## Verification

- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Audit shows no critical/high for targeted CVEs

Resolves: MTV-6157 MTV-6158 MTV-6159 MTV-6160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled link-detection component to version 5.0.2 for improved consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->