### PR TITLE
Resolves: MTV-6160 | Fix CVE vulnerabilities for release-2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
     "dompurify": ">=3.3.2",
+    "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "monaco-editor": "^0.52.2",
     "node-forge": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6776,12 +6776,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^2.0.3:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+linkify-it@5.0.2, linkify-it@^2.0.3:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 lint-staged@^15.4.3:
   version "15.5.2"
@@ -9369,10 +9369,10 @@ typescript@^5.0.4, typescript@^5.8.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
-uc.micro@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
-  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Links

> References: https://issues.redhat.com/browse/MTV-6160

## Description

Fix CVE vulnerabilities in dependencies for the `release-2.9` branch.

**CVEs addressed:**
- CVE-2026-48801 (`linkify-it` 2.2.0 → 5.0.2 via override/resolution)

**Companion PRs:**
- main: https://github.com/kubev2v/forklift-console-plugin/pull/2531
- release-2.12: https://github.com/kubev2v/forklift-console-plugin/pull/2532
- release-2.11: https://github.com/kubev2v/forklift-console-plugin/pull/2533
- release-2.10: https://github.com/kubev2v/forklift-console-plugin/pull/2534
- release-2.9: https://github.com/kubev2v/forklift-console-plugin/pull/2535

## Verification

- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Audit shows no critical/high for targeted CVEs

Resolves: MTV-6160