### PR TITLE
Resolves: MTV-855 | Advertise KubeVirt default virt storage class

### DIFF
--- a/.cursor/rules/frontend/mappings.mdc
+++ b/.cursor/rules/frontend/mappings.mdc
@@ -133,7 +133,7 @@ Used in: list row actions + details page header.
 | `useOpenShiftNetworks` | NADs on OpenShift target |
 | `useTargetNetworks` | Target network select options |
 | `useSourceStorages` | Source datastores/storage domains (provider-type-specific) |
-| `useTargetStorages` | Target StorageClasses (+ default ordering, NetApp Shift) |
+| `useTargetStorages` | Target StorageClasses (virt-default → k8s-default ordering, NetApp Shift) |
 | `useProviderInventory` | Low-level Forklift inventory REST client |
 | `useStorageMapCrd` | CRD schema for enum discovery |
 | `useOffloadPlugins` | Offload plugin names from CRD + constants |

--- a/src/storageMaps/components/TargetStorageField.tsx
+++ b/src/storageMaps/components/TargetStorageField.tsx
@@ -28,9 +28,19 @@ type TargetStorageFieldProps = {
   suggestedVendorProduct?: StorageVendorProduct;
 };
 
+const shouldShowDefaultLabel = (storage: TargetStorage): boolean =>
+  storage.isDefaultVirt || storage.isDefault;
+
 const renderStorageOption = (storage: TargetStorage, t: (k: string) => string) => (
   <Split hasGutter>
     <SplitItem isFilled>{storage.name}</SplitItem>
+    {shouldShowDefaultLabel(storage) && (
+      <SplitItem>
+        <Label isCompact color="green">
+          {t('Default')}
+        </Label>
+      </SplitItem>
+    )}
     {storage.isNetAppShift && (
       <SplitItem>
         <Label isCompact color="blue">

--- a/src/storageMaps/utils/__tests__/netAppShift.test.ts
+++ b/src/storageMaps/utils/__tests__/netAppShift.test.ts
@@ -32,6 +32,7 @@ describe('getNetAppShiftLabels', () => {
   const shiftStorage: TargetStorage = {
     id: 'sc-1',
     isDefault: false,
+    isDefaultVirt: false,
     isNetAppShift: true,
     name: 'netapp-sc',
   };
@@ -39,6 +40,7 @@ describe('getNetAppShiftLabels', () => {
   const regularStorage: TargetStorage = {
     id: 'sc-2',
     isDefault: true,
+    isDefaultVirt: false,
     name: 'standard-sc',
   };
 

--- a/src/utils/hooks/useTargetStorages.ts
+++ b/src/utils/hooks/useTargetStorages.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useOpenShiftStorages } from 'src/utils/hooks/useStorages';
 
 import type { V1beta1Provider } from '@forklift-ui/types';
-import { isNetAppShiftStorageClassAnnotations } from '@utils/storage/netAppShift';
-import { StorageClassAnnotation, type TargetStorage } from '@utils/storage/types';
+import { mapTargetStorages } from '@utils/storage/mapTargetStorages';
+import type { TargetStorage } from '@utils/storage/types';
 
 const useTargetStorages = (
   targetProvider: V1beta1Provider | undefined,
@@ -13,27 +13,7 @@ const useTargetStorages = (
     useOpenShiftStorages(targetProvider);
 
   const targetStorages = useMemo(
-    () =>
-      availableTargetStorages?.reduce((acc: TargetStorage[], storage) => {
-        if (storage.namespace === targetProject || !storage.namespace) {
-          const scAnnotations = storage?.object?.metadata?.annotations;
-          const isDefault = scAnnotations?.[StorageClassAnnotation.IsDefault] === 'true';
-          const targetStorage: TargetStorage = {
-            id: storage.uid,
-            isDefault,
-            isNetAppShift: isNetAppShiftStorageClassAnnotations(scAnnotations),
-            name: storage.name,
-            provisioner: storage?.object?.provisioner,
-          };
-
-          if (isDefault) {
-            return [targetStorage, ...acc];
-          }
-          return [...acc, targetStorage];
-        }
-
-        return acc;
-      }, []),
+    () => mapTargetStorages(availableTargetStorages, targetProject),
     [availableTargetStorages, targetProject],
   );
 

--- a/src/utils/storage/__tests__/mapTargetStorages.test.ts
+++ b/src/utils/storage/__tests__/mapTargetStorages.test.ts
@@ -1,0 +1,85 @@
+import type { OpenShiftStorageClass } from '@forklift-ui/types';
+import { mapTargetStorages } from '@utils/storage/mapTargetStorages';
+import { StorageClassAnnotation } from '@utils/storage/types';
+
+const makeStorage = (
+  name: string,
+  annotations: Record<string, string> = {},
+  namespace?: string,
+): OpenShiftStorageClass =>
+  ({
+    name,
+    namespace,
+    object: {
+      metadata: { annotations },
+      provisioner: 'test.csi/driver',
+    },
+    uid: `uid-${name}`,
+  }) as OpenShiftStorageClass;
+
+describe('mapTargetStorages', () => {
+  it('places virt-default ahead of k8s-default and others', () => {
+    const storages = [
+      makeStorage('other-a'),
+      makeStorage('k8s-default', { [StorageClassAnnotation.IsDefault]: 'true' }),
+      makeStorage('other-b'),
+      makeStorage('virt-default', {
+        [StorageClassAnnotation.IsDefaultVirtClass]: 'true',
+      }),
+    ];
+
+    const result = mapTargetStorages(storages, undefined);
+
+    expect(result.map((storage) => storage.name)).toEqual([
+      'virt-default',
+      'k8s-default',
+      'other-a',
+      'other-b',
+    ]);
+    expect(result[0].isDefaultVirt).toBe(true);
+    expect(result[1].isDefault).toBe(true);
+  });
+
+  it('places k8s-default first when no virt-default exists', () => {
+    const storages = [
+      makeStorage('other'),
+      makeStorage('k8s-default', { [StorageClassAnnotation.IsDefault]: 'true' }),
+    ];
+
+    const result = mapTargetStorages(storages, undefined);
+
+    expect(result.map((storage) => storage.name)).toEqual(['k8s-default', 'other']);
+  });
+
+  it('treats a class with both annotations as virt-default only', () => {
+    const storages = [
+      makeStorage('k8s-only', { [StorageClassAnnotation.IsDefault]: 'true' }),
+      makeStorage('both', {
+        [StorageClassAnnotation.IsDefault]: 'true',
+        [StorageClassAnnotation.IsDefaultVirtClass]: 'true',
+      }),
+    ];
+
+    const result = mapTargetStorages(storages, undefined);
+
+    expect(result.map((storage) => storage.name)).toEqual(['both', 'k8s-only']);
+    expect(result[0].isDefaultVirt).toBe(true);
+    expect(result[0].isDefault).toBe(true);
+  });
+
+  it('filters namespaced storages that do not match the target project', () => {
+    const storages = [
+      makeStorage('in-project', {}, 'ns-a'),
+      makeStorage('other-project', {}, 'ns-b'),
+      makeStorage('cluster-scoped'),
+    ];
+
+    const result = mapTargetStorages(storages, 'ns-a');
+
+    expect(result.map((storage) => storage.name)).toEqual(['in-project', 'cluster-scoped']);
+  });
+
+  it('returns an empty list when input is undefined', () => {
+    expect(mapTargetStorages(undefined, 'ns-a')).toEqual([]);
+  });
+});

--- a/src/utils/storage/mapTargetStorages.ts
+++ b/src/utils/storage/mapTargetStorages.ts
@@ -1,0 +1,43 @@
+import type { OpenShiftStorageClass } from '@forklift-ui/types';
+import { isNetAppShiftStorageClassAnnotations } from '@utils/storage/netAppShift';
+import { StorageClassAnnotation, type TargetStorage } from '@utils/storage/types';
+
+/**
+ * Maps OpenShift StorageClasses to TargetStorage entries, ordered so that
+ * KubeVirt virt-default classes come first, then k8s default, then others.
+ */
+export const mapTargetStorages = (
+  availableTargetStorages: OpenShiftStorageClass[] | undefined,
+  targetProject: string | undefined,
+): TargetStorage[] => {
+  const virtDefaults: TargetStorage[] = [];
+  const k8sDefaults: TargetStorage[] = [];
+  const others: TargetStorage[] = [];
+
+  for (const storage of availableTargetStorages ?? []) {
+    if (storage.namespace === targetProject || !storage.namespace) {
+      const scAnnotations = storage.object?.metadata?.annotations;
+      const isDefault = scAnnotations?.[StorageClassAnnotation.IsDefault] === 'true';
+      const isDefaultVirt = scAnnotations?.[StorageClassAnnotation.IsDefaultVirtClass] === 'true';
+
+      const targetStorage: TargetStorage = {
+        id: storage.uid,
+        isDefault,
+        isDefaultVirt,
+        isNetAppShift: isNetAppShiftStorageClassAnnotations(scAnnotations),
+        name: storage.name,
+        provisioner: storage.object?.provisioner,
+      };
+
+      if (isDefaultVirt) {
+        virtDefaults.push(targetStorage);
+      } else if (isDefault) {
+        k8sDefaults.push(targetStorage);
+      } else {
+        others.push(targetStorage);
+      }
+    }
+  }
+
+  return [...virtDefaults, ...k8sDefaults, ...others];
+};

--- a/src/utils/storage/types.ts
+++ b/src/utils/storage/types.ts
@@ -10,12 +10,14 @@ export type TargetStorage = {
   id: string;
   name: string;
   isDefault: boolean;
+  isDefaultVirt: boolean;
   isNetAppShift?: boolean;
   provisioner?: string;
 };
 
 export enum StorageClassAnnotation {
   IsDefault = 'storageclass.kubernetes.io/is-default-class',
+  IsDefaultVirtClass = 'storageclass.kubevirt.io/is-default-virt-class',
   NetAppShiftStorageClassType = 'shift.netapp.io/storage-class-type',
 }
 


### PR DESCRIPTION
## Summary
- Prefer StorageClasses annotated with `storageclass.kubevirt.io/is-default-virt-class` ahead of the Kubernetes default when listing target storages
- Show a green **Default** label on virt-default (and k8s-default) options in the target storage selector
- Covers plan wizard, plan mappings edit, and storage map create/edit via shared `useTargetStorages` / `TargetStorageField`

## Test plan
- [x] Unit: `npm test -- --testPathPattern=mapTargetStorages`
- [x] UI: Create storage map → select OpenShift target provider → open **Target storage** dropdown
- [x] Confirm virt-default SC (e.g. `ocs-storagecluster-ceph-rbd-virtualization`) is listed first with a **Default** label
- [x] Same check from Plan create wizard → Storage map step (new map)

## Demo

<img width="666" height="338" alt="Screenshot (68)" src="https://github.com/user-attachments/assets/cac1bfd4-5c5f-4d68-89a8-c6052c0071ab" />

Resolves: MTV-855


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage options now clearly display a green **Default** label when marked as the default virtualization or Kubernetes storage.
  * Target storage options are ordered with virtualization defaults first, followed by Kubernetes defaults and other available options.
  * Storage lists now show only project-compatible options while retaining cluster-wide storage choices.
  * Existing **NetApp Shift** labels remain available alongside default indicators.
* **Documentation**
  * Updated architecture documentation to reflect the new target storage ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->