### PR TITLE
Resolves: MTV-6186 | Fix CVE vulnerabilities for release-2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8589,9 +8589,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   "overrides": {
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
-    "dompurify": ">=3.3.2",
+    "dompurify": ">=3.4.7",
     "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "monaco-editor": "^0.52.2",


### PR DESCRIPTION
## Links

> References: https://issues.redhat.com/browse/MTV-6186

## Description

Fix CVE vulnerabilities in dependencies for the `release-2.11` branch.

**CVEs addressed:**
- CVE-2026-49978 (dompurify XSS) — bump override/resolution to `>=3.4.7` (locked at 3.4.12)

**Companion PRs:**
- release-2.12: #2572
- release-2.10: #2574

## Verification

- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Audit shows no critical/high for targeted CVEs

Resolves: MTV-6186