### PR TITLE
Resolves: MTV-6187 | Fix CVE vulnerabilities for release-2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   "resolutions": {
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
-    "dompurify": ">=3.3.2",
+    "dompurify": ">=3.4.7",
     "linkify-it": "5.0.2",
     "lodash": "4.18.1",
     "monaco-editor": "^0.52.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3974,10 +3974,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@>=3.3.2, dompurify@^3.2.4:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
-  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
+dompurify@>=3.4.7, dompurify@^3.2.4:
+  version "3.4.12"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
+  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Links

> References: https://issues.redhat.com/browse/MTV-6187

## Description

Fix CVE vulnerabilities in dependencies for the `release-2.10` branch.

**CVEs addressed:**
- CVE-2026-49978 (dompurify XSS) — bump override/resolution to `>=3.4.7` (locked at 3.4.12)

**Companion PRs:**
- release-2.12: #2572
- release-2.11: #2573

## Verification

- [x] Lint passes
- [x] Tests pass
- [x] Build succeeds
- [x] Audit shows no critical/high for targeted CVEs

Resolves: MTV-6187