### PR TITLE
Resolves: MTV-2152 | add sort to Disk transfer/counter columns and fix value mismatch

### DIFF
--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/__tests__/getVMDiskTransferPipeline.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/__tests__/getVMDiskTransferPipeline.test.ts
@@ -1,0 +1,145 @@
+import type {
+  V1beta1PlanStatusMigrationVms,
+  V1beta1PlanStatusMigrationVmsPipeline,
+} from '@forklift-ui/types';
+import { describe, expect, it } from '@jest/globals';
+
+import { getVMDiskTransferPipeline } from '../utils';
+
+const makePipe = (
+  overrides: Partial<V1beta1PlanStatusMigrationVmsPipeline> & { name: string },
+): V1beta1PlanStatusMigrationVmsPipeline => ({
+  progress: { completed: 0, total: 0 },
+  ...overrides,
+});
+
+const makeStatusVM = (
+  pipeline: V1beta1PlanStatusMigrationVmsPipeline[],
+): V1beta1PlanStatusMigrationVms => ({ pipeline }) as unknown as V1beta1PlanStatusMigrationVms;
+
+describe('getVMDiskTransferPipeline', () => {
+  it('returns undefined when pipeline is empty', () => {
+    expect(getVMDiskTransferPipeline(makeStatusVM([]))).toBeUndefined();
+  });
+
+  it('returns undefined when statusVM is undefined', () => {
+    expect(getVMDiskTransferPipeline(undefined)).toBeUndefined();
+  });
+
+  it('returns the only disk step when there is exactly one', () => {
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(
+      makeStatusVM([makePipe({ name: 'Initialize', phase: 'Completed' }), diskTransfer]),
+    );
+
+    expect(result).toBe(diskTransfer);
+  });
+
+  it('prefers the currently active/running disk step', () => {
+    const diskAllocation = makePipe({
+      name: 'DiskAllocation',
+      phase: 'Running',
+      progress: { completed: 5120, total: 10240 },
+    });
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(makeStatusVM([diskAllocation, diskTransfer]));
+
+    expect(result).toBe(diskAllocation);
+  });
+
+  it('falls back to DiskAllocation progress on healthy pipeline (copy-offload regression guard)', () => {
+    const diskAllocation = makePipe({
+      name: 'DiskAllocation',
+      phase: 'Completed',
+      progress: { completed: 10240, total: 10240 },
+    });
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(
+      makeStatusVM([
+        makePipe({ name: 'Initialize', phase: 'Completed' }),
+        diskAllocation,
+        makePipe({ name: 'ImageConversion', phase: 'Completed' }),
+        diskTransfer,
+      ]),
+    );
+
+    expect(result).toBe(diskAllocation);
+  });
+
+  it('returns DiskTransfer when pipeline has a blocking failure (mismatch fix)', () => {
+    const diskAllocation = makePipe({
+      name: 'DiskAllocation',
+      phase: 'Completed',
+      progress: { completed: 10240, total: 10240 },
+    });
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(
+      makeStatusVM([
+        makePipe({ name: 'Initialize', phase: 'Completed' }),
+        diskAllocation,
+        makePipe({
+          error: { phase: 'ImageConversion', reasons: ['Guest conversion failed'] },
+          name: 'ImageConversion',
+          phase: 'Completed',
+        }),
+        diskTransfer,
+      ]),
+    );
+
+    expect(result).toBe(diskTransfer);
+  });
+
+  it('prefers DiskTransfer with progress over DiskAllocation on healthy pipeline', () => {
+    const diskAllocation = makePipe({
+      name: 'DiskAllocation',
+      phase: 'Completed',
+      progress: { completed: 10240, total: 10240 },
+    });
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Completed',
+      progress: { completed: 10240, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(
+      makeStatusVM([
+        makePipe({ name: 'Initialize', phase: 'Completed' }),
+        diskAllocation,
+        diskTransfer,
+      ]),
+    );
+
+    expect(result).toBe(diskTransfer);
+  });
+
+  it('returns DiskTransfer by default when neither step has progress and pipeline is healthy', () => {
+    const diskAllocation = makePipe({
+      name: 'DiskAllocation',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const diskTransfer = makePipe({
+      name: 'DiskTransferV2v',
+      phase: 'Pending',
+      progress: { completed: 0, total: 10240 },
+    });
+    const result = getVMDiskTransferPipeline(makeStatusVM([diskAllocation, diskTransfer]));
+
+    expect(result).toBe(diskTransfer);
+  });
+});

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/constants.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/constants.ts
@@ -47,12 +47,14 @@ export const planMigrationVirtualMachinesFields: ResourceField[] = [
     jsonPath: getVMDiskProgress,
     label: t('Disk transfer'),
     resourceFieldId: MigrationStatusVirtualMachinesTableResourceId.Transfer,
+    sortable: true,
   },
   {
     isVisible: true,
     jsonPath: getVMDiskProgress,
     label: t('Disk counter'),
     resourceFieldId: MigrationStatusVirtualMachinesTableResourceId.DiskCounter,
+    sortable: true,
   },
   {
     filter: {

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
@@ -102,11 +102,17 @@ const isStepActive = (pipe: V1beta1PlanStatusMigrationVmsPipeline): boolean =>
   pipe.phase !== taskStatuses.pending &&
   pipe.phase !== taskStatuses.completed;
 
+const hasPipelineBlockingFailure = (pipeline: V1beta1PlanStatusMigrationVmsPipeline[]): boolean =>
+  pipeline.some((pipe) => Boolean(pipe?.error));
+
 /**
  * Returns the pipeline step representing disk transfer progress.
  * For copy-offload migrations, actual transfer happens in DiskAllocation
  * while DiskTransferV2v runs instantly with no per-task progress.
- * Prefers the currently active step; falls back to the one with more progress.
+ * Prefers the currently active step; falls back to the one with more progress
+ * only when the pipeline has no blocking failures (a failed earlier step would
+ * leave DiskTransferV2v at 0 while DiskAllocation already shows 100% from PVC
+ * binding, producing a misleading "transfer complete" in the row cell).
  */
 export const getVMDiskTransferPipeline = (
   statusVM: V1beta1PlanStatusMigrationVms | undefined,
@@ -123,8 +129,10 @@ export const getVMDiskTransferPipeline = (
   const diskTransfer = diskSteps.find((pipe) => pipe.name.startsWith(DISK_TRANSFER_PREFIX));
   const diskAllocation = diskSteps.find((pipe) => pipe.name === DISK_ALLOCATION_NAME);
 
-  if ((diskTransfer?.progress?.completed ?? 0) > 0) return diskTransfer;
-  if ((diskAllocation?.progress?.completed ?? 0) > 0) return diskAllocation;
+  if (!hasPipelineBlockingFailure(pipeline)) {
+    if ((diskTransfer?.progress?.completed ?? 0) > 0) return diskTransfer;
+    if ((diskAllocation?.progress?.completed ?? 0) > 0) return diskAllocation;
+  }
 
   return diskTransfer ?? diskAllocation;
 };


### PR DESCRIPTION
## Summary

1. **Sortable columns**: Enable sorting on the "Disk transfer" and "Disk counter" columns in the migration status VM list (Plan details → Virtual machines tab) by adding `sortable: true` to their field definitions.

2. **Fix value mismatch**: Fix a data-accuracy bug where the row-level "Disk transfer" and "Disk counter" values showed misleadingly complete numbers (e.g. `10240 / 10240 MB`, `1 / 1 Disks`) when the actual `DiskTransfer` pipeline step was still pending/blocked by an earlier failure. The expanded pipeline tasks drawer already showed the correct value (`0 / 10240 MB`) — now the row agrees.

## Root cause (mismatch)

`getVMDiskTransferPipeline` unconditionally preferred whichever disk-related pipeline step (`DiskAllocation` or `DiskTransfer`) had more `progress.completed`. `DiskAllocation` reports `completed == total` as soon as a PVC is bound — which happens for **every** migration, not just copy-offload — regardless of whether actual data transfer occurred. When a later step (e.g. Image conversion) failed and blocked `DiskTransferV2v` from starting, the fallback picked `DiskAllocation`'s 100% and surfaced it under the "Disk transfer" label.

## Fix

Gate the "prefer more progress" fallback behind `hasPipelineBlockingFailure(pipeline)`: when any pipeline step has an error, skip the fallback and always return the `DiskTransfer` step directly (showing its real 0/N progress). The live-progress path (active/Running step preferred first) and the healthy-pipeline fallback (needed for the copy-offload MTV-5679 fix) remain completely untouched.

## Before / After

| | Before | After |
|---|---|---|
| Columns | "Disk transfer" and "Disk counter" headers had no sort affordance | Both columns now sortable |
| Values (blocked migration) | Row: `10240 / 10240 MB`, `1 / 1 Disks` (wrong) | Row: `0 / 10240 MB`, `0 / 1 Disks` (correct, matches drawer) |

## Testing

- Added 8 unit tests for `getVMDiskTransferPipeline` covering:
  - Active/running step preferred
  - Healthy-pipeline fallback to DiskAllocation (MTV-5679 regression guard)
  - **Blocked pipeline → returns DiskTransfer (new fix)**
  - Single disk step, edge cases
- All 753 existing tests continue to pass
- Build and lint clean

## Demo

Before:
<img width="1920" height="879" alt="MTV-2152-before-1-migration-vm-list-columns" src="https://github.com/user-attachments/assets/3fa48310-6093-4d21-a4d8-1f8426d0fb23" />

After:
<img width="1920" height="879" alt="MTV-2152-after-1-migration-vm-list-columns" src="https://github.com/user-attachments/assets/f10c2ea9-572b-4d58-9207-9b1239930d7e" />


Resolves: MTV-2152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine migration status reporting when earlier pipeline steps fail.
  * Prevented disk transfers from being shown as complete when a blocking migration error is present.

* **New Features**
  * Enabled sorting for the “Disk transfer” and “Disk counter” fields.

* **Tests**
  * Added Jest coverage for disk transfer status across multiple migration pipeline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->