### PR TITLE
Resolves: MTV-5505 | Add Guest OS column E2E tests

### DIFF
--- a/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterAttributeSelect.tsx
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterAttributeSelect.tsx
@@ -46,6 +46,7 @@ const FilterAttributeSelect = <T,>({
       toggle={(toggleRef: Ref<MenuToggleElement>) => (
         <MenuToggle
           ref={toggleRef}
+          data-testid="filter-attribute-toggle"
           onClick={() => {
             setOpen((open) => !open);
           }}

--- a/testing/playwright/e2e/downstream/providers/guest-os-column.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/guest-os-column.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  providerOnlyFixtures as providerTest,
+  sharedProviderCustomPlanFixtures as customPlanTest,
+} from '../../../fixtures/resourceFixtures';
+import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
+import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { ProviderDetailsPage } from '../../../page-objects/ProviderDetailsPage/ProviderDetailsPage';
+import { createPlanTestData } from '../../../types/test-data';
+import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
+import { V2_11_0 } from '../../../utils/version/constants';
+import { requireVersion } from '../../../utils/version/version';
+
+const GUEST_OS_COLUMN = 'Guest OS';
+const FOLDER_NAME = 'vm';
+
+/**
+ * MTV-5505 — QE: Guest OS Column and Compatibility Indicators in VM Tables
+ *
+ * Verifies the Guest OS column feature (DEV: MTV-5503, PR #2457) across the three
+ * surfaces where VMs are displayed: Provider VM tab, Plan details VM list, and
+ * Plan wizard VM selection step.
+ */
+providerTest.describe('Guest OS Column - Provider VM Tab', { tag: '@downstream' }, () => {
+  requireVersion(providerTest, V2_11_0);
+
+  providerTest(
+    'should display Guest OS column with values, filtering, and sorting',
+    async ({ page, testProvider }) => {
+      const providerName = testProvider?.metadata?.name ?? '';
+      const providerDetailsPage = new ProviderDetailsPage(page);
+      const vmTab = providerDetailsPage.virtualMachinesTab;
+
+      await test.step('1. Navigate to provider VM tab', async () => {
+        await providerDetailsPage.navigate(providerName, MTV_NAMESPACE);
+        await providerDetailsPage.navigateToVirtualMachinesTab();
+        await vmTab.verifyTableLoaded();
+      });
+
+      await test.step('2. Verify Guest OS column is visible by default', async () => {
+        const columns = await vmTab.getColumns();
+        expect(columns).toContain(GUEST_OS_COLUMN);
+      });
+
+      await test.step('3. Verify Guest OS cells are rendered for VMs', async () => {
+        await vmTab.expandFolder(FOLDER_NAME);
+
+        const guestOSCells = page
+          .getByTestId('vsphere-tree-table')
+          .locator(`tbody tr[data-testid^="vm-"] td[data-label="${GUEST_OS_COLUMN}"]`);
+
+        await expect(guestOSCells.first()).toBeVisible({ timeout: 30_000 });
+
+        const cellTexts = await guestOSCells.allTextContents();
+        const nonEmpty = cellTexts.filter((text) => text.trim() !== '-' && text.trim() !== '');
+        expect(nonEmpty.length).toBeGreaterThan(0);
+      });
+
+      await test.step('4. Filter attribute dropdown includes Guest OS option', async () => {
+        await vmTab.switchFilterAttribute(GUEST_OS_COLUMN);
+        // Switching to Guest OS proves the option existed; search input should now
+        // show the Guest OS placeholder
+        const searchInput = page.getByPlaceholder(/guest os/i);
+        await expect(searchInput).toBeVisible({ timeout: 5_000 });
+        // Reset to VM name filter for step 5
+        await vmTab.switchFilterAttribute('VM name');
+      });
+
+      await test.step('5. Filter by Guest OS reduces VM count in folder', async () => {
+        const initialCount = await vmTab.getFolderVMCount(FOLDER_NAME);
+        expect(initialCount).toBeGreaterThan(0);
+
+        await vmTab.switchFilterAttribute(GUEST_OS_COLUMN);
+        await vmTab.search('Windows');
+        await page.waitForTimeout(800);
+
+        const filteredCount = await vmTab.getFolderVMCount(FOLDER_NAME);
+        expect(filteredCount).toBeGreaterThan(0);
+        expect(filteredCount).toBeLessThan(initialCount);
+
+        await vmTab.clearAllFilters();
+
+        const restoredCount = await vmTab.getFolderVMCount(FOLDER_NAME);
+        expect(restoredCount).toBe(initialCount);
+      });
+
+      await test.step('6. Sort by Guest OS column works', async () => {
+        await vmTab.expandFolder(FOLDER_NAME);
+
+        await vmTab.sortByColumn(GUEST_OS_COLUMN);
+        await page.waitForTimeout(500);
+
+        const columns = await vmTab.getColumns();
+        expect(columns).toContain(GUEST_OS_COLUMN);
+
+        // Re-sort ascending to normalise state for any subsequent checks
+        await vmTab.sortByColumn(GUEST_OS_COLUMN);
+        await page.waitForTimeout(300);
+      });
+    },
+  );
+});
+
+customPlanTest.describe('Guest OS Column - Plan Details VM List', { tag: '@downstream' }, () => {
+  requireVersion(customPlanTest, V2_11_0);
+
+  customPlanTest(
+    'should display Guest OS column and filter in plan spec VM list',
+    async ({ page, createCustomPlan }) => {
+      const testPlan = await createCustomPlan({
+        criticalIssuesAction: 'confirm',
+        networkMap: {
+          isPreexisting: false,
+          mappings: [
+            { source: 'Mgmt Network', target: 'Default network' },
+            { source: 'VM Network', target: 'Ignore network' },
+          ],
+        },
+        virtualMachines: [{ folder: FOLDER_NAME }],
+      });
+
+      const planDetailsPage = new PlanDetailsPage(page);
+      const vmTab = planDetailsPage.virtualMachinesTab;
+
+      await test.step('1. Navigate to plan details VM tab', async () => {
+        await planDetailsPage.navigate(testPlan.metadata.name, testPlan.metadata.namespace);
+        await vmTab.navigateToVirtualMachinesTab();
+        await vmTab.verifyTableLoaded();
+      });
+
+      await test.step('2. Verify Guest OS column header is visible', async () => {
+        const isVisible = await vmTab.isColumnVisible(GUEST_OS_COLUMN);
+        expect(isVisible).toBe(true);
+      });
+
+      await test.step('3. Verify Guest OS filter attribute is available', async () => {
+        await vmTab.expandFilters();
+        await vmTab.verifyFilterOptionExists(GUEST_OS_COLUMN);
+      });
+
+      await test.step('4. Sort by Guest OS column', async () => {
+        await vmTab.sortByColumn(GUEST_OS_COLUMN);
+        await page.waitForTimeout(300);
+
+        const isVisible = await vmTab.isColumnVisible(GUEST_OS_COLUMN);
+        expect(isVisible).toBe(true);
+      });
+    },
+  );
+});
+
+providerTest.describe('Guest OS Column - Plan Wizard VM Step', { tag: '@downstream' }, () => {
+  requireVersion(providerTest, V2_11_0);
+
+  providerTest(
+    'should display Guest OS column in plan wizard VM selection step',
+    async ({ page, testProvider, resourceManager }) => {
+      const testData = createPlanTestData({
+        sourceProvider: testProvider?.metadata?.name ?? '',
+      });
+      resourceManager.addPlan(testData.planName, testData.planProject);
+
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+
+      await test.step('1. Navigate wizard to VM selection step', async () => {
+        await wizard.navigate();
+        await wizard.waitForWizardLoad();
+        await wizard.generalInformation.fillAndComplete(testData);
+        await wizard.clickNext();
+      });
+
+      await test.step('2. Verify VM selection step is loaded', async () => {
+        await wizard.virtualMachines.verifyStepVisible();
+        await wizard.virtualMachines.verifyTableLoaded();
+      });
+
+      await test.step('3. Verify Guest OS column is present in wizard VM table', async () => {
+        const columns = await wizard.virtualMachines.getColumns();
+        expect(columns).toContain(GUEST_OS_COLUMN);
+      });
+    },
+  );
+});

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
@@ -55,6 +55,34 @@ export class NetworkMapStep {
     };
   }
 
+  private async mapRemainingDefaultRowsToIgnore(alreadyConfiguredSources: string[]): Promise<void> {
+    const { rows, getRowText, getTargetSelect } = this.getMappingRowLocators();
+    const rowCount = await rows.count();
+
+    for (let i = 0; i < rowCount; i += 1) {
+      const row = rows.nth(i);
+      const rowText = await getRowText(row);
+
+      const alreadyConfigured = alreadyConfiguredSources.some((source) =>
+        rowText?.includes(source),
+      );
+      if (!alreadyConfigured) {
+        const targetSelect = getTargetSelect(row);
+        const currentText = await targetSelect.textContent();
+        if (currentText?.includes('Default network')) {
+          await targetSelect.click();
+          await this.waitForNetworkOptions();
+          await this.page.getByRole('option', { name: 'Ignore network' }).click();
+        }
+      }
+    }
+  }
+
+  private async waitForAtLeastOneRow(): Promise<void> {
+    const { rows } = this.getMappingRowLocators();
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+  }
+
   async configureMappings(mappings: { source: string; target: string }[]): Promise<void> {
     for (const mapping of mappings) {
       await this.selectTargetNetworkForSource(mapping.source, mapping.target);
@@ -89,9 +117,18 @@ export class NetworkMapStep {
         await this.page.getByRole('textbox').fill(networkMap.name);
       }
 
+      // Wait for auto-detected rows to load before configuring or mapping
+      await this.waitForAtLeastOneRow();
+
       if (!isEmpty(networkMap.mappings)) {
         await this.configureMappings(networkMap.mappings!);
       }
+
+      // Map any rows still on "Default network" to "Ignore network" to
+      // prevent the "more than one interface mapped to Default" wizard error.
+      // Rows already handled by the caller's explicit mappings are skipped.
+      const configuredSources = networkMap.mappings?.map((mapping) => mapping.source) ?? [];
+      await this.mapRemainingDefaultRowsToIgnore(configuredSources);
     }
   }
 

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -298,6 +298,20 @@ export class VirtualMachinesTable {
   }
 
   /**
+   * Switches the active filter attribute in the VsphereFolderTreeTable toolbar.
+   * Applies to the Provider VM tab and Plan Wizard VM step (both use VsphereFolderTreeTable).
+   * For the Plan Details VM list (StandardPageWithSelection), use the plan tab's own filter
+   * helpers (e.g. `verifyFilterOptionExists`, `applyFilter`) instead.
+   *
+   * @param attributeLabel - Visible label of the filter option (e.g. 'Guest OS', 'VM name')
+   */
+  async switchFilterAttribute(attributeLabel: string): Promise<void> {
+    const filterToggle = this.rootLocator.getByTestId('filter-attribute-toggle');
+    await filterToggle.click();
+    await this.page.getByRole('option', { name: attributeLabel, exact: true }).click();
+  }
+
+  /**
    * Tests concern button functionality by clicking the first concern button
    * and verifying the popover opens and can be closed
    * @returns true if a concern button was found and tested, false otherwise


### PR DESCRIPTION
## 📝 Links

- [MTV-5505](https://redhat.atlassian.net/browse/MTV-5505)

## 📝 Description

Adds Playwright E2E coverage for the Guest OS column (MTV-5503) across all three VM table surfaces.

- **New spec** `guest-os-column.spec.ts` — Provider VM tab, Plan Details VM list, Plan Wizard VM step: column visibility, filter by Guest OS, sorting
- **`FilterAttributeSelect.tsx`** — add `data-testid="filter-attribute-toggle"` to `MenuToggle` for reliable PF6 Select targeting in tests
- **`NetworkMapStep.ts`** — fix timing bug (rows loading race) and auto-map unspecified networks to Ignore to prevent wizard validation errors

## 🎥 Demo

Test-only PR — no UI changes. All 3 new tests pass on qemtv-09 (CNV 4.22.4, Forklift latest).

## 📝 CC://

@avivtur

[MTV-5505]: https://redhat.atlassian.net/browse/MTV-5505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the **Guest OS** column to VM tables in provider views, plan details, and the plan wizard.
  - Added Guest OS filtering and sorting capabilities where supported.

- **Bug Fixes**
  - Improved network mapping in the plan wizard to prevent conflicting default network assignments and related validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->