### PR TITLE
MTV-6258 | Fix i18n defaultValue for secondary locales

### DIFF
--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'i18next-cli';
 export default defineConfig({
   extract: {
     defaultNS: 'plugin__forklift-console-plugin',
-    defaultValue: (key: string): string => key,
+    defaultValue: (key: string, _namespace: string, _language: string): string => key,
     extractFromComments: true,
     functions: ['t', '*.t'],
     input: ['src/**/*.{js,jsx,ts,tsx}', 'plugin-extensions.ts'],


### PR DESCRIPTION
## Summary

Fix a regression from the i18next-parser → i18next-cli migration (#2585) where new translation keys in non-English locale files get empty strings `""` instead of the English key as placeholder.

The `defaultValue` function in `i18next.config.ts` used a single-parameter signature `(key) => key` which i18next-cli only applies to the primary locale. Secondary locales received `""` by design. Using the full `(key, namespace, language)` signature restores the old behavior where all locales get the English key as fallback.

**Before:** New keys in es/fr/ja/ko/zh → `"Resume": ""`  (blank text at runtime)
**After:** New keys in es/fr/ja/ko/zh → `"Resume": "Resume"` (English fallback until translated)

Reference: https://github.com/i18next/i18next-cli/issues/52

## Test plan

- [x] Added a temporary test key, ran `npm run i18n`, confirmed all 6 locales get the key text
- [x] `npm run build` passes
- [x] `npm run test:i18n` passes
- [x] Pre-commit hooks (eslint, prettier, i18n, knip) pass

Resolves: MTV-6258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated localization configuration compatibility without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->