### PR TITLE
fix(e2e): restore controller_transfer_network after settings tests

### DIFF
--- a/testing/playwright/fixtures/helpers/settingsHelpers.ts
+++ b/testing/playwright/fixtures/helpers/settingsHelpers.ts
@@ -7,6 +7,7 @@ const FIELD_MAP = {
   aapTokenSecretName: 'aap_token_secret_name',
   aapUrl: 'aap_url',
   controllerMemoryLimit: 'controller_container_limits_memory',
+  controllerTransferNetwork: 'controller_transfer_network',
   cpuLimit: 'controller_container_limits_cpu',
   inventoryMemoryLimit: 'inventory_container_limits_memory',
   maxVmInFlight: 'controller_max_vm_inflight',
@@ -14,10 +15,17 @@ const FIELD_MAP = {
   snapshotPollingInterval: 'controller_snapshot_status_check_rate_seconds',
 } as const;
 
+// Empty string is the "None" baseline for controllerTransferNetwork (matches the
+// UI's blank-option behavior in EditControllerTransferNetwork.tsx). Tracking it here
+// ensures any NetworkAttachmentDefinition reference set during a test is cleared
+// before resourceManager.cleanupAll() deletes the NAD -- otherwise the ForkliftController
+// is left pointing at a deleted NAD, which makes every reconcile (including finalizer
+// teardown on delete) fail permanently.
 export const KNOWN_SETTINGS = {
   aapTokenSecretName: '',
   aapUrl: '',
   controllerMemoryLimit: '800Mi',
+  controllerTransferNetwork: '',
   cpuLimit: '500m',
   inventoryMemoryLimit: '1000Mi',
   maxVmInFlight: 10,


### PR DESCRIPTION
## Summary
- The "Overview Page - Settings" E2E test creates a `NetworkAttachmentDefinition`, sets it as the `ForkliftController`'s transfer network via the Settings UI, then deletes the NAD during cleanup.
- `controller_transfer_network` was never tracked by the shared settings helper (`settingsHelpers.ts`), so it was never restored to its original value before the NAD got deleted.
- This leaves the `ForkliftController` CR referencing a NetworkAttachmentDefinition that no longer exists, which makes **every** subsequent reconcile fail (`NetworkAttachmentDefinition '...' not found in namespace '...'`) — including the Ansible-operator's finalizer teardown run on delete. The object gets permanently stuck in `Terminating`, blocking any later attempt to clean up/redeploy MTV on that cluster.
- This bug has existed since the test was first introduced (MTV-3649, Jan 2026) and caused a real QE cluster (`qemtv-09`) to get stuck, breaking a Jenkins `mtv-deploy-dynamic` run.

## Fix
- Track `controllerTransferNetwork` (`controller_transfer_network`) in `FIELD_MAP`/`KNOWN_SETTINGS` in `testing/playwright/fixtures/helpers/settingsHelpers.ts`, using `''` ("None") as the baseline — matching the UI's own blank-option behavior in `EditControllerTransferNetwork.tsx`.
- This makes `initializeForkliftSettings`/`restoreForkliftSettings` capture and restore this field the same way they already do for CPU/memory limits, precopy interval, etc., so the reference is cleared **before** `resourceManager.cleanupAll()` deletes the NAD.

## Test plan
- [ ] Run `testing/playwright/e2e/downstream/overview-page.spec.ts` ("Overview Page - Settings") and confirm `ForkliftController.spec.controller_transfer_network` is restored to its pre-test value (or removed) after the suite completes, even though the test NAD is deleted.
- [ ] Confirm the `ForkliftController` CR is not left in a stuck `Terminating` state after the test suite's cleanup runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test coverage to include the controller’s transfer network setting.
  * Improved test setup and cleanup so network attachment references are consistently reset between scenarios.
  * Updated settings capture and restoration to preserve this configuration during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->