### PR TITLE
chore: bump @forklift-ui/types to 1.3.0

### DIFF
--- a/.cursor/skills/types-update/SKILL.md
+++ b/.cursor/skills/types-update/SKILL.md
@@ -22,6 +22,7 @@ For conflict resolution rules, Jira payload template, CRD verification, and edge
 - `~/.jira-creds` configured (see `~/.cursor/rules/jira-api.mdc`)
 - `curl`, `jq`, `npm`, `node >= 20` installed
 - Java runtime (required by `openapi-generator-cli` in the types repo)
+- Types package depends on `@openshift/api-types` (installed via `npm ci` in the types repo). After every generation update, run `npm run align:k8s-base` (see Phase 3e / MTV-6057).
 
 ## Permissions — Cross-Project File Access
 
@@ -46,6 +47,7 @@ Types Update Progress:
 - [ ] Phase 2: Create Jira ticket
 - [ ] Phase 2.5: Update inventory types from Go source
 - [ ] Phase 3: Update generated types in forked repo
+- [ ] Phase 3e: Run `npm run align:k8s-base` (mandatory after generation)
 - [ ] GATE 1: User approves conflict resolution (if any)
 - [ ] Phase 4: Version bump, tracking update, and PR
 - [ ] GATE 2: User confirms types PR is merged
@@ -150,7 +152,7 @@ The hand-written inventory types in `$TYPES_REPO_DIR/src/types/` mirror Go struc
 
 > **Permissions reminder:** This phase edits files in the types repo (outside workspace). Use Shell with `required_permissions: ["all"]` for all commands and file writes. See the **Permissions** section above.
 
-**Scope**: `src/types/provider/` (per-provider types) and `src/types/provider/base/` (shared model types). The `src/types/secret/` and `src/types/k8s/` directories are NOT derivable from Go and remain manual.
+**Scope**: `src/types/provider/` (per-provider types) and `src/types/provider/base/` (shared model types). The `src/types/secret/` directory is NOT derivable from Go and remains manual. `src/types/k8s/` re-exports `K8sResourceCommon` / `ObjectMetadata` / `ManagedFieldsEntry` / `FieldsV1` from `@openshift/api-types` (plus a few local helpers) — do **not** regenerate those from Go or reintroduce a local `FieldsV1` clone.
 
 See [reference.md](reference.md) for the complete Go source file map, type mapping table, and edge cases.
 
@@ -287,31 +289,23 @@ Use AskQuestion:
 
 If no conflicts were found, skip this gate.
 
-### 3e. Fix ObjectMeta timestamp types
+### 3e. Align K8s base types with `@openshift/api-types`
 
-The `openapi-generator` maps OpenAPI `date-time` fields to TypeScript `Date`, but the Kubernetes API returns ISO 8601 strings and `@openshift-console/dynamic-plugin-sdk` expects `creationTimestamp` and `deletionTimestamp` as `string`. After running the update scripts, this **must** be fixed.
+After running the update scripts, align generated ObjectMeta / ManagedFieldsEntry models and remaining Date timestamps with `@openshift/api-types` / Console SDK expectations.
 
-Run the post-generation fix script (if it exists):
 ```bash
-npm run fix:timestamps
+npm run align:k8s-base
+# → node ./scripts/align-k8s-base/align.mjs
 ```
 
-If the script does not exist, manually fix all ObjectMeta types:
-```bash
-for f in $(grep -rl "Timestamp?: Date" src/generated/); do
-  sed -i '' \
-    -e 's/creationTimestamp?: Date;/creationTimestamp?: string;/' \
-    -e 's/deletionTimestamp?: Date;/deletionTimestamp?: string;/' \
-    -e "s/(new Date(json\['creationTimestamp'\]))/json['creationTimestamp']/" \
-    -e "s/(new Date(json\['deletionTimestamp'\]))/json['deletionTimestamp']/" \
-    -e "s/((value\['creationTimestamp'\]).toISOString())/value['creationTimestamp']/" \
-    -e "s/((value\['deletionTimestamp'\]).toISOString())/value['deletionTimestamp']/" \
-    "$f"
-  echo "Fixed: $f"
-done
-```
+This Node script (templates under `scripts/align-k8s-base/templates/`):
 
-**This step is mandatory.** Skipping it causes ~370 TypeScript errors in the consumer project where Forklift CRD types become incompatible with the Console SDK's `K8sResourceCommon`.
+1. Overwrites the six generated ObjectMeta / ManagedFieldsEntry model files with thin shims that alias to `ObjectMetadata` / `ManagedFieldsEntry` from `@openshift/api-types` (keeping FromJSON/ToJSON stubs)
+2. Converts remaining `Date` timestamp fields under `src/generated/**/*.ts` to `string`
+
+**This step is mandatory.** Skipping it regenerates full ObjectMeta models that drift from the Console SDK's `K8sResourceCommon` / `ObjectMetadata` and causes widespread TypeScript errors in the consumer project.
+
+See MTV-6057 / types repo `MAINTENANCE.md` (Post-Generation Fixes).
 
 ### 3f. Build verification
 

--- a/.cursor/skills/types-update/reference.md
+++ b/.cursor/skills/types-update/reference.md
@@ -338,7 +338,7 @@ If a new provider is added upstream (e.g., `ec2`), add it to all union types and
 ### Files to leave untouched
 
 - `src/types/secret/` -- K8s Secret data shapes, not derivable from Go inventory structs
-- `src/types/k8s/` -- small K8s helper types (`K8sResourceCommon`, `K8sResourceCondition`, `V1NetworkAttachmentDefinition`)
+- `src/types/k8s/` -- re-exports `K8sResourceCommon`, `ObjectMetadata`, `ManagedFieldsEntry`, `FieldsV1` from `@openshift/api-types`; also local helpers (`K8sResourceCondition`, `V1NetworkAttachmentDefinition`). Do not hand-clone FieldsV1/ObjectMeta here.
 - `src/types/Modify.ts` -- utility type
 - `src/types/MustGatherResponse.ts` -- must-gather API response, not from inventory
 - `src/types/constants/` -- UI constants
@@ -371,18 +371,15 @@ Common patterns:
 - **Field type changed**: compare the old and new model file for the specific type. Common changes: `string | undefined` becoming `string`, optional fields becoming required, enum values changing.
 - **New type conflicts in consumer**: if the consumer defines a local type with the same name as a new export, rename the local type.
 
-### ObjectMeta `creationTimestamp: Date` breaks SDK compatibility
+### ObjectMeta / ManagedFieldsEntry drift from `@openshift/api-types`
 
-**Root cause**: The `openapi-generator` maps OpenAPI `date-time` format to TypeScript `Date`. Kubernetes ObjectMeta fields `creationTimestamp` and `deletionTimestamp` are `date-time` in the spec, so the generator produces `Date`. However, the Kubernetes API returns ISO 8601 strings, and `@openshift-console/dynamic-plugin-sdk` types these as `string` in its `ObjectMetadata`.
+**Root cause**: OpenAPI generation produces separate ObjectMeta / ManagedFieldsEntry models (and `Date` timestamps) that drift from Console SDK expectations (`ObjectMetadata`, recursive `FieldsV1`, string timestamps from `@openshift/api-types`).
 
-**Symptom**: ~370 TS errors like `Type 'Date | undefined' is not assignable to type 'string | undefined'` on every `useK8sWatchResource`, `k8sPatch`, `getName`, etc. call that touches a Forklift CRD type.
+**Symptom**: Widespread TS errors on `useK8sWatchResource`, `k8sPatch`, `getName`, etc. when Forklift CRD types no longer match the SDK's `K8sResourceCommon` / `ObjectMetadata`.
 
-**Affected files**: All `ObjectMeta` types across Kubernetes, KubeVirt, and CDI:
-- `src/generated/kubernetes/models/IoK8sApimachineryPkgApisMetaV1ObjectMeta.ts`
-- `src/generated/kubevirt/models/K8sIoApimachineryPkgApisMetaV1ObjectMeta.ts`
-- `src/generated/containerized-data-importer/models/V1ObjectMeta.ts`
+**Affected files**: ObjectMeta / ManagedFieldsEntry models across Kubernetes, KubeVirt, and CDI (shimmed by align script), plus any remaining `Date` timestamp fields under `src/generated/`.
 
-**Fix**: Run `npm run fix:timestamps` after every update script run. See Phase 3 step 3e in the skill. This was introduced after the Kubernetes v1.36.0 update (types repo PR #26).
+**Fix**: Run `npm run align:k8s-base` after every update script run. See Phase 3 step 3e in the skill. Introduced by MTV-6057 (supersedes older `fix:timestamps` / `fix:fields-v1` scripts and types repo PR #26).
 
 ### Inventory type field casing changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@forklift-ui/types": "^1.2.2",
+        "@forklift-ui/types": "^1.3.0",
         "@openshift-console/dynamic-plugin-sdk": "4.22.0",
         "@patternfly/patternfly": "6.4.0",
         "@patternfly/quickstarts": "6.4.0",
@@ -1722,10 +1722,13 @@
       }
     },
     "node_modules/@forklift-ui/types": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@forklift-ui/types/-/types-1.2.2.tgz",
-      "integrity": "sha512-3Uy8sF3+kOSHPC6CIXNHkl5pBpPn4HVNwr8lmh0Q1HJJHZiRnzRN0QKWi1jPpPrr3hx6zJ6TbxbNuIsqHzWmrg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@forklift-ui/types/-/types-1.3.0.tgz",
+      "integrity": "sha512-afecKE1eizKgoRLM1IeQV9udW7sseJ9UxHNh+E5k+0M+uS/igfKtMcDrqnf5zpo2me/0pcbadSbr/3uEEXYzYA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@openshift/api-types": "^1.0.0"
+      },
       "engines": {
         "node": ">=20"
       }
@@ -3382,6 +3385,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@openshift/api-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/api-types/-/api-types-1.0.0.tgz",
+      "integrity": "sha512-LUWH0raMvKQUN63inYmA8+73iKAwLPDYqkTKncSoHEgjZ2YNvuqvcyHOvLkczFdx9ALWuAU9NIMatjGJ9zpe6w==",
+      "license": "Apache-2.0"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postinstall": "husky"
   },
   "dependencies": {
-    "@forklift-ui/types": "^1.2.2",
+    "@forklift-ui/types": "^1.3.0",
     "@openshift-console/dynamic-plugin-sdk": "4.22.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/quickstarts": "6.4.0",


### PR DESCRIPTION
## Summary
- Bumps `@forklift-ui/types` from `^1.2.2` to `^1.3.0` (adopts `@openshift/api-types` for K8s base types)
- Updates types-update skill docs for `npm run align:k8s-base` (Node script + TS templates; replaces old fix scripts)

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [ ] CI green

## Links
- Types PR: https://github.com/kubev2v/forklift-console-types/pull/31
- Jira: https://issues.redhat.com/browse/MTV-6057

Resolves: MTV-6057

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the type-generation workflow with mandatory Kubernetes type alignment steps.
  * Clarified which Kubernetes and secret type files should remain unchanged or manually maintained.
  * Added troubleshooting guidance for metadata and timestamp compatibility issues.

* **Chores**
  * Updated `@forklift-ui/types` to version 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->