### PR TITLE
Resolves: MTV-6166 | Fix Tips and tricks accordion click latency

### DIFF
--- a/src/onlineHelp/learningExperienceDrawer/context/AccordionContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/AccordionContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+import type { AccordionContextType } from '../utils/types';
+
+import { createAccordionContext } from './createAccordionContext';
+
+export const AccordionContext = createContext<AccordionContextType>(createAccordionContext());

--- a/src/onlineHelp/learningExperienceDrawer/context/AccordionContextProvider.tsx
+++ b/src/onlineHelp/learningExperienceDrawer/context/AccordionContextProvider.tsx
@@ -1,0 +1,16 @@
+import type { FC, ReactNode } from 'react';
+
+import { AccordionContext } from './AccordionContext';
+import { useAccordionContext } from './useAccordionContext';
+
+type AccordionContextProviderProps = {
+  children: ReactNode;
+};
+
+const AccordionContextProvider: FC<AccordionContextProviderProps> = ({ children }) => {
+  const value = useAccordionContext();
+
+  return <AccordionContext.Provider value={value}>{children}</AccordionContext.Provider>;
+};
+
+export default AccordionContextProvider;

--- a/src/onlineHelp/learningExperienceDrawer/context/__tests__/useAccordionContext.test.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/__tests__/useAccordionContext.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useAccordionContext } from '../useAccordionContext';
+
+import { testItemId, testItemId2 } from './constants';
+import { createMockPersistedState, mockPersistValue, setupMocks } from './utils';
+
+jest.mock('../../utils/utils', () => ({
+  findTopicById: jest.fn(),
+  persistValue: jest.fn(),
+}));
+
+jest.mock('@utils/userSettingsHelpers', () => ({
+  parseOrClean: jest.fn(),
+}));
+
+describe('useAccordionContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks({});
+  });
+
+  it('returns empty openExpansionItems by default', () => {
+    const { result } = renderHook(() => useAccordionContext());
+
+    expect(result.current.openExpansionItems).toEqual([]);
+  });
+
+  it('restores openExpansionItems from storage', () => {
+    const storedItems = [testItemId, testItemId2];
+    setupMocks(createMockPersistedState({ openExpansionItems: storedItems }));
+
+    const { result } = renderHook(() => useAccordionContext());
+
+    expect(result.current.openExpansionItems).toEqual(storedItems);
+  });
+
+  it('openExpansionItem adds item and persists', () => {
+    const { result } = renderHook(() => useAccordionContext());
+
+    act(() => {
+      result.current.openExpansionItem(testItemId);
+    });
+
+    expect(result.current.openExpansionItems).toContain(testItemId);
+    expect(mockPersistValue).toHaveBeenCalledWith('openExpansionItems', [testItemId]);
+  });
+
+  it('openExpansionItem does not duplicate existing item', () => {
+    setupMocks(createMockPersistedState({ openExpansionItems: [testItemId] }));
+
+    const { result } = renderHook(() => useAccordionContext());
+
+    act(() => {
+      result.current.openExpansionItem(testItemId);
+    });
+
+    expect(result.current.openExpansionItems.filter((id) => id === testItemId)).toHaveLength(1);
+  });
+
+  it('closeExpansionItem removes item and persists', () => {
+    setupMocks(createMockPersistedState({ openExpansionItems: [testItemId, testItemId2] }));
+
+    const { result } = renderHook(() => useAccordionContext());
+
+    act(() => {
+      result.current.closeExpansionItem(testItemId);
+    });
+
+    expect(result.current.openExpansionItems).not.toContain(testItemId);
+    expect(result.current.openExpansionItems).toContain(testItemId2);
+    expect(mockPersistValue).toHaveBeenCalledWith('openExpansionItems', [testItemId2]);
+  });
+
+  it('closeExpansionItem handles non-existent item gracefully', () => {
+    setupMocks(createMockPersistedState({ openExpansionItems: [testItemId] }));
+
+    const { result } = renderHook(() => useAccordionContext());
+
+    act(() => {
+      result.current.closeExpansionItem('non-existent-id');
+    });
+
+    expect(result.current.openExpansionItems).toEqual([testItemId]);
+  });
+});

--- a/src/onlineHelp/learningExperienceDrawer/context/__tests__/useLearningExperienceContext.actions.test.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/__tests__/useLearningExperienceContext.actions.test.ts
@@ -5,8 +5,6 @@ import { useLearningExperienceContext } from '../useLearningExperienceContext';
 import {
   testDrawerWidth,
   testExistingTopicId,
-  testItemId,
-  testItemId2,
   testReferenceId,
   testReferenceScrollPosition,
   testScrollPosition,
@@ -94,57 +92,6 @@ describe('useLearningExperienceContext - Actions', () => {
       expect(mockPersistValue).toHaveBeenCalledWith('referenceScrollPositions', {
         [testReferenceId]: testReferenceScrollPosition,
       });
-    });
-  });
-
-  describe('Expansion Items', () => {
-    it('openExpansionItem adds item and persists', () => {
-      const { result } = renderHook(() => useLearningExperienceContext());
-
-      act(() => {
-        result.current.openExpansionItem(testItemId);
-      });
-
-      expect(result.current.openExpansionItems).toContain(testItemId);
-      expect(mockPersistValue).toHaveBeenCalledWith('openExpansionItems', [testItemId]);
-    });
-
-    it('openExpansionItem does not duplicate existing item', () => {
-      setupMocks(createMockPersistedState({ openExpansionItems: [testItemId] }));
-
-      const { result } = renderHook(() => useLearningExperienceContext());
-
-      act(() => {
-        result.current.openExpansionItem(testItemId);
-      });
-
-      expect(result.current.openExpansionItems.filter((id) => id === testItemId)).toHaveLength(1);
-    });
-
-    it('closeExpansionItem removes item and persists', () => {
-      setupMocks(createMockPersistedState({ openExpansionItems: [testItemId, testItemId2] }));
-
-      const { result } = renderHook(() => useLearningExperienceContext());
-
-      act(() => {
-        result.current.closeExpansionItem(testItemId);
-      });
-
-      expect(result.current.openExpansionItems).not.toContain(testItemId);
-      expect(result.current.openExpansionItems).toContain(testItemId2);
-      expect(mockPersistValue).toHaveBeenCalledWith('openExpansionItems', [testItemId2]);
-    });
-
-    it('closeExpansionItem handles non-existent item gracefully', () => {
-      setupMocks(createMockPersistedState({ openExpansionItems: [testItemId] }));
-
-      const { result } = renderHook(() => useLearningExperienceContext());
-
-      act(() => {
-        result.current.closeExpansionItem('non-existent-id');
-      });
-
-      expect(result.current.openExpansionItems).toEqual([testItemId]);
     });
   });
 

--- a/src/onlineHelp/learningExperienceDrawer/context/__tests__/useLearningExperienceContext.initialization.test.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/__tests__/useLearningExperienceContext.initialization.test.ts
@@ -5,8 +5,6 @@ import { useLearningExperienceContext } from '../useLearningExperienceContext';
 
 import {
   testDrawerWidth,
-  testItemId,
-  testItemId2,
   testReferenceId,
   testScrollPosition,
   testStoredReferencePosition,
@@ -35,7 +33,6 @@ describe('useLearningExperienceContext - Initialization', () => {
     const { result } = renderHook(() => useLearningExperienceContext());
 
     expect(result.current.isLearningExperienceOpen).toBe(false);
-    expect(result.current.openExpansionItems).toEqual([]);
     expect(result.current.scrollPosition).toBe(0);
     expect(result.current.referenceScrollPositions).toEqual({});
     expect(result.current.selectedTopic).toBeNull();
@@ -49,15 +46,6 @@ describe('useLearningExperienceContext - Initialization', () => {
     const { result } = renderHook(() => useLearningExperienceContext());
 
     expect(result.current.isLearningExperienceOpen).toBe(true);
-  });
-
-  it('restores openExpansionItems from storage', () => {
-    const storedItems = [testItemId, testItemId2];
-    setupMocks(createMockPersistedState({ openExpansionItems: storedItems }));
-
-    const { result } = renderHook(() => useLearningExperienceContext());
-
-    expect(result.current.openExpansionItems).toEqual(storedItems);
   });
 
   it('restores scrollPosition from storage', () => {

--- a/src/onlineHelp/learningExperienceDrawer/context/createAccordionContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/createAccordionContext.ts
@@ -1,0 +1,7 @@
+import type { AccordionContextType } from '../utils/types';
+
+export const createAccordionContext = (): AccordionContextType => ({
+  closeExpansionItem: () => null,
+  openExpansionItem: () => null,
+  openExpansionItems: [],
+});

--- a/src/onlineHelp/learningExperienceDrawer/context/createLearningExperienceContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/createLearningExperienceContext.ts
@@ -3,13 +3,10 @@ import type { LearningExperienceContextType } from '../utils/types';
 
 export const createLearningExperienceContext = (): LearningExperienceContextType => ({
   clearData: () => null,
-  closeExpansionItem: () => null,
   closeLearningExperience: () => null,
   data: {},
   drawerWidth: DEFAULT_DRAWER_WIDTH,
   isLearningExperienceOpen: false,
-  openExpansionItem: () => null,
-  openExpansionItems: [],
   openLearningExperience: () => null,
   referenceScrollPositions: {},
   scrollPosition: 0,

--- a/src/onlineHelp/learningExperienceDrawer/context/useAccordionContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/useAccordionContext.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { parseOrClean } from '@utils/userSettingsHelpers';
+
+import { STORAGE_KEY } from '../utils/constants';
+import type { AccordionContextType, PersistedState } from '../utils/types';
+import { persistValue } from '../utils/utils';
+
+export const useAccordionContext = (): AccordionContextType => {
+  const [persistedState] = useState(() => parseOrClean<PersistedState>(STORAGE_KEY));
+  const [openExpansionItems, setOpenExpansionItems] = useState<string[]>(
+    persistedState.openExpansionItems ?? [],
+  );
+
+  const openExpansionItem = useCallback((itemId: string) => {
+    setOpenExpansionItems((prev) => {
+      if (prev.includes(itemId)) {
+        return prev;
+      }
+      const newItems = [...prev, itemId];
+      persistValue('openExpansionItems', newItems);
+      return newItems;
+    });
+  }, []);
+
+  const closeExpansionItem = useCallback((itemId: string) => {
+    setOpenExpansionItems((prev) => {
+      if (prev.includes(itemId)) {
+        const newItems = prev.filter((openId) => openId !== itemId);
+        persistValue('openExpansionItems', newItems);
+        return newItems;
+      }
+      return prev;
+    });
+  }, []);
+
+  return useMemo(
+    () => ({
+      closeExpansionItem,
+      openExpansionItem,
+      openExpansionItems,
+    }),
+    [closeExpansionItem, openExpansionItem, openExpansionItems],
+  );
+};

--- a/src/onlineHelp/learningExperienceDrawer/context/useLearningExperienceContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/useLearningExperienceContext.ts
@@ -13,9 +13,6 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
   const [isLearningExperienceOpen, setIsLearningExperienceOpen] = useState(
     persistedState.isLearningExperienceOpen ?? false,
   );
-  const [openExpansionItems, setOpenExpansionItems] = useState<string[]>(
-    persistedState.openExpansionItems ?? [],
-  );
   const [scrollPosition, setScrollPosition] = useState(persistedState.scrollPosition ?? 0);
   const [referenceScrollPositions, setReferenceScrollPositions] = useState<Record<string, number>>(
     persistedState.referenceScrollPositions ?? {},
@@ -36,28 +33,6 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
   const closeLearningExperience = useCallback(() => {
     setIsLearningExperienceOpen(false);
     persistValue('isLearningExperienceOpen', false);
-  }, []);
-
-  const openExpansionItem = useCallback((itemId: string) => {
-    setOpenExpansionItems((prev) => {
-      if (prev.includes(itemId)) {
-        return prev;
-      }
-      const newItems = [...prev, itemId];
-      persistValue('openExpansionItems', newItems);
-      return newItems;
-    });
-  }, []);
-
-  const closeExpansionItem = useCallback((itemId: string) => {
-    setOpenExpansionItems((prev) => {
-      if (prev.includes(itemId)) {
-        const newItems = prev.filter((openId) => openId !== itemId);
-        persistValue('openExpansionItems', newItems);
-        return newItems;
-      }
-      return prev;
-    });
   }, []);
 
   const setDataItem = useCallback((dataItem: string, value: unknown): void => {
@@ -106,13 +81,10 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
   return useMemo(
     () => ({
       clearData,
-      closeExpansionItem,
       closeLearningExperience,
       data,
       drawerWidth,
       isLearningExperienceOpen,
-      openExpansionItem,
-      openExpansionItems,
       openLearningExperience,
       referenceScrollPositions,
       scrollPosition,
@@ -125,13 +97,10 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
     }),
     [
       clearData,
-      closeExpansionItem,
       closeLearningExperience,
       data,
       drawerWidth,
       isLearningExperienceOpen,
-      openExpansionItem,
-      openExpansionItems,
       openLearningExperience,
       referenceScrollPositions,
       scrollPosition,

--- a/src/onlineHelp/learningExperienceDrawer/utils/types.ts
+++ b/src/onlineHelp/learningExperienceDrawer/utils/types.ts
@@ -1,11 +1,16 @@
 import type { LearningExperienceTopic } from 'src/onlineHelp/utils/types';
 
+export type AccordionContextType = {
+  openExpansionItems: string[];
+  openExpansionItem: (itemId: string) => void;
+  closeExpansionItem: (itemId: string) => void;
+};
+
 export type LearningExperienceContextType = {
   isLearningExperienceOpen: boolean;
   selectedTopic: LearningExperienceTopic | null;
   scrollPosition: number;
   referenceScrollPositions: Record<string, number>;
-  openExpansionItems: string[];
   drawerWidth: string;
   data: Record<string, unknown>;
   openLearningExperience: () => void;
@@ -14,8 +19,6 @@ export type LearningExperienceContextType = {
   setScrollPosition: (scrollPosition: number) => void;
   setReferenceScrollPosition: (id: string, position: number) => void;
   setDrawerWidth: (width: string) => void;
-  openExpansionItem: (itemId: string) => void;
-  closeExpansionItem: (itemId: string) => void;
   setData: (dataItem: string, dataValue: unknown) => void;
   clearData: (dataItem?: string) => void;
 };

--- a/src/onlineHelp/learningExperienceStructure/HelpTopic/HelpTopic.tsx
+++ b/src/onlineHelp/learningExperienceStructure/HelpTopic/HelpTopic.tsx
@@ -1,4 +1,4 @@
-import { type FC, useContext } from 'react';
+import { type FC, memo, useContext } from 'react';
 import { ListStyleType } from 'src/onlineHelp/utils/types';
 
 import { Content } from '@patternfly/react-core';
@@ -51,4 +51,4 @@ const HelpTopic: FC = () => {
   );
 };
 
-export default HelpTopic;
+export default memo(HelpTopic);

--- a/src/onlineHelp/learningExperienceStructure/HelpTopicSection/HelpTopicSection.tsx
+++ b/src/onlineHelp/learningExperienceStructure/HelpTopicSection/HelpTopicSection.tsx
@@ -1,10 +1,10 @@
-import { type FC, useContext } from 'react';
+import { type FC, memo, useContext } from 'react';
 import { type LearningExperienceSubTopic, ListStyleType } from 'src/onlineHelp/utils/types';
 
 import { ExpandableSection } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 
-import { LearningExperienceContext } from '../../learningExperienceDrawer/context/LearningExperienceContext';
+import { AccordionContext } from '../../learningExperienceDrawer/context/AccordionContext';
 
 import SubTopicsContent from './components/SubTopicsContent';
 import TopicTitle from './components/TopicTitle';
@@ -17,7 +17,7 @@ type HelpTopicSectionProps = {
 
 const HelpTopicSection: FC<HelpTopicSectionProps> = ({ index, listStyleType, topic }) => {
   const { closeExpansionItem, openExpansionItem, openExpansionItems } =
-    useContext(LearningExperienceContext);
+    useContext(AccordionContext);
 
   const isExpanded = openExpansionItems.includes(topic.id);
   const hasSubTopics = Boolean(topic.subTopics);
@@ -43,6 +43,8 @@ const HelpTopicSection: FC<HelpTopicSectionProps> = ({ index, listStyleType, top
         !hasSubTopics && 'm-non-expandable',
         topic.subListStyleType === ListStyleType.DESCRIPTIONS && 'm-has-descriptions',
       )}
+      contentId={`help-topic-content-${topic.id}`}
+      toggleId={`help-topic-toggle-${topic.id}`}
       toggleContent={
         <div className="pf-v6-u-ml-sm">
           <TopicTitle title={topic.title} listStyleType={listStyleType} prefix={prefix} />
@@ -56,4 +58,4 @@ const HelpTopicSection: FC<HelpTopicSectionProps> = ({ index, listStyleType, top
   );
 };
 
-export default HelpTopicSection;
+export default memo(HelpTopicSection);

--- a/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/LearningExperiencePanel.tsx
+++ b/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/LearningExperiencePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { TIPS_AND_TRICKS_LABEL } from '@utils/constants';
 
+import AccordionContextProvider from '../../learningExperienceDrawer/context/AccordionContextProvider';
 import { LearningExperienceContext } from '../../learningExperienceDrawer/context/LearningExperienceContext';
 import HelpTopic from '../HelpTopic/HelpTopic';
 
@@ -48,33 +49,35 @@ const LearningExperiencePanel: FC = () => {
       }}
       className="pfext-quick-start__base forklift--learning"
     >
-      <div ref={panelContentRef} className="forklift--learning__panel">
-        <div className="pfext-quick-start-panel-content pfext-quick-start-panel-content__header pfext-quick-start-panel-content__header--blue-white forklift--learning__header">
-          <DrawerHead>
-            <div className="pfext-quick-start-panel-content__title" tabIndex={-1}>
-              <Title headingLevel="h2" size="xl">
-                {TIPS_AND_TRICKS_LABEL}
-              </Title>
-            </div>
-            <DrawerActions>
-              <DrawerCloseButton
-                className="pfext-quick-start-panel-content__close-button"
-                onClick={() => {
-                  closeLearningExperience();
-                  setSelectedTopic(null);
-                }}
-              />
-            </DrawerActions>
-            <LearningExperienceSelect />
-          </DrawerHead>
+      <AccordionContextProvider>
+        <div ref={panelContentRef} className="forklift--learning__panel">
+          <div className="pfext-quick-start-panel-content pfext-quick-start-panel-content__header pfext-quick-start-panel-content__header--blue-white forklift--learning__header">
+            <DrawerHead>
+              <div className="pfext-quick-start-panel-content__title" tabIndex={-1}>
+                <Title headingLevel="h2" size="xl">
+                  {TIPS_AND_TRICKS_LABEL}
+                </Title>
+              </div>
+              <DrawerActions>
+                <DrawerCloseButton
+                  className="pfext-quick-start-panel-content__close-button"
+                  onClick={() => {
+                    closeLearningExperience();
+                    setSelectedTopic(null);
+                  }}
+                />
+              </DrawerActions>
+              <LearningExperienceSelect />
+            </DrawerHead>
+          </div>
+          <DrawerPanelBody className="pfext-quick-start-panel-content__body">
+            <HelpTopic />
+            <LearningTopicsCards />
+            <QuickReferencesSection />
+            <ExternalLinksSection />
+          </DrawerPanelBody>
         </div>
-        <DrawerPanelBody className="pfext-quick-start-panel-content__body">
-          <HelpTopic />
-          <LearningTopicsCards />
-          <QuickReferencesSection />
-          <ExternalLinksSection />
-        </DrawerPanelBody>
-      </div>
+      </AccordionContextProvider>
     </DrawerPanelContent>
   );
 };

--- a/src/onlineHelp/learningExperienceStructure/ReferenceSection/ReferenceSection.tsx
+++ b/src/onlineHelp/learningExperienceStructure/ReferenceSection/ReferenceSection.tsx
@@ -1,7 +1,8 @@
-import { type FC, type ReactNode, useContext } from 'react';
+import { type FC, memo, type ReactNode, useContext } from 'react';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
 
+import { AccordionContext } from '../../learningExperienceDrawer/context/AccordionContext';
 import { LearningExperienceContext } from '../../learningExperienceDrawer/context/LearningExperienceContext';
 import { useScrollPositionPersistence } from '../LearningExperiencePanel/hooks/useScrollPositionPersistence';
 
@@ -16,13 +17,10 @@ type ReferenceSectionProps = {
 };
 
 const ReferenceSection: FC<ReferenceSectionProps> = ({ children, icon, id, title }) => {
-  const {
-    closeExpansionItem,
-    openExpansionItem,
-    openExpansionItems,
-    referenceScrollPositions,
-    setReferenceScrollPosition,
-  } = useContext(LearningExperienceContext);
+  const { closeExpansionItem, openExpansionItem, openExpansionItems } =
+    useContext(AccordionContext);
+  const { referenceScrollPositions, setReferenceScrollPosition } =
+    useContext(LearningExperienceContext);
 
   const isExpanded = openExpansionItems.includes(id);
 
@@ -52,4 +50,4 @@ const ReferenceSection: FC<ReferenceSectionProps> = ({ children, icon, id, title
   );
 };
 
-export default ReferenceSection;
+export default memo(ReferenceSection);


### PR DESCRIPTION
## Summary
- Isolate Tips and tricks accordion expansion state into a panel-scoped `AccordionContext` so toggles no longer fan out re-renders through the root-mounted learning-experience context
- Pass stable `contentId`/`toggleId` to PatternFly `ExpandableSection` to stop `getUniqueId()` DOM id churn on every render
- Memo leaf consumers (`HelpTopicSection`, `ReferenceSection`, `HelpTopic`) as a backstop

## Test plan
- [x] Unit tests for `useAccordionContext` + updated learning-experience context tests
- [x] `npm run build` / lint on changed files
- [x] Manual/Playwright smoke: Tips and tricks → switch topics → toggle first 3 accordions; stable `help-topic-*` ids, `idChurn` 0, clicks stay ~tens of ms
- [ ] Downstream `learning-experience.spec.ts` if CI/cluster available

Resolves: MTV-6166
