### PR TITLE
Resolves: MTV-5509 | Add fixture-driven E2E coverage for post-migration setup status

### DIFF
--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -19,10 +19,20 @@ import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 
 const WINDOWS_VM_ID = 'vm-win-1';
 const WINDOWS_VM_NAME = 'test-windows-vm';
+const LINUX_VM_ID = 'vm-linux-1';
+const LINUX_VM_NAME = 'test-linux-vm';
 
-const buildMockPlan = () => {
-  const started = new Date(Date.now() - 12 * 60_000).toISOString();
-  const vmCreatedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+const MILLISECONDS_PER_MINUTE = 60_000;
+const MIGRATION_STARTED_MINUTES_AGO = 12;
+const VM_CREATED_MINUTES_AGO = 3;
+
+const buildMockPlan = (): object => {
+  const started = new Date(
+    Date.now() - MIGRATION_STARTED_MINUTES_AGO * MILLISECONDS_PER_MINUTE,
+  ).toISOString();
+  const vmCreatedAt = new Date(
+    Date.now() - VM_CREATED_MINUTES_AGO * MILLISECONDS_PER_MINUTE,
+  ).toISOString();
 
   return {
     apiVersion: 'forklift.konveyor.io/v1beta1',
@@ -43,7 +53,10 @@ const buildMockPlan = () => {
       pvcNameTemplateUseGenerateName: true,
       skipGuestConversion: false,
       targetNamespace: TEST_DATA.targetProject,
-      vms: [{ id: WINDOWS_VM_ID, name: WINDOWS_VM_NAME }],
+      vms: [
+        { id: WINDOWS_VM_ID, name: WINDOWS_VM_NAME },
+        { id: LINUX_VM_ID, name: LINUX_VM_NAME },
+      ],
       warm: false,
     },
     status: {
@@ -72,6 +85,18 @@ const buildMockPlan = () => {
                 phase: 'Running',
               },
               { name: 'PostHook', phase: 'Pending' },
+            ],
+            started,
+          },
+          {
+            // A second, unrelated VM ("Running", not post-migration setup) so the
+            // "Pipeline status" filter test can prove real filtering by asserting
+            // this VM is excluded, rather than the filter being a no-op.
+            id: LINUX_VM_ID,
+            name: LINUX_VM_NAME,
+            pipeline: [
+              { completed: started, name: 'Initialize', phase: 'Completed' },
+              { name: 'DiskTransfer', phase: 'Running' },
             ],
             started,
           },
@@ -158,14 +183,23 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
       await expect(page.getByText(WINDOWS_VM_NAME, { exact: true })).toBeVisible();
     });
 
-    await test.step('"Pipeline status" filter offers "Post-migration setup" and filtering keeps the VM visible', async () => {
+    await test.step('"Pipeline status" filter offers "Post-migration setup" and filtering excludes non-matching VMs', async () => {
+      await virtualMachinesTab.verifyRowIsVisible({ Name: LINUX_VM_NAME });
+
       await virtualMachinesTab.verifyPrimaryFilterValues('status', ['Post-migration setup']);
       await virtualMachinesTab.applyPrimaryFilter('status', 'Post-migration setup');
+
       await virtualMachinesTab.verifyRowIsVisible({ Name: WINDOWS_VM_NAME });
+      await expect(page.getByText(LINUX_VM_NAME, { exact: true })).toHaveCount(0);
+
       await virtualMachinesTab.clearFilters();
+      await virtualMachinesTab.verifyRowIsVisible({ Name: LINUX_VM_NAME });
     });
 
     await test.step('Expanded pipeline table shows the "Post-migration setup" step and warning alert', async () => {
+      // Narrow to the Windows VM so "first" row is unambiguous now that the fixture
+      // has two VMs.
+      await virtualMachinesTab.search(WINDOWS_VM_NAME);
       await virtualMachinesTab.expandFirstVMDetailsRow();
       await expect(page.getByText('Post-migration setup', { exact: true })).toBeVisible();
       await expect(page.getByText('Do not access this VM')).toBeVisible();

--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { type Page, test } from '@playwright/test';
 
 import { TEST_DATA } from '../../fixtures/test-data';
 import { setupForkliftIntercepts, setupMigrationVmResourceIntercepts } from '../../intercepts';
@@ -194,27 +194,5 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
       await virtualMachinesTab.expandFirstVMDetailsRow();
       await virtualMachinesTab.postMigrationSetup.verifyDetailsVisible();
     });
-  });
-
-  test('[Known bug] "Pipeline status" column text should read "Post-migration setup" while WaitForGuestReboots is running', async ({
-    page,
-  }) => {
-    // MTV-6278: MigrationStatusLabel reads a stale duplicate of getVMMigrationStatus that lacks
-    // the isPostMigrationSetup branch, so it falls through to "Running". Remove test.fail() once
-    // MTV-6278 lands.
-    test.fail(true, 'Known bug MTV-6278 — filed as a follow-up to MTV-5509/MTV-5507');
-
-    const planDetailsPage = new PlanDetailsPage(page);
-    const { virtualMachinesTab } = planDetailsPage;
-
-    await planDetailsPage.navigate(TEST_DATA.planName, MTV_NAMESPACE);
-    await virtualMachinesTab.navigateToVirtualMachinesTab();
-
-    const statusCell = await virtualMachinesTab.getTableCell(
-      'Name',
-      WINDOWS_VM_NAME,
-      'Pipeline status',
-    );
-    await expect(statusCell).toContainText('Post-migration setup');
   });
 });

--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -171,8 +171,7 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
 
     await test.step('VM row is visible but its name is not a navigable link', async () => {
       await virtualMachinesTab.verifyRowIsVisible({ Name: WINDOWS_VM_NAME });
-      await expect(page.getByRole('link', { name: WINDOWS_VM_NAME, exact: true })).toHaveCount(0);
-      await expect(page.getByText(WINDOWS_VM_NAME, { exact: true })).toBeVisible();
+      await virtualMachinesTab.postMigrationSetup.verifyVMNameIsNotLink(WINDOWS_VM_NAME);
     });
 
     await test.step('"Pipeline status" filter offers "Post-migration setup" and filtering excludes non-matching VMs', async () => {
@@ -182,7 +181,7 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
       await virtualMachinesTab.applyPrimaryFilter('status', 'Post-migration setup');
 
       await virtualMachinesTab.verifyRowIsVisible({ Name: WINDOWS_VM_NAME });
-      await expect(page.getByText(LINUX_VM_NAME, { exact: true })).toHaveCount(0);
+      await virtualMachinesTab.verifyVMNotVisible(LINUX_VM_NAME);
 
       await virtualMachinesTab.clearFilters();
       await virtualMachinesTab.verifyRowIsVisible({ Name: LINUX_VM_NAME });
@@ -193,11 +192,7 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
       // has two VMs.
       await virtualMachinesTab.search(WINDOWS_VM_NAME);
       await virtualMachinesTab.expandFirstVMDetailsRow();
-      await expect(page.getByText('Post-migration setup', { exact: true })).toBeVisible();
-      await expect(page.getByText('Do not access this VM')).toBeVisible();
-      await expect(
-        page.getByText(/installing drivers and completing post-migration setup/iu),
-      ).toBeVisible();
+      await virtualMachinesTab.postMigrationSetup.verifyDetailsVisible();
     });
   });
 

--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -1,0 +1,203 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { TEST_DATA } from '../../fixtures/test-data';
+import { setupForkliftIntercepts, setupMigrationVmResourceIntercepts } from '../../intercepts';
+import { PlanDetailsPage } from '../../page-objects/PlanDetailsPage/PlanDetailsPage';
+import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
+
+/**
+ * MTV-5509 / MTV-5507 — "Post-Migration Setup" phase in the migration progress UI.
+ *
+ * Fixture-driven (no live cluster / real Windows VM needed): mocks a Plan whose
+ * `status.migration.vms[0].pipeline` has the backend's `WaitForGuestReboots` step
+ * `Running`, which is what the UI renders while a migrated Windows VM is still
+ * rebooting to finish driver installation.
+ *
+ * See docs/test-report-mtv-5509-post-migration-setup.md for the live-cluster
+ * exploration this spec formalizes into a fast, repeatable regression test.
+ */
+
+const WINDOWS_VM_ID = 'vm-win-1';
+const WINDOWS_VM_NAME = 'test-windows-vm';
+
+const buildMockPlan = () => {
+  const started = new Date(Date.now() - 12 * 60_000).toISOString();
+  const vmCreatedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+
+  return {
+    apiVersion: 'forklift.konveyor.io/v1beta1',
+    kind: 'Plan',
+    metadata: {
+      creationTimestamp: new Date().toISOString(),
+      name: TEST_DATA.planName,
+      namespace: MTV_NAMESPACE,
+      resourceVersion: '999999',
+      uid: 'test-plan-uid-1',
+    },
+    spec: {
+      migrateSharedDisks: false,
+      provider: {
+        destination: { name: TEST_DATA.providers.target.name, namespace: MTV_NAMESPACE },
+        source: { name: TEST_DATA.providers.source.name, namespace: MTV_NAMESPACE },
+      },
+      pvcNameTemplateUseGenerateName: true,
+      skipGuestConversion: false,
+      targetNamespace: TEST_DATA.targetProject,
+      vms: [{ id: WINDOWS_VM_ID, name: WINDOWS_VM_NAME }],
+      warm: false,
+    },
+    status: {
+      conditions: [
+        {
+          category: 'Advisory',
+          lastTransitionTime: new Date().toISOString(),
+          message: 'The plan is executing.',
+          reason: 'ExecutionInProgress',
+          status: 'True',
+          type: 'Executing',
+        },
+      ],
+      migration: {
+        vms: [
+          {
+            id: WINDOWS_VM_ID,
+            name: WINDOWS_VM_NAME,
+            pipeline: [
+              { completed: started, name: 'Initialize', phase: 'Completed' },
+              { completed: started, name: 'DiskTransfer', phase: 'Completed' },
+              { completed: vmCreatedAt, name: 'VirtualMachineCreation', phase: 'Completed' },
+              {
+                description: 'Waiting for guest reboots to complete',
+                name: 'WaitForGuestReboots',
+                phase: 'Running',
+              },
+              { name: 'PostHook', phase: 'Pending' },
+            ],
+            started,
+          },
+        ],
+      },
+    },
+  };
+};
+
+/**
+ * Overrides the baseline `setupPlansIntercepts` plan routes (GET, watch, and
+ * fieldSelector variants) for `TEST_DATA.planName` with a plan whose migration
+ * status has a VM in the `WaitForGuestReboots` ("Post-migration setup") phase.
+ * Playwright resolves overlapping `page.route` handlers most-recently-registered
+ * first, so calling this after `setupForkliftIntercepts` makes it take priority.
+ */
+const setupPostMigrationSetupPlanOverride = async (page: Page): Promise<void> => {
+  const mockPlan = buildMockPlan();
+  const planByNameUrl = `**/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/${MTV_NAMESPACE}/plans/${TEST_DATA.planName}`;
+
+  await page.route(planByNameUrl, async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        body: JSON.stringify(mockPlan),
+        contentType: 'application/json',
+        status: 200,
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route(`**/namespaces/${MTV_NAMESPACE}/plans?watch=true**`, async (route) => {
+    const url = route.request().url();
+    if (url.includes(TEST_DATA.planName) || url.includes('fieldSelector')) {
+      await route.fulfill({
+        body: JSON.stringify({ object: mockPlan, type: 'ADDED' }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await page.route(
+    `**/api/kubernetes/apis/forklift.konveyor.io/v1beta1/namespaces/${MTV_NAMESPACE}/plans?**`,
+    async (route) => {
+      const url = route.request().url();
+      if (url.includes(TEST_DATA.planName) && route.request().method() === 'GET') {
+        await route.fulfill({
+          body: JSON.stringify(mockPlan),
+          contentType: 'application/json',
+          status: 200,
+        });
+      } else {
+        await route.continue();
+      }
+    },
+  );
+};
+
+test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@upstream' }, () => {
+  test.beforeEach(async ({ page }) => {
+    await setupForkliftIntercepts(page);
+    await setupMigrationVmResourceIntercepts(page);
+    await setupPostMigrationSetupPlanOverride(page);
+  });
+
+  test('shows the Post-migration setup pipeline step, warning alert, filter option, and suppresses the VM link while WaitForGuestReboots is running', async ({
+    page,
+  }) => {
+    const planDetailsPage = new PlanDetailsPage(page);
+    const { virtualMachinesTab } = planDetailsPage;
+
+    await test.step('Navigate to the plan Virtual machines tab', async () => {
+      await planDetailsPage.navigate(TEST_DATA.planName, MTV_NAMESPACE);
+      await virtualMachinesTab.navigateToVirtualMachinesTab();
+    });
+
+    await test.step('VM row is visible but its name is not a navigable link', async () => {
+      await virtualMachinesTab.verifyRowIsVisible({ Name: WINDOWS_VM_NAME });
+      await expect(page.getByRole('link', { name: WINDOWS_VM_NAME, exact: true })).toHaveCount(0);
+      await expect(page.getByText(WINDOWS_VM_NAME, { exact: true })).toBeVisible();
+    });
+
+    await test.step('"Pipeline status" filter offers "Post-migration setup" and filtering keeps the VM visible', async () => {
+      await virtualMachinesTab.verifyPrimaryFilterValues('status', ['Post-migration setup']);
+      await virtualMachinesTab.applyPrimaryFilter('status', 'Post-migration setup');
+      await virtualMachinesTab.verifyRowIsVisible({ Name: WINDOWS_VM_NAME });
+      await virtualMachinesTab.clearFilters();
+    });
+
+    await test.step('Expanded pipeline table shows the "Post-migration setup" step and warning alert', async () => {
+      await virtualMachinesTab.expandFirstVMDetailsRow();
+      await expect(page.getByText('Post-migration setup', { exact: true })).toBeVisible();
+      await expect(page.getByText('Do not access this VM')).toBeVisible();
+      await expect(
+        page.getByText(/installing drivers and completing post-migration setup/iu),
+      ).toBeVisible();
+    });
+  });
+
+  test('[Known bug] "Pipeline status" column text should read "Post-migration setup" while WaitForGuestReboots is running', async ({
+    page,
+  }) => {
+    // MigrationStatusLabel (rendered in this column via fields.tsx) sources its text from a
+    // stale, duplicated getVMMigrationStatus in
+    // src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts,
+    // which lacks the isPostMigrationSetup branch present in the canonical implementation
+    // (MigrationStatusVirtualMachineList/utils/utils.ts). It currently falls through to
+    // "Running". Remove test.fail() once the duplicate is consolidated and this passes for
+    // real -- see docs/test-report-mtv-5509-post-migration-setup.md.
+    test.fail(true, 'Known bug — filed as a follow-up to MTV-5509/MTV-5507');
+
+    const planDetailsPage = new PlanDetailsPage(page);
+    const { virtualMachinesTab } = planDetailsPage;
+
+    await planDetailsPage.navigate(TEST_DATA.planName, MTV_NAMESPACE);
+    await virtualMachinesTab.navigateToVirtualMachinesTab();
+
+    const statusCell = await virtualMachinesTab.getTableCell(
+      'Name',
+      WINDOWS_VM_NAME,
+      'Pipeline status',
+    );
+    await expect(statusCell).toContainText('Post-migration setup');
+  });
+});

--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -212,14 +212,10 @@ test.describe('Plan Virtual Machines — Post-Migration Setup status', { tag: '@
   test('[Known bug] "Pipeline status" column text should read "Post-migration setup" while WaitForGuestReboots is running', async ({
     page,
   }) => {
-    // MigrationStatusLabel (rendered in this column via fields.tsx) sources its text from a
-    // stale, duplicated getVMMigrationStatus in
-    // src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts,
-    // which lacks the isPostMigrationSetup branch present in the canonical implementation
-    // (MigrationStatusVirtualMachineList/utils/utils.ts). It currently falls through to
-    // "Running". Remove test.fail() once the duplicate is consolidated and this passes for
-    // real -- see docs/test-report-mtv-5509-post-migration-setup.md.
-    test.fail(true, 'Known bug — filed as a follow-up to MTV-5509/MTV-5507');
+    // MTV-6278: MigrationStatusLabel reads a stale duplicate of getVMMigrationStatus that lacks
+    // the isPostMigrationSetup branch, so it falls through to "Running". Remove test.fail() once
+    // MTV-6278 lands.
+    test.fail(true, 'Known bug MTV-6278 — filed as a follow-up to MTV-5509/MTV-5507');
 
     const planDetailsPage = new PlanDetailsPage(page);
     const { virtualMachinesTab } = planDetailsPage;

--- a/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
+++ b/testing/playwright/e2e/upstream/plan-post-migration-setup-status.spec.ts
@@ -5,17 +5,9 @@ import { setupForkliftIntercepts, setupMigrationVmResourceIntercepts } from '../
 import { PlanDetailsPage } from '../../page-objects/PlanDetailsPage/PlanDetailsPage';
 import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 
-/**
- * MTV-5509 / MTV-5507 — "Post-Migration Setup" phase in the migration progress UI.
- *
- * Fixture-driven (no live cluster / real Windows VM needed): mocks a Plan whose
- * `status.migration.vms[0].pipeline` has the backend's `WaitForGuestReboots` step
- * `Running`, which is what the UI renders while a migrated Windows VM is still
- * rebooting to finish driver installation.
- *
- * See docs/test-report-mtv-5509-post-migration-setup.md for the live-cluster
- * exploration this spec formalizes into a fast, repeatable regression test.
- */
+// MTV-5509 / MTV-5507 — mocks a Plan with the `WaitForGuestReboots` pipeline step
+// `Running`: the phase where a migrated Windows VM is still rebooting to finish
+// driver installation.
 
 const WINDOWS_VM_ID = 'vm-win-1';
 const WINDOWS_VM_NAME = 'test-windows-vm';

--- a/testing/playwright/intercepts/index.ts
+++ b/testing/playwright/intercepts/index.ts
@@ -4,6 +4,7 @@ export { setupCoreKubernetesIntercepts } from './core';
 export { setupDatastoresIntercepts } from './datastores';
 export { setupHostsIntercepts } from './hosts';
 export { setupLightspeedIntercepts } from './lightspeed';
+export { setupMigrationVmResourceIntercepts } from './migrationVmResources';
 export { setupNetworkMapsIntercepts } from './networkMaps';
 export { setupPlanDetailsIntercepts } from './planDetails';
 export { setupPlansIntercepts } from './plans';

--- a/testing/playwright/intercepts/migrationVmResources.ts
+++ b/testing/playwright/intercepts/migrationVmResources.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Mocks the Pod/Job/PVC/DataVolume list watches that
+ * `useMigrationResources` (Plan > Virtual machines tab, migration-in-progress view) issues
+ * per VM via `selector: { matchLabels: { plan: <planUid> } }`. Returning empty lists lets
+ * those watches resolve to `loaded: true` immediately without needing real migration
+ * workload resources.
+ */
+export const setupMigrationVmResourceIntercepts = async (page: Page): Promise<void> => {
+  const emptyList = (kind: string, apiVersion: string) => ({
+    apiVersion,
+    kind: `${kind}List`,
+    metadata: {},
+    items: [],
+  });
+
+  await page.route('**/api/kubernetes/api/v1/namespaces/*/pods**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(emptyList('Pod', 'v1')),
+    });
+  });
+
+  await page.route('**/api/kubernetes/apis/batch/v1/namespaces/*/jobs**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(emptyList('Job', 'batch/v1')),
+    });
+  });
+
+  await page.route(
+    '**/api/kubernetes/api/v1/namespaces/*/persistentvolumeclaims**',
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(emptyList('PersistentVolumeClaim', 'v1')),
+      });
+    },
+  );
+
+  await page.route(
+    '**/api/kubernetes/apis/cdi.kubevirt.io/v1beta1/namespaces/*/datavolumes**',
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(emptyList('DataVolume', 'cdi.kubevirt.io/v1beta1')),
+      });
+    },
+  );
+};

--- a/testing/playwright/intercepts/migrationVmResources.ts
+++ b/testing/playwright/intercepts/migrationVmResources.ts
@@ -1,5 +1,12 @@
 import type { Page } from '@playwright/test';
 
+type EmptyListPayload = {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, never>;
+  items: never[];
+};
+
 /**
  * Mocks the Pod/Job/PVC/DataVolume list watches that
  * `useMigrationResources` (Plan > Virtual machines tab, migration-in-progress view) issues
@@ -8,7 +15,7 @@ import type { Page } from '@playwright/test';
  * workload resources.
  */
 export const setupMigrationVmResourceIntercepts = async (page: Page): Promise<void> => {
-  const emptyList = (kind: string, apiVersion: string) => ({
+  const emptyList = (kind: string, apiVersion: string): EmptyListPayload => ({
     apiVersion,
     kind: `${kind}List`,
     metadata: {},

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/PostMigrationSetupHelpers.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/PostMigrationSetupHelpers.ts
@@ -1,25 +1,27 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 /** Assertions for the "Post-migration setup" (`WaitForGuestReboots`) VM state. */
 export class PostMigrationSetupHelpers {
-  private readonly page: Page;
+  // Scopes assertions to the VM grid, matching ConcernsHelpers, so page-wide
+  // filter chips/options can't be mistaken for the pipeline step or VM row.
+  private readonly vmTable: Locator;
 
   constructor(page: Page) {
-    this.page = page;
+    this.vmTable = page.getByRole('grid', { name: 'Virtual machines' });
   }
 
   /** Expanded VM details row while `WaitForGuestReboots` runs: step name + warning alert. */
   async verifyDetailsVisible(): Promise<void> {
-    await expect(this.page.getByText('Post-migration setup', { exact: true })).toBeVisible();
-    await expect(this.page.getByText('Do not access this VM')).toBeVisible();
+    await expect(this.vmTable.getByText('Post-migration setup', { exact: true })).toBeVisible();
+    await expect(this.vmTable.getByText('Do not access this VM')).toBeVisible();
     await expect(
-      this.page.getByText(/installing drivers and completing post-migration setup/iu),
+      this.vmTable.getByText(/installing drivers and completing post-migration setup/iu),
     ).toBeVisible();
   }
 
   /** Asserts the VM name renders as plain text in the table, not a navigable link. */
   async verifyVMNameIsNotLink(vmName: string): Promise<void> {
-    await expect(this.page.getByRole('link', { name: vmName, exact: true })).toHaveCount(0);
-    await expect(this.page.getByText(vmName, { exact: true })).toBeVisible();
+    await expect(this.vmTable.getByRole('link', { name: vmName, exact: true })).toHaveCount(0);
+    await expect(this.vmTable.getByText(vmName, { exact: true })).toBeVisible();
   }
 }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/PostMigrationSetupHelpers.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/PostMigrationSetupHelpers.ts
@@ -1,0 +1,25 @@
+import { expect, type Page } from '@playwright/test';
+
+/** Assertions for the "Post-migration setup" (`WaitForGuestReboots`) VM state. */
+export class PostMigrationSetupHelpers {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** Expanded VM details row while `WaitForGuestReboots` runs: step name + warning alert. */
+  async verifyDetailsVisible(): Promise<void> {
+    await expect(this.page.getByText('Post-migration setup', { exact: true })).toBeVisible();
+    await expect(this.page.getByText('Do not access this VM')).toBeVisible();
+    await expect(
+      this.page.getByText(/installing drivers and completing post-migration setup/iu),
+    ).toBeVisible();
+  }
+
+  /** Asserts the VM name renders as plain text in the table, not a navigable link. */
+  async verifyVMNameIsNotLink(vmName: string): Promise<void> {
+    await expect(this.page.getByRole('link', { name: vmName, exact: true })).toHaveCount(0);
+    await expect(this.page.getByText(vmName, { exact: true })).toBeVisible();
+  }
+}

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
@@ -38,6 +38,18 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     await this.page.keyboard.press('Escape');
   }
 
+  /**
+   * Applies a "primary" enum filter (e.g. "Pipeline status") which renders its own
+   * always-visible toggle in the toolbar, unlike secondary filters that live behind
+   * the "attribute-filter-toggle" attribute selector. `filterId` is the field's
+   * `resourceFieldId` (e.g. `'status'`), matching the `filter-toggle-${filterId}` testid.
+   */
+  async applyPrimaryFilter(filterId: string, value: string): Promise<void> {
+    await this.page.getByTestId(`filter-toggle-${filterId}`).click();
+    await this.page.getByTestId(`filter-value-${value}`).click();
+    await this.page.keyboard.press('Escape');
+  }
+
   get cancelButton() {
     return this.page.getByTestId('modal-cancel-button');
   }
@@ -319,6 +331,15 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
       }
     } else {
       expect(await this.page.getByRole('menuitem').count()).toBeGreaterThan(0);
+    }
+    await this.page.keyboard.press('Escape');
+  }
+
+  /** See `applyPrimaryFilter` for why primary filters need their own verification helper. */
+  async verifyPrimaryFilterValues(filterId: string, expectedValues: string[]): Promise<void> {
+    await this.page.getByTestId(`filter-toggle-${filterId}`).click();
+    for (const value of expectedValues) {
+      await expect(this.page.getByTestId(`filter-value-${value}`)).toBeVisible();
     }
     await this.page.keyboard.press('Escape');
   }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
@@ -6,16 +6,19 @@ import { AddVirtualMachinesModal } from '../modals/AddVirtualMachinesModal';
 
 import { ConcernsHelpers } from './ConcernsHelpers';
 import { PlanVmInstanceTypeModal } from './PlanVmInstanceTypeModal';
+import { PostMigrationSetupHelpers } from './PostMigrationSetupHelpers';
 
 /** VirtualMachines tab for Plan Details page (flat grid, no folder hierarchy). */
 export class VirtualMachinesTab extends VirtualMachinesTable {
   readonly concerns: ConcernsHelpers;
   readonly editVmInstanceTypeModal: PlanVmInstanceTypeModal;
+  readonly postMigrationSetup: PostMigrationSetupHelpers;
 
   constructor(page: Page) {
     super(page, page.locator('main'));
     this.concerns = new ConcernsHelpers(page);
     this.editVmInstanceTypeModal = new PlanVmInstanceTypeModal(page);
+    this.postMigrationSetup = new PostMigrationSetupHelpers(page);
   }
 
   private async dismissOpenModals(): Promise<void> {
@@ -219,19 +222,21 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
   get powerStateOptionAuto() {
     return this.page.getByRole('option', { name: 'Retain source VM power state', exact: true });
   }
+
   get powerStateOptionInherit() {
     return this.page.getByTestId('power-state-option-inherit');
   }
+
   get powerStateOptionOff() {
     return this.page.getByRole('option', { name: 'Powered off', exact: true });
   }
+
   get powerStateOptionOn() {
     return this.page.getByRole('option', { name: 'Powered on', exact: true });
   }
   get renameTargetNameInput() {
     return this.page.getByTestId('vm-target-name-input');
   }
-
   async renameVM(sourceName: string, targetName: string): Promise<void> {
     await this.search(sourceName);
     const vmRow = this.table.getRow({ Name: sourceName });
@@ -253,11 +258,9 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
     await this.cancelButton.click();
     await this.clearAllFilters();
   }
-
   get saveButton() {
     return this.page.getByRole('button', { name: /save|confirm/iu });
   }
-
   async selectVirtualMachine(vmName: string): Promise<void> {
     await this.table.selectRow({ Name: vmName });
   }
@@ -265,9 +268,11 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
   get sharedDisksModalSaveButton() {
     return this.editSharedDisksModal.getByTestId('modal-confirm-button');
   }
+
   get sharedDisksOptionDisabled() {
     return this.editSharedDisksModal.getByTestId('shared-disks-option-disabled');
   }
+
   get sharedDisksOptionEnabled() {
     return this.editSharedDisksModal.getByTestId('shared-disks-option-enabled');
   }
@@ -275,7 +280,6 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
   get sharedDisksOptionInherit() {
     return this.editSharedDisksModal.getByTestId('shared-disks-option-inherit');
   }
-
   override async sortByColumn(columnName: string): Promise<void> {
     const columnHeader = this.vmTable
       .getByRole('columnheader')
@@ -285,7 +289,6 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
       .toBeVisible()
       .catch(() => undefined);
   }
-
   async sortByConcerns(): Promise<void> {
     await this.page.getByTestId('concerns-column-header').click();
   }

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -415,7 +415,7 @@ export class VirtualMachinesTable {
   }
 
   async verifyVMNotVisible(vmName: string): Promise<void> {
-    await expect(this.page.getByText(vmName, { exact: true })).toHaveCount(0);
+    await expect(this.table.getRow({ Name: vmName })).not.toBeVisible();
   }
 
   async verifyVMsExist(vmNames: string[]): Promise<void> {

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -414,6 +414,10 @@ export class VirtualMachinesTable {
     await this.table.verifyRowIsVisible({ Name: vmName });
   }
 
+  async verifyVMNotVisible(vmName: string): Promise<void> {
+    await expect(this.page.getByText(vmName, { exact: true })).toHaveCount(0);
+  }
+
   async verifyVMsExist(vmNames: string[]): Promise<void> {
     for (const vmName of vmNames) {
       await this.verifyVMExists(vmName);


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-5509](https://redhat.atlassian.net/browse/MTV-5509)
- Related: [MTV-5507](https://redhat.atlassian.net/browse/MTV-5507) (dev), [MTV-6278](https://redhat.atlassian.net/browse/MTV-6278) (known bug pinned by this PR)

## 📝 Description

Adds fixture-driven Playwright E2E coverage for the "Post-migration setup" phase (`WaitForGuestReboots` pipeline step), which previously had no automated coverage. A second test pins the known "Pipeline status" column text bug (MTV-6278) as an expected failure via `test.fail()`, so it surfaces automatically once that bug is fixed.

## 🎥 Demo

N/A — test-only change (new Playwright spec + supporting page-object/intercept helpers), no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-5509]: https://redhat.atlassian.net/browse/MTV-5509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-5507]: https://redhat.atlassian.net/browse/MTV-5507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6278]: https://redhat.atlassian.net/browse/MTV-6278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an upstream Playwright regression test for Plan Details → Virtual Machines “Post-migration setup” UI state.
  * Verifies the Windows VM row appears while its VM name is not rendered as a link during the “Wait for guest reboots” phase, and confirms “Pipeline status” filtering and expanded “Post-migration setup” step/details.

* **Test Infrastructure**
  * Added Playwright intercept helpers to stub migration-related Pod/Job/PVC/CDI DataVolume list/watch requests with empty list payloads.

* **Automation (Page Objects)**
  * Enhanced primary filter application/verification and added VM “not visible” assertions.
  * Introduced a dedicated helper for Post-migration setup UI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->