### PR TITLE
Resolves: MTV-6269 | Enable ESLint quick-win rules 

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -96,7 +96,7 @@ export const createEslintConfig = () =>
         '@typescript-eslint/naming-convention': 'off',
         '@typescript-eslint/no-deprecated': 'off',
         '@typescript-eslint/no-dynamic-delete': 'off',
-        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-explicit-any': 'error',
         '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true }],
         '@typescript-eslint/no-magic-numbers': 'off',
         '@typescript-eslint/no-misused-promises': [
@@ -120,6 +120,14 @@ export const createEslintConfig = () =>
             enforceForJSX: true,
           },
         ],
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            argsIgnorePattern: '^_',
+            caughtErrorsIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+          },
+        ],
         '@typescript-eslint/prefer-readonly-parameter-types': 'off',
         '@typescript-eslint/strict-boolean-expressions': 'off',
         '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
@@ -127,6 +135,7 @@ export const createEslintConfig = () =>
         camelcase: ['error', { allow: ['required_'] }],
         'capitalized-comments': 'off',
         complexity: 'off',
+        curly: 'error',
         'id-length': ['error', { exceptions: ['t', 'e', 'x', 'y', 'a', 'b', '_', 'i'] }],
         'import/no-named-as-default-member': 'off',
         'import/no-unresolved': 'off',
@@ -205,7 +214,7 @@ export const createEslintConfig = () =>
         ],
         'no-ternary': 'off',
         'no-undefined': 'off',
-        'no-warning-comments': 'off',
+        'no-warning-comments': 'warn',
         'one-var': 'off',
         'perfectionist/sort-classes': [
           'error',
@@ -267,7 +276,6 @@ export const createEslintConfig = () =>
 
         // Rules redundant with TypeScript compiler + IDE
         '@typescript-eslint/no-redeclare': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
         'import/default': 'off',
         'import/named': 'off',
         'import/namespace': 'off',
@@ -325,13 +333,16 @@ export const createEslintConfig = () =>
         '@typescript-eslint/no-unsafe-call': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
         // Many page-object getter methods are async for API consistency but call
         // Playwright locator APIs that return Promises without needing await.
         // TODO: audit and fix each site, then remove this override.
         '@typescript-eslint/require-await': 'off',
+        'max-lines': 'off',
         'max-lines-per-function': 'off',
         'no-await-in-loop': 'off',
         'no-console': 'off',
+        'no-warning-comments': 'off',
         'perfectionist/sort-objects': 'off',
         'react-refresh/only-export-components': 'off',
         'require-unicode-regexp': 'off',

--- a/src/components/AffinityModal/AffinityModal.tsx
+++ b/src/components/AffinityModal/AffinityModal.tsx
@@ -52,7 +52,9 @@ const AffinityModal: ModalComponent<AffinityModalProps> = ({
   const onAffinityChange = (updatedAffinity: AffinityRowData) => {
     setAffinities((prevAffinities) =>
       prevAffinities.map((affinity) => {
-        if (affinity.id === updatedAffinity.id) return { ...affinity, ...updatedAffinity };
+        if (affinity.id === updatedAffinity.id) {
+          return { ...affinity, ...updatedAffinity };
+        }
         return affinity;
       }),
     );

--- a/src/components/Concerns/components/ConcernsPopover.tsx
+++ b/src/components/Concerns/components/ConcernsPopover.tsx
@@ -16,7 +16,9 @@ const ConcernPopover: FC<{
 }> = ({ category, concerns, conditions }) => {
   const { t } = useForkliftTranslation();
 
-  if (isEmpty(concerns) && isEmpty(conditions)) return null;
+  if (isEmpty(concerns) && isEmpty(conditions)) {
+    return null;
+  }
 
   const totalLength = concerns.length + conditions.length;
 

--- a/src/components/Concerns/utils/category.tsx
+++ b/src/components/Concerns/utils/category.tsx
@@ -56,7 +56,9 @@ export const getCategoryIcon = (category: string): ReactNode => {
 };
 
 export const getCategoryStatus = (category: string): PfLabelStatus | undefined => {
-  if (isConcernCategory(category)) return CATEGORY_STATUS[category];
+  if (isConcernCategory(category)) {
+    return CATEGORY_STATUS[category];
+  }
   return PF_LABEL_STATUS.WARNING;
 };
 
@@ -69,7 +71,9 @@ export const groupConcernsByCategory = (
 ): Record<ConcernCategory, Concern[]> => {
   return concerns.reduce<Record<string, Concern[]>>(
     (acc, concern) => {
-      if (isEmpty(concern)) return acc;
+      if (isEmpty(concern)) {
+        return acc;
+      }
       if (isEmpty(acc[concern?.category])) {
         acc[concern?.category] = [];
       }
@@ -92,7 +96,9 @@ export const groupConditionsByCategory = (
   return conditions.reduce<Record<string, V1beta1PlanStatusConditions[]>>(
     (acc, condition) => {
       const label = getCategoryLabel(condition?.category);
-      if (isEmpty(label)) return acc;
+      if (isEmpty(label)) {
+        return acc;
+      }
       if (isEmpty(acc[label])) {
         acc[label] = [];
       }

--- a/src/components/InspectVirtualMachines/InspectionConcernBadges.tsx
+++ b/src/components/InspectVirtualMachines/InspectionConcernBadges.tsx
@@ -32,7 +32,9 @@ const InspectionConcernBadges: FC<InspectionConcernBadgesProps> = ({ concerns })
     <Split hasGutter>
       {ORDERED_INSPECTION_CONCERN_CATEGORIES.map((category) => {
         const items = grouped.get(category) ?? [];
-        if (isEmpty(items)) return null;
+        if (isEmpty(items)) {
+          return null;
+        }
 
         return (
           <SplitItem key={category}>

--- a/src/components/InspectVirtualMachines/InspectionExpandedSection.tsx
+++ b/src/components/InspectVirtualMachines/InspectionExpandedSection.tsx
@@ -42,8 +42,11 @@ const InspectionExpandedSection: FC<InspectionExpandedSectionProps> = ({
   const toggleExpand = (uid: string): void => {
     onToggleExpand((prev) => {
       const next = new Set(prev);
-      if (next.has(uid)) next.delete(uid);
-      else next.add(uid);
+      if (next.has(uid)) {
+        next.delete(uid);
+      } else {
+        next.add(uid);
+      }
       return next;
     });
   };

--- a/src/components/InspectVirtualMachines/InspectionVmTable.tsx
+++ b/src/components/InspectVirtualMachines/InspectionVmTable.tsx
@@ -14,8 +14,12 @@ import VmConfigForm from './VmConfigForm';
 const INSPECTION_VM_TABLE_ID = 'inspection-vm-table';
 
 const getDiskEncryptionLabel = (overrides?: VmOverrides): string | undefined => {
-  if (overrides?.nbdeClevis) return DISK_ENCRYPTION_TYPE.CLEVIS;
-  if (overrides?.passphrases?.some((phrase) => !isEmpty(phrase))) return DISK_ENCRYPTION_TYPE.LUKS;
+  if (overrides?.nbdeClevis) {
+    return DISK_ENCRYPTION_TYPE.CLEVIS;
+  }
+  if (overrides?.passphrases?.some((phrase) => !isEmpty(phrase))) {
+    return DISK_ENCRYPTION_TYPE.LUKS;
+  }
   return undefined;
 };
 
@@ -57,7 +61,9 @@ const InspectionVmTable: FC<InspectionVmTableProps> = ({
 
   const expanded = useCallback(
     (props: { resourceData: InspectionVmRowData }) => {
-      if (!isProviderFlow || !onVmOverrideChange) return null;
+      if (!isProviderFlow || !onVmOverrideChange) {
+        return null;
+      }
       const vmId = props.resourceData.id;
       return (
         <VmConfigForm

--- a/src/components/InspectVirtualMachines/utils/buildConversionCR.ts
+++ b/src/components/InspectVirtualMachines/utils/buildConversionCR.ts
@@ -28,8 +28,12 @@ const DEFAULT_GENERATE_NAME_PREFIX = 'vm';
 const sanitizeForK8sName = (value: string): string => {
   const sanitized = Array.from(value.toLowerCase()).reduce((acc, char) => {
     const isValid = (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9');
-    if (isValid) return acc + char;
-    if (!isEmpty(acc) && !acc.endsWith('-')) return `${acc}-`;
+    if (isValid) {
+      return acc + char;
+    }
+    if (!isEmpty(acc) && !acc.endsWith('-')) {
+      return `${acc}-`;
+    }
     return acc;
   }, '');
 

--- a/src/components/InspectVirtualMachines/utils/createDeepInspections.ts
+++ b/src/components/InspectVirtualMachines/utils/createDeepInspections.ts
@@ -41,7 +41,9 @@ const processChunk = async (
   offset: number,
   plan?: V1beta1Plan,
 ): Promise<void> => {
-  if (offset >= vms.length) return;
+  if (offset >= vms.length) {
+    return;
+  }
 
   const chunk = vms.slice(offset, offset + CONCURRENCY_LIMIT);
   await Promise.allSettled(

--- a/src/components/InspectVirtualMachines/utils/resolveDiskEncryption.ts
+++ b/src/components/InspectVirtualMachines/utils/resolveDiskEncryption.ts
@@ -10,7 +10,9 @@ export const resolveDiskEncryption = async (
   vmName: string,
   namespace: string,
 ): Promise<DiskEncryptionParam | undefined> => {
-  if (!overrides) return undefined;
+  if (!overrides) {
+    return undefined;
+  }
 
   if (overrides.nbdeClevis) {
     return { type: DISK_ENCRYPTION_TYPE.CLEVIS };

--- a/src/components/OvaFileUploader/OvaFileUploader.tsx
+++ b/src/components/OvaFileUploader/OvaFileUploader.tsx
@@ -31,7 +31,9 @@ const OvaFileUploader: FC<OvaFileUploaderProps> = ({ provider }) => {
   const [validation, setValidation] = useState<OvaValidationVariant>(OvaValidationVariant.Default);
 
   const handleUpload = async () => {
-    if (!file) return;
+    if (!file) {
+      return;
+    }
 
     setError(null);
     setUploading(true);

--- a/src/components/ProviderSelect/utils/utils.ts
+++ b/src/components/ProviderSelect/utils/utils.ts
@@ -8,7 +8,9 @@ const isProvider = (obj: unknown): obj is V1beta1Provider =>
   (obj as V1beta1Provider).kind === 'Provider';
 
 export const extractProviders = (value: unknown): V1beta1Provider[] => {
-  if (!value) return [];
+  if (!value) {
+    return [];
+  }
 
   if (Array.isArray(value) && (isEmpty(value) || isProvider(value[0]))) {
     return value as V1beta1Provider[];

--- a/src/components/TableBulkSelect.tsx
+++ b/src/components/TableBulkSelect.tsx
@@ -68,7 +68,9 @@ const TableBulkSelect: FC<TableBulkSelectProps> = ({
     </div>
   );
 
-  if (canPageSelect) return bulkSelect;
+  if (canPageSelect) {
+    return bulkSelect;
+  }
 
   return (
     <Popover

--- a/src/components/TableCell/VisibleTableData.tsx
+++ b/src/components/TableCell/VisibleTableData.tsx
@@ -21,7 +21,9 @@ const VisibleTableData: FC<VisibleTableDataProps> = ({
     [fieldId, resourceFields],
   );
 
-  if (!isVisible) return null;
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <Td className={className} dataLabel={fieldId}>

--- a/src/components/VddkUploader/VddkUploader.tsx
+++ b/src/components/VddkUploader/VddkUploader.tsx
@@ -32,11 +32,15 @@ const VddkUploader: FC<VddkUploaderProps> = ({ onChangeVddk }) => {
   const { body, isBuildFailed, isBuilding, isBuildSucceeded, title, variant } = vddkBuild ?? {};
 
   useEffect(() => {
-    if (isBuildSucceeded) onChangeVddk(body!);
+    if (isBuildSucceeded) {
+      onChangeVddk(body!);
+    }
   }, [body, isBuildSucceeded, onChangeVddk]);
 
   const handleUpload = async () => {
-    if (!file) return;
+    if (!file) {
+      return;
+    }
 
     setError(null);
     setUploading(true);

--- a/src/components/VddkUploader/hooks/useVddkBuildImage.ts
+++ b/src/components/VddkUploader/hooks/useVddkBuildImage.ts
@@ -25,7 +25,9 @@ export const useVddkBuildImage = (buildName: string) => {
       : null,
   );
 
-  if (isEmpty(vddkBuild)) return null;
+  if (isEmpty(vddkBuild)) {
+    return null;
+  }
 
   const buildImageResponse = getVddkImageBuildResponse(vddkBuild?.status);
 

--- a/src/components/VddkUploader/utils/utils.ts
+++ b/src/components/VddkUploader/utils/utils.ts
@@ -52,7 +52,11 @@ export const getVddkImageBuildResponse = (status: VddkBuild['status']): VddkBuil
 };
 
 export const getUploadButtonText = (uploading: boolean, buildingImage?: boolean) => {
-  if (uploading) return t('Uploading...');
-  if (buildingImage) return t('Building image...');
+  if (uploading) {
+    return t('Uploading...');
+  }
+  if (buildingImage) {
+    return t('Building image...');
+  }
   return t('Upload');
 };

--- a/src/components/VsphereFoldersTable/VsphereFolderTreeTable.tsx
+++ b/src/components/VsphereFoldersTable/VsphereFolderTreeTable.tsx
@@ -6,6 +6,7 @@ import SectionHeading from '@components/headers/SectionHeading';
 import InspectVirtualMachinesButton from '@components/InspectVirtualMachines/InspectVirtualMachinesButton';
 import type { ProviderHost, V1beta1Provider, VSphereResource } from '@forklift-ui/types';
 import {
+  type OnSetPage,
   PageSection,
   Pagination,
   Toolbar,
@@ -41,6 +42,18 @@ type VsphereFolderTreeTableProps = {
   providerNamespace?: string;
   providerUid?: string;
   vmData: ProviderVmData[] | undefined;
+};
+
+const snapPageToValidRange = (
+  itemCount: number,
+  onSetPage: OnSetPage,
+  page: number,
+  perPage: number,
+): void => {
+  const maxPage = Math.max(1, Math.ceil(itemCount / perPage));
+  if (page > maxPage) {
+    onSetPage({} as MouseEvent, 1);
+  }
 };
 
 const VsphereFolderTreeTable: FC<VsphereFolderTreeTableProps> = ({
@@ -132,9 +145,7 @@ const VsphereFolderTreeTable: FC<VsphereFolderTreeTableProps> = ({
   const { itemCount, pagedRows } = useTreePagination({ blocks: sortedBlocks, page, perPage });
 
   useEffect(() => {
-    // if page > max pages after filter/sort, snap back
-    const maxPage = Math.max(1, Math.ceil(itemCount / perPage));
-    if (page > maxPage) onSetPage({} as MouseEvent, 1);
+    snapPageToValidRange(itemCount, onSetPage, page, perPage);
   }, [itemCount, onSetPage, page, perPage]);
 
   const pagination = (

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/hooks/useAttributeFilters.ts
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/hooks/useAttributeFilters.ts
@@ -71,7 +71,9 @@ export const useAttributeFilters = <T>(attributes: AttributeConfig<T>[]): Attrib
               }
             };
             const match = attr.match ?? def;
-            if (!match(needle, hay)) return false;
+            if (!match(needle, hay)) {
+              return false;
+            }
           }
         } else {
           const sel = checks[attr.id];
@@ -83,7 +85,9 @@ export const useAttributeFilters = <T>(attributes: AttributeConfig<T>[]): Attrib
             } else if (value) {
               arr = [value];
             }
-            if (!arr.some((element) => sel.has(element))) return false;
+            if (!arr.some((element) => sel.has(element))) {
+              return false;
+            }
           }
         }
       }
@@ -112,13 +116,17 @@ export const useAttributeFilters = <T>(attributes: AttributeConfig<T>[]): Attrib
   const deleteChip = useCallback(
     (attrId: string, chipLabel: string) => {
       const attr = attributes.find((attribute) => attribute.id === attrId);
-      if (!attr) return;
+      if (!attr) {
+        return;
+      }
       if (attr.kind === AttributeKind.Text) {
         clearText(attrId);
         return;
       }
       const opt = attr.options.find((option) => (option.label ?? option.id) === chipLabel);
-      if (opt) toggleCheck(attrId, opt.id);
+      if (opt) {
+        toggleCheck(attrId, opt.id);
+      }
     },
     [attributes, clearText, toggleCheck],
   );
@@ -126,7 +134,9 @@ export const useAttributeFilters = <T>(attributes: AttributeConfig<T>[]): Attrib
   const deleteChipGroup = useCallback(
     (attrId: string) => {
       const attr = attributes.find((attribute) => attribute.id === attrId);
-      if (!attr) return;
+      if (!attr) {
+        return;
+      }
       if (attr.kind === AttributeKind.Text) {
         clearText(attrId);
         return;

--- a/src/components/VsphereFoldersTable/components/VmTreeRow/VmTreeRow.tsx
+++ b/src/components/VsphereFoldersTable/components/VmTreeRow/VmTreeRow.tsx
@@ -62,9 +62,13 @@ const VmTreeRow: FC<VmTreeRowProps> = ({ columns, conversions, row }) => {
         {row.vmData.name}
       </Td>
       {columns.map((col) => {
-        if (!col.isVisible) return null;
+        if (!col.isVisible) {
+          return null;
+        }
         const Component = VmCells[col.resourceFieldId!];
-        if (!Component) return null;
+        if (!Component) {
+          return null;
+        }
         return (
           <Td
             key={col.resourceFieldId}

--- a/src/components/VsphereFoldersTable/hooks/useSelectedTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useSelectedTreeRows.ts
@@ -49,15 +49,21 @@ const useSelectedTreeRows: UseSelectedTreeRows = (controls) => {
       setSelectedVmKeys((prev) => {
         const next = new Set(prev);
         if (Array.isArray(keys)) {
-          if (isChecked) keys.forEach((id) => next.add(id));
-          else keys.forEach((id) => next.delete(id));
+          if (isChecked) {
+            keys.forEach((id) => next.add(id));
+          } else {
+            keys.forEach((id) => next.delete(id));
+          }
 
           return Array.from(next);
         }
 
         if (typeof keys === 'string') {
-          if (isChecked) next.add(keys);
-          else next.delete(keys);
+          if (isChecked) {
+            next.add(keys);
+          } else {
+            next.delete(keys);
+          }
         }
 
         return Array.from(next);

--- a/src/components/VsphereFoldersTable/hooks/useSlug.ts
+++ b/src/components/VsphereFoldersTable/hooks/useSlug.ts
@@ -4,7 +4,9 @@ export const useSlug = () => {
   const cacheRef = useRef(new Map<string, string>());
   return useCallback((value: string) => {
     const cached = cacheRef.current.get(value);
-    if (cached) return cached;
+    if (cached) {
+      return cached;
+    }
     const slugged = value
       .toLowerCase()
       .replace(/\s+/gu, '_')

--- a/src/components/VsphereFoldersTable/hooks/useToggleTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useToggleTreeRows.ts
@@ -8,8 +8,11 @@ const useToggleTreeRows = () => {
     <T extends string>(setFn: Dispatch<SetStateAction<Set<T>>>, id: T) => {
       setFn((prev) => {
         const next = new Set(prev);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
         return next;
       });
     },

--- a/src/components/VsphereFoldersTable/hooks/useTreePagination.tsx
+++ b/src/components/VsphereFoldersTable/hooks/useTreePagination.tsx
@@ -44,7 +44,9 @@ const useTreePagination = ({
       Number.isFinite(perPage) && perPage > 0 ? perPage : paginationInitialState.perPage;
     const safePage = Number.isFinite(page) && page > 0 ? page : paginationInitialState.page;
 
-    if (!hasBlocks) return { itemCount: 0, pagedRows: [] };
+    if (!hasBlocks) {
+      return { itemCount: 0, pagedRows: [] };
+    }
 
     const descriptors: PageDescriptor[] = [];
 
@@ -70,7 +72,9 @@ const useTreePagination = ({
     }
 
     const itemCount = descriptors.length;
-    if (itemCount === 0) return { itemCount: 0, pagedRows: [] };
+    if (itemCount === 0) {
+      return { itemCount: 0, pagedRows: [] };
+    }
 
     const pageStartIndex = (safePage - 1) * safePerPage;
     const pageEndIndex = Math.min(pageStartIndex + safePerPage, itemCount);

--- a/src/components/VsphereFoldersTable/hooks/useTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeRows.ts
@@ -111,7 +111,9 @@ export const useTreeRows: UseTreeRows = ({
         const isVmExpanded = expandedVMs.has(vmKey);
         const vmData = vmByKey.get(vmKey);
 
-        if (!vmData) return;
+        if (!vmData) {
+          return;
+        }
 
         const { concernsRow, vmRow } = makeVmAndConcernsRows({
           canSelect,
@@ -141,7 +143,9 @@ export const useTreeRows: UseTreeRows = ({
       const isVmExpanded = expandedVMs.has(vmKey);
       const vmData = vmByKey.get(vmKey);
 
-      if (!vmData) return;
+      if (!vmData) {
+        return;
+      }
 
       const { concernsRow, vmRow } = makeVmAndConcernsRows({
         canSelect,

--- a/src/components/VsphereFoldersTable/hooks/useTreeSortBlocks.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeSortBlocks.ts
@@ -47,7 +47,9 @@ const useTreeSortBlocks: UseTreeSortBlocks = ({ columns, conversions, filteredRo
   const getVmInspectionStatus = useVmInspectionStatus(conversions);
 
   const sortedBlocks = useMemo(() => {
-    if (isEmpty(filteredRows)) return [];
+    if (isEmpty(filteredRows)) {
+      return [];
+    }
 
     const blocks: Block[] = [];
     let current: Block | null = null;
@@ -88,14 +90,20 @@ const useTreeSortBlocks: UseTreeSortBlocks = ({ columns, conversions, filteredRo
     const cmpVm = buildVmComparator(sort, getVmInspectionStatus);
     for (const block of blocks) {
       const { items } = block;
-      if (items.length > 1) items.sort((first, second) => cmpVm(first.vm, second.vm));
+      if (items.length > 1) {
+        items.sort((first, second) => cmpVm(first.vm, second.vm));
+      }
     }
 
     if (sort.column === COLUMN_IDS.Name && blocks.length > 1) {
       const dir = sort.direction === 'asc' ? 1 : -1;
       blocks.sort((a, b) => {
-        if (a.kind === BlockKind.Root && b.kind === BlockKind.Folder) return -1 * dir;
-        if (a.kind === BlockKind.Folder && b.kind === BlockKind.Root) return dir;
+        if (a.kind === BlockKind.Root && b.kind === BlockKind.Folder) {
+          return -1 * dir;
+        }
+        if (a.kind === BlockKind.Folder && b.kind === BlockKind.Root) {
+          return dir;
+        }
 
         if (a.kind === BlockKind.Folder && b.kind === BlockKind.Folder) {
           const fa = getFolderNameFromFolderRow(a.folder);
@@ -138,7 +146,9 @@ const useTreeSortBlocks: UseTreeSortBlocks = ({ columns, conversions, filteredRo
     newDirection,
   ) => {
     const col = visibleCols[columnIndex];
-    if (!col?.sortable) return;
+    if (!col?.sortable) {
+      return;
+    }
     const nextDir = columnIndex === activeIndex ? newDirection : 'asc';
     setSort({ column: col.id as SortColumn, direction: nextDir });
   };

--- a/src/components/VsphereFoldersTable/hooks/useTreeVMFilters.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeVMFilters.ts
@@ -57,7 +57,9 @@ const useTreeFilters = ({ filters, rows, showAll }: UseTreeFilters): UseTreeFilt
   }, [rows, filters, showAll]);
 
   const filteredRows: RowNode[] = useMemo(() => {
-    if (!filters.hasAttrFilters && showAll) return rows;
+    if (!filters.hasAttrFilters && showAll) {
+      return rows;
+    }
 
     const isVisibleFolder = (row: FolderRow) => visibleFolderKeySet.has(row.key);
 
@@ -82,7 +84,9 @@ const useTreeFilters = ({ filters, rows, showAll }: UseTreeFilters): UseTreeFilt
         }
 
         case ROW_TYPE.Vm: {
-          if (!isVisibleVm(row)) break;
+          if (!isVisibleVm(row)) {
+            break;
+          }
           out.push(row);
 
           const folderName = getFolderNameFromKey(row.parentFolderKey);

--- a/src/components/VsphereFoldersTable/hooks/utils/treeUtils.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/treeUtils.ts
@@ -51,7 +51,9 @@ export const getVmConcernCategories = (row: VmRow): ConcernCategory[] => {
   // Try the most likely locations first; adjust if your app stores concerns differently.
   const rawConcerns: Concern[] = (row.vmData.vm as VirtualMachineWithConcerns)?.concerns ?? [];
 
-  if (!Array.isArray(rawConcerns)) return [];
+  if (!Array.isArray(rawConcerns)) {
+    return [];
+  }
 
   const out = new Set<ConcernCategory>();
   for (const concern of rawConcerns) {
@@ -88,9 +90,15 @@ const getConcernCounts = (row: VmRow): Counts => {
 
 const cmpCountsQuantityAsc = (first: Counts, second: Counts) => {
   // Desc by Critical, then Warning, then Information
-  if (first.Critical !== second.Critical) return second.Critical - first.Critical;
-  if (first.Warning !== second.Warning) return second.Warning - first.Warning;
-  if (first.Information !== second.Information) return second.Information - first.Information;
+  if (first.Critical !== second.Critical) {
+    return second.Critical - first.Critical;
+  }
+  if (first.Warning !== second.Warning) {
+    return second.Warning - first.Warning;
+  }
+  if (first.Information !== second.Information) {
+    return second.Information - first.Information;
+  }
   return 0;
 };
 
@@ -118,7 +126,9 @@ export const buildVmComparator = (
         const ca = getConcernCounts(a);
         const cb = getConcernCounts(b);
         const base = cmpCountsQuantityAsc(ca, cb);
-        if (base !== 0) return base * dir;
+        if (base !== 0) {
+          return base * dir;
+        }
         return cmpStr(getVmName(a), getVmName(b)) * dir;
       };
     case COLUMN_IDS.InspectionStatus:
@@ -131,7 +141,9 @@ export const buildVmComparator = (
           INSPECTION_STATUS.NOT_INSPECTED;
         const rankDiff =
           INSPECTION_STATUS_SEVERITY_RANK[statusA] - INSPECTION_STATUS_SEVERITY_RANK[statusB];
-        if (rankDiff !== 0) return rankDiff * dir;
+        if (rankDiff !== 0) {
+          return rankDiff * dir;
+        }
         return cmpStr(getVmName(first), getVmName(second)) * dir;
       };
     default:
@@ -148,7 +160,9 @@ export const getVmConcernLabels = (
 } => {
   const vm = row?.vmData?.vm as VirtualMachineWithConcerns | undefined;
   const concerns: Concern[] = vm?.concerns ?? [];
-  if (!Array.isArray(concerns)) return { categoryMapper: {}, labelIconMapper: {}, labels: [] };
+  if (!Array.isArray(concerns)) {
+    return { categoryMapper: {}, labelIconMapper: {}, labels: [] };
+  }
 
   const out = new Set<string>();
   const outIcons: Record<string, ReactNode> = {};

--- a/src/components/VsphereFoldersTable/hooks/utils/utils.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/utils.ts
@@ -70,13 +70,17 @@ export const isFolderChecked = (
   selectedSet: Set<string>,
 ): boolean | null => {
   const total = vmIdsInFolder.length;
-  if (total === 0) return false;
+  if (total === 0) {
+    return false;
+  }
   let selected = 0;
 
   for (const id of vmIdsInFolder) {
     if (selectedSet.has(id)) {
       selected += 1;
-      if (selected === total) return true;
+      if (selected === total) {
+        return true;
+      }
     }
   }
   return selected > 0 ? null : false;

--- a/src/components/common/Page/userSettings.ts
+++ b/src/components/common/Page/userSettings.ts
@@ -9,13 +9,19 @@ import {
 
 import type { UserSettings } from './types';
 
-const parseOrClean = (key: string): Record<string, any> => {
+type StoredUserSettings = {
+  fields?: unknown;
+  filters?: Record<string, unknown>;
+  perPage?: unknown;
+};
+
+const parseOrClean = (key: string): StoredUserSettings => {
   try {
     const storedData = loadFromLocalStorage(key);
     if (!storedData) {
       return {};
     }
-    return (JSON.parse(storedData) ?? {}) as object;
+    return (JSON.parse(storedData) ?? {}) as StoredUserSettings;
   } catch (_e) {
     removeFromLocalStorage(key);
     // eslint-disable-next-line no-console
@@ -24,11 +30,11 @@ const parseOrClean = (key: string): Record<string, any> => {
   return {};
 };
 
-const saveRestOrRemoveKey = (key: string, { rest }: Record<string, Record<string, unknown>>) => {
+const saveRestOrRemoveKey = (key: string, rest: StoredUserSettings): void => {
   if (isEmpty(Object.keys(rest))) {
     removeFromLocalStorage(key);
   } else {
-    saveToLocalStorage(key, JSON.stringify({ ...rest }));
+    saveToLocalStorage(key, JSON.stringify(rest));
   }
 };
 
@@ -66,8 +72,8 @@ export const loadUserSettings = ({ pageId }: { pageId: string }): UserSettings =
   return {
     fields: {
       clear: () => {
-        const { fields: keyFields, ...rest } = parseOrClean(key);
-        saveRestOrRemoveKey(key, { fields: keyFields, rest });
+        const { fields: _keyFields, ...rest } = parseOrClean(key);
+        saveRestOrRemoveKey(key, rest);
       },
       data: sanitizeFields(fields),
       save: (newFields) => {
@@ -79,18 +85,18 @@ export const loadUserSettings = ({ pageId }: { pageId: string }): UserSettings =
     },
     filters: {
       clear: () => {
-        const { filters: keyFilters, ...rest } = parseOrClean(key);
-        saveRestOrRemoveKey(key, { filters: keyFilters, rest });
+        const { filters: _keyFilters, ...rest } = parseOrClean(key);
+        saveRestOrRemoveKey(key, rest);
       },
-      data: filters,
+      data: filters ?? {},
       save: (newFilters) => {
         saveToLocalStorage(key, JSON.stringify({ ...parseOrClean(key), filters: newFilters }));
       },
     },
     pagination: {
       clear: () => {
-        const { perPage: keyPerPage, ...rest } = parseOrClean(key);
-        saveRestOrRemoveKey(key, { perPage: keyPerPage, rest });
+        const { perPage: _keyPerPage, ...rest } = parseOrClean(key);
+        saveRestOrRemoveKey(key, rest);
       },
       perPage: typeof perPage === 'number' ? perPage : DEFAULT_PER_PAGE,
       save: (newPerPage) => {

--- a/src/components/common/TableView/DefaultRow.tsx
+++ b/src/components/common/TableView/DefaultRow.tsx
@@ -17,7 +17,10 @@ export const DefaultRow = <T,>({ resourceData, resourceFields }: RowProps<T>) =>
           acc.push(
             <Td key={resourceFieldId} dataLabel={label ?? undefined}>
               {(getResourceFieldValue(
-                resourceData as any,
+                resourceData as Record<
+                  string,
+                  object | string | boolean | ((data: unknown) => unknown)
+                >,
                 resourceFieldId ?? '',
                 resourceFields,
               ) as string) ?? ''}

--- a/src/components/common/TableView/ManageColumnsModal.tsx
+++ b/src/components/common/TableView/ManageColumnsModal.tsx
@@ -82,7 +82,7 @@ export const ManageColumnsModal = ({
   description = 'Selected columns will be displayed in the table.',
   onChange,
   onClose,
-  reorderLabel = 'Reorder',
+  reorderLabel: _reorderLabel = 'Reorder',
   resourceFields,
   restoreLabel = 'Restore default columns',
   saveLabel = 'Save',

--- a/src/components/common/TableView/sort.ts
+++ b/src/components/common/TableView/sort.ts
@@ -8,6 +8,16 @@ import type { ResourceField, SortDirection } from '../utils/types';
 
 import type { SortType } from './types';
 
+const toSortKey = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? '';
+};
+
 /**
  * Compares all types by converting them to string.
  * Nullish entities are converted to empty string.
@@ -16,8 +26,8 @@ import type { SortType } from './types';
  * @param b
  * @param locale to be used by string compareFn
  */
-export const universalComparator = (a: any, b: any, locale: string) => {
-  return localeCompare(String(a ?? ''), String(b ?? ''), locale);
+export const universalComparator = (a: unknown, b: unknown, locale: string): number => {
+  return localeCompare(toSortKey(a), toSortKey(b), locale);
 };
 
 /**
@@ -36,7 +46,7 @@ export const compareWith = <
 >(
   currentSort: SortType,
   locale: string | undefined,
-  fieldComparator: ((a: any, b: any, locale: string) => number) | undefined,
+  fieldComparator: ((a: string, b: string, locale: string) => number) | undefined,
   fields: ResourceField[],
 ): ((a?: T | null, b?: T | null) => number) => {
   return (a, b) => {
@@ -45,8 +55,8 @@ export const compareWith = <
     }
     const compareFn = fieldComparator ?? universalComparator;
     const compareValue = compareFn(
-      getResourceFieldValue<T>(a, currentSort.resourceFieldId, fields, true),
-      getResourceFieldValue<T>(b, currentSort.resourceFieldId, fields, true),
+      String(getResourceFieldValue<T>(a, currentSort.resourceFieldId, fields, true) ?? ''),
+      String(getResourceFieldValue<T>(b, currentSort.resourceFieldId, fields, true) ?? ''),
       locale ?? 'en',
     );
     return currentSort.isAsc ? compareValue : -compareValue;
@@ -67,7 +77,7 @@ export const useSort = (
   fields: ResourceField[],
   resolvedLanguage = 'en',
   defaultSort?: { resourceFieldId: string; direction: SortDirection },
-): [SortType, (sort: SortType) => void, (a: any, b: any) => number] => {
+): [SortType, (sort: SortType) => void, (a: unknown, b: unknown) => number] => {
   // by default sort by the first identity column (if any)
   const [firstField] = [...fields].sort(
     (a, b) => Number(Boolean(b.isIdentity)) - Number(Boolean(a.isIdentity)),
@@ -100,7 +110,7 @@ export const useSort = (
     [activeSort, resolvedLanguage, fields],
   );
 
-  return [activeSort, setActiveSort, compareFn];
+  return [activeSort, setActiveSort, compareFn as (a: unknown, b: unknown) => number];
 };
 
 /**

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadMenuToggle.tsx
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadMenuToggle.tsx
@@ -76,13 +76,19 @@ const MultiTypeaheadMenuToggle: FC<MultiTypeaheadMenuToggleProps> = ({
   }, [allowClear, selectedOptions, isFiltering, inputValue, isFocused, isHovered]);
 
   const handleToggleClick = (): void => {
-    if (isDisabled) return;
+    if (isDisabled) {
+      return;
+    }
     onToggleClick();
-    if (!isOpen) setTimeout(() => inputRef.current?.focus(), 0);
+    if (!isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
   };
 
   const handleInputChange = (event: FormEvent<HTMLInputElement>, newValue: string): void => {
-    if (isDisabled) return;
+    if (isDisabled) {
+      return;
+    }
     onInputValueChange(newValue, true);
     onInputChange?.(newValue);
 

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadFiltering.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadFiltering.ts
@@ -70,7 +70,9 @@ export const useMultiTypeaheadFiltering = ({
   );
 
   const displayOptions = useMemo(() => {
-    if (isFiltering) return filteredOptions;
+    if (isFiltering) {
+      return filteredOptions;
+    }
     if (isEmpty(options)) {
       return [
         {

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadInteractions.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadInteractions.ts
@@ -83,7 +83,9 @@ export const useMultiTypeaheadInteractions = ({
 
   const handleSelect = useCallback(
     (selectedValue: string | number | undefined) => {
-      if (isPlaceholderValue(selectedValue) || selectedValue === undefined) return;
+      if (isPlaceholderValue(selectedValue) || selectedValue === undefined) {
+        return;
+      }
 
       const existsInOptions = options.some((opt) => opt.value === selectedValue);
       const isCreatePick = !existsInOptions && isCreatable;
@@ -109,13 +111,19 @@ export const useMultiTypeaheadInteractions = ({
           if (isOpen && currentFocused && !currentFocused.optionProps?.isAriaDisabled) {
             handleSelect(currentFocused.value);
           }
-          if (!isOpen) setIsOpen(true);
+          if (!isOpen) {
+            setIsOpen(true);
+          }
           return;
         }
         case 'ArrowUp': {
           event.preventDefault();
-          if (!isOpen) setIsOpen(true);
-          if (isEmpty(displayOptions)) return;
+          if (!isOpen) {
+            setIsOpen(true);
+          }
+          if (isEmpty(displayOptions)) {
+            return;
+          }
 
           const startIndex =
             focusedItemIndex === null ? displayOptions.length - 1 : focusedItemIndex - 1;
@@ -125,8 +133,12 @@ export const useMultiTypeaheadInteractions = ({
         }
         case 'ArrowDown': {
           event.preventDefault();
-          if (!isOpen) setIsOpen(true);
-          if (isEmpty(displayOptions)) return;
+          if (!isOpen) {
+            setIsOpen(true);
+          }
+          if (isEmpty(displayOptions)) {
+            return;
+          }
 
           const startIndex = focusedItemIndex === null ? 0 : focusedItemIndex + 1;
           const nextIndex = getNextEnabledIndex(displayOptions, startIndex);

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadOpen.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/useMultiTypeaheadOpen.ts
@@ -36,8 +36,11 @@ export const useMultiTypeaheadOpen = ({
   }, []);
 
   const onInputClick = useCallback(() => {
-    if (!isOpen) setIsOpen(true);
-    else if (!inputValue) setIsOpen(false);
+    if (!isOpen) {
+      setIsOpen(true);
+    } else if (!inputValue) {
+      setIsOpen(false);
+    }
   }, [inputValue, isOpen]);
 
   const onInputValueChange = useCallback(

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
@@ -8,12 +8,18 @@ export const getPrevEnabledIndex = (
   startIndex: number,
 ): number => {
   let index = startIndex;
-  if (index < 0) index = options.length - 1;
+  if (index < 0) {
+    index = options.length - 1;
+  }
 
   for (const option of options) {
-    if (!option?.optionProps?.isDisabled) return index;
+    if (!option?.optionProps?.isDisabled) {
+      return index;
+    }
     index -= 1;
-    if (index < 0) index = options.length - 1;
+    if (index < 0) {
+      index = options.length - 1;
+    }
   }
   return startIndex;
 };
@@ -23,12 +29,18 @@ export const getNextEnabledIndex = (
   startIndex: number,
 ): number => {
   let index = startIndex;
-  if (index >= options.length) index = 0;
+  if (index >= options.length) {
+    index = 0;
+  }
 
   for (const option of options) {
-    if (!option?.optionProps?.isDisabled) return index;
+    if (!option?.optionProps?.isDisabled) {
+      return index;
+    }
     index += 1;
-    if (index >= options.length) index = 0;
+    if (index >= options.length) {
+      index = 0;
+    }
   }
   return startIndex;
 };

--- a/src/components/common/TypeaheadSelect/TypeaheadMenuToggle.tsx
+++ b/src/components/common/TypeaheadSelect/TypeaheadMenuToggle.tsx
@@ -58,7 +58,9 @@ const TypeaheadMenuToggle: FC<TypeaheadMenuToggleProps> = ({
   const displayValue = isFiltering ? inputValue : (selectedOption?.content?.toString() ?? '');
 
   const handleToggleClick = (): void => {
-    if (isDisabled) return;
+    if (isDisabled) {
+      return;
+    }
     onToggleClick();
 
     if (!isOpen) {

--- a/src/components/common/TypeaheadSelect/TypeaheadSelect.tsx
+++ b/src/components/common/TypeaheadSelect/TypeaheadSelect.tsx
@@ -31,6 +31,15 @@ import TypeaheadMenuToggle from './TypeaheadMenuToggle';
 
 import './TypeaheadSelect.scss';
 
+const closeSelectWhenBlurred = (
+  open: boolean,
+  setIsOpen: (value: boolean | ((prev: boolean) => boolean)) => void,
+): void => {
+  if (!open) {
+    setIsOpen(false);
+  }
+};
+
 type TypeaheadSelectProps = {
   options: TypeaheadSelectOption[];
   value?: string | number;
@@ -127,7 +136,9 @@ const TypeaheadSelect = (
   }, [options, filteredOptions, noOptionsMessage]);
 
   const handleSelect = (selectedValue: string | number | undefined): void => {
-    if (isPlaceholderValue(selectedValue)) return;
+    if (isPlaceholderValue(selectedValue)) {
+      return;
+    }
 
     const existingOption = options.find((option) => option.value === selectedValue);
     if (existingOption || isCreatable) {
@@ -156,10 +167,6 @@ const TypeaheadSelect = (
     setIsFiltering(newIsFiltering);
   };
 
-  const handleOpenChange = (open: boolean): void => {
-    if (!open) setIsOpen(false);
-  };
-
   const handleFooterClick = (): void => {
     setIsOpen(false);
   };
@@ -170,7 +177,9 @@ const TypeaheadSelect = (
       onSelect={(_, selectedValue: string | number | undefined) => {
         handleSelect(selectedValue);
       }}
-      onOpenChange={handleOpenChange}
+      onOpenChange={(open) => {
+        closeSelectWhenBlurred(open, setIsOpen);
+      }}
       toggle={(toggleRef) => (
         <TypeaheadMenuToggle
           toggleRef={toggleRef}

--- a/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
+++ b/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
@@ -30,7 +30,9 @@ export const NetworkMapActionsDropdownItems = ({
   });
 
   const onDelete = () => {
-    if (!networkMap) return;
+    if (!networkMap) {
+      return;
+    }
     launcher<DeleteModalProps>(DeleteModal, { model: NetworkMapModel, resource: networkMap });
   };
 

--- a/src/onlineHelp/learningExperienceContent/topics/components/utils.ts
+++ b/src/onlineHelp/learningExperienceContent/topics/components/utils.ts
@@ -1,5 +1,9 @@
 export const getNavigationTarget = (href?: string, isCreateForm?: boolean, url?: string) => {
-  if (href) return href;
-  if (isCreateForm) return `${url}/~new`;
+  if (href) {
+    return href;
+  }
+  if (isCreateForm) {
+    return `${url}/~new`;
+  }
   return url;
 };

--- a/src/onlineHelp/learningExperienceDrawer/context/useLearningExperienceContext.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/useLearningExperienceContext.ts
@@ -26,7 +26,7 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
   const [drawerWidth, setDrawerWidth] = useState(
     persistedState.drawerWidth ?? DEFAULT_DRAWER_WIDTH,
   );
-  const [data, setData] = useState<Record<string, any>>(persistedState.data ?? DEFAULT_DATA);
+  const [data, setData] = useState<Record<string, unknown>>(persistedState.data ?? DEFAULT_DATA);
 
   const openLearningExperience = useCallback(() => {
     setIsLearningExperienceOpen(true);
@@ -60,7 +60,7 @@ export const useLearningExperienceContext = (): LearningExperienceContextType =>
     });
   }, []);
 
-  const setDataItem = useCallback((dataItem: string, value: any): void => {
+  const setDataItem = useCallback((dataItem: string, value: unknown): void => {
     setData((prev) => {
       const newData = { ...prev, [dataItem]: value };
       persistValue('data', newData);

--- a/src/onlineHelp/learningExperienceDrawer/utils/types.ts
+++ b/src/onlineHelp/learningExperienceDrawer/utils/types.ts
@@ -7,7 +7,7 @@ export type LearningExperienceContextType = {
   referenceScrollPositions: Record<string, number>;
   openExpansionItems: string[];
   drawerWidth: string;
-  data: Record<string, any>;
+  data: Record<string, unknown>;
   openLearningExperience: () => void;
   closeLearningExperience: () => void;
   setSelectedTopic: (topic: LearningExperienceTopic | null) => void;
@@ -16,7 +16,7 @@ export type LearningExperienceContextType = {
   setDrawerWidth: (width: string) => void;
   openExpansionItem: (itemId: string) => void;
   closeExpansionItem: (itemId: string) => void;
-  setData: (dataItem: string, dataValue: any) => void;
+  setData: (dataItem: string, dataValue: unknown) => void;
   clearData: (dataItem?: string) => void;
 };
 
@@ -27,5 +27,5 @@ export type PersistedState = {
   referenceScrollPositions?: Record<string, number>;
   selectedTopicId?: string | null;
   drawerWidth?: string;
-  data?: Record<string, any>;
+  data?: Record<string, unknown>;
 };

--- a/src/onlineHelp/learningExperienceDrawer/utils/utils.ts
+++ b/src/onlineHelp/learningExperienceDrawer/utils/utils.ts
@@ -11,7 +11,9 @@ import type { PersistedState } from './types';
 export const findTopicById = (
   topicId: string | null | undefined,
 ): LearningExperienceTopic | null => {
-  if (!topicId) return null;
+  if (!topicId) {
+    return null;
+  }
   return learningExperienceTopics.find((topic) => topic.id === topicId) ?? null;
 };
 
@@ -21,7 +23,9 @@ let writeTimeout: ReturnType<typeof setTimeout> | null = null;
 const DEBOUNCE_MS = 200;
 
 const flushToStorage = (): void => {
-  if (isEmpty(Object.keys(pendingWrites))) return;
+  if (isEmpty(Object.keys(pendingWrites))) {
+    return;
+  }
 
   const current = parseOrClean<PersistedState>(STORAGE_KEY);
   saveToLocalStorage(STORAGE_KEY, JSON.stringify({ ...current, ...pendingWrites }));

--- a/src/overview/hooks/useOverviewContext.ts
+++ b/src/overview/hooks/useOverviewContext.ts
@@ -43,8 +43,11 @@ export const useOverviewContext = (): OverviewContextType => {
       data,
       setData: (newState: OverviewContextData) => {
         // Save/clear the user settings stored in local storage
-        if (newState.hideWelcomeCardByContext) userSettings?.welcome?.save(true);
-        else userSettings?.welcome?.clear();
+        if (newState.hideWelcomeCardByContext) {
+          userSettings?.welcome?.save(true);
+        } else {
+          userSettings?.welcome?.clear();
+        }
 
         saveOverviewSelectedRanges({
           vmMigrationsDonutSelectedRange: newState.vmMigrationsDonutSelectedRange,

--- a/src/overview/tabs/History/utils/matchers.ts
+++ b/src/overview/tabs/History/utils/matchers.ts
@@ -8,13 +8,17 @@ import type { V1beta1Migration } from '@forklift-ui/types';
 export const dateRangeObjectMatcher: ValueMatcher = {
   filterType: FilterDefType.DateRange,
   matchValue: (value: unknown) => (filter: string) => {
-    if (!value || typeof value !== 'object') return false;
+    if (!value || typeof value !== 'object') {
+      return false;
+    }
     const obj = value as { started?: string; completed?: string };
     const [from, to] = filter.split('/');
     const fromDate = DateTime.fromISO(from);
     const toDate = DateTime.fromISO(to);
     const inRange = (dateStr?: string) => {
-      if (!dateStr) return false;
+      if (!dateStr) {
+        return false;
+      }
       const date = DateTime.fromISO(dateStr);
       return date >= fromDate && date <= toDate;
     };

--- a/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryChart.tsx
+++ b/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryChart.tsx
@@ -95,7 +95,9 @@ const VmMigrationsHistoryChart = ({
       {
         eventHandlers: {
           onClick: () => {
-            if (!activeInterval) return;
+            if (!activeInterval) {
+              return;
+            }
             navigateToHistoryTab({
               interval: activeInterval,
               navigate,

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
@@ -55,7 +55,9 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
   );
 
   useEffect(() => {
-    if (!loaded || error) return;
+    if (!loaded || error) {
+      return;
+    }
 
     const currentIds = data.map((series) => series.planId);
     const currentIdSet = new Set(currentIds);

--- a/src/overview/tabs/Overview/utils/getVmCounts.ts
+++ b/src/overview/tabs/Overview/utils/getVmCounts.ts
@@ -6,10 +6,14 @@ import { TimeRangeOptions, TimeRangeOptionsDictionary } from './timeRangeOptions
 
 // Helper function to process 'True' vm conditions
 const processVmConditions = (vm: V1beta1MigrationStatusVms) => {
-  if (!('conditions' in vm)) return [];
+  if (!('conditions' in vm)) {
+    return [];
+  }
 
   return (vm.conditions ?? []).reduce((acc: string[], condition) => {
-    if (condition.status === 'True') acc.push(condition.type);
+    if (condition.status === 'True') {
+      acc.push(condition.type);
+    }
     return acc;
   }, []);
 };
@@ -32,7 +36,9 @@ const incrementCounts = (
 
   if (isCompleted) {
     conditions.forEach((condition) => {
-      if (condition in vmCounts) vmCounts[condition] += 1;
+      if (condition in vmCounts) {
+        vmCounts[condition] += 1;
+      }
     });
   }
 };

--- a/src/overview/tabs/Settings/components/ControllerTransferNetwork/EditControllerTransferNetwork.tsx
+++ b/src/overview/tabs/Settings/components/ControllerTransferNetwork/EditControllerTransferNetwork.tsx
@@ -28,15 +28,21 @@ const EditControllerTransferNetwork: FC = () => {
   });
 
   const controllerTransferNetworkOptions = useMemo(() => {
-    if (!loaded || loadError) return [];
+    if (!loaded || loadError) {
+      return [];
+    }
 
-    if (!Array.isArray(nads) || isEmpty(nads)) return [];
+    if (!Array.isArray(nads) || isEmpty(nads)) {
+      return [];
+    }
 
     return nads.reduce<Option[]>((acc, nad) => {
       const name = getName(nad) ?? '';
       const namespace = getNamespace(nad) ?? '';
       const key = `${namespace}/${name}`;
-      if (!name || !namespace) return acc;
+      if (!name || !namespace) {
+        return acc;
+      }
       return [
         ...acc,
         {

--- a/src/overview/tabs/Settings/components/SettingsNumberInput.tsx
+++ b/src/overview/tabs/Settings/components/SettingsNumberInput.tsx
@@ -17,7 +17,9 @@ const SettingsNumberInput: FC<SettingsNumberInputProps> = ({
 }) => {
   const normalize = (val: number | string) => {
     const num = typeof val === 'number' ? val : parseInt(val, 10);
-    if (isNaN(num) || num < 1) return defaultValue;
+    if (isNaN(num) || num < 1) {
+      return defaultValue;
+    }
     return num;
   };
 

--- a/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
+++ b/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
@@ -51,7 +51,9 @@ const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...re
     date,
   ) => {
     setIsDateValid(Boolean(date));
-    if (!date) return;
+    if (!date) {
+      return;
+    }
 
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 
@@ -77,7 +79,9 @@ const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...re
     setTime(timeInput);
     setIsTimeValid(Boolean(timeValid) && Boolean(timeInput));
 
-    if (!timeValid) return;
+    if (!timeValid) {
+      return;
+    }
 
     const updatedFromDate = cutoverDate ? new Date(cutoverDate) : new Date();
 

--- a/src/plans/actions/utils/utils.ts
+++ b/src/plans/actions/utils/utils.ts
@@ -22,7 +22,9 @@ export const startDescription: StartDescriptionMap = Object.values(PlanStatuses)
 );
 
 export const getDuplicateDescription = (planStatus: PlanStatuses): string | null => {
-  if (planStatus === PlanStatuses.CannotStart) return t('The plan cannot be duplicated');
+  if (planStatus === PlanStatuses.CannotStart) {
+    return t('The plan cannot be duplicated');
+  }
   return null;
 };
 
@@ -31,8 +33,11 @@ export const getEditDescription = (planStatus: PlanStatuses): string | null => {
     planStatus === PlanStatuses.Executing ||
     planStatus === PlanStatuses.Paused ||
     planStatus === PlanStatuses.Pending
-  )
+  ) {
     return t('Plans cannot be modified during migration');
-  if (planStatus === PlanStatuses.Archived) return t('Archived plans cannot be edited');
+  }
+  if (planStatus === PlanStatuses.Archived) {
+    return t('Archived plans cannot be edited');
+  }
   return null;
 };

--- a/src/plans/create/CreatePlanWizardFooter.tsx
+++ b/src/plans/create/CreatePlanWizardFooter.tsx
@@ -54,7 +54,9 @@ const CreatePlanWizardFooter: FC<CreatePlanWizardFooterProps> = ({
 
   const onNextClick = useCallback(
     async (event: MouseEvent<HTMLButtonElement>) => {
-      if (onSubmit) return onSubmit(event);
+      if (onSubmit) {
+        return onSubmit(event);
+      }
 
       const isValid = await validateStep(activeStep.id as PlanWizardStepId);
       if (isValid) {

--- a/src/plans/create/hooks/useInitializeMappings.ts
+++ b/src/plans/create/hooks/useInitializeMappings.ts
@@ -31,7 +31,9 @@ export const useInitializeMappings = <T extends Record<string, unknown>>({
   const autoMappedSourcesRef = useRef(new Set<string>());
 
   const mappedSourceNames = useMemo(() => {
-    if (!currentMap?.length) return new Set<string>();
+    if (!currentMap?.length) {
+      return new Set<string>();
+    }
 
     return new Set(
       currentMap

--- a/src/plans/create/hooks/useSourceProviderFromSearchParams.ts
+++ b/src/plans/create/hooks/useSourceProviderFromSearchParams.ts
@@ -19,8 +19,9 @@ export const useSourceProviderFromSearchParams = (
   const hasSetProvider = useRef(false);
 
   useEffect(() => {
-    if (!sourceProviderName || hasSetProvider.current || !loaded || !provider?.metadata?.name)
+    if (!sourceProviderName || hasSetProvider.current || !loaded || !provider?.metadata?.name) {
       return;
+    }
 
     setValue(GeneralFormFieldId.SourceProvider, provider);
     hasSetProvider.current = true;

--- a/src/plans/create/hooks/useStepValidation.ts
+++ b/src/plans/create/hooks/useStepValidation.ts
@@ -16,7 +16,9 @@ export const useStepValidation = () => {
   const validateStep = useCallback(
     async (stepId: PlanWizardStepId): Promise<boolean> => {
       const fieldIds = stepFieldMap[stepId];
-      if (!fieldIds?.length) return true;
+      if (!fieldIds?.length) {
+        return true;
+      }
 
       return trigger(fieldIds, { shouldFocus: true });
     },

--- a/src/plans/create/steps/customization-scripts/utils.ts
+++ b/src/plans/create/steps/customization-scripts/utils.ts
@@ -48,7 +48,9 @@ export const validateUniqueScriptKey = (
   allScripts: CustomScript[],
 ): string | undefined => {
   const nameError = validateScriptName(script.name);
-  if (nameError) return nameError;
+  if (nameError) {
+    return nameError;
+  }
 
   const currentKey = buildConfigMapKey(script);
   const isDuplicate = allScripts.some(

--- a/src/plans/create/steps/migration-type/MigrationTypeRadio.tsx
+++ b/src/plans/create/steps/migration-type/MigrationTypeRadio.tsx
@@ -38,7 +38,9 @@ const MigrationTypeRadio: FC<MigrationTypeRadioProps> = ({
 
   const isVddkInitImageNotSet = isEmpty(sourceProvider?.spec?.settings?.vddkInitImage);
 
-  if (!canRender) return null;
+  if (!canRender) {
+    return null;
+  }
 
   const { description, helpBody, helpLink, PreviewLabel } = getMigrationTypeConfig(migrationType);
   const isWarmOptionSelected =

--- a/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapFieldTable.tsx
@@ -123,7 +123,7 @@ const NetworkMapFieldTable: FC<NetworkMapFieldTableProps> = ({
               remove(index);
             }
           },
-          tooltip: (index) => {
+          tooltip: (_index) => {
             if (netMappingFields.length <= 1) {
               return t('At least one network mapping must be provided.');
             }

--- a/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
+++ b/src/plans/create/steps/network-map/NewNetworkMapFields.tsx
@@ -65,11 +65,15 @@ const NewNetworkMapFields: FC = () => {
   });
 
   useEffect(() => {
-    if (isLoading || !networkMap?.length) return;
+    if (isLoading || !networkMap?.length) {
+      return;
+    }
 
     const vmsList = Object.values(vms) as TypesProviderVirtualMachine[];
     const multiNicIds = getMultiNicSourceNetworks(vmsList, oVirtNicProfiles);
-    if (multiNicIds.size === 0) return;
+    if (multiNicIds.size === 0) {
+      return;
+    }
 
     let updated = false;
     const updatedMap = networkMap.map((mapping) => {

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -29,7 +29,9 @@ type ValidateNetworkMapParams = {
 };
 
 const toNetworksOrProfiles = (vm: ProviderVirtualMachine): string[] => {
-  if (isEc2Vm(vm)) return getEc2SubnetIds(vm);
+  if (isEc2Vm(vm)) {
+    return getEc2SubnetIds(vm);
+  }
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {
@@ -163,7 +165,9 @@ const collectDistinctVlansByNetwork = (nics: HypervNic[]): Map<string, Set<numbe
   for (const nic of nics) {
     const netId = nic.network?.id;
     if (netId) {
-      if (!vlansByNetwork.has(netId)) vlansByNetwork.set(netId, new Set<number>());
+      if (!vlansByNetwork.has(netId)) {
+        vlansByNetwork.set(netId, new Set<number>());
+      }
       vlansByNetwork.get(netId)!.add(nic.vlanId ?? 0);
     }
   }
@@ -177,7 +181,9 @@ const upsertVlanEntry = (
   vlanId: number,
 ): void => {
   const key = vlanId === 0 ? `${networkId}/untagged` : `${networkId}/${vlanId}`;
-  if (vlanEntries.has(key)) return;
+  if (vlanEntries.has(key)) {
+    return;
+  }
   vlanEntries.set(
     key,
     vlanId === 0
@@ -284,13 +290,16 @@ export const validateNetworkMap = (validateNetworkMapParams: ValidateNetworkMapP
   const hasUnmappedNetwork = !usedSourceNetworks.every((sourceNetwork) =>
     mappedNetworkNames.has(sourceNetwork.name),
   );
-  if (hasUnmappedNetwork) return t('All networks detected on the selected VMs require a mapping.');
+  if (hasUnmappedNetwork) {
+    return t('All networks detected on the selected VMs require a mapping.');
+  }
 
   const hasMultiplePodNetwork = hasMultiplePodNetworkMappings(values, vms, oVirtNicProfiles);
-  if (hasMultiplePodNetwork)
+  if (hasMultiplePodNetwork) {
     return t(
       'At least one VM is detected with more than one interface mapped to Default Network. This is not allowed.',
     );
+  }
 
   return undefined;
 };

--- a/src/plans/create/steps/review/AapReviewContent.tsx
+++ b/src/plans/create/steps/review/AapReviewContent.tsx
@@ -18,7 +18,9 @@ const formatTemplateDisplay = (
   fallback: string,
   translate: (key: string, options?: Record<string, unknown>) => string,
 ): string => {
-  if (id === undefined) return fallback;
+  if (id === undefined) {
+    return fallback;
+  }
   return name ? translate('{{name}} (ID: {{id}})', { id: String(id), name }) : String(id);
 };
 

--- a/src/plans/create/steps/review/DiskDecryptionReviewItem.tsx
+++ b/src/plans/create/steps/review/DiskDecryptionReviewItem.tsx
@@ -29,7 +29,9 @@ const DiskDecryptionReviewItem: FC<DiskDecryptionReviewItemProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  if (nbdeClevis) return null;
+  if (nbdeClevis) {
+    return null;
+  }
 
   if (diskDecryptionType === DiskDecryptionType.Existing) {
     return (

--- a/src/plans/create/steps/review/MigrationTypeReviewSection.tsx
+++ b/src/plans/create/steps/review/MigrationTypeReviewSection.tsx
@@ -33,7 +33,9 @@ const MigrationTypeReviewSection: FC<{ isLiveMigrationFeatureEnabled: boolean }>
     hasWarmMigrationProviderType(sourceProvider) ||
     (hasLiveMigrationProviderType(sourceProvider) && isLiveMigrationFeatureEnabled);
 
-  if (!planSupportMigrationTypes) return null;
+  if (!planSupportMigrationTypes) {
+    return null;
+  }
 
   return (
     <ExpandableReviewSection

--- a/src/plans/create/steps/review/StorageMapReviewTable.tsx
+++ b/src/plans/create/steps/review/StorageMapReviewTable.tsx
@@ -23,7 +23,9 @@ const StorageMapReviewTable: FC<StorageMapReviewTableProps> = ({ storageMap }) =
   const { t } = useForkliftTranslation();
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
 
-  if (!storageMap) return null;
+  if (!storageMap) {
+    return null;
+  }
 
   const hasValidMappings = storageMap.some(
     (mapping) =>

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -4,7 +4,9 @@ import { PROVIDER_TYPES } from '@utils/providers/constants';
 import { getEc2SubnetIds, isEc2Vm } from '@utils/types/ec2Inventory';
 
 const getNetworksForVM = (vm: ProviderVirtualMachine) => {
-  if (isEc2Vm(vm)) return getEc2SubnetIds(vm);
+  if (isEc2Vm(vm)) {
+    return getEc2SubnetIds(vm);
+  }
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere: {

--- a/src/plans/create/utils/hasMultiplePodNetworkMappings.ts
+++ b/src/plans/create/utils/hasMultiplePodNetworkMappings.ts
@@ -17,7 +17,9 @@ export const hasMultiplePodNetworkMappings = (
 
   return Object.values(vms).some((vm) => {
     const networks = getVMNetworksOrProfiles(vm, oVirtNicProfiles);
-    if (!networks || !Array.isArray(networks)) return false;
+    if (!networks || !Array.isArray(networks)) {
+      return false;
+    }
 
     const uniqueNetworks = networks.filter((value, index, array) => array.indexOf(value) === index);
     const mappedNetworks = uniqueNetworks.filter((id) => netIdsMappedToPodNet.has(id as string));

--- a/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanAlerts/PlanAlerts.tsx
@@ -49,7 +49,9 @@ const PlanAlerts: FC<Props> = ({ plan, setIsDrawerOpen }) => {
     [status],
   );
 
-  if (alertsNotRelevant || !showCriticalConditions) return null;
+  if (alertsNotRelevant || !showCriticalConditions) {
+    return null;
+  }
 
   return (
     <PageSection hasBodyWrapper={false} className="plan-header-alerts">

--- a/src/plans/details/components/PlanPageHeader/components/PlanCriticalAlerts.tsx
+++ b/src/plans/details/components/PlanPageHeader/components/PlanCriticalAlerts.tsx
@@ -27,7 +27,9 @@ const PlanCriticalAlerts: FC<PlanCriticalAlertsProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  if (isEmpty(conditions) && isEmpty(concerns)) return null;
+  if (isEmpty(conditions) && isEmpty(concerns)) {
+    return null;
+  }
 
   return (
     <Alert

--- a/src/plans/details/components/PlanStatus/StatusPopover.tsx
+++ b/src/plans/details/components/PlanStatus/StatusPopover.tsx
@@ -60,7 +60,9 @@ const StatusPopover: FC<StatusPopoverProps> = ({ count, plan, status, vms }) => 
           <StackItem>
             <List>
               {vms.map(({ failedTaskName, name }, idx) => {
-                if (idx >= STATUS_POPOVER_VMS_COUNT_THRESHOLD) return null; // show only first items
+                if (idx >= STATUS_POPOVER_VMS_COUNT_THRESHOLD) {
+                  return null;
+                } // show only first items
                 return (
                   <ListItem key={name}>
                     {name}

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -62,17 +62,25 @@ export const getMigrationVMStatus = (
     (condition) =>
       condition.type === CATEGORY_TYPES.CANCELED && condition.status === CONDITION_STATUS.TRUE,
   );
-  if (isCanceled) return MigrationVirtualMachineStatus.Canceled;
+  if (isCanceled) {
+    return MigrationVirtualMachineStatus.Canceled;
+  }
 
   const isSucceeded = conditions.some(
     (condition) =>
       condition.type === CATEGORY_TYPES.SUCCEEDED && condition.status === CONDITION_STATUS.TRUE,
   );
-  if (isSucceeded) return MigrationVirtualMachineStatus.Succeeded;
+  if (isSucceeded) {
+    return MigrationVirtualMachineStatus.Succeeded;
+  }
 
-  if (vm?.error) return MigrationVirtualMachineStatus.Failed;
+  if (vm?.error) {
+    return MigrationVirtualMachineStatus.Failed;
+  }
 
-  if (isMigrationVirtualMachinePaused(vm)) return MigrationVirtualMachineStatus.Paused;
+  if (isMigrationVirtualMachinePaused(vm)) {
+    return MigrationVirtualMachineStatus.Paused;
+  }
 
   if (vm?.started && !vm?.completed && !vm?.error) {
     return MigrationVirtualMachineStatus.InProgress;
@@ -144,7 +152,9 @@ const isPlanWaitingForCutover = (plan: V1beta1Plan) =>
   getPlanIsWarm(plan);
 
 const isPlanPendingExecution = (plan: V1beta1Plan): boolean => {
-  if (!isPlanExecuting(plan)) return false;
+  if (!isPlanExecuting(plan)) {
+    return false;
+  }
 
   const vms = getPlanVirtualMachinesMigrationStatus(plan);
 
@@ -160,7 +170,9 @@ export const isPlanArchived = (plan: V1beta1Plan) => {
 };
 
 export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
-  if (!plan) return PlanStatuses.Unknown;
+  if (!plan) {
+    return PlanStatuses.Unknown;
+  }
 
   const conditions = getConditions(plan);
 

--- a/src/plans/details/hooks/useCbtDisabledVms.ts
+++ b/src/plans/details/hooks/useCbtDisabledVms.ts
@@ -21,7 +21,9 @@ export const useCbtDisabledVms = (
   const planVmIds = useMemo(() => new Set(getPlanVirtualMachines(plan).map((vm) => vm.id)), [plan]);
 
   const cbtDisabledVms = useMemo((): ProviderVirtualMachine[] => {
-    if (isVmDataLoading || !isVsphere || isEmpty(providerVmData)) return [];
+    if (isVmDataLoading || !isVsphere || isEmpty(providerVmData)) {
+      return [];
+    }
 
     return providerVmData
       .filter((data) => planVmIds.has(data.vm.id))

--- a/src/plans/details/hooks/usePlanMappingData.ts
+++ b/src/plans/details/hooks/usePlanMappingData.ts
@@ -52,7 +52,9 @@ export const usePlanMappingData = ({
   );
 
   const sourceStorages = useMemo(() => {
-    if (!isEmpty(providerStorages)) return providerStorages;
+    if (!isEmpty(providerStorages)) {
+      return providerStorages;
+    }
 
     return (planStorageMap?.status?.references ?? []).map((ref) => ({
       id: ref.id ?? '',
@@ -62,7 +64,9 @@ export const usePlanMappingData = ({
   }, [providerStorages, planStorageMap, sourceProvider]);
 
   const sourceNetworks = useMemo(() => {
-    if (!isEmpty(providerNetworks)) return providerNetworks;
+    if (!isEmpty(providerNetworks)) {
+      return providerNetworks;
+    }
 
     return (planNetworkMap?.status?.references ?? []).map((ref) => ({
       id: ref.id ?? '',

--- a/src/plans/details/tabs/Automation/hooks/usePlanCustomScripts.ts
+++ b/src/plans/details/tabs/Automation/hooks/usePlanCustomScripts.ts
@@ -36,7 +36,9 @@ export const usePlanCustomScripts = (plan: V1beta1Plan): UsePlanCustomScriptsRes
   const configMapDataJson = JSON.stringify(configMap?.data ?? null);
 
   const scripts = useMemo((): CustomScript[] => {
-    if (!hasRef) return [];
+    if (!hasRef) {
+      return [];
+    }
     const parsed = JSON.parse(configMapDataJson) as Record<string, string> | null;
     return parseConfigMapScripts(parsed ?? undefined);
   }, [configMapDataJson, hasRef]);

--- a/src/plans/details/tabs/Automation/utils/validateScripts.ts
+++ b/src/plans/details/tabs/Automation/utils/validateScripts.ts
@@ -1,7 +1,9 @@
 import { t } from '@utils/i18n';
 
 export const validateScriptContent = (value: string): string | undefined => {
-  if (!value?.trim()) return t('Script content is required.');
+  if (!value?.trim()) {
+    return t('Script content is required.');
+  }
 
   return undefined;
 };

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/MigrationTypeDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/MigrationTypeDetailsItem.tsx
@@ -22,7 +22,9 @@ const MigrationTypeDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const migrationType = getPlanMigrationType(plan);
 

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/LocalProviderNamespaceSelect.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/LocalProviderNamespaceSelect.tsx
@@ -10,7 +10,9 @@ import TargetNamespaceSelect from './TargetNamespaceSelect';
 const LocalProviderNamespaceSelect: FC<TargetNamespaceSelectInputProps> = ({ onChange, value }) => {
   const [projectNames, loaded, loadError] = useWatchProjectNames();
 
-  if (!loaded && isEmpty(loadError)) return <Loading />;
+  if (!loaded && isEmpty(loadError)) {
+    return <Loading />;
+  }
 
   return (
     <TargetNamespaceSelect

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/RemoteProviderNamespaceSelect.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/RemoteProviderNamespaceSelect.tsx
@@ -19,7 +19,9 @@ const RemoteProviderNamespaceSelect: FC<RemoteProviderNamespaceSelectProps> = ({
 }) => {
   const [projectNames, loaded, loadError] = useTargetNamespaces(targetProvider);
 
-  if (!loaded && isEmpty(loadError)) return <Loading />;
+  if (!loaded && isEmpty(loadError)) {
+    return <Loading />;
+  }
 
   return (
     <TargetNamespaceSelect

--- a/src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts
@@ -12,14 +12,18 @@ export const getMigrationStatusLabel = (
   vmStatuses: MigrationVirtualMachinesStatusesCounts,
   migrationVMsCounts: number | undefined,
 ): MigrationVirtualMachineStatus | null => {
-  if (vmStatuses[MigrationVirtualMachineStatus.InProgress].count > 0)
+  if (vmStatuses[MigrationVirtualMachineStatus.InProgress].count > 0) {
     return MigrationVirtualMachineStatus.InProgress;
-  if (vmStatuses[MigrationVirtualMachineStatus.Failed].count > 0)
+  }
+  if (vmStatuses[MigrationVirtualMachineStatus.Failed].count > 0) {
     return MigrationVirtualMachineStatus.Failed;
-  if (vmStatuses[MigrationVirtualMachineStatus.Paused].count > 0)
+  }
+  if (vmStatuses[MigrationVirtualMachineStatus.Paused].count > 0) {
     return MigrationVirtualMachineStatus.Paused;
-  if (vmStatuses[MigrationVirtualMachineStatus.Succeeded].count === migrationVMsCounts)
+  }
+  if (vmStatuses[MigrationVirtualMachineStatus.Succeeded].count === migrationVMsCounts) {
     return MigrationVirtualMachineStatus.Succeeded;
+  }
 
   return null;
 };

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/utils.ts
@@ -37,9 +37,13 @@ export const getSelectedOption = (
   value: string | undefined,
   allowInherit: boolean,
 ): NameTemplateOptions => {
-  if (value) return NameTemplateOptions.customNameTemplate;
+  if (value) {
+    return NameTemplateOptions.customNameTemplate;
+  }
 
-  if (allowInherit) return NameTemplateOptions.inheritPlanWideSetting;
+  if (allowInherit) {
+    return NameTemplateOptions.inheritPlanWideSetting;
+  }
 
   return NameTemplateOptions.defaultNameTemplate;
 };

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionDetailsItem.tsx
@@ -20,7 +20,9 @@ const GuestConversionDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const skipGuestConversion = getSkipGuestConversion(plan);
   const useCompatibilityMode = getUseCompatibilityMode(plan) ?? true;

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
@@ -21,7 +21,9 @@ const NetworkNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const content = (
     <Label isCompact color="grey">

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
@@ -19,7 +19,9 @@ const PVCNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const content = (
     <Label isCompact color="grey">

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
@@ -21,7 +21,9 @@ const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const migrateSharedDisks = getMigrateSharedDisksValue(plan);
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/utils/utils.ts
@@ -54,7 +54,9 @@ export const onConfirmVmMigrateSharedDisks =
     const path = `/spec/vms/${vmIndex}/migrateSharedDisks`;
 
     if (newValue === undefined) {
-      if (current === undefined) return resource;
+      if (current === undefined) {
+        return resource;
+      }
 
       return k8sPatch({
         data: [{ op: REMOVE, path }],

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/TransferNetworkDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/TransferNetworkDetailsItem.tsx
@@ -22,7 +22,9 @@ const TransferNetworkDetailItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const networkName = getNetworkName(getPlanTransferNetwork(plan)!);
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/utils.ts
@@ -10,7 +10,9 @@ import { getPlanTransferNetwork } from '@utils/crds/plans/selectors';
 import { PROVIDER_DEFAULTS } from './constants';
 
 export const getNetworkName = (value: V1beta1PlanSpecTransferNetwork | null): string => {
-  if (!value || typeof value === 'string') return PROVIDER_DEFAULTS;
+  if (!value || typeof value === 'string') {
+    return PROVIDER_DEFAULTS;
+  }
   return `${value?.namespace}/${value?.name}`;
 };
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveClusterCpuModelDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveClusterCpuModelDetailsItem.tsx
@@ -20,7 +20,9 @@ const PreserveClusterCpuModelDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const preserveClusterCpuModel = getPlanPreserveClusterCpuModel(plan);
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/PreserveStaticIPsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/PreserveStaticIPsDetailsItem.tsx
@@ -20,7 +20,9 @@ const PreserveStaticIPsDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const preserveStaticIPs = getPlanPreserveIP(plan);
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/RootDiskDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/RootDiskDetailsItem.tsx
@@ -17,7 +17,9 @@ const RootDiskDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan, sho
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const rootDisk = getRootDisk(plan);
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/EditRootDiskModalAlert.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/components/EditRootDiskModalAlert.tsx
@@ -12,7 +12,9 @@ const EditRootDiskModalAlert: FC<EditRootDiskModalAlertProps> = ({ vms }) => {
   const { t } = useForkliftTranslation();
   const rootDisk = vms?.[0]?.rootDisk;
   const allVMsMatch = vms.every((vm) => vm.rootDisk === rootDisk);
-  if (allVMsMatch) return null;
+  if (allVMsMatch) {
+    return null;
+  }
 
   return (
     <AlertMessageForModals

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/SetLUKSEncryptionPasswordsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/SetLUKSEncryptionPasswordsDetailsItem.tsx
@@ -20,7 +20,9 @@ const SetLUKSEncryptionPasswordsDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   return (
     <DetailsItem

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/components/EditLUKSModalAlert.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/components/EditLUKSModalAlert.tsx
@@ -11,7 +11,9 @@ type EditLUKSModalAlertProps = {
 const EditLUKSModalAlert: FC<EditLUKSModalAlertProps> = ({ shouldRender }) => {
   const { t } = useForkliftTranslation();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
   return (
     <AlertMessageForModals
       variant="warning"

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/hooks/useEditLUKSState.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/hooks/useEditLUKSState.ts
@@ -58,7 +58,9 @@ export const useEditLUKSState = (resource: EditLUKSState['resource']): EditLUKSS
   }, [resource]);
 
   useEffect(() => {
-    if (modeInitialized || !secret?.metadata) return;
+    if (modeInitialized || !secret?.metadata) {
+      return;
+    }
 
     const isFromExisting = Boolean(secret.metadata.labels?.[SOURCE_SECRET_LABEL]);
     if (isFromExisting) {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/utils/utils.ts
@@ -14,10 +14,14 @@ import { isEmpty } from '@utils/helpers';
 
 const createIndexedBase64Object = (encodedString: string): Record<number, string> | undefined => {
   const list: string[] = JSON.parse(encodedString || '[]');
-  if (isEmpty(list) || list.every((item) => !item)) return undefined;
+  if (isEmpty(list) || list.every((item) => !item)) {
+    return undefined;
+  }
 
   const result = list.reduce<Record<number, string>>((acc, item, index) => {
-    if (item) acc[index] = btoa(item);
+    if (item) {
+      acc[index] = btoa(item);
+    }
     return acc;
   }, {});
 
@@ -111,7 +115,9 @@ const deleteCurrentSecret = async (
   secretName: string | undefined,
   namespace: string | undefined,
 ): Promise<void> => {
-  if (!secretName) return;
+  if (!secretName) {
+    return;
+  }
 
   await k8sDelete({
     model: SecretModel,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
@@ -19,7 +19,9 @@ const VolumeNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const content = (
     <Label isCompact color="grey">

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/XfsCompatibilityDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/XfsCompatibilityDetailsItem.tsx
@@ -20,7 +20,9 @@ const XfsCompatibilityDetailsItem: FC<EditableDetailsItemProps> = ({
   const { t } = useForkliftTranslation();
   const launcher = useModal();
 
-  if (!shouldRender) return null;
+  if (!shouldRender) {
+    return null;
+  }
 
   const xfsCompatibility = getPlanXfsCompatibility(plan);
 

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/components/PlanNetworkMapFieldsTable.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/components/PlanNetworkMapFieldsTable.tsx
@@ -144,7 +144,7 @@ const PlanNetworkMapFieldsTable: FC<PlanNetworkMapFieldsTableProps> = ({
               remove(index);
             }
           },
-          tooltip: (index) => {
+          tooltip: (_index) => {
             if (networkMappingFields.length <= 1) {
               return t('At least one network mapping must be provided.');
             }

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/components/PlanStorageMapFieldsTable.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/components/PlanStorageMapFieldsTable.tsx
@@ -200,7 +200,9 @@ const PlanStorageMapFieldsTable: FC<PlanStorageMapFieldsTableProps> = ({
       }}
       removeButton={{
         isDisabled: (index) => {
-          if (Boolean(isIscsi) || storageMappingFields.length <= 1) return true;
+          if (Boolean(isIscsi) || storageMappingFields.length <= 1) {
+            return true;
+          }
           return usedSourceStorages.some(
             (storage) =>
               storage.id === storageMappingFields[index][StorageMapFieldId.SourceStorage].id,

--- a/src/plans/details/tabs/Mappings/hooks/usePlanMappingVms.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanMappingVms.ts
@@ -20,7 +20,9 @@ export const usePlanMappingVms = (
       return {};
     }
     return providerVmData?.reduce((acc: Record<string, ProviderVirtualMachine>, data) => {
-      if (!planVmIds.includes(data.vm.id)) return acc;
+      if (!planVmIds.includes(data.vm.id)) {
+        return acc;
+      }
 
       return {
         ...acc,

--- a/src/plans/details/tabs/Resources/PlanResourcesPage.tsx
+++ b/src/plans/details/tabs/Resources/PlanResourcesPage.tsx
@@ -43,7 +43,9 @@ const PlanResourcesPage: FC<PlanPageProps> = ({ name, namespace }) => {
 
   const planResourcesTableProps = getPlanResourcesTableProps(planInventory, provider?.spec?.type);
 
-  if (!planResourcesTableProps) return <LoadingSuspend />;
+  if (!planResourcesTableProps) {
+    return <LoadingSuspend />;
+  }
 
   return (
     <LoadingSuspend obj={plan} loaded={!inventoryLoading} loadError={inventoryLoadError}>

--- a/src/plans/details/tabs/Resources/utils/utils.ts
+++ b/src/plans/details/tabs/Resources/utils/utils.ts
@@ -164,10 +164,14 @@ const getK8sVMMemory = (vm: V1VirtualMachine): string =>
 
 const k8sMemoryToBytes = (quantity: string, fallback: number | null = null): number | null => {
   const input = quantity.trim();
-  if (!input) return fallback;
+  if (!input) {
+    return fallback;
+  }
 
   const numericPart = parseFloat(input);
-  if (Number.isNaN(numericPart)) return fallback;
+  if (Number.isNaN(numericPart)) {
+    return fallback;
+  }
 
   const numericPartLength = numericPart.toString().length;
   const unitPart = input.slice(numericPartLength).toUpperCase() as K8sUnit;

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/DisksCounter.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/DisksCounter.tsx
@@ -12,7 +12,9 @@ type DisksCounterProps = {
 const DisksCounter: FC<DisksCounterProps> = ({ diskTransferPipeline }) => {
   const { completedTasks, totalTasks } = countTasks(diskTransferPipeline);
 
-  if (!diskTransferPipeline || !totalTasks) return <>{EMPTY_MSG}</>;
+  if (!diskTransferPipeline || !totalTasks) {
+    return <>{EMPTY_MSG}</>;
+  }
 
   return (
     <>

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/DisksTransfer.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/DisksTransfer.tsx
@@ -13,7 +13,9 @@ const DisksTransfer: FC<DisksTransferProps> = ({ diskTransferPipeline }) => {
   const annotations = diskTransferPipeline?.annotations ?? {};
   const { completed, total } = getTransferProgress(diskTransferPipeline);
 
-  if (!diskTransferPipeline || !annotations?.unit) return <>{EMPTY_MSG}</>;
+  if (!diskTransferPipeline || !annotations?.unit) {
+    return <>{EMPTY_MSG}</>;
+  }
 
   return (
     <>

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
@@ -4,23 +4,25 @@ import { CheckIcon, ResourcesEmptyIcon, TimesIcon } from '@patternfly/react-icon
 import { PF_LABEL_STATUS, taskStatuses } from '@utils/constants';
 
 export const getPipelineProgressIcon = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
-  if (pipeline?.error)
+  if (pipeline?.error) {
     return (
       <Icon status={PF_LABEL_STATUS.DANGER}>
         <TimesIcon />
       </Icon>
     );
+  }
 
   const isCompleted =
     pipeline?.phase === taskStatuses.completed ||
     (pipeline?.progress !== undefined && pipeline.progress.completed === pipeline.progress.total);
 
-  if (isCompleted)
+  if (isCompleted) {
     return (
       <Icon status={PF_LABEL_STATUS.SUCCESS}>
         <CheckIcon />
       </Icon>
     );
+  }
 
   return <ResourcesEmptyIcon />;
 };

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
@@ -120,18 +120,28 @@ export const getVMDiskTransferPipeline = (
   const pipeline = statusVM?.pipeline ?? [];
   const diskSteps = pipeline.filter(isDiskTransferStep);
 
-  if (isEmpty(diskSteps)) return undefined;
-  if (diskSteps.length === 1) return diskSteps[0];
+  if (isEmpty(diskSteps)) {
+    return undefined;
+  }
+  if (diskSteps.length === 1) {
+    return diskSteps[0];
+  }
 
   const running = diskSteps.find(isStepActive);
-  if (running) return running;
+  if (running) {
+    return running;
+  }
 
   const diskTransfer = diskSteps.find((pipe) => pipe.name.startsWith(DISK_TRANSFER_PREFIX));
   const diskAllocation = diskSteps.find((pipe) => pipe.name === DISK_ALLOCATION_NAME);
 
   if (!hasPipelineBlockingFailure(pipeline)) {
-    if ((diskTransfer?.progress?.completed ?? 0) > 0) return diskTransfer;
-    if ((diskAllocation?.progress?.completed ?? 0) > 0) return diskAllocation;
+    if ((diskTransfer?.progress?.completed ?? 0) > 0) {
+      return diskTransfer;
+    }
+    if ((diskAllocation?.progress?.completed ?? 0) > 0) {
+      return diskAllocation;
+    }
   }
 
   return diskTransfer ?? diskAllocation;
@@ -150,7 +160,9 @@ export const groupByVmId = <T extends K8sResourceCommon>(items: T[]) =>
   items.reduce<Record<string, T[]>>((acc, item) => {
     const vmID = item?.metadata?.labels?.vmID;
     if (vmID) {
-      if (!acc[vmID]) acc[vmID] = [];
+      if (!acc[vmID]) {
+        acc[vmID] = [];
+      }
 
       acc[vmID].push(item);
     }

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesListData.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesListData.ts
@@ -43,7 +43,9 @@ export const useSpecVirtualMachinesListData = (
   }, [vmInventoryData]);
 
   const specVirtualMachinesListData = useMemo<SpecVirtualMachinePageData[]>(() => {
-    if (loading || !isEmpty(error)) return EMPTY_LIST;
+    if (loading || !isEmpty(error)) {
+      return EMPTY_LIST;
+    }
 
     const out: SpecVirtualMachinePageData[] = [];
     let vmIndex = 0;

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/getUniqueMapByCategory.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/getUniqueMapByCategory.ts
@@ -13,7 +13,11 @@ type UniqueMaps = ReturnType<typeof createInitialUniqueMaps>;
 
 export const getUniqueMapByCategory = (acc: UniqueMaps, category: string) => {
   const label = getCategoryLabel(category);
-  if (label === ConcernCategory.Critical) return acc.critical;
-  if (label === ConcernCategory.Warning) return acc.warning;
+  if (label === ConcernCategory.Critical) {
+    return acc.critical;
+  }
+  if (label === ConcernCategory.Warning) {
+    return acc.warning;
+  }
   return acc.information;
 };

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/utils.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/utils.tsx
@@ -168,7 +168,9 @@ export const getPlanConditionsDict = (
       condition?.items?.forEach((item) => {
         const { id: vmID } = extractIdAndNameFromConditionItem(item);
         if (vmID) {
-          if (!dict[vmID]) dict[vmID] = [];
+          if (!dict[vmID]) {
+            dict[vmID] = [];
+          }
 
           dict[vmID].push(condition);
         }

--- a/src/plans/list/components/PlansAddButton.tsx
+++ b/src/plans/list/components/PlansAddButton.tsx
@@ -51,7 +51,9 @@ const PlansAddButton: FC<PlansAddButtonProps> = ({ canCreate, namespace, testId 
     </Button>
   );
 
-  if (hasSufficientProviders) return button;
+  if (hasSufficientProviders) {
+    return button;
+  }
 
   return (
     <Tooltip

--- a/src/providers/actions/ProviderActionsDropdownItems.tsx
+++ b/src/providers/actions/ProviderActionsDropdownItems.tsx
@@ -27,7 +27,9 @@ const ProviderActionsDropdownItems: FC<ProviderActionsDropdownItemsProps> = ({
 
   const { provider } = data;
 
-  if (!provider || !getName(provider) || !getNamespace(provider)) return null;
+  if (!provider || !getName(provider) || !getNamespace(provider)) {
+    return null;
+  }
 
   const providerURL = getProviderDetailsPageUrl(provider);
 

--- a/src/providers/create/fields/ProviderFormPasswordInput.tsx
+++ b/src/providers/create/fields/ProviderFormPasswordInput.tsx
@@ -7,18 +7,12 @@ import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import { getInputValidated } from '@utils/form';
 
 import { useCreateProviderFormContext } from '../hooks/useCreateProviderFormContext';
-import type { CreateProviderFormData } from '../types';
 
 import type { ProviderFormFieldIdType } from './constants';
 
 type ProviderFormPasswordInputProps = {
   fieldId: ProviderFormFieldIdType;
-  fieldRules:
-    | Omit<
-        RegisterOptions<CreateProviderFormData, any>,
-        'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
-      >
-    | undefined;
+  fieldRules?: Omit<RegisterOptions, 'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'>;
   label: string;
   isRequired?: boolean;
   testId?: string;

--- a/src/providers/create/fields/ProviderFormTextInput.tsx
+++ b/src/providers/create/fields/ProviderFormTextInput.tsx
@@ -6,16 +6,12 @@ import { type FormGroupProps, TextInput } from '@patternfly/react-core';
 import { getInputValidated } from '@utils/form';
 
 import { useCreateProviderFormContext } from '../hooks/useCreateProviderFormContext';
-import type { CreateProviderFormData } from '../types';
 
 import type { ProviderFormFieldIdType } from './constants';
 
 type ProviderFormTextInputProps = {
   fieldId: ProviderFormFieldIdType;
-  fieldRules?: Omit<
-    RegisterOptions<CreateProviderFormData, any>,
-    'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
-  >;
+  fieldRules?: Omit<RegisterOptions, 'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'>;
   label: string;
   labelHelp?: FormGroupProps['labelHelp'];
   testId?: string;

--- a/src/providers/create/fields/hyperv/SmbDirectoryField.tsx
+++ b/src/providers/create/fields/hyperv/SmbDirectoryField.tsx
@@ -20,7 +20,9 @@ const SmbUrlField: FC = () => {
         required: t('SMB share URL is required'),
         validate: {
           pattern: (val): string | undefined => {
-            if (!val) return undefined;
+            if (!val) {
+              return undefined;
+            }
             if (!isValidSmbPath(val as string)) {
               return t('SMB path must be in format: //server/share or \\\\server\\share');
             }

--- a/src/providers/create/utils/buildOpenstackProviderResources.ts
+++ b/src/providers/create/utils/buildOpenstackProviderResources.ts
@@ -58,7 +58,9 @@ const AUTH_TYPE_FIELDS: Record<OpenstackAuthType, FieldMapping> = {
 
 export const getAuthTypeValue = (authType: OpenstackAuthType | undefined): string => {
   const type = authType ?? OpenstackAuthType.Password;
-  if (type === OpenstackAuthType.Password) return 'password';
+  if (type === OpenstackAuthType.Password) {
+    return 'password';
+  }
   if (type === OpenstackAuthType.TokenWithUserId || type === OpenstackAuthType.TokenWithUsername) {
     return 'token';
   }

--- a/src/providers/create/utils/createProviderSecret.ts
+++ b/src/providers/create/utils/createProviderSecret.ts
@@ -38,7 +38,9 @@ export const createProviderSecret = async (
 
   const newSecret: IoK8sApiCoreV1Secret = produce(secret, (draft) => {
     draft.data = cleanedData;
-    if (draft.data && url) draft.data.url = encode(url);
+    if (draft.data && url) {
+      draft.data.url = encode(url);
+    }
     if (draft.metadata) {
       draft.metadata.generateName = generateName;
       draft.metadata.labels = {

--- a/src/providers/details/tabs/Details/components/DetailsSection/DetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/DetailsSection.tsx
@@ -13,11 +13,14 @@ const DetailsSection: FC<DetailsSectionProps> = ({ data }) => {
 
   const { permissions, provider } = data;
 
-  if (isEmpty(provider) || isEmpty(permissions))
+  if (isEmpty(provider) || isEmpty(permissions)) {
     return <span className="text-muted">{t('No provider data available.')}</span>;
+  }
 
   const DetailsSectionByType = getDetailsSectionByType(provider?.spec?.type);
-  if (!DetailsSectionByType) return null;
+  if (!DetailsSectionByType) {
+    return null;
+  }
 
   return (
     <PageSection hasBodyWrapper={false} className="forklift-page-section--details">

--- a/src/providers/details/tabs/Details/components/DetailsSection/HyperVDetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/HyperVDetailsSection.tsx
@@ -18,7 +18,9 @@ const HyperVDetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { permissions, provider } = data;
 
-  if (!provider || !permissions) return null;
+  if (!provider || !permissions) {
+    return null;
+  }
 
   const isIscsi = isHypervIscsiProvider(provider);
   const isCluster = isHypervClusterProvider(provider);

--- a/src/providers/details/tabs/Details/components/DetailsSection/OVADetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/OVADetailsSection.tsx
@@ -16,7 +16,9 @@ const OVADetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { permissions, provider } = data;
 
-  if (!provider) return null;
+  if (!provider) {
+    return null;
+  }
 
   const canPatch = permissions?.canPatch ?? false;
 

--- a/src/providers/details/tabs/Details/components/DetailsSection/OpenshiftDetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/OpenshiftDetailsSection.tsx
@@ -20,7 +20,9 @@ const OpenshiftDetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { permissions, provider } = data;
 
-  if (!provider || !permissions) return null;
+  if (!provider || !permissions) {
+    return null;
+  }
 
   return (
     <DescriptionList

--- a/src/providers/details/tabs/Details/components/DetailsSection/OpenstackDetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/OpenstackDetailsSection.tsx
@@ -18,7 +18,9 @@ const OpenstackDetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { permissions, provider } = data;
 
-  if (!provider || !permissions) return null;
+  if (!provider || !permissions) {
+    return null;
+  }
 
   return (
     <DescriptionList

--- a/src/providers/details/tabs/Details/components/DetailsSection/OvirtDetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/OvirtDetailsSection.tsx
@@ -18,7 +18,9 @@ const OvirtDetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { permissions, provider } = data;
 
-  if (!provider || !permissions) return null;
+  if (!provider || !permissions) {
+    return null;
+  }
 
   return (
     <DescriptionList

--- a/src/providers/details/tabs/Details/components/DetailsSection/UploadFilesSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/UploadFilesSection.tsx
@@ -15,11 +15,16 @@ const UploadFilesSection: FC<DetailsSectionProps> = ({ data }) => {
 
   const { permissions, provider } = data;
 
-  if (isEmpty(provider) || isEmpty(permissions))
+  if (isEmpty(provider) || isEmpty(permissions)) {
     return <span className="text-muted">{t('No provider data available.')}</span>;
+  }
 
-  if (provider?.spec?.type !== PROVIDER_TYPES.ova) return null;
-  if (!isApplianceManagementEnabled(provider)) return null;
+  if (provider?.spec?.type !== PROVIDER_TYPES.ova) {
+    return null;
+  }
+  if (!isApplianceManagementEnabled(provider)) {
+    return null;
+  }
 
   return (
     <PageSection hasBodyWrapper={false} className="forklift-page-section--details">

--- a/src/providers/details/tabs/Details/components/DetailsSection/VSphereDetailsSection.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/VSphereDetailsSection.tsx
@@ -20,7 +20,9 @@ const VSphereDetailsSection: FC<DetailsSectionProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const { inventory, permissions, provider } = data;
 
-  if (!provider || !permissions) return null;
+  if (!provider || !permissions) {
+    return null;
+  }
 
   return (
     <DescriptionList

--- a/src/providers/details/tabs/Details/components/DetailsSection/onUpdateApplianceManagement.ts
+++ b/src/providers/details/tabs/Details/components/DetailsSection/onUpdateApplianceManagement.ts
@@ -11,7 +11,9 @@ const onUpdateApplianceManagement = async (
 ): Promise<V1beta1Provider> => {
   const currentValue = getApplianceManagement(provider);
 
-  if (currentValue === enabled.toString()) return provider;
+  if (currentValue === enabled.toString()) {
+    return provider;
+  }
 
   const obj = await k8sPatch({
     data: [

--- a/src/providers/details/tabs/Hosts/components/HypervHostsCells.tsx
+++ b/src/providers/details/tabs/Hosts/components/HypervHostsCells.tsx
@@ -9,7 +9,9 @@ import type { HypervHost } from '../types';
 const BYTES_PER_GIB = 1024 ** 3;
 
 const formatBytes = (bytes: number): string => {
-  if (!bytes) return '0 GiB';
+  if (!bytes) {
+    return '0 GiB';
+  }
   const gb = bytes / BYTES_PER_GIB;
   return `${gb.toFixed(1)} GiB`;
 };

--- a/src/providers/details/tabs/Hosts/components/HypervHostsList.tsx
+++ b/src/providers/details/tabs/Hosts/components/HypervHostsList.tsx
@@ -73,7 +73,9 @@ const HypervHostsList: FC<HypervHostsListProps> = ({ data }) => {
     subPath: 'hosts?detail=4',
   });
 
-  if (!provider) return <Bullseye className="text-muted">{t('No data available.')}</Bullseye>;
+  if (!provider) {
+    return <Bullseye className="text-muted">{t('No data available.')}</Bullseye>;
+  }
 
   return (
     <StandardPageWithSelection<HypervHost>

--- a/src/providers/details/tabs/Hosts/components/VSphereHostsList.tsx
+++ b/src/providers/details/tabs/Hosts/components/VSphereHostsList.tsx
@@ -46,8 +46,9 @@ const VSphereHostsList: FC<VSphereHostsListProps> = ({ data }) => {
 
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  if (!provider || !namespace || !permissions || !inventoryHosts)
+  if (!provider || !namespace || !permissions || !inventoryHosts) {
     return <Bullseye className="text-muted">{t('No data available.')}</Bullseye>;
+  }
 
   const hostsData = matchHostsToInventory(inventoryHosts, hosts, provider);
 

--- a/src/providers/details/tabs/Hosts/components/utils/renderTd.tsx
+++ b/src/providers/details/tabs/Hosts/components/utils/renderTd.tsx
@@ -31,7 +31,9 @@ const cellRenderers: Record<string, FC<HostCellProps>> = {
  * and there's no inventory data, it won't render the cell.
  */
 export const RenderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
-  if (!resourceFieldId) return <Td></Td>;
+  if (!resourceFieldId) {
+    return <Td></Td>;
+  }
 
   const CellRenderer = cellRenderers?.[resourceFieldId] ?? null;
 

--- a/src/providers/details/tabs/VirtualMachines/components/constants.ts
+++ b/src/providers/details/tabs/VirtualMachines/components/constants.ts
@@ -50,7 +50,9 @@ export const extraSupportedMatchers: ValueMatcher[] = [
   {
     filterType: CustomFilterType.Features,
     matchValue: (value: unknown) => (filter: string) => {
-      if (!value || typeof value !== 'object') return false;
+      if (!value || typeof value !== 'object') {
+        return false;
+      }
       const features = value as Record<string, boolean>;
       return features?.[filter] ?? false;
     },

--- a/src/providers/hooks/usePlanSourceProvider.tsx
+++ b/src/providers/hooks/usePlanSourceProvider.tsx
@@ -10,7 +10,7 @@ import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 const usePlanSourceProvider = (
   plan: V1beta1Plan,
   namespace: string,
-): [V1beta1Provider | undefined, boolean, any] => {
+): [V1beta1Provider | undefined, boolean, unknown] => {
   const planSourceProviderName = plan?.spec?.provider?.source?.name;
 
   const [providers, providersLoaded, providersLoadError] = useK8sWatchResource<V1beta1Provider[]>({

--- a/src/providers/hooks/useTlsCertificate.ts
+++ b/src/providers/hooks/useTlsCertificate.ts
@@ -9,7 +9,9 @@ import { getServicesApiUrl } from '@utils/api/getApiUrl';
  * @returns parsed certificate or undefined if parsing failed
  */
 const parseToX509 = (value: string) => {
-  if (!value) return undefined;
+  if (!value) {
+    return undefined;
+  }
   try {
     const cert = new X509();
     cert.readCertPEM(value);

--- a/src/providers/list/components/ProviderDataCell.tsx
+++ b/src/providers/list/components/ProviderDataCell.tsx
@@ -29,7 +29,9 @@ const ProviderDataCell: FC<ProviderDataCellProps> = ({
     [resourceFieldId, hasInventoryData, isInventoryField],
   );
 
-  if (isEmptyCell) return <TableEmptyCell />;
+  if (isEmptyCell) {
+    return <TableEmptyCell />;
+  }
 
   const DataCellRenderer =
     ProviderDataCellRenderers?.[resourceFieldId! as ProvidersResourceFieldId];

--- a/src/providers/list/hooks/useProvidersInventoryList.ts
+++ b/src/providers/list/hooks/useProvidersInventoryList.ts
@@ -45,8 +45,9 @@ const useProvidersInventoryList = (
           ? await consoleFetchJSON(getInventoryApiUrl(`providers?detail=1`))
           : await getProvidersInventoryByNamespace(namespace);
 
-        if (inventoryHasChanged(newInventory, oldDataRef, DEFAULT_FIELDS_TO_AVOID_COMPARING))
+        if (inventoryHasChanged(newInventory, oldDataRef, DEFAULT_FIELDS_TO_AVOID_COMPARING)) {
           updateInventory(newInventory, setInventory, oldDataRef);
+        }
         setLoading(false);
       } catch (e) {
         handleError(e as Error);

--- a/src/providers/list/utils/inventoryHasChanged.ts
+++ b/src/providers/list/utils/inventoryHasChanged.ts
@@ -22,7 +22,9 @@ export const inventoryHasChanged = (
   const newTotalLength = totalNumOfProviders(newInventoryList);
 
   const hasInventorySizeChanged = oldTotalLength !== newTotalLength;
-  if (hasInventorySizeChanged) return true;
+  if (hasInventorySizeChanged) {
+    return true;
+  }
 
   if (!hasInventorySizeChanged && oldTotalLength !== 0) {
     return inventoryContentHasChanged(newInventoryList, oldDataRef, fieldsToAvoidComparing);

--- a/src/providers/utils/validators/provider/openstack/validateOpenstackUILink.ts
+++ b/src/providers/utils/validators/provider/openstack/validateOpenstackUILink.ts
@@ -36,11 +36,12 @@ export const validateOpenstackUILink = (uiLink: string | number): ValidationMsg 
     };
   }
 
-  if (!trimmedUrl.endsWith('dashboard'))
+  if (!trimmedUrl.endsWith('dashboard')) {
     return {
       msg: 'The link for the OpenStack dashboard does not end with /dashboard path, for example: https://identity_service.com/dashboard.',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The link for the OpenStack dashboard. For example, https://identity_service.com/dashboard.',

--- a/src/providers/utils/validators/provider/openstack/validateOpenstackURL.ts
+++ b/src/providers/utils/validators/provider/openstack/validateOpenstackURL.ts
@@ -33,11 +33,12 @@ export const validateOpenstackURL = (url: string | number | undefined): Validati
     };
   }
 
-  if (!trimmedUrl.endsWith('v3'))
+  if (!trimmedUrl.endsWith('v3')) {
     return {
       msg: 'The URL does not end with a /v3 path, for example a URL with v3 path: https://identity_service.com:5000/v3 .',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The URL of the OpenStack Identity (Keystone) API endpoint, for example: https://identity_service.com:5000/v3 .',

--- a/src/providers/utils/validators/provider/ovirt/validateOvirtUILink.ts
+++ b/src/providers/utils/validators/provider/ovirt/validateOvirtUILink.ts
@@ -36,11 +36,12 @@ export const validateOvirtUILink = (uiLink: string | number): ValidationMsg => {
     };
   }
 
-  if (!trimmedUrl.endsWith('ovirt-engine') && !trimmedUrl.endsWith('ovirt-engine/'))
+  if (!trimmedUrl.endsWith('ovirt-engine') && !trimmedUrl.endsWith('ovirt-engine/')) {
     return {
       msg: 'The link for the Red Hat Virtualization Manager landing page does not end with a /ovirt-engine path, for example: https://rhv-host-example.com/ovirt-engine.',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The link for the Red Hat Virtualization Manager landing page. For example, https://rhv-host-example.com/ovirt-engine.',

--- a/src/providers/utils/validators/provider/ovirt/validateOvirtURL.ts
+++ b/src/providers/utils/validators/provider/ovirt/validateOvirtURL.ts
@@ -33,11 +33,12 @@ export const validateOvirtURL = (url: string | number | undefined): ValidationMs
     };
   }
 
-  if (!trimmedUrl.endsWith('ovirt-engine/api'))
+  if (!trimmedUrl.endsWith('ovirt-engine/api')) {
     return {
       msg: 'The URL does not end with a /ovirt-engine/api path, for example a URL with a path: https://rhv-host-example.com/ovirt-engine/api .',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The URL of the Red Hat Virtualization Manager (RHVM) API endpoint, for example: https://rhv-host-example.com/ovirt-engine/api .',

--- a/src/providers/utils/validators/provider/vsphere/validateEsxiURL.ts
+++ b/src/providers/utils/validators/provider/vsphere/validateEsxiURL.ts
@@ -33,11 +33,12 @@ export const validateEsxiURL = (url: string | number | undefined): ValidationMsg
     };
   }
 
-  if (!trimmedUrl.endsWith('sdk'))
+  if (!trimmedUrl.endsWith('sdk')) {
     return {
       msg: 'The URL does not end with a /sdk path, for example a URL with sdk path: https://host-example.com/sdk.',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The URL of the ESXi API endpoint for example: https://host-example.com/sdk.',

--- a/src/providers/utils/validators/provider/vsphere/validateVCenterURL.ts
+++ b/src/providers/utils/validators/provider/vsphere/validateVCenterURL.ts
@@ -61,11 +61,12 @@ export const validateVCenterURL = (
     }
   }
 
-  if (!trimmedUrl.endsWith('sdk'))
+  if (!trimmedUrl.endsWith('sdk')) {
     return {
       msg: 'The URL does not end with a /sdk path, for example a URL with sdk path: https://host-example.com/sdk.',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The URL of the vCenter API endpoint for example: https://host-example.com/sdk.',

--- a/src/providers/utils/validators/provider/vsphere/validateVDDKImage.ts
+++ b/src/providers/utils/validators/provider/vsphere/validateVDDKImage.ts
@@ -4,11 +4,12 @@ import { type ValidationMsg, ValidationState } from '@utils/validation/Validatio
 
 export const validateVDDKImage = (vddkImage?: string | number): ValidationMsg => {
   // For a newly opened form where the field is not set yet, set the validation type to default.
-  if (vddkImage === undefined)
+  if (vddkImage === undefined) {
     return {
       msg: 'The VDDK image is empty. It is strongly recommended to provide an image using the following format: <registry_route_or_server_path>/vddk:<tag> .',
       type: ValidationState.Default,
     };
+  }
 
   // Sanity check
   if (typeof vddkImage !== 'string') {
@@ -18,11 +19,12 @@ export const validateVDDKImage = (vddkImage?: string | number): ValidationMsg =>
   const trimmedVddkImage: string = vddkImage.trim();
   const isValidTrimmedVddkImage = validateContainerImage(trimmedVddkImage);
 
-  if (trimmedVddkImage === '')
+  if (trimmedVddkImage === '') {
     return {
       msg: 'The VDDK image is empty. It is strongly recommended to provide an image using the following format: <registry_route_or_server_path>/vddk:<tag> .',
       type: ValidationState.Error,
     };
+  }
 
   if (!isValidTrimmedVddkImage) {
     return {

--- a/src/providers/utils/validators/provider/vsphere/validateVSphereUILink.ts
+++ b/src/providers/utils/validators/provider/vsphere/validateVSphereUILink.ts
@@ -36,11 +36,12 @@ export const validateVSphereUILink = (uiLink: string | number): ValidationMsg =>
     };
   }
 
-  if (!trimmedUrl.endsWith('ui') && !trimmedUrl.endsWith('ui/'))
+  if (!trimmedUrl.endsWith('ui') && !trimmedUrl.endsWith('ui/')) {
     return {
       msg: 'The link for the VMware vSphere UI does not end with a /ui path, for example: https://vSphere-host-example.com/ui.',
       type: ValidationState.Warning,
     };
+  }
 
   return {
     msg: 'The link of the VMware vSphere UI. For example, https://vSphere-host-example.com/ui.',

--- a/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
+++ b/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
@@ -30,7 +30,9 @@ export const StorageMapActionsDropdownItems = ({
   });
 
   const onDelete = () => {
-    if (!storageMap) return;
+    if (!storageMap) {
+      return;
+    }
     launcher<DeleteModalProps>(DeleteModal, { model: StorageMapModel, resource: storageMap });
   };
 

--- a/src/storageMaps/components/StorageMapStatusAlerts.tsx
+++ b/src/storageMaps/components/StorageMapStatusAlerts.tsx
@@ -18,7 +18,9 @@ const StorageMapStatusAlerts: FC<StorageMapStatusAlertsProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return null;
+  }
 
   if (isIscsi) {
     return (

--- a/src/storageMaps/create/fields/utils.ts
+++ b/src/storageMaps/create/fields/utils.ts
@@ -9,7 +9,9 @@ import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
  * @returns Translation key string for validation error or true if valid
  */
 export const validateStorageMaps = (values: StorageMapping[]) => {
-  if (!Array.isArray(values)) return t('Invalid mappings');
+  if (!Array.isArray(values)) {
+    return t('Invalid mappings');
+  }
 
   let emptyCount = 0;
   let validCount = 0;

--- a/src/storageMaps/details/utils/utils.ts
+++ b/src/storageMaps/details/utils/utils.ts
@@ -121,7 +121,9 @@ export const transformStorageMapToFormValues = (
  * @returns Translation key string for validation error or undefined if valid
  */
 export const validateUpdatedStorageMaps = (values: StorageMapping[]) => {
-  if (!Array.isArray(values)) return t('Invalid mappings');
+  if (!Array.isArray(values)) {
+    return t('Invalid mappings');
+  }
 
   let emptyCount = 0;
   let validCount = 0;

--- a/src/utils/crds/conversion/selectors.ts
+++ b/src/utils/crds/conversion/selectors.ts
@@ -26,10 +26,16 @@ export const getInspectionResult = (conversion: V1beta1Conversion): InspectionRe
 
 /** Handles backend snake_case bug: reads both `allChecksPassed` and `all_checks_passed`. */
 export const hasInspectionPassed = (result: InspectionResult | undefined): boolean | undefined => {
-  if (!result) return undefined;
+  if (!result) {
+    return undefined;
+  }
   const value = result.allChecksPassed ?? result.all_checks_passed;
-  if (value !== undefined) return value;
-  if (!isEmpty(result.concerns)) return false;
+  if (value !== undefined) {
+    return value;
+  }
+  if (!isEmpty(result.concerns)) {
+    return false;
+  }
   return undefined;
 };
 
@@ -37,11 +43,15 @@ export const getInspectionStatus = (
   phase: ConversionPhase | undefined,
   inspectionPassed: boolean | undefined,
 ): InspectionStatus => {
-  if (!phase) return INSPECTION_STATUS.NOT_INSPECTED;
+  if (!phase) {
+    return INSPECTION_STATUS.NOT_INSPECTED;
+  }
 
   switch (phase) {
     case CONVERSION_PHASE.SUCCEEDED:
-      if (inspectionPassed === false) return INSPECTION_STATUS.ISSUES_FOUND;
+      if (inspectionPassed === false) {
+        return INSPECTION_STATUS.ISSUES_FOUND;
+      }
       return INSPECTION_STATUS.INSPECTION_PASSED;
     case CONVERSION_PHASE.FAILED:
       return INSPECTION_STATUS.FAILED;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -5,7 +5,9 @@ export const createCancellableDebounce = <T extends (...args: Parameters<T>) => 
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const debouncedFn = (...args: Parameters<T>) => {
-    if (timeoutId) clearTimeout(timeoutId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
     timeoutId = setTimeout(() => {
       func(...args);
     }, wait);

--- a/src/utils/hooks/useVmInspectionStatus.ts
+++ b/src/utils/hooks/useVmInspectionStatus.ts
@@ -27,8 +27,12 @@ const shouldReplace = (existing: V1beta1Conversion, candidate: V1beta1Conversion
   const candidateActive = isConversionActive(candidate);
   const existingActive = isConversionActive(existing);
 
-  if (candidateActive && !existingActive) return true;
-  if (!candidateActive && existingActive) return false;
+  if (candidateActive && !existingActive) {
+    return true;
+  }
+  if (!candidateActive && existingActive) {
+    return false;
+  }
 
   return (getCreatedAt(candidate) ?? '') > (getCreatedAt(existing) ?? '');
 };
@@ -56,7 +60,9 @@ export const useVmInspectionStatus = (
   return useCallback(
     (vmId: string): VmInspectionStatus | undefined => {
       const conversion = vmStatusMap.get(vmId);
-      if (!conversion) return undefined;
+      if (!conversion) {
+        return undefined;
+      }
 
       const phase = getConversionPhase(conversion);
       const inspectionPassed = hasInspectionPassed(getInspectionResult(conversion));

--- a/src/utils/types/ec2Inventory.ts
+++ b/src/utils/types/ec2Inventory.ts
@@ -50,7 +50,9 @@ export const getEc2SubnetIds = (vm: Ec2VmLike): string[] => {
       (acc, nic) => (nic.SubnetId ? [...acc, nic.SubnetId] : acc),
       [],
     );
-    if (!isEmpty(subnetIds)) return subnetIds;
+    if (!isEmpty(subnetIds)) {
+      return subnetIds;
+    }
   }
 
   return vm.object?.SubnetId ? [vm.object.SubnetId] : [];

--- a/src/utils/virtual-machines/getVmPowerState.ts
+++ b/src/utils/virtual-machines/getVmPowerState.ts
@@ -49,8 +49,12 @@ const getOpenShiftVmPowerState = (vm: OpenshiftVM): PowerState =>
 const getHypervVmPowerState = (vm: HypervVM): PowerState => {
   // Backend returns powerState as 'On' or 'Off' (capitalized)
   const powerState = (vm as HypervVM & { powerState?: string })?.powerState?.toLowerCase();
-  if (powerState === 'on') return 'on';
-  if (powerState === 'off') return 'off';
+  if (powerState === 'on') {
+    return 'on';
+  }
+  if (powerState === 'off') {
+    return 'off';
+  }
   return 'unknown';
 };
 
@@ -69,7 +73,9 @@ const getEc2VmPowerState = (vm: Ec2VM): PowerState => {
 };
 
 export const getVmPowerState = (vm: ProviderVirtualMachine | Ec2VM | undefined): PowerState => {
-  if (!vm) return 'unknown';
+  if (!vm) {
+    return 'unknown';
+  }
 
   switch (vm?.providerType) {
     case 'ovirt':

--- a/src/utils/vm/getVmGuestOS.ts
+++ b/src/utils/vm/getVmGuestOS.ts
@@ -2,7 +2,9 @@ import type { ProviderVirtualMachine } from '@forklift-ui/types';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 
 export const getVmGuestOS = (vm: ProviderVirtualMachine | undefined): string => {
-  if (!vm) return '';
+  if (!vm) {
+    return '';
+  }
 
   switch (vm.providerType) {
     case PROVIDER_TYPES.vsphere:

--- a/testing/playwright/e2e/downstream/network-maps/network-map-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/network-maps/network-map-edit.spec.ts
@@ -14,7 +14,9 @@ test.describe('Network Map Details - Editing', { tag: '@downstream' }, () => {
     testNetworkMap,
     testProvider: _testProvider,
   }) => {
-    if (!testNetworkMap) throw new Error('testNetworkMap is required');
+    if (!testNetworkMap) {
+      throw new Error('testNetworkMap is required');
+    }
 
     const networkMapDetailsPage = new NetworkMapDetailsPage(page);
     await networkMapDetailsPage.navigate(testNetworkMap.name);

--- a/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
@@ -23,7 +23,9 @@ const SELECT_ALL_PEER_VM = 'mtv-func-rhel9';
 
 const test = sharedProviderFixtures.extend<{ testPlan: Awaited<ReturnType<typeof createPlan>> }>({
   testPlan: async ({ page, resourceManager, testProvider }, setValue) => {
-    if (!testProvider) throw new Error('testPlan fixture requires testProvider');
+    if (!testProvider) {
+      throw new Error('testPlan fixture requires testProvider');
+    }
     const plan = await createPlan(page, resourceManager, {
       sourceProvider: testProvider,
       customPlanData: {
@@ -58,7 +60,9 @@ const setupPlanDetailsPage = async (
   page: Page,
   testPlan: TestPlan | undefined,
 ): Promise<SetupResult> => {
-  if (!testPlan) throw new Error('testPlan is required');
+  if (!testPlan) {
+    throw new Error('testPlan is required');
+  }
   const planDetailsPage = new PlanDetailsPage(page);
   const { name: planName, namespace } = testPlan.metadata;
   const firstVmName = testPlan.testData.virtualMachines?.[0]?.sourceName;

--- a/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-details-mappings-offload.spec.ts
@@ -16,7 +16,9 @@ test.describe('Storage Offloading - Plan Details Mappings Tab', { tag: '@downstr
     testPlan,
     testProvider: _testProvider,
   }) => {
-    if (!testPlan) throw new Error('testPlan is required');
+    if (!testPlan) {
+      throw new Error('testPlan is required');
+    }
 
     const planDetailsPage = new PlanDetailsPage(page);
     const secretName = await createOffloadTestSecret(resourceManager);

--- a/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-instance-type.spec.ts
@@ -63,7 +63,9 @@ const pickAndSaveNonNoneInstanceType = async (
   await expect(listbox).toBeVisible();
   const nonNoneOption = listbox.getByRole('option').filter({ hasNotText: /^None/ }).first();
   const picked = (await nonNoneOption.innerText()).split('\n')[0]?.trim() ?? '';
-  if (!picked) throw new Error('pickAndSaveNonNoneInstanceType: no non-None option available');
+  if (!picked) {
+    throw new Error('pickAndSaveNonNoneInstanceType: no non-None option available');
+  }
   await nonNoneOption.click();
   await virtualMachinesTab.instanceTypeModalSaveButton.click();
   await expect(virtualMachinesTab.editInstanceTypeModal).not.toBeVisible();

--- a/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-mappings-edit.spec.ts
@@ -13,7 +13,9 @@ test.describe('Plan Details - Network Mapping Editing', { tag: '@downstream' }, 
     testPlan,
     testProvider: _testProvider,
   }, testInfo) => {
-    if (!testPlan) throw new Error('testPlan is required');
+    if (!testPlan) {
+      throw new Error('testPlan is required');
+    }
 
     const planDetailsPage = new PlanDetailsPage(page);
     await planDetailsPage.mappingsTab.navigateToMappingsTab();

--- a/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-status-consistency.spec.ts
@@ -45,7 +45,9 @@ type MapVerifyOptions = {
 
 const verifyMapNotStale = async (opts: MapVerifyOptions): Promise<void> => {
   const { fallbackNamespace, mapKind, planConditions, ref, resourceManager } = opts;
-  if (!ref?.name) return;
+  if (!ref?.name) {
+    return;
+  }
 
   const fetchMethod = mapKind === 'network' ? 'fetchNetworkMap' : 'fetchStorageMap';
   const mapResource = await resourceManager[fetchMethod](
@@ -83,7 +85,9 @@ test.describe(
     }) => {
       test.setTimeout(120_000);
 
-      if (!testPlan) throw new Error('testPlan fixture is required');
+      if (!testPlan) {
+        throw new Error('testPlan fixture is required');
+      }
 
       const { name: planName, namespace: planNamespace } = testPlan.metadata;
       const planDetailsPage = new PlanDetailsPage(page);
@@ -148,7 +152,9 @@ test.describe(
     }, testInfo) => {
       test.setTimeout(120_000);
 
-      if (!testPlan) throw new Error('testPlan fixture is required');
+      if (!testPlan) {
+        throw new Error('testPlan fixture is required');
+      }
 
       const { name: planName, namespace: planNamespace } = testPlan.metadata;
       const planDetailsPage = new PlanDetailsPage(page);
@@ -172,7 +178,9 @@ test.describe(
 
       const networkMapRef = plan.spec?.map?.network;
       testInfo.skip(!networkMapRef?.name, 'Plan has no referenced NetworkMap');
-      if (!networkMapRef?.name) return;
+      if (!networkMapRef?.name) {
+        return;
+      }
 
       const nmNamespace = networkMapRef.namespace ?? planNamespace;
 
@@ -187,7 +195,9 @@ test.describe(
         !originalProvider?.source?.name,
         'NetworkMap has no source provider to restore',
       );
-      if (!originalProvider?.source?.name) return;
+      if (!originalProvider?.source?.name) {
+        return;
+      }
 
       const missingProviderName = `missing-provider-${Date.now()}`;
 

--- a/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-wizard-offload.spec.ts
@@ -19,7 +19,9 @@ test.describe(
       resourceManager,
       testProvider,
     }) => {
-      if (!testProvider) throw new Error('testProvider is required');
+      if (!testProvider) {
+        throw new Error('testProvider is required');
+      }
 
       const planName = `offload-test-${crypto.randomUUID().slice(0, 8)}`;
       const testPlanData = createPlanTestData({

--- a/testing/playwright/e2e/downstream/providers/provider-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/providers/provider-deep-inspection.spec.ts
@@ -13,7 +13,9 @@ const setupProviderDetailsPage = async (
   page: Page,
   testProvider: TestProvider | undefined,
 ): Promise<ProviderDetailsPage> => {
-  if (!testProvider) throw new Error('testProvider is required');
+  if (!testProvider) {
+    throw new Error('testProvider is required');
+  }
   const providerDetailsPage = new ProviderDetailsPage(page);
   await providerDetailsPage.navigate(testProvider.metadata.name, testProvider.metadata.namespace);
   await providerDetailsPage.waitForInventoryReady();

--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -21,7 +21,9 @@ test.describe(
       resourceManager,
       testProvider,
     }) => {
-      if (!testProvider) throw new Error('testProvider is required');
+      if (!testProvider) {
+        throw new Error('testProvider is required');
+      }
 
       const storageMapName = `offload-sm-${crypto.randomUUID().slice(0, 8)}`;
       const listPage = new StorageMapsListPage(page);

--- a/testing/playwright/e2e/downstream/storage-maps/storage-map-access-mode.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/storage-map-access-mode.spec.ts
@@ -19,7 +19,9 @@ providerOnlyFixtures.describe('Access Mode - Create Storage Map', { tag: '@downs
   providerOnlyFixtures(
     'should create storage map with access mode selection',
     async ({ page, resourceManager, testProvider }) => {
-      if (!testProvider) throw new Error('testProvider is required');
+      if (!testProvider) {
+        throw new Error('testProvider is required');
+      }
 
       const storageMapName = `access-mode-sm-${crypto.randomUUID().slice(0, 8)}`;
       const listPage = new StorageMapsListPage(page);
@@ -96,7 +98,9 @@ sharedProviderStorageMapFixtures.describe(
     sharedProviderStorageMapFixtures(
       'should persist access mode through edit flow',
       async ({ page, testStorageMap, testProvider: _testProvider }) => {
-        if (!testStorageMap) throw new Error('testStorageMap is required');
+        if (!testStorageMap) {
+          throw new Error('testStorageMap is required');
+        }
 
         const detailsPage = new StorageMapDetailsPage(page);
         await detailsPage.navigate(testStorageMap.name);
@@ -172,7 +176,9 @@ sharedProviderFixtures.describe('Access Mode - Plan Wizard Review', { tag: '@dow
   sharedProviderFixtures(
     'should display access mode in plan wizard review step',
     async ({ page, testPlan, testProvider: _testProvider }) => {
-      if (!testPlan) throw new Error('testPlan is required');
+      if (!testPlan) {
+        throw new Error('testPlan is required');
+      }
 
       const planDetailsPage = new PlanDetailsPage(page);
 
@@ -195,7 +201,9 @@ sharedProviderFixtures.describe('Access Mode - Plan Details Edit', { tag: '@down
   sharedProviderFixtures(
     'should persist access mode through plan details storage map edit',
     async ({ page, testPlan, testProvider: _testProvider }) => {
-      if (!testPlan) throw new Error('testPlan is required');
+      if (!testPlan) {
+        throw new Error('testPlan is required');
+      }
 
       const planDetailsPage = new PlanDetailsPage(page);
       await planDetailsPage.mappingsTab.navigateToMappingsTab();
@@ -234,7 +242,9 @@ sharedProviderStorageMapFixtures.describe(
     sharedProviderStorageMapFixtures(
       'should show RWO warning for Ceph-backed storage classes',
       async ({ page, testStorageMap, testProvider: _testProvider }) => {
-        if (!testStorageMap) throw new Error('testStorageMap is required');
+        if (!testStorageMap) {
+          throw new Error('testStorageMap is required');
+        }
 
         const detailsPage = new StorageMapDetailsPage(page);
         await detailsPage.navigate(testStorageMap.name);

--- a/testing/playwright/e2e/downstream/storage-maps/storage-map-edit.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/storage-map-edit.spec.ts
@@ -13,7 +13,9 @@ test.describe('Storage Map Details - Editing', { tag: '@downstream' }, () => {
     testStorageMap,
     testProvider: _testProvider,
   }) => {
-    if (!testStorageMap) throw new Error('testStorageMap is required');
+    if (!testStorageMap) {
+      throw new Error('testStorageMap is required');
+    }
 
     const storageMapDetailsPage = new StorageMapDetailsPage(page);
     await storageMapDetailsPage.navigate(testStorageMap.name);

--- a/testing/playwright/fixtures/helpers/planDetailsHelpers.ts
+++ b/testing/playwright/fixtures/helpers/planDetailsHelpers.ts
@@ -17,7 +17,9 @@ export const setupPlanDetailsPage = async (
   page: Page,
   testPlan: TestPlan | undefined,
 ): Promise<PlanDetailsSetup> => {
-  if (!testPlan) throw new Error('testPlan is required');
+  if (!testPlan) {
+    throw new Error('testPlan is required');
+  }
   const planDetailsPage = new PlanDetailsPage(page);
   const { name: planName, namespace } = testPlan.metadata;
   await planDetailsPage.navigate(planName, namespace);

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -95,7 +95,9 @@ const buildTestProviderFixture = (
           skipProviderReadyWait,
         })
           .then((result) => {
-            if (!result) throw new Error('Failed to create provider');
+            if (!result) {
+              throw new Error('Failed to create provider');
+            }
             return result;
           })
           .catch(async (error: unknown) => {

--- a/testing/playwright/global.setup.ts
+++ b/testing/playwright/global.setup.ts
@@ -66,11 +66,15 @@ const CONSOLE_ROUTE_HOST_PREFIX = 'console-openshift-console.apps.';
  */
 const deriveClusterApiUrlFromConsoleAddress = (): string | null => {
   const consoleAddress = process.env.BRIDGE_BASE_ADDRESS ?? process.env.BASE_ADDRESS;
-  if (!consoleAddress) return null;
+  if (!consoleAddress) {
+    return null;
+  }
 
   try {
     const { hostname } = new URL(consoleAddress);
-    if (!hostname.startsWith(CONSOLE_ROUTE_HOST_PREFIX)) return null;
+    if (!hostname.startsWith(CONSOLE_ROUTE_HOST_PREFIX)) {
+      return null;
+    }
 
     const clusterDomain = hostname.slice(CONSOLE_ROUTE_HOST_PREFIX.length);
     return `https://api.${clusterDomain}:${DEFAULT_CLUSTER_API_PORT}`;

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
@@ -19,7 +19,9 @@ export class NetworkMapStep {
       .isVisible({ timeout: 1_000 })
       .catch(() => false);
 
-    if (!hasAlert) return;
+    if (!hasAlert) {
+      return;
+    }
 
     const rows = getMappingWizardFieldRows(this.page);
     const count = await rows.count();

--- a/testing/playwright/page-objects/CreateProviderPage/selectProviderProject.ts
+++ b/testing/playwright/page-objects/CreateProviderPage/selectProviderProject.ts
@@ -19,7 +19,9 @@ export const selectProviderProject = async (page: Page, projectName: string): Pr
   await projectSelect.waitFor({ state: 'visible', timeout: 10000 });
   const textInput = projectSelect.locator('input');
   const currentValue = await textInput.inputValue();
-  if (currentValue === projectName) return;
+  if (currentValue === projectName) {
+    return;
+  }
   await textInput.click();
   await textInput.clear();
   await textInput.fill(projectName);

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/ConcernsHelpers.ts
@@ -38,7 +38,9 @@ export class ConcernsHelpers {
           break;
         }
       }
-      if (!clicked) return false;
+      if (!clicked) {
+        return false;
+      }
     }
     await expect(popover).toBeVisible();
     return true;

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
@@ -278,7 +278,9 @@ export class DetailsTab {
   }
 
   async verifyGuestConversionModeTexts(texts: string[]): Promise<void> {
-    for (const text of texts) await this.verifyGuestConversionModeText(text);
+    for (const text of texts) {
+      await this.verifyGuestConversionModeText(text);
+    }
   }
 
   async verifyMigrationType(type: MigrationType): Promise<void> {
@@ -301,7 +303,9 @@ export class DetailsTab {
     );
     await expect(this.page.getByTestId('created-at-detail-item')).toBeVisible();
     await expect(this.page.getByTestId('owner-detail-item')).toContainText('No owner');
-    if (isVersionAtLeast(V2_11_0)) await this.verifyDescriptionText(planData.description ?? 'None');
+    if (isVersionAtLeast(V2_11_0)) {
+      await this.verifyDescriptionText(planData.description ?? 'None');
+    }
     if (planData.additionalPlanSettings?.targetPowerState) {
       const labels = { auto: 'Retain source VM power state', off: 'Powered off', on: 'Powered on' };
       await expect(

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/VirtualMachinesTab.ts
@@ -44,7 +44,9 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
 
   async clearFilters(): Promise<void> {
     const btn = this.page.getByRole('button', { name: 'Clear all filters' });
-    if (await btn.isVisible().catch(() => false)) await btn.click();
+    if (await btn.isVisible().catch(() => false)) {
+      await btn.click();
+    }
   }
 
   async clickAddVirtualMachines(): Promise<AddVirtualMachinesModal> {
@@ -77,7 +79,9 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
 
   async expandFilters(): Promise<void> {
     const btn = this.page.getByRole('button', { name: 'Show Filters' });
-    if (await btn.isVisible()) await btn.click();
+    if (await btn.isVisible()) {
+      await btn.click();
+    }
   }
 
   async expandFirstVMDetailsRow(): Promise<void> {
@@ -322,7 +326,9 @@ export class VirtualMachinesTab extends VirtualMachinesTable {
   async verifyVirtualMachinesTab(planData: PlanTestData): Promise<void> {
     await this.table.waitForTableLoad();
     for (const vm of planData.virtualMachines ?? []) {
-      if (vm.sourceName) await this.verifyRowIsVisible({ Name: vm.sourceName });
+      if (vm.sourceName) {
+        await this.verifyRowIsVisible({ Name: vm.sourceName });
+      }
     }
   }
 

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -88,7 +88,9 @@ export class VirtualMachinesTable {
     const firstFolderRow = this.page.getByTestId(/^folder-/).first();
     // Wait for the tree table to finish loading before checking for folders.
     await firstFolderRow.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => null);
-    if ((await firstFolderRow.count()) === 0) return;
+    if ((await firstFolderRow.count()) === 0) {
+      return;
+    }
     const expandButton = firstFolderRow.locator('button').first();
     if (await expandButton.isVisible().catch(() => false)) {
       const isExpanded = await expandButton.getAttribute('aria-expanded');
@@ -106,7 +108,9 @@ export class VirtualMachinesTable {
   async expandFirstVMRow(): Promise<void> {
     const firstVmRow = this.page.getByTestId(/^vm-/).first();
     await firstVmRow.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => null);
-    if ((await firstVmRow.count()) === 0) return;
+    if ((await firstVmRow.count()) === 0) {
+      return;
+    }
     const expandButton = firstVmRow.locator('button').first();
     if (await expandButton.isVisible().catch(() => false)) {
       const isExpanded = await expandButton.getAttribute('aria-expanded');

--- a/testing/playwright/utils/aws/aws.ts
+++ b/testing/playwright/utils/aws/aws.ts
@@ -12,7 +12,9 @@ const SKIP_MESSAGE = 'Skipped: no EC2 provider in .providers.json (non-AWS clust
  * The presence of such an entry indicates the cluster is running on AWS.
  */
 const isAwsPlatform = (): boolean => {
-  if (!existsSync(PROVIDERS_FILE)) return false;
+  if (!existsSync(PROVIDERS_FILE)) {
+    return false;
+  }
 
   try {
     const providers = JSON.parse(readFileSync(PROVIDERS_FILE, 'utf-8')) as Record<

--- a/testing/playwright/utils/requireVddk.ts
+++ b/testing/playwright/utils/requireVddk.ts
@@ -12,7 +12,9 @@ type ProviderEntry = {
 export const isVddkConfigured = (): boolean => {
   const providersFile = join(__dirname, '../../.providers.json');
 
-  if (!existsSync(providersFile)) return false;
+  if (!existsSync(providersFile)) {
+    return false;
+  }
 
   const providers = JSON.parse(readFileSync(providersFile, 'utf8')) as Record<
     string,

--- a/testing/playwright/utils/resource-manager/BaseResourceManager.ts
+++ b/testing/playwright/utils/resource-manager/BaseResourceManager.ts
@@ -46,14 +46,18 @@ type StorageState = {
  */
 const tryKubeconfigAuth = (): AuthConfig | null => {
   const kubeconfigPath = process.env.KUBECONFIG_PATH;
-  if (!kubeconfigPath || !existsSync(kubeconfigPath)) return null;
+  if (!kubeconfigPath || !existsSync(kubeconfigPath)) {
+    return null;
+  }
 
   try {
     const kc = new KubeConfig();
     kc.loadFromFile(kubeconfigPath);
     const cluster = kc.getCurrentCluster();
     const user = kc.getCurrentUser();
-    if (!cluster?.server || !user?.token) return null;
+    if (!cluster?.server || !user?.token) {
+      return null;
+    }
 
     return {
       baseUrl: cluster.server.replace(/\/$/, ''),
@@ -112,7 +116,9 @@ const getConsoleBaseUrl = (): string =>
  */
 const getAuthConfig = (): AuthConfig => {
   const kubeconfigAuth = tryKubeconfigAuth();
-  if (kubeconfigAuth) return kubeconfigAuth;
+  if (kubeconfigAuth) {
+    return kubeconfigAuth;
+  }
 
   const { cookieHeader, csrfToken } = getSessionCookies();
   return {
@@ -147,7 +153,9 @@ export abstract class BaseResourceManager {
   static async apiDelete<R>(apiPath: string): Promise<R | null> {
     const result = await BaseResourceManager.apiRequest<R>(apiPath, { method: 'DELETE' });
 
-    if (result.success) return result.data;
+    if (result.success) {
+      return result.data;
+    }
 
     const HTTP_NOT_FOUND = 404;
 
@@ -162,7 +170,9 @@ export abstract class BaseResourceManager {
   static async apiGet<R>(apiPath: string): Promise<R | null> {
     const result = await BaseResourceManager.apiRequest<R>(apiPath, { method: 'GET' });
 
-    if (result.success) return result.data;
+    if (result.success) {
+      return result.data;
+    }
 
     console.error(`API GET ${apiPath} failed: ${result.error}`);
     return null;
@@ -179,7 +189,9 @@ export abstract class BaseResourceManager {
       method: 'PATCH',
     });
 
-    if (result.success) return result.data;
+    if (result.success) {
+      return result.data;
+    }
 
     console.error(`API PATCH ${apiPath} failed: ${result.error}`);
     return null;
@@ -191,7 +203,9 @@ export abstract class BaseResourceManager {
       method: 'POST',
     });
 
-    if (result.success) return result.data;
+    if (result.success) {
+      return result.data;
+    }
 
     const HTTP_CONFLICT = 409;
 
@@ -265,7 +279,9 @@ export abstract class BaseResourceManager {
         resolve({ error: err.message, status: 0, success: false });
       });
 
-      if (body) req.write(body);
+      if (body) {
+        req.write(body);
+      }
       req.end();
     });
   }

--- a/testing/playwright/utils/resource-manager/ResourceFetcher.ts
+++ b/testing/playwright/utils/resource-manager/ResourceFetcher.ts
@@ -69,7 +69,9 @@ export class ResourceFetcher extends BaseResourceManager {
     const apiPath = `${API_PATHS.OLM_CSV}/namespaces/${namespace}/clusterserviceversions`;
     const data = await ResourceFetcher.apiGet<CsvList>(apiPath);
 
-    if (!data?.items) return null;
+    if (!data?.items) {
+      return null;
+    }
 
     const csv = data.items.find((item) =>
       prefixes.some((prefix) => item.metadata?.name?.startsWith(prefix)),

--- a/testing/playwright/utils/version/version.ts
+++ b/testing/playwright/utils/version/version.ts
@@ -29,8 +29,12 @@ const resolveTuple = (version: VersionTuple | string): VersionTuple | null =>
   Array.isArray(version) ? version : parseVersion(version);
 
 const compareTuples = (a: VersionTuple, b: VersionTuple): number => {
-  if (a[0] !== b[0]) return a[0] - b[0];
-  if (a[1] !== b[1]) return a[1] - b[1];
+  if (a[0] !== b[0]) {
+    return a[0] - b[0];
+  }
+  if (a[1] !== b[1]) {
+    return a[1] - b[1];
+  }
   return a[2] - b[2];
 };
 
@@ -60,12 +64,20 @@ const versionAtLeast = (
   whenUnset: boolean,
 ): boolean => {
   const versionString = getVersionString(envVar);
-  if (!versionString) return whenUnset;
-  if (isLatest(versionString)) return true;
+  if (!versionString) {
+    return whenUnset;
+  }
+  if (isLatest(versionString)) {
+    return true;
+  }
   const currentVersion = getVersionTuple(envVar);
-  if (!currentVersion) return false;
+  if (!currentVersion) {
+    return false;
+  }
   const resolvedMinimum = resolveTuple(minimumVersion);
-  if (!resolvedMinimum) return false;
+  if (!resolvedMinimum) {
+    return false;
+  }
   return compareTuples(currentVersion, resolvedMinimum) >= 0;
 };
 
@@ -83,7 +95,9 @@ const versionInStreams = (
 
   if (!currentVersion) {
     const versionString = getVersionString(envVar);
-    if (!versionString) return whenUnset;
+    if (!versionString) {
+      return whenUnset;
+    }
     return isLatest(versionString);
   }
 
@@ -91,7 +105,9 @@ const versionInStreams = (
     .map(resolveTuple)
     .filter((tuple): tuple is VersionTuple => tuple !== null);
 
-  if (parsedMinimums.length === 0) return false;
+  if (parsedMinimums.length === 0) {
+    return false;
+  }
 
   const matchingStreamMinimum = parsedMinimums.find(
     ([major, minor]) => currentVersion[0] === major && currentVersion[1] === minor,


### PR DESCRIPTION
## Summary
- Enable `curly`, `@typescript-eslint/no-explicit-any`, `@typescript-eslint/no-unused-vars`, and `no-warning-comments` (warn) in `eslint.config.ts`
- Auto-fix brace style across `src/` and `testing/`; replace `any` with proper types/`unknown`; fix unused-vars
- Defer `@typescript-eslint/no-deprecated` to [MTV-6280](https://redhat.atlassian.net/browse/MTV-6280) (`useModal` → `useOverlay`)
- Relax `max-lines` / unused-vars / warning-comments for `testing/**`; `curly` and `eqeqeq` still apply everywhere

Resolves: MTV-6269

## Test plan
- [x] `npx eslint 'src/**/*.{ts,tsx}' 'testing/playwright/**/*.ts' --quiet` passes
- [x] `npm run build` passes
- [x] Sort unit tests pass (`sort.test.ts`, `useSort.test.tsx`)
- [ ] Spot-check Learning Experience drawer and table column management in UI
- [x] Confirm CI lint job is green


Made with [Cursor](https://cursor.com)

[MTV-6280]: https://redhat.atlassian.net/browse/MTV-6280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ