### PR TITLE
Resolves: MTV-5516 | Add Jest coverage for cutover ASAP button gating

### DIFF
--- a/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
+++ b/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
@@ -1,0 +1,107 @@
+import type { V1beta1Migration, V1beta1Plan } from '@forklift-ui/types';
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+const mockUsePlanMigration = jest.fn();
+jest.mock('src/plans/hooks/usePlanMigration', () => ({
+  usePlanMigration: jest.fn((...args: unknown[]) => mockUsePlanMigration(...args)),
+}));
+
+const mockLauncher = jest.fn();
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useModal: () => mockLauncher,
+}));
+
+const mockT = (key: string): string => key;
+jest.mock('@utils/i18n', () => ({
+  ForkliftTrans: ({ children }: { children: unknown }) => children,
+  t: mockT,
+  useForkliftTranslation: () => ({ t: mockT }),
+}));
+
+// eslint-disable-next-line import/first
+import { ButtonVariant } from '@patternfly/react-core';
+
+// eslint-disable-next-line import/first
+import PlanEditCutoverButton from '../PlanEditCutoverButton';
+
+const buildPlan = (
+  specOverrides: Partial<V1beta1Plan['spec']> = {},
+  statusOverrides: Partial<V1beta1Plan['status']> = {},
+): V1beta1Plan =>
+  ({
+    metadata: { name: 'test-plan', namespace: 'test-ns' },
+    spec: { warm: true, ...specOverrides },
+    status: {
+      conditions: [{ status: 'True', type: 'Executing' }],
+      // A running VM (started=true) is required, otherwise getPlanStatus() treats an
+      // executing plan with no VM status yet as "Pending" and the button stays hidden.
+      migration: { vms: [{ started: true }] },
+      ...statusOverrides,
+    },
+  }) as unknown as V1beta1Plan;
+
+const runningMigrationWithoutCutover = {
+  metadata: { name: 'test-migration', namespace: 'test-ns' },
+  spec: {},
+} as unknown as V1beta1Migration;
+
+const runningMigrationWithCutover = {
+  metadata: { name: 'test-migration', namespace: 'test-ns' },
+  spec: { cutover: '2026-08-15T10:00:00.000Z' },
+} as unknown as V1beta1Migration;
+
+describe('PlanEditCutoverButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePlanMigration.mockReturnValue([runningMigrationWithoutCutover, true, undefined]);
+  });
+
+  it('renders nothing when the plan is not warm', () => {
+    const { container } = render(
+      <PlanEditCutoverButton plan={buildPlan({ warm: false })} variant={ButtonVariant.primary} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the plan is not executing', () => {
+    const plan = buildPlan({}, { conditions: [] });
+    const { container } = render(
+      <PlanEditCutoverButton plan={plan} variant={ButtonVariant.primary} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the plan is archived', () => {
+    const plan = buildPlan({ archived: true });
+    const { container } = render(
+      <PlanEditCutoverButton plan={plan} variant={ButtonVariant.primary} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "Schedule cutover" when there is a running migration without an existing cutover', () => {
+    render(<PlanEditCutoverButton plan={buildPlan()} variant={ButtonVariant.primary} />);
+
+    expect(screen.getByRole('button', { name: 'Schedule cutover' })).toBeInTheDocument();
+  });
+
+  it('renders "Edit cutover" when the running migration already has a cutover set', () => {
+    mockUsePlanMigration.mockReturnValue([runningMigrationWithCutover, true, undefined]);
+    render(<PlanEditCutoverButton plan={buildPlan()} variant={ButtonVariant.primary} />);
+
+    expect(screen.getByRole('button', { name: 'Edit cutover' })).toBeInTheDocument();
+  });
+
+  it('opens the cutover modal on click', async () => {
+    const user = userEvent.setup();
+    render(<PlanEditCutoverButton plan={buildPlan()} variant={ButtonVariant.primary} />);
+
+    await user.click(screen.getByRole('button', { name: 'Schedule cutover' }));
+
+    expect(mockLauncher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
+++ b/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
@@ -78,8 +78,8 @@ describe('PlanEditCutoverButton', () => {
   });
 
   it('renders nothing when the plan status is Pending', () => {
-    // Executing condition but no VM has started yet → getPlanStatus() returns Pending
-    const plan = buildPlan({}, { migration: { vms: [{ started: false }] } });
+    // Executing condition but no VM status yet → getPlanStatus() returns Pending
+    const plan = buildPlan({}, { migration: { vms: [] } });
     const { container } = render(
       <PlanEditCutoverButton plan={plan} variant={ButtonVariant.primary} />,
     );

--- a/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
+++ b/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
@@ -1,6 +1,13 @@
 import type { V1beta1Migration, V1beta1Plan } from '@forklift-ui/types';
+import { ButtonVariant } from '@patternfly/react-core';
+import { mockI18n } from '@test-utils/mockI18n';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+
+import PlanCutoverMigrationModal from '../components/CutoverModal/PlanCutoverMigrationModal';
+import PlanEditCutoverButton from '../PlanEditCutoverButton';
+
+mockI18n();
 
 const mockUsePlanMigration = jest.fn();
 jest.mock('src/plans/hooks/usePlanMigration', () => ({
@@ -11,19 +18,6 @@ const mockLauncher = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   useModal: () => mockLauncher,
 }));
-
-const mockT = (key: string): string => key;
-jest.mock('@utils/i18n', () => ({
-  ForkliftTrans: ({ children }: { children: unknown }) => children,
-  t: mockT,
-  useForkliftTranslation: () => ({ t: mockT }),
-}));
-
-// eslint-disable-next-line import/first
-import { ButtonVariant } from '@patternfly/react-core';
-
-// eslint-disable-next-line import/first
-import PlanEditCutoverButton from '../PlanEditCutoverButton';
 
 const buildPlan = (
   specOverrides: Partial<V1beta1Plan['spec']> = {},
@@ -83,6 +77,16 @@ describe('PlanEditCutoverButton', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('renders nothing when the plan status is Pending', () => {
+    // Executing condition but no VM has started yet → getPlanStatus() returns Pending
+    const plan = buildPlan({}, { migration: { vms: [{ started: false }] } });
+    const { container } = render(
+      <PlanEditCutoverButton plan={plan} variant={ButtonVariant.primary} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('renders "Schedule cutover" when there is a running migration without an existing cutover', () => {
     render(<PlanEditCutoverButton plan={buildPlan()} variant={ButtonVariant.primary} />);
 
@@ -98,10 +102,11 @@ describe('PlanEditCutoverButton', () => {
 
   it('opens the cutover modal on click', async () => {
     const user = userEvent.setup();
-    render(<PlanEditCutoverButton plan={buildPlan()} variant={ButtonVariant.primary} />);
+    const plan = buildPlan();
+    render(<PlanEditCutoverButton plan={plan} variant={ButtonVariant.primary} />);
 
     await user.click(screen.getByRole('button', { name: 'Schedule cutover' }));
 
-    expect(mockLauncher).toHaveBeenCalledTimes(1);
+    expect(mockLauncher).toHaveBeenCalledWith(PlanCutoverMigrationModal, { plan });
   });
 });

--- a/src/plans/hooks/__tests__/usePlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/usePlanMigration.test.ts
@@ -19,10 +19,10 @@ type MigrationTestOverrides = {
   metadata?: {
     name?: string;
     namespace?: string;
-    ownerReferences?: Array<{ uid: string }>;
+    ownerReferences?: { uid: string }[];
   };
   status?: {
-    conditions?: Array<{ status: string; type: string }>;
+    conditions?: { status: string; type: string }[];
   };
 };
 

--- a/src/plans/hooks/__tests__/usePlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/usePlanMigration.test.ts
@@ -1,18 +1,18 @@
 import type { V1beta1Migration, V1beta1Plan } from '@forklift-ui/types';
 import { renderHook } from '@testing-library/react';
 
+import { usePlanMigration } from '../usePlanMigration';
+
 const mockUseK8sWatchResource = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
 }));
 
-// eslint-disable-next-line import/first
-import { usePlanMigration } from '../usePlanMigration';
-
 const PLAN_UID = 'plan-uid-123';
+const TEST_NAMESPACE = 'test-ns';
 
 const mockPlan = {
-  metadata: { name: 'test-plan', namespace: 'test-ns', uid: PLAN_UID },
+  metadata: { name: 'test-plan', namespace: TEST_NAMESPACE, uid: PLAN_UID },
 } as unknown as V1beta1Plan;
 
 const buildMigration = (overrides: Partial<V1beta1Migration> = {}): V1beta1Migration =>
@@ -20,7 +20,7 @@ const buildMigration = (overrides: Partial<V1beta1Migration> = {}): V1beta1Migra
     ...overrides,
     metadata: {
       name: 'test-migration',
-      namespace: 'test-ns',
+      namespace: TEST_NAMESPACE,
       ownerReferences: [{ uid: PLAN_UID }],
       ...overrides.metadata,
     },
@@ -58,7 +58,7 @@ describe('usePlanMigration', () => {
     const otherPlansMigration = buildMigration({
       metadata: {
         name: 'other',
-        namespace: 'test-ns',
+        namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: 'some-other-uid' }],
       },
     });
@@ -95,14 +95,14 @@ describe('usePlanMigration', () => {
     const otherPlansMigration = buildMigration({
       metadata: {
         name: 'other',
-        namespace: 'test-ns',
+        namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: 'some-other-uid' }],
       },
     });
     const ownedButNotRunning = buildMigration({
       metadata: {
         name: 'owned-not-running',
-        namespace: 'test-ns',
+        namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: PLAN_UID }],
       },
       status: { conditions: [{ status: 'False', type: 'Running' }] },
@@ -110,7 +110,7 @@ describe('usePlanMigration', () => {
     const ownedAndRunning = buildMigration({
       metadata: {
         name: 'owned-running',
-        namespace: 'test-ns',
+        namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: PLAN_UID }],
       },
     });

--- a/src/plans/hooks/__tests__/usePlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/usePlanMigration.test.ts
@@ -15,7 +15,18 @@ const mockPlan = {
   metadata: { name: 'test-plan', namespace: TEST_NAMESPACE, uid: PLAN_UID },
 } as unknown as V1beta1Plan;
 
-const buildMigration = (overrides: Partial<V1beta1Migration> = {}): V1beta1Migration =>
+type MigrationTestOverrides = {
+  metadata?: {
+    name?: string;
+    namespace?: string;
+    ownerReferences?: Array<{ uid: string }>;
+  };
+  status?: {
+    conditions?: Array<{ status: string; type: string }>;
+  };
+};
+
+const buildMigration = (overrides: MigrationTestOverrides = {}): V1beta1Migration =>
   ({
     ...overrides,
     metadata: {

--- a/src/plans/hooks/__tests__/usePlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/usePlanMigration.test.ts
@@ -1,0 +1,127 @@
+import type { V1beta1Migration, V1beta1Plan } from '@forklift-ui/types';
+import { renderHook } from '@testing-library/react';
+
+const mockUseK8sWatchResource = jest.fn();
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
+}));
+
+// eslint-disable-next-line import/first
+import { usePlanMigration } from '../usePlanMigration';
+
+const PLAN_UID = 'plan-uid-123';
+
+const mockPlan = {
+  metadata: { name: 'test-plan', namespace: 'test-ns', uid: PLAN_UID },
+} as unknown as V1beta1Plan;
+
+const buildMigration = (overrides: Partial<V1beta1Migration> = {}): V1beta1Migration =>
+  ({
+    ...overrides,
+    metadata: {
+      name: 'test-migration',
+      namespace: 'test-ns',
+      ownerReferences: [{ uid: PLAN_UID }],
+      ...overrides.metadata,
+    },
+    status: {
+      conditions: [{ status: 'True', type: 'Running' }],
+      ...overrides.status,
+    },
+  }) as unknown as V1beta1Migration;
+
+describe('usePlanMigration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when no migrations are loaded yet', () => {
+    mockUseK8sWatchResource.mockReturnValue([undefined, false, undefined]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('returns undefined when there is a load error', () => {
+    const loadError = new Error('boom');
+    mockUseK8sWatchResource.mockReturnValue([[buildMigration()], true, loadError]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[2]).toBe(loadError);
+  });
+
+  it('ignores migrations owned by a different plan', () => {
+    const otherPlansMigration = buildMigration({
+      metadata: {
+        name: 'other',
+        namespace: 'test-ns',
+        ownerReferences: [{ uid: 'some-other-uid' }],
+      },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[otherPlansMigration], true, undefined]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('ignores an owned migration that is not Running', () => {
+    const pendingMigration = buildMigration({
+      status: { conditions: [{ status: 'False', type: 'Running' }] },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[pendingMigration], true, undefined]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('returns the owned migration with a Running=True condition', () => {
+    const runningMigration = buildMigration();
+    mockUseK8sWatchResource.mockReturnValue([[runningMigration], true, undefined]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBe(runningMigration);
+    expect(result.current[1]).toBe(true);
+    expect(result.current[2]).toBeUndefined();
+  });
+
+  it('picks the owned+Running migration out of several unrelated ones', () => {
+    const otherPlansMigration = buildMigration({
+      metadata: {
+        name: 'other',
+        namespace: 'test-ns',
+        ownerReferences: [{ uid: 'some-other-uid' }],
+      },
+    });
+    const ownedButNotRunning = buildMigration({
+      metadata: {
+        name: 'owned-not-running',
+        namespace: 'test-ns',
+        ownerReferences: [{ uid: PLAN_UID }],
+      },
+      status: { conditions: [{ status: 'False', type: 'Running' }] },
+    });
+    const ownedAndRunning = buildMigration({
+      metadata: {
+        name: 'owned-running',
+        namespace: 'test-ns',
+        ownerReferences: [{ uid: PLAN_UID }],
+      },
+    });
+    mockUseK8sWatchResource.mockReturnValue([
+      [otherPlansMigration, ownedButNotRunning, ownedAndRunning],
+      true,
+      undefined,
+    ]);
+
+    const { result } = renderHook(() => usePlanMigration(mockPlan));
+
+    expect(result.current[0]).toBe(ownedAndRunning);
+  });
+});


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-5516](https://redhat.atlassian.net/browse/MTV-5516)
- Related: [MTV-5514](https://redhat.atlassian.net/browse/MTV-5514) (dev PR that introduced the ASAP/Scheduled cutover feature this covers)

## 📝 Description

The cutover button (`PlanEditCutoverButton`) only renders once a `Migration` CR owned by the plan reaches `Running=True`, gated by the `usePlanMigration` hook. Previously the only way to exercise this logic was a real warm migration reaching the running phase. Adds Jest coverage for both, mocking `useK8sWatchResource` per existing project convention:

- `usePlanMigration.test.ts` — owner-reference and `Running` condition filtering.
- `PlanEditCutoverButton.test.tsx` — visibility rules and label switching ("Schedule cutover" vs "Edit cutover").

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!-- @tag reviewers if needed -->

[MTV-5516]: https://redhat.atlassian.net/browse/MTV-5516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-5514]: https://redhat.atlassian.net/browse/MTV-5514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for displaying and labeling the plan cutover button based on plan status.
  - Added coverage verifying that selecting the cutover action opens the appropriate modal.
  - Added tests for migration loading, errors, ownership, running status, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->