### PR TITLE
Resolves: MTV-5497 | Add plan wizard E2E coverage for storage access mode

### DIFF
--- a/testing/playwright/e2e/downstream/storage-maps/storage-map-access-mode.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/storage-map-access-mode.spec.ts
@@ -5,10 +5,12 @@ import {
   sharedProviderFixtures,
   sharedProviderStorageMapFixtures,
 } from '../../../fixtures/resourceFixtures';
+import { CreatePlanWizardPage } from '../../../page-objects/CreatePlanWizard/CreatePlanWizardPage';
 import { PlanDetailsPage } from '../../../page-objects/PlanDetailsPage/PlanDetailsPage';
 import { StorageMapCreatePage } from '../../../page-objects/StorageMapCreatePage';
 import { StorageMapDetailsPage } from '../../../page-objects/StorageMapDetailsPage';
 import { StorageMapsListPage } from '../../../page-objects/StorageMapsListPage';
+import { createPlanTestData } from '../../../types/test-data';
 import { MTV_NAMESPACE } from '../../../utils/resource-manager/constants';
 import { V5_0_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
@@ -170,30 +172,127 @@ sharedProviderStorageMapFixtures.describe(
   },
 );
 
-sharedProviderFixtures.describe('Access Mode - Plan Wizard Review', { tag: '@downstream' }, () => {
-  requireVersion(sharedProviderFixtures, V5_0_0);
+providerOnlyFixtures.describe('Access Mode - Plan Wizard', { tag: '@downstream' }, () => {
+  requireVersion(providerOnlyFixtures, V5_0_0);
 
-  sharedProviderFixtures(
-    'should display access mode in plan wizard review step',
-    async ({ page, testPlan, testProvider: _testProvider }) => {
-      if (!testPlan) {
-        throw new Error('testPlan is required');
+  providerOnlyFixtures(
+    'should configure access mode in plan wizard and display it in review',
+    async ({ page, resourceManager, testProvider }) => {
+      if (!testProvider) {
+        throw new Error('testProvider is required');
       }
 
-      const planDetailsPage = new PlanDetailsPage(page);
+      const planName = `access-mode-plan-${crypto.randomUUID().slice(0, 8)}`;
+      const testPlanData = createPlanTestData({
+        planName,
+        sourceProvider: testProvider.metadata.name,
+        storageMap: {
+          isPreexisting: false,
+          name: `${planName}-storage-map`,
+        },
+        targetProject: { isPreexisting: true, name: 'default' },
+      });
 
-      await sharedProviderFixtures.step(
-        'Navigate to plan details mappings tab and verify access mode column',
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+
+      await providerOnlyFixtures.step('Navigate to Storage Map step', async () => {
+        await wizard.navigate();
+        await wizard.navigateToStorageMapStep(testPlanData);
+      });
+
+      await providerOnlyFixtures.step(
+        'Configure new storage map and select ReadWriteMany (RWX)',
         async () => {
+          await wizard.storageMap.verifyStepVisible();
+          await wizard.storageMap.waitForData();
+          await wizard.storageMap.fillAndComplete(testPlanData.storageMap);
+
+          await wizard.storageMap.accessMode.verifyAdvancedOptionsToggleVisible(0);
+          await wizard.storageMap.accessMode.expandAdvancedOptions(0);
+          await wizard.storageMap.accessMode.selectAccessMode(0, 'ReadWriteMany (RWX)');
+          const text = await wizard.storageMap.accessMode.getAccessModeText(0);
+          expect(text).toBe('ReadWriteMany (RWX)');
+        },
+      );
+
+      await providerOnlyFixtures.step(
+        'Verify RWO warning appears and clears on Ceph-backed target',
+        async () => {
+          await wizard.storageMap.accessMode.selectAccessMode(0, 'ReadWriteOnce (RWO)');
+          await wizard.storageMap.accessMode.verifyRwoWarningVisible();
+
+          await wizard.storageMap.accessMode.selectAccessMode(0, 'ReadWriteMany (RWX)');
+          await wizard.storageMap.accessMode.verifyRwoWarningNotVisible();
+        },
+      );
+
+      await providerOnlyFixtures.step('Proceed past Storage Map and skip to review', async () => {
+        await wizard.clickNext();
+        await wizard.clickSkipToReview();
+      });
+
+      await providerOnlyFixtures.step(
+        'Verify access mode in review storage map table',
+        async () => {
+          await wizard.review.verifyStepVisible();
+          await expect(wizard.review.storageMapSection).toBeVisible();
+          await wizard.review.verifyStorageMapAccessMode(0, 'ReadWriteMany');
+        },
+      );
+
+      await providerOnlyFixtures.step('Create plan and register for cleanup', async () => {
+        await wizard.clickNext();
+        await wizard.waitForPlanCreation();
+        resourceManager.addPlan(planName, MTV_NAMESPACE);
+      });
+
+      await providerOnlyFixtures.step(
+        'Verify access mode persists on plan details mappings tab',
+        async () => {
+          const planDetailsPage = new PlanDetailsPage(page);
           await planDetailsPage.mappingsTab.navigateToMappingsTab();
-          const reviewTable = page.getByTestId('storage-map-review-table');
-          await expect(reviewTable).toBeVisible();
-          await expect(reviewTable.getByText('Access mode')).toBeVisible();
+          await expect(planDetailsPage.mappingsTab.storageMapReviewTable).toBeVisible();
+          await expect(
+            planDetailsPage.mappingsTab.storageMapReviewTable.getByText('Access mode'),
+          ).toBeVisible();
+          await expect(
+            planDetailsPage.mappingsTab.storageMapReviewTable.getByText('ReadWriteMany'),
+          ).toBeVisible();
         },
       );
     },
   );
 });
+
+sharedProviderFixtures.describe(
+  'Access Mode - Plan Details Mappings Display',
+  { tag: '@downstream' },
+  () => {
+    requireVersion(sharedProviderFixtures, V5_0_0);
+
+    sharedProviderFixtures(
+      'should display access mode column on plan details mappings tab',
+      async ({ page, testPlan, testProvider: _testProvider }) => {
+        if (!testPlan) {
+          throw new Error('testPlan is required');
+        }
+
+        const planDetailsPage = new PlanDetailsPage(page);
+
+        await sharedProviderFixtures.step(
+          'Navigate to plan details mappings tab and verify access mode column',
+          async () => {
+            await planDetailsPage.navigate(testPlan.metadata.name, testPlan.metadata.namespace);
+            await planDetailsPage.mappingsTab.navigateToMappingsTab();
+            const reviewTable = planDetailsPage.mappingsTab.storageMapReviewTable;
+            await expect(reviewTable).toBeVisible();
+            await expect(reviewTable.getByText('Access mode')).toBeVisible();
+          },
+        );
+      },
+    );
+  },
+);
 
 sharedProviderFixtures.describe('Access Mode - Plan Details Edit', { tag: '@downstream' }, () => {
   requireVersion(sharedProviderFixtures, V5_0_0);

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/ReviewStep.ts
@@ -254,6 +254,18 @@ export class ReviewStep {
     await expect(this.page.getByRole('heading', { name: /Review and create/i })).toBeVisible();
   }
 
+  async verifyStorageMapAccessMode(
+    mappingIndex: number,
+    expectedAccessMode: string,
+  ): Promise<void> {
+    const reviewTable = this.page.getByTestId('storage-map-review-table');
+    await expect(reviewTable).toBeVisible();
+    await expect(reviewTable.getByText('Access mode')).toBeVisible();
+
+    const rows = reviewTable.locator('tbody tr');
+    await expect(rows.nth(mappingIndex)).toContainText(expectedAccessMode);
+  }
+
   async verifyStorageMapOffloadDetails(
     mappingIndex: number,
     expectedOffload: {


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-5497](https://redhat.atlassian.net/browse/MTV-5497)
- Related: [MTV-5495](https://redhat.atlassian.net/browse/MTV-5495) (DEV UI implementation)

## 📝 Description

Adds a plan-wizard Playwright E2E that selects storage access mode on the Storage Map step, verifies the RWO warning on Ceph-backed targets, asserts the Review step Access mode column, and confirms the value on the plan details Mappings tab after create. Also renames the previous misnamed “plan wizard review” test that only checked the details mappings table, and adds `ReviewStep.verifyStorageMapAccessMode()`.

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-5497]: https://redhat.atlassian.net/browse/MTV-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-5495]: https://redhat.atlassian.net/browse/MTV-5495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for configuring storage map access modes during plan creation.
  * Added verification that RWO displays the appropriate warning and RWX clears it.
  * Added checks confirming the selected access mode appears in the review step and plan details mappings.
  * Added validation that the plan details mappings table includes an “Access mode” column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->