### PR TITLE
Resolves: MTV-6014 | Fix frozen Tips and tricks and time-range i18n labels

### DIFF
--- a/src/onlineHelp/learningExperienceDrawer/LearningExperienceButton.tsx
+++ b/src/onlineHelp/learningExperienceDrawer/LearningExperienceButton.tsx
@@ -3,11 +3,12 @@ import { type FC, useContext } from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { TELEMETRY_EVENTS } from '@utils/analytics/constants';
 import { useForkliftAnalytics } from '@utils/analytics/hooks/useForkliftAnalytics';
-import { TIPS_AND_TRICKS_LABEL } from '@utils/constants';
+import { useForkliftTranslation } from '@utils/i18n';
 
 import { LearningExperienceContext } from './context/LearningExperienceContext';
 
 const LearningExperienceButton: FC = () => {
+  const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
   const { isLearningExperienceOpen, openLearningExperience } =
     useContext(LearningExperienceContext);
@@ -25,7 +26,7 @@ const LearningExperienceButton: FC = () => {
         openLearningExperience();
       }}
     >
-      {TIPS_AND_TRICKS_LABEL}
+      {t('Tips and tricks')}
     </Button>
   );
 };

--- a/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/LearningExperiencePanel.tsx
+++ b/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/LearningExperiencePanel.tsx
@@ -10,7 +10,7 @@ import {
   DrawerPanelContent,
   Title,
 } from '@patternfly/react-core';
-import { TIPS_AND_TRICKS_LABEL } from '@utils/constants';
+import { useForkliftTranslation } from '@utils/i18n';
 
 import AccordionContextProvider from '../../learningExperienceDrawer/context/AccordionContextProvider';
 import { LearningExperienceContext } from '../../learningExperienceDrawer/context/LearningExperienceContext';
@@ -24,6 +24,7 @@ import '@patternfly/quickstarts/dist/quickstarts.css';
 import './LearningExperiencePanel.scss';
 
 const LearningExperiencePanel: FC = () => {
+  const { t } = useForkliftTranslation();
   const {
     closeLearningExperience,
     drawerWidth,
@@ -55,7 +56,7 @@ const LearningExperiencePanel: FC = () => {
             <DrawerHead>
               <div className="pfext-quick-start-panel-content__title" tabIndex={-1}>
                 <Title headingLevel="h2" size="xl">
-                  {TIPS_AND_TRICKS_LABEL}
+                  {t('Tips and tricks')}
                 </Title>
               </div>
               <DrawerActions>

--- a/src/overview/tabs/Overview/cards/CardHeaderActions.tsx
+++ b/src/overview/tabs/Overview/cards/CardHeaderActions.tsx
@@ -1,9 +1,9 @@
 import { type MouseEvent, type Ref, useState } from 'react';
 
 import { MenuToggle, type MenuToggleElement, Select, SelectOption } from '@patternfly/react-core';
-import { t } from '@utils/i18n';
+import { useForkliftTranslation } from '@utils/i18n';
 
-import { TimeRangeOptions, valueToLabel } from '../utils/timeRangeOptions';
+import { getValueToLabel, TimeRangeOptions } from '../utils/timeRangeOptions';
 
 const HeaderActions = ({
   selectedTimeRange,
@@ -14,7 +14,9 @@ const HeaderActions = ({
   setSelectedTimeRange: (range: TimeRangeOptions) => void;
   showAll?: boolean;
 }) => {
+  const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const valueToLabel = getValueToLabel();
 
   const onSelect = (_event: MouseEvent | undefined, value: string | number | undefined) => {
     setSelectedTimeRange(value as TimeRangeOptions);

--- a/src/overview/tabs/Overview/utils/timeRangeOptions.ts
+++ b/src/overview/tabs/Overview/utils/timeRangeOptions.ts
@@ -20,12 +20,12 @@ type TimeRangeOptionsProperties = {
   filter: (date: DateTime) => boolean;
 };
 
-export const valueToLabel = {
+export const getValueToLabel = (): Record<TimeRangeOptions, string> => ({
   [TimeRangeOptions.All]: t('All'),
   [TimeRangeOptions.Last10Days]: t('Last 10 days'),
   [TimeRangeOptions.Last24H]: t('Last 24 hours'),
   [TimeRangeOptions.Last31Days]: t('Last 31 days'),
-};
+});
 
 export const TimeRangeOptionsDictionary: {
   Last10Days: TimeRangeOptionsProperties;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -93,8 +93,6 @@ export const FEATURE_FLAG_DEFAULTS: Record<string, boolean> = {
 
 export const DEFAULT_NETWORK = t('Default network');
 
-export const TIPS_AND_TRICKS_LABEL = t('Tips and tricks');
-
 export const POD = 'pod';
 export const MULTUS = 'multus';
 export const IGNORED = 'ignored';


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6014](https://redhat.atlassian.net/browse/MTV-6014)

## 📝 Description

Module-level `t()` calls froze "Tips and tricks" and History time-range labels to the language active at first import, so they did not update on in-session language switch.

- Remove `TIPS_AND_TRICKS_LABEL`; translate at render time via `useForkliftTranslation` in the learning experience button and panel
- Replace `valueToLabel` with `getValueToLabel()` called during render in the Overview time-range select

## 🎥 Demo

N/A — label-only i18n fix; no layout or interaction changes. Verify by switching language without reload and confirming Tips and tricks + Last 10 days (etc.) update.

## 📝 CC://

<!-- @tag as needed -->

[MTV-6014]: https://redhat.atlassian.net/browse/MTV-6014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling for the “Tips and tricks” learning experience and overview time-range labels.
  * Ensured displayed labels are consistently localized across the interface.
  * Updated label rendering to provide more reliable translations in supported languages.
  * Preserved existing panel, button, and time-range interactions while improving localization consistency throughout these areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->