### PR TITLE
Resolves: None | Bump Playwright to 1.62.1 for E2E tests and container

### DIFF
--- a/testing/PlaywrightContainerFile
+++ b/testing/PlaywrightContainerFile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.60.0-noble
+FROM mcr.microsoft.com/playwright:v1.62.1-noble
 
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -13,9 +13,9 @@
       },
       "devDependencies": {
         "@kubernetes/client-node": "^1.4.0",
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^20.0.0",
-        "playwright": "^1.61.1",
+        "playwright": "^1.62.1",
         "typescript": "^5.8.2"
       }
     },
@@ -95,19 +95,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@types/js-yaml": {
@@ -753,35 +753,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pump": {

--- a/testing/package.json
+++ b/testing/package.json
@@ -17,9 +17,9 @@
   "description": "",
   "devDependencies": {
     "@kubernetes/client-node": "^1.4.0",
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^20.0.0",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.1",
     "typescript": "^5.8.2"
   },
   "dependencies": {

--- a/testing/run-e2e-docker.sh
+++ b/testing/run-e2e-docker.sh
@@ -17,5 +17,5 @@ docker run --rm -it \
   --env LC_ALL=en_US.UTF-8 \
   --env LANG=en_US.UTF-8 \
   --env LANGUAGE=en_US.UTF-8 \
-  mcr.microsoft.com/playwright:v1.60.0-noble \
+  mcr.microsoft.com/playwright:v1.62.1-noble \
   bash -c "npm install && npx playwright test --grep @downstream"


### PR DESCRIPTION
## 📝 Links

- Resolves: None

## 📝 Description

Align Playwright npm packages and container image pins to **1.62.1** so the E2E test runner and browser image stay in sync (previously npm `1.61.1` vs image `1.60.0`).

Updated:
- `testing/package.json` / `package-lock.json`
- `testing/PlaywrightContainerFile`
- `testing/run-e2e-docker.sh`

## 🎥 Demo

N/A — dependency/version bump only; no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->