### PR TITLE
Resolves: MTV-6286 | Audit Playwright require-await override

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -425,10 +425,7 @@ export const createEslintConfig = () =>
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-unused-vars': 'off',
-        // Many page-object getter methods are async for API consistency but call
-        // Playwright locator APIs that return Promises without needing await.
-        // TODO: audit and fix each site, then remove this override.
-        '@typescript-eslint/require-await': 'off',
+        '@typescript-eslint/promise-function-async': 'off',
         'jsdoc/require-jsdoc': 'off',
         'jsdoc/require-param': 'off',
         'jsdoc/require-param-name': 'off',

--- a/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
+++ b/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
@@ -15,7 +15,7 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 }));
 
 jest.mock('src/plans/create/utils/addOwnerRefs', () => ({
-  addOwnerRefs: jest.fn().mockResolvedValue(undefined),
+  addOwnerRefs: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('@utils/crds/common/utils', () => ({

--- a/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
+++ b/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
@@ -15,7 +15,7 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 }));
 
 jest.mock('src/plans/create/utils/addOwnerRefs', () => ({
-  addOwnerRefs: jest.fn(async () => undefined),
+  addOwnerRefs: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('@utils/crds/common/utils', () => ({
@@ -93,10 +93,12 @@ const configMap: IoK8sApiCoreV1ConfigMap = {
 describe('createDuplicatePlanAndMapResources', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockK8sCreate.mockImplementation(async ({ data }) => ({
-      ...data,
-      metadata: { ...data.metadata, uid: `uid-${data.metadata?.name}` },
-    }));
+    mockK8sCreate.mockImplementation(({ data }) =>
+      Promise.resolve({
+        ...data,
+        metadata: { ...data.metadata, uid: `uid-${data.metadata?.name}` },
+      }),
+    );
   });
 
   it('creates duplicated hooks when plan has hooks', async () => {

--- a/src/plans/list/components/BulkPlanActions/__tests__/utils.test.ts
+++ b/src/plans/list/components/BulkPlanActions/__tests__/utils.test.ts
@@ -181,10 +181,11 @@ describe('BulkPlanActions utils', () => {
   it('collects rejected results from batched workers', async () => {
     const results = await runSettledInBatches(
       [1, 2, 3],
-      async (value) => {
+      (value) => {
         if (value === 2) {
-          throw new Error('boom');
+          return Promise.reject(new Error('boom'));
         }
+        return Promise.resolve();
       },
       2,
     );

--- a/testing/playwright/e2e/downstream/plans/plan-vm-selected-toggle.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-vm-selected-toggle.spec.ts
@@ -18,7 +18,7 @@ test.describe('Plan Creation Wizard - Selected VMs toggle', { tag: '@downstream'
   }) => {
     test.setTimeout(300_000);
 
-    const provider = await test.step('Create oVirt source provider', async () => {
+    const provider = await test.step('Create oVirt source provider', () => {
       return createCustomProvider({
         namePrefix: 'ovirt-selected-toggle',
         providerKey: OVIRT_PROVIDER_KEY,

--- a/testing/playwright/fixtures/resourceFixtures.ts
+++ b/testing/playwright/fixtures/resourceFixtures.ts
@@ -20,7 +20,7 @@ import {
   type TestStorageMap,
 } from './helpers/resourceCreationHelpers';
 
-const createAuthenticatedContext = async (browser: Browser): Promise<BrowserContext> => {
+const createAuthenticatedContext = (browser: Browser): Promise<BrowserContext> => {
   return browser.newContext({
     ignoreHTTPSErrors: true,
     storageState: existsSync(AUTH_FILE) ? AUTH_FILE : undefined,

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
@@ -43,7 +43,7 @@ export class NetworkMapStep {
     if (isVersionAtLeast(V2_11_0)) {
       return {
         rows: getMappingWizardFieldRows(this.page),
-        getRowText: async (row: Locator) => row.textContent(),
+        getRowText: (row: Locator) => row.textContent(),
         getTargetSelect: (row: Locator) => row.getByTestId('network-map-target-network-select'),
       };
     }
@@ -52,7 +52,7 @@ export class NetworkMapStep {
     const bodyRowGroup = grid.getByRole('rowgroup').nth(1);
     return {
       rows: bodyRowGroup.getByRole('row'),
-      getRowText: async (row: Locator) => row.getByRole('gridcell').first().textContent(),
+      getRowText: (row: Locator) => row.getByRole('gridcell').first().textContent(),
       getTargetSelect: (row: Locator) => row.getByRole('gridcell').nth(1).getByRole('button'),
     };
   }

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/StorageMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/StorageMapStep.ts
@@ -31,7 +31,7 @@ export class StorageMapStep {
     if (isVersionAtLeast(V2_11_0)) {
       return {
         rows: getMappingWizardFieldRows(this.page),
-        getSourceText: async (row: Locator) => row.locator('td').first().textContent(),
+        getSourceText: (row: Locator) => row.locator('td').first().textContent(),
         getTargetSelect: (row: Locator) => row.getByTestId('target-storage-select'),
       };
     }
@@ -40,7 +40,7 @@ export class StorageMapStep {
     const bodyRowGroup = grid.getByRole('rowgroup').nth(1);
     return {
       rows: bodyRowGroup.getByRole('row'),
-      getSourceText: async (row: Locator) => row.getByRole('gridcell').first().textContent(),
+      getSourceText: (row: Locator) => row.getByRole('gridcell').first().textContent(),
       getTargetSelect: (row: Locator) => row.getByRole('gridcell').nth(1).getByRole('button'),
     };
   }

--- a/testing/playwright/page-objects/InspectVirtualMachinesModal.ts
+++ b/testing/playwright/page-objects/InspectVirtualMachinesModal.ts
@@ -58,19 +58,19 @@ export class InspectVirtualMachinesModal {
     return (await statusCell.textContent())?.trim() ?? '';
   }
 
-  async getVmRowCount(): Promise<number> {
+  getVmRowCount(): Promise<number> {
     return this.vmTableBodyRows.count();
   }
 
-  async isConfirmDisabled(): Promise<boolean> {
+  isConfirmDisabled(): Promise<boolean> {
     return this.confirmButton.isDisabled();
   }
 
-  async isVmCheckboxChecked(vmName: string): Promise<boolean> {
+  isVmCheckboxChecked(vmName: string): Promise<boolean> {
     return this.vmCheckbox(vmName).isChecked();
   }
 
-  async isVmCheckboxDisabled(vmName: string): Promise<boolean> {
+  isVmCheckboxDisabled(vmName: string): Promise<boolean> {
     return this.vmCheckbox(vmName).isDisabled();
   }
 

--- a/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
+++ b/testing/playwright/page-objects/OverviewPage/modals/SettingsEditModal.ts
@@ -93,15 +93,15 @@ export class SettingsEditModal extends BaseModal {
     return (await this.aapUrlInput.inputValue()) ?? '';
   }
 
-  async getControllerCpuLimitValue(): Promise<string | null> {
+  getControllerCpuLimitValue(): Promise<string | null> {
     return this.controllerCpuLimitDropdown.textContent();
   }
 
-  async getControllerMemoryLimitValue(): Promise<string | null> {
+  getControllerMemoryLimitValue(): Promise<string | null> {
     return this.controllerMemoryLimitDropdown.textContent();
   }
 
-  async getInventoryMemoryLimitValue(): Promise<string | null> {
+  getInventoryMemoryLimitValue(): Promise<string | null> {
     return this.inventoryMemoryLimitDropdown.textContent();
   }
 
@@ -109,15 +109,15 @@ export class SettingsEditModal extends BaseModal {
     return (await this.maxVmInFlightInput.inputValue()) ?? '';
   }
 
-  async getPrecopyIntervalValue(): Promise<string | null> {
+  getPrecopyIntervalValue(): Promise<string | null> {
     return this.preCopyIntervalDropdown.textContent();
   }
 
-  async getSnapshotPollingIntervalValue(): Promise<string | null> {
+  getSnapshotPollingIntervalValue(): Promise<string | null> {
     return this.snapshotPollingIntervalDropdown.textContent();
   }
 
-  async getTransferNetworkCurrentValue(): Promise<string | null> {
+  getTransferNetworkCurrentValue(): Promise<string | null> {
     return this.controllerTransferNetworkDropdown.textContent();
   }
 

--- a/testing/playwright/page-objects/OverviewPage/tabs/SettingsTab.ts
+++ b/testing/playwright/page-objects/OverviewPage/tabs/SettingsTab.ts
@@ -38,7 +38,7 @@ export class SettingsTab {
     await this.settingsEditModal.save();
   }
 
-  async getTransferNetworkCurrentValue(): Promise<string | null> {
+  getTransferNetworkCurrentValue(): Promise<string | null> {
     return this.controllerTransferNetworkField.textContent();
   }
 

--- a/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/PlanDetailsPage.ts
@@ -178,7 +178,7 @@ export class PlanDetailsPage {
   /**
    * Checks if the critical concerns alert is visible.
    */
-  async hasCriticalConcernsAlert(): Promise<boolean> {
+  hasCriticalConcernsAlert(): Promise<boolean> {
     return this.criticalConcernsAlert.isVisible({ timeout: 3000 }).catch(() => false);
   }
 
@@ -186,7 +186,7 @@ export class PlanDetailsPage {
     return this.page.getByTestId('plan-inspect-vms-button');
   }
 
-  async isInspectVmsButtonDisabled(): Promise<boolean> {
+  isInspectVmsButtonDisabled(): Promise<boolean> {
     return this.inspectVmsButton.isDisabled();
   }
 

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -26,7 +26,7 @@ export class ScriptEditModal extends BaseModal {
     await fillScriptFields(this.page, index, config, MODAL_FIELD_TEST_IDS);
   }
 
-  async getScriptCount(): Promise<number> {
+  getScriptCount(): Promise<number> {
     return this.modal.locator('[data-testid^="field-row-"]').count();
   }
 

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/MappingsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/MappingsTab.ts
@@ -121,12 +121,11 @@ export class MappingsTab {
     return (await this.networkMapNameItem.getByRole('link').textContent()) ?? '';
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getNetworkMappingCount(): Promise<number> {
     return this.page.locator('[data-testid^="network-mapping-row-"]').count();
   }
 
-  async getNetworkMappingCountFromReviewTable(): Promise<number> {
+  getNetworkMappingCountFromReviewTable(): Promise<number> {
     return this.networkMapReviewTable.locator('tbody tr').count();
   }
 
@@ -134,7 +133,6 @@ export class MappingsTab {
     return (await this.storageMapNameItem.getByRole('link').textContent()) ?? '';
   }
 
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   getStorageMappingCount(): Promise<number> {
     return this.page.locator('[data-testid^="storage-mapping-row-"]').count();
   }

--- a/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/ProviderDetailsPage.ts
@@ -90,7 +90,7 @@ export class ProviderDetailsPage {
     return this.page.getByTestId('provider-actions-inspect-menuitem');
   }
 
-  async isInspectVmsButtonVisible(): Promise<boolean> {
+  isInspectVmsButtonVisible(): Promise<boolean> {
     return this.inspectVmsButton.isVisible();
   }
 

--- a/testing/playwright/page-objects/ProviderDetailsPage/modals/CredentialEditModal.ts
+++ b/testing/playwright/page-objects/ProviderDetailsPage/modals/CredentialEditModal.ts
@@ -82,7 +82,7 @@ export class CredentialEditModal extends BaseModal {
     return (await this.usernameInput.inputValue()) ?? '';
   }
 
-  async isConfigureCertificateSelected(): Promise<boolean> {
+  isConfigureCertificateSelected(): Promise<boolean> {
     return this.configureCertificateRadio.isChecked();
   }
 
@@ -91,7 +91,7 @@ export class CredentialEditModal extends BaseModal {
     return type === 'text';
   }
 
-  async isSkipCertificateSelected(): Promise<boolean> {
+  isSkipCertificateSelected(): Promise<boolean> {
     return this.skipCertificateRadio.isChecked();
   }
 

--- a/testing/playwright/page-objects/common/AccessModeOptions.ts
+++ b/testing/playwright/page-objects/common/AccessModeOptions.ts
@@ -29,7 +29,7 @@ export class AccessModeOptions {
     return this.container.getByTestId(fieldId);
   }
 
-  private async isExpanded(mappingIndex: number): Promise<boolean> {
+  private isExpanded(mappingIndex: number): Promise<boolean> {
     return this.fieldToggleButton(ACCESS_MODE_FIELD.accessMode(mappingIndex)).isVisible();
   }
 

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -41,7 +41,7 @@ export class OffloadOptions {
     return this.container.getByTestId(fieldId);
   }
 
-  private async isOffloadExpanded(mappingIndex: number): Promise<boolean> {
+  private isOffloadExpanded(mappingIndex: number): Promise<boolean> {
     return this.fieldToggleButton(OFFLOAD_FIELD.offloadPlugin(mappingIndex)).isVisible();
   }
 

--- a/testing/playwright/page-objects/common/Table.ts
+++ b/testing/playwright/page-objects/common/Table.ts
@@ -156,7 +156,7 @@ export class Table {
     const count = await headers.count();
 
     const headerTexts = await Promise.all(
-      Array.from({ length: count }, async (_, i) => headers.nth(i).textContent()),
+      Array.from({ length: count }, (_, i) => headers.nth(i).textContent()),
     );
 
     return headerTexts
@@ -182,7 +182,7 @@ export class Table {
     return this.rootLocator.getByTestId(testId);
   }
 
-  async getRowCount(): Promise<number> {
+  getRowCount(): Promise<number> {
     const tableContainer = this.getTableContainer();
     return tableContainer.locator('tbody tr').count();
   }


### PR DESCRIPTION
## Summary
- Audited `@typescript-eslint/require-await` violations in `testing/` — found **28 violations** across 15 files, all the same pattern: page-object methods marked `async` that return Playwright Promises (`textContent`, `isVisible`, `isChecked`, `isDisabled`, `count`) without internal `await`
- Fixed all 28 by removing the unnecessary `async` keyword — safe because callers already `await` these methods and return types (`Promise<T>`) are unchanged
- Removed the `require-await: 'off'` override and its TODO comment from the ESLint testing config
- Disabled `promise-function-async` in the testing override to prevent the complementary rule from conflicting (Playwright page objects naturally have simple Promise-returning getters)
- Cleaned up two inline `eslint-disable-next-line` comments in MappingsTab.ts now covered by the config override

## Test plan
- [x] `npx eslint testing/ --quiet` passes
- [x] Playwright tests still pass (no behavioral change from removing unnecessary async)
- [x] CI passes

Resolves: MTV-6286

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified asynchronous handling across automated testing utilities and page interactions.
  * Removed redundant asynchronous wrappers while preserving existing return values and behavior.
  * Improved consistency in promise handling and streamlined test-related code.

* **Tests**
  * Updated test mocks and browser test callbacks to use clearer promise patterns.
  * Maintained existing test coverage and functionality with no end-user-facing behavior changes.
  * Refined linting configuration for asynchronous test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->