### PR TITLE
Resolves: MTV-6285 | Fix setState-in-useEffect and enable rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -348,8 +348,7 @@ export const createEslintConfig = () =>
       files: ['src/**/*.{ts,tsx}'],
       rules: {
         ...eslintReact.configs['recommended-typescript'].rules,
-        // setState-in-effect is common in this codebase; enable in a follow-up
-        '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'off',
+        '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'error',
       },
     },
     {
@@ -413,7 +412,6 @@ export const createEslintConfig = () =>
       files: ['testing/**/*.{js,ts,jsx,tsx}', '**/__{tests,mocks}__/**/*.{js,ts,jsx,tsx}'],
       rules: {
         '@cspell/spellchecker': 'off',
-        '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'off',
         '@typescript-eslint/class-methods-use-this': 'off',
         '@typescript-eslint/consistent-type-definitions': 'off',
         '@typescript-eslint/no-explicit-any': 'off',

--- a/src/components/AffinityModal/PreferredAffinityWeightInput.tsx
+++ b/src/components/AffinityModal/PreferredAffinityWeightInput.tsx
@@ -1,11 +1,4 @@
-import {
-  type Dispatch,
-  type FC,
-  type FormEvent,
-  type SetStateAction,
-  useEffect,
-  useState,
-} from 'react';
+import { type Dispatch, type FC, type FormEvent, type SetStateAction, useEffect } from 'react';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
@@ -26,22 +19,17 @@ const PreferredAffinityWeightInput: FC<PreferredAffinityWeightInputProps> = ({
   setSubmitDisabled,
 }) => {
   const { t } = useForkliftTranslation();
-  const [validated, setValidated] = useState<ValidatedOptions>(ValidatedOptions.default);
   const { weight } = focusedAffinity || {};
+  const isInvalid = !weight || weight < 1 || weight > 100;
+  const validated = isInvalid ? ValidatedOptions.error : ValidatedOptions.default;
 
   const onChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
     setFocusedAffinity({ ...focusedAffinity, weight: Number(value) });
   };
 
   useEffect(() => {
-    if (!weight || weight < 1 || weight > 100) {
-      setValidated(ValidatedOptions.error);
-      setSubmitDisabled(true);
-    } else {
-      setValidated(ValidatedOptions.default);
-      setSubmitDisabled(false);
-    }
-  }, [weight, setSubmitDisabled]);
+    setSubmitDisabled(isInvalid);
+  }, [isInvalid, setSubmitDisabled]);
 
   return (
     <FormGroup fieldId="weight" isRequired label={t('Weight')}>

--- a/src/components/AffinityModal/TopologyKeyInput.tsx
+++ b/src/components/AffinityModal/TopologyKeyInput.tsx
@@ -1,4 +1,4 @@
-import { type Dispatch, type FC, type SetStateAction, useEffect, useState } from 'react';
+import { type Dispatch, type FC, type SetStateAction, useEffect } from 'react';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
@@ -20,22 +20,17 @@ const TopologyKeyInput: FC<TopologyKeyInputProps> = ({
   setSubmitDisabled,
 }) => {
   const { t } = useForkliftTranslation();
-  const [validated, setValidated] = useState<ValidatedOptions>(ValidatedOptions.default);
   const { topologyKey } = focusedAffinity || {};
+  const isInvalid = !topologyKey || isEmpty(topologyKey);
+  const validated = isInvalid ? ValidatedOptions.error : ValidatedOptions.default;
 
   const onChange = (value: string) => {
     setFocusedAffinity({ ...focusedAffinity, topologyKey: value });
   };
 
   useEffect(() => {
-    if (!topologyKey || isEmpty(topologyKey)) {
-      setValidated(ValidatedOptions.error);
-      setSubmitDisabled(true);
-    } else {
-      setValidated(ValidatedOptions.default);
-      setSubmitDisabled(false);
-    }
-  }, [topologyKey, setSubmitDisabled]);
+    setSubmitDisabled(isInvalid);
+  }, [isInvalid, setSubmitDisabled]);
 
   return (
     <FormGroup fieldId="topology-key" isRequired label={t('Topology key')}>

--- a/src/components/FilterableSelect/FilterableSelect.tsx
+++ b/src/components/FilterableSelect/FilterableSelect.tsx
@@ -3,7 +3,7 @@ import {
   type MouseEvent,
   type ReactNode,
   type Ref,
-  useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -77,7 +77,6 @@ export const FilterableSelect: FunctionComponent<FilterableSelectProps> = ({
    * This is typically synchronized with inputValue, but they can be different if needed.
    */
   const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<SelectOptionProps[]>(initialSelectOptions);
   const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
 
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -95,25 +94,20 @@ export const FilterableSelect: FunctionComponent<FilterableSelectProps> = ({
     onSelect(newValue);
   };
 
-  /**
-   * Updates the select options based on the filter value.
-   */
-  useEffect(() => {
-    let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
-
-    // Filter menu items based on the text input value when one exists
-    if (filterValue) {
-      newSelectOptions = initialSelectOptions.filter((menuItem) =>
-        String(menuItem.itemId).toLowerCase().includes(filterValue.toLowerCase()),
-      );
-
-      // When no options are found after filtering, display 'No results found'
-      if (isEmpty(newSelectOptions)) {
-        newSelectOptions = [{ children: noResultFoundLabel, isDisabled: true }];
-      }
+  const selectOptions = useMemo(() => {
+    if (!filterValue) {
+      return initialSelectOptions;
     }
 
-    setSelectOptions(newSelectOptions);
+    const filteredOptions = initialSelectOptions.filter((menuItem) =>
+      String(menuItem.itemId).toLowerCase().includes(filterValue.toLowerCase()),
+    );
+
+    if (isEmpty(filteredOptions)) {
+      return [{ children: noResultFoundLabel, isDisabled: true }];
+    }
+
+    return filteredOptions;
   }, [filterValue, initialSelectOptions, noResultFoundLabel]);
 
   /**

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterValueMultiSelect.tsx
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterValueMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { type Ref, useEffect, useMemo, useState } from 'react';
+import { type Ref, useMemo, useState } from 'react';
 
 import {
   Badge,
@@ -32,11 +32,12 @@ const FilterValueMultiSelect = <T,>({
 }: FilterValueMultiSelectProps<T>) => {
   const { t } = useForkliftTranslation();
   const [isOpen, setOpen] = useState(false);
+  const [prevCloseKey, setPrevCloseKey] = useState(closeKey);
 
-  // Close when switching active attribute (preserves your old behavior)
-  useEffect(() => {
+  if (closeKey !== prevCloseKey) {
+    setPrevCloseKey(closeKey);
     setOpen(false);
-  }, [closeKey]);
+  }
 
   const selectedValues = useMemo(() => Array.from(selected ?? new Set<string>()), [selected]);
 

--- a/src/components/page/hooks/usePageData.ts
+++ b/src/components/page/hooks/usePageData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import type { ResourceField } from '@components/common/utils/types';
 import { isEmpty } from '@utils/helpers';
@@ -40,38 +40,34 @@ export const usePageData = <T>({
   postFilterData,
   selectedFilters,
 }: UsePageDataProps<T>): UsePageDataResult<T> => {
-  const [sortedData, setSortedData] = useState<T[]>([]);
-  const [filteredData, setFilteredData] = useState<T[]>([]);
-  const [finalFilteredData, setFinalFilteredData] = useState<T[]>([]);
-
-  useEffect(() => {
+  const sortedData = useMemo(() => {
     if (flatData && loaded && !error) {
-      setSortedData([...flatData].sort(compareFn));
+      return [...flatData].sort(compareFn);
     }
+    return [];
   }, [flatData, compareFn, loaded, error]);
 
-  useEffect(() => {
+  const filteredData = useMemo(() => {
     if (sortedData && loaded && !error) {
-      setFilteredData(sortedData.filter(metaMatcher));
+      return sortedData.filter(metaMatcher);
     }
+    return [];
   }, [sortedData, metaMatcher, loaded, error]);
 
-  useEffect(() => {
+  const finalFilteredData = useMemo(() => {
     if (!loaded || error) {
-      return;
+      return [];
     }
 
     if (!filteredData || isEmpty(filteredData)) {
-      setFinalFilteredData([]);
-      return;
+      return [];
     }
 
     if (!postFilterData) {
-      setFinalFilteredData(filteredData);
-      return;
+      return filteredData;
     }
 
-    setFinalFilteredData(postFilterData(filteredData, selectedFilters, fields));
+    return postFilterData(filteredData, selectedFilters, fields);
   }, [filteredData, postFilterData, selectedFilters, fields, loaded, error]);
 
   return {

--- a/src/components/page/hooks/usePageSelection.ts
+++ b/src/components/page/hooks/usePageSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 type UsePageSelectionProps<T> = {
   toId?: (item: T) => string;
@@ -27,16 +27,20 @@ export const usePageSelection = <T>({
 }: UsePageSelectionProps<T>): UsePageSelectionResult<T> => {
   const [internalSelectedIds, setInternalSelectedIds] = useState(selectedIds);
   const [internalExpandedIds, setInternalExpandedIds] = useState(expandedIds);
+  const [prevSelectedIds, setPrevSelectedIds] = useState(selectedIds);
+  const [prevExpandedIds, setPrevExpandedIds] = useState(expandedIds);
+
+  if (selectedIds !== prevSelectedIds) {
+    setPrevSelectedIds(selectedIds);
+    setInternalSelectedIds(selectedIds);
+  }
+
+  if (expandedIds !== prevExpandedIds) {
+    setPrevExpandedIds(expandedIds);
+    setInternalExpandedIds(expandedIds);
+  }
 
   const itemToId = useCallback((item: T) => (toId ? toId(item) : ''), [toId]);
-
-  useEffect(() => {
-    setInternalSelectedIds(selectedIds);
-  }, [selectedIds]);
-
-  useEffect(() => {
-    setInternalExpandedIds(expandedIds);
-  }, [expandedIds]);
 
   const isExpanded = useMemo(
     () =>

--- a/src/components/page/hooks/usePagination.ts
+++ b/src/components/page/hooks/usePagination.ts
@@ -66,10 +66,15 @@ export const usePagination = <T>({
     [pageRef],
   );
 
-  const itemsPerPageValue =
-    typeof pagination === 'number' ? pagination : (userSettings?.perPage ?? DEFAULT_PER_PAGE);
+  const { itemsPerPage: perPageFromSettings, setPerPage } = usePerPagePagination({
+    filteredDataLength: finalFilteredData.length,
+    userSettings,
+  });
+
+  // Keep clamp and slice on the same effective page size (fixed `pagination` number wins).
+  const itemsPerPage = typeof pagination === 'number' ? pagination : perPageFromSettings;
   const hasActiveFilters = Object.values(selectedFilters).some((filter) => !isEmpty(filter));
-  const maxPage = Math.ceil(finalFilteredData.length / itemsPerPageValue);
+  const maxPage = Math.ceil(finalFilteredData.length / itemsPerPage);
   const fallbackPage = maxPage > 0 ? maxPage : INITIAL_PAGE;
   const clampedPage = hasActiveFilters && page > maxPage ? fallbackPage : page;
 
@@ -82,11 +87,6 @@ export const usePagination = <T>({
     () => pagination === 'on' || (typeof pagination === 'number' && sortedDataLength > pagination),
     [pagination, sortedDataLength],
   );
-
-  const { itemsPerPage, setPerPage } = usePerPagePagination({
-    filteredDataLength: finalFilteredData.length,
-    userSettings,
-  });
 
   const pageData = useMemo(
     () => finalFilteredData.slice((clampedPage - 1) * itemsPerPage, clampedPage * itemsPerPage),

--- a/src/components/page/hooks/usePagination.ts
+++ b/src/components/page/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback, useEffect, useMemo, useState } from 'react';
+import { type MutableRefObject, useCallback, useMemo, useState } from 'react';
 
 import type { PaginationSettings } from '@components/common/Page/types';
 import {
@@ -46,7 +46,17 @@ export const usePagination = <T>({
   sortedDataLength,
   userSettings,
 }: UsePaginationProps<T>): UsePaginationResult<T> => {
-  const [page, setPageState] = useState(initialPage);
+  const [page, setPageState] = useState(() =>
+    pageRef.current === initialPage ? initialPage : pageRef.current,
+  );
+  const [prevInitialPage, setPrevInitialPage] = useState(initialPage);
+
+  if (initialPage !== prevInitialPage) {
+    setPrevInitialPage(initialPage);
+    if (pageRef.current !== initialPage) {
+      setPageState(pageRef.current);
+    }
+  }
 
   const setPage = useCallback(
     (newPage: number) => {
@@ -56,26 +66,17 @@ export const usePagination = <T>({
     [pageRef],
   );
 
-  useEffect(() => {
-    if (pageRef.current !== initialPage) {
-      setPageState(pageRef.current);
-    }
-  }, [initialPage, pageRef]);
+  const itemsPerPageValue =
+    typeof pagination === 'number' ? pagination : (userSettings?.perPage ?? DEFAULT_PER_PAGE);
+  const hasActiveFilters = Object.values(selectedFilters).some((filter) => !isEmpty(filter));
+  const maxPage = Math.ceil(finalFilteredData.length / itemsPerPageValue);
+  const fallbackPage = maxPage > 0 ? maxPage : INITIAL_PAGE;
+  const clampedPage = hasActiveFilters && page > maxPage ? fallbackPage : page;
 
-  useEffect(() => {
-    const hasActiveFilters = Object.values(selectedFilters).some((filter) => !isEmpty(filter));
-    if (!hasActiveFilters) {
-      return;
-    }
-
-    const itemsPerPageValue =
-      typeof pagination === 'number' ? pagination : (userSettings?.perPage ?? DEFAULT_PER_PAGE);
-    const maxPage = Math.ceil(finalFilteredData.length / itemsPerPageValue);
-
-    if (page > maxPage) {
-      setPage(maxPage > 0 ? maxPage : INITIAL_PAGE);
-    }
-  }, [selectedFilters, finalFilteredData.length, pagination, userSettings?.perPage, page, setPage]);
+  if (clampedPage !== page) {
+    pageRef.current = clampedPage;
+    setPageState(clampedPage);
+  }
 
   const showPagination = useMemo(
     () => pagination === 'on' || (typeof pagination === 'number' && sortedDataLength > pagination),
@@ -88,8 +89,8 @@ export const usePagination = <T>({
   });
 
   const pageData = useMemo(
-    () => finalFilteredData.slice((page - 1) * itemsPerPage, page * itemsPerPage),
-    [finalFilteredData, page, itemsPerPage],
+    () => finalFilteredData.slice((clampedPage - 1) * itemsPerPage, clampedPage * itemsPerPage),
+    [finalFilteredData, clampedPage, itemsPerPage],
   );
 
   const onSetPage = useCallback<OnSetPage>(
@@ -111,7 +112,7 @@ export const usePagination = <T>({
     itemsPerPage,
     onPerPageSelect,
     onSetPage,
-    page,
+    page: clampedPage,
     pageData,
     setPage,
     setPerPage,

--- a/src/components/page/hooks/usePagination.ts
+++ b/src/components/page/hooks/usePagination.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback, useMemo, useState } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useMemo, useState } from 'react';
 
 import type { PaginationSettings } from '@components/common/Page/types';
 import {
@@ -79,9 +79,15 @@ export const usePagination = <T>({
   const clampedPage = hasActiveFilters && page > maxPage ? fallbackPage : page;
 
   if (clampedPage !== page) {
-    pageRef.current = clampedPage;
     setPageState(clampedPage);
   }
+
+  // Sync parent-owned pageRef after commit — avoid mutating the ref during render.
+  useEffect(() => {
+    if (pageRef.current !== clampedPage) {
+      pageRef.current = clampedPage;
+    }
+  }, [clampedPage, pageRef]);
 
   const showPagination = useMemo(
     () => pagination === 'on' || (typeof pagination === 'number' && sortedDataLength > pagination),

--- a/src/networkMaps/create/fields/ProjectSelectField.tsx
+++ b/src/networkMaps/create/fields/ProjectSelectField.tsx
@@ -35,12 +35,13 @@ const ProjectSelectField: FC = () => {
 
   const defaultProject = useDefaultProject(projectNames);
   const [showDefaultProjects, setShowDefaultProjects] = useState<boolean>(false);
+  const effectiveShowDefaultProjects =
+    showDefaultProjects || Boolean(defaultProject && isSystemNamespace(defaultProject));
 
   // Automatically set the default project once it's resolved
   useEffect(() => {
     if (defaultProject) {
       setValue(NetworkMapFieldId.Project, defaultProject);
-      setShowDefaultProjects((prev) => prev || isSystemNamespace(defaultProject));
     }
   }, [defaultProject, setValue]);
 
@@ -66,7 +67,7 @@ const ProjectSelectField: FC = () => {
         render={({ field }) => (
           <div ref={field.ref}>
             <ProjectSelect
-              showDefaultProjects={showDefaultProjects}
+              showDefaultProjects={effectiveShowDefaultProjects}
               setShowDefaultProjects={setShowDefaultProjects}
               isDisabled={isSubmitting}
               placeholder={t('Select project')}

--- a/src/overview/hooks/useK8sWatchForkliftController.ts
+++ b/src/overview/hooks/useK8sWatchForkliftController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import {
   ForkliftControllerModelGroupVersionKind,
@@ -21,37 +21,16 @@ type K8sForkliftControllerWatchResult = [
  * @returns {K8sProvidersWatchResult} - the first forklift controller CR found.
  */
 export const useK8sWatchForkliftController = (): K8sForkliftControllerWatchResult => {
-  const [controller, setController] = useState<V1beta1ForkliftController | undefined>(undefined);
-  const [controllerLoaded, setControllerLoaded] = useState(false);
-  const [controllerLoadError, setControllerLoadError] = useState<Error | null>(null);
-
   const [controllers, loaded, loadError] = useK8sWatchResource<V1beta1ForkliftController[]>({
     groupVersionKind: ForkliftControllerModelGroupVersionKind,
     isList: true,
     namespaced: true,
   });
 
-  const handleLoadError = useCallback((error: Error | null) => {
-    setControllerLoadError(error);
-    setControllerLoaded(true);
-  }, []);
-
-  const handleLoadedForkliftControllers = useCallback(() => {
-    setControllerLoaded(true);
-
+  const controller = useMemo(() => {
     const [firstController] = controllers ?? [];
-    setController(firstController);
+    return firstController;
   }, [controllers]);
 
-  useEffect(() => {
-    if (!loaded) {
-      return;
-    }
-    if (loadError) {
-      handleLoadError(loadError as Error);
-    }
-    handleLoadedForkliftControllers();
-  }, [controllers, loaded, loadError, handleLoadError, handleLoadedForkliftControllers]);
-
-  return [controller, controllerLoaded, controllerLoadError];
+  return [controller, loaded, (loadError as Error | null) ?? null];
 };

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo, useRef, useState } from 'react';
+import { type FC, useMemo, useState } from 'react';
 
 import {
   Bullseye,
@@ -37,7 +37,7 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
     ThroughputTimeRange.Last1H,
   );
   const [selectedPlanIds, setSelectedPlanIds] = useState<string[]>([]);
-  const knownPlanIdsRef = useRef<Set<string>>(new Set());
+  const [knownPlanIds, setKnownPlanIds] = useState<Set<string>>(() => new Set());
   const [prevDataKey, setPrevDataKey] = useState('');
 
   const { data, error, loaded } = useThroughputQuery(metricName, selectedRange);
@@ -63,8 +63,8 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
       setPrevDataKey(dataKey);
 
       const currentIdSet = new Set(currentIds);
-      const trulyNewIds = currentIds.filter((id) => !knownPlanIdsRef.current.has(id));
-      knownPlanIdsRef.current = currentIdSet;
+      const trulyNewIds = currentIds.filter((id) => !knownPlanIds.has(id));
+      setKnownPlanIds(currentIdSet);
 
       setSelectedPlanIds((prev) => {
         if (isEmpty(prev) && !isEmpty(currentIds)) {

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect, useMemo, useRef, useState } from 'react';
+import { type FC, useMemo, useRef, useState } from 'react';
 
 import {
   Bullseye,
@@ -38,6 +38,7 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
   );
   const [selectedPlanIds, setSelectedPlanIds] = useState<string[]>([]);
   const knownPlanIdsRef = useRef<Set<string>>(new Set());
+  const [prevDataKey, setPrevDataKey] = useState('');
 
   const { data, error, loaded } = useThroughputQuery(metricName, selectedRange);
 
@@ -54,26 +55,27 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
     [data],
   );
 
-  useEffect(() => {
-    if (!loaded || error) {
-      return;
-    }
-
+  if (loaded && !error) {
     const currentIds = data.map((series) => series.planId);
-    const currentIdSet = new Set(currentIds);
-    const trulyNewIds = currentIds.filter((id) => !knownPlanIdsRef.current.has(id));
+    const dataKey = currentIds.join(',');
 
-    knownPlanIdsRef.current = currentIdSet;
+    if (dataKey !== prevDataKey) {
+      setPrevDataKey(dataKey);
 
-    setSelectedPlanIds((prev) => {
-      if (isEmpty(prev) && !isEmpty(currentIds)) {
-        return currentIds;
-      }
+      const currentIdSet = new Set(currentIds);
+      const trulyNewIds = currentIds.filter((id) => !knownPlanIdsRef.current.has(id));
+      knownPlanIdsRef.current = currentIdSet;
 
-      const validPrev = prev.filter((id) => currentIdSet.has(id));
-      return [...validPrev, ...trulyNewIds];
-    });
-  }, [data, loaded, error]);
+      setSelectedPlanIds((prev) => {
+        if (isEmpty(prev) && !isEmpty(currentIds)) {
+          return currentIds;
+        }
+
+        const validPrev = prev.filter((id) => currentIdSet.has(id));
+        return [...validPrev, ...trulyNewIds];
+      });
+    }
+  }
 
   const renderBody = (): JSX.Element => {
     if (!loaded && !error) {

--- a/src/overview/tabs/Overview/hooks/useMigrationCounts.ts
+++ b/src/overview/tabs/Overview/hooks/useMigrationCounts.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { MigrationModelGroupVersionKind, type V1beta1Migration } from '@forklift-ui/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -16,49 +16,39 @@ type MigrationCountsHookResponse = {
   loadError: Error | null;
 };
 
-type CountState = {
-  migrationCounts: MigrationCounts;
-  vmCounts: MigrationCounts;
+const EMPTY_COUNTS: MigrationCounts = {
+  Failure: 0,
+  Running: 0,
+  Successful: 0,
+  Total: 0,
 };
 
 /**
  * Custom hook to watch Kubernetes migrations and return their counts by phase.
- * Consolidates migration and vm counts into a single state.
- * Only triggers a re-render if the counts change.
+ * Consolidates migration and vm counts into a single derived value.
  * @return {MigrationCountsHookResponse} An object with 'count', 'vmCount', 'loaded', and 'loadError' keys.
  */
 const useMigrationCounts = (
   range: TimeRangeOptions = TimeRangeOptions.Last10Days,
 ): MigrationCountsHookResponse => {
-  const [counts, setCounts] = useState<CountState>({
-    migrationCounts: {
-      Failure: 0,
-      Running: 0,
-      Successful: 0,
-      Total: 0,
-    },
-    vmCounts: {
-      Failure: 0,
-      Running: 0,
-      Successful: 0,
-      Total: 0,
-    },
-  });
-
   const [migrations, loaded, loadError] = useK8sWatchResource<V1beta1Migration[]>({
     groupVersionKind: MigrationModelGroupVersionKind,
     isList: true,
     namespaced: true,
   });
 
-  // Update 'counts' whenever 'migrations' changes and 'loaded' is true and 'loadError' is false.
-  useEffect(() => {
-    if (loaded && !loadError) {
-      setCounts({
-        migrationCounts: getPlanMigrationCounts(migrations),
-        vmCounts: getVmCounts(migrations, range),
-      });
+  const counts = useMemo(() => {
+    if (!loaded || loadError) {
+      return {
+        migrationCounts: EMPTY_COUNTS,
+        vmCounts: EMPTY_COUNTS,
+      };
     }
+
+    return {
+      migrationCounts: getPlanMigrationCounts(migrations),
+      vmCounts: getVmCounts(migrations, range),
+    };
   }, [migrations, loaded, loadError, range]);
 
   return {

--- a/src/overview/tabs/Overview/hooks/useMigrationCounts.ts
+++ b/src/overview/tabs/Overview/hooks/useMigrationCounts.ts
@@ -7,7 +7,13 @@ import { getPlanMigrationCounts } from '../utils/getMigrationCounts';
 import { getVmCounts } from '../utils/getVmCounts';
 import { TimeRangeOptions } from '../utils/timeRangeOptions';
 
-type MigrationCounts = Record<string, number>;
+type MigrationCounts = {
+  Canceled: number;
+  Failure: number;
+  Running: number;
+  Successful: number;
+  Total: number;
+};
 
 type MigrationCountsHookResponse = {
   count: MigrationCounts;
@@ -17,11 +23,23 @@ type MigrationCountsHookResponse = {
 };
 
 const EMPTY_COUNTS: MigrationCounts = {
+  Canceled: 0,
   Failure: 0,
   Running: 0,
   Successful: 0,
   Total: 0,
 };
+
+/**
+ * Helpers use condition type names (Failed/Succeeded); consumers expect Failure/Successful.
+ */
+const normalizeCounts = (counts: Record<string, number>): MigrationCounts => ({
+  Canceled: counts.Canceled ?? 0,
+  Failure: counts.Failed ?? counts.Failure ?? 0,
+  Running: counts.Running ?? 0,
+  Successful: counts.Succeeded ?? counts.Successful ?? 0,
+  Total: counts.Total ?? 0,
+});
 
 /**
  * Custom hook to watch Kubernetes migrations and return their counts by phase.
@@ -46,8 +64,8 @@ const useMigrationCounts = (
     }
 
     return {
-      migrationCounts: getPlanMigrationCounts(migrations),
-      vmCounts: getVmCounts(migrations, range),
+      migrationCounts: normalizeCounts(getPlanMigrationCounts(migrations)),
+      vmCounts: normalizeCounts(getVmCounts(migrations, range)),
     };
   }, [migrations, loaded, loadError, range]);
 

--- a/src/overview/tabs/Overview/hooks/usePlanStatusCounts.ts
+++ b/src/overview/tabs/Overview/hooks/usePlanStatusCounts.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { PlanModelGroupVersionKind, type V1beta1Plan } from '@forklift-ui/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -13,38 +13,27 @@ type PlanStatusCountsHookResponse = {
   loadError: Error | null;
 };
 
-type CountState = {
-  planStatusCounts: PlanStatusCounts;
-};
-
 /**
  * Custom hook to watch Kubernetes plans and return their counts by phase.
- * Only triggers a re-render if the counts change.
  * @return {PlanStatusCountsHookResponse} An object with 'count', 'loaded', and 'loadError' keys.
  */
 const usePlanStatusCounts = (): PlanStatusCountsHookResponse => {
-  const initialPlanStatusCounts = getPlanStatusCounts();
-  const [counts, setCounts] = useState<CountState>({
-    planStatusCounts: initialPlanStatusCounts,
-  });
-
   const [plans, loaded, loadError] = useK8sWatchResource<V1beta1Plan[]>({
     groupVersionKind: PlanModelGroupVersionKind,
     isList: true,
     namespaced: true,
   });
 
-  // Update 'counts' whenever 'plans' changes and 'loaded' is true and 'loadError' is false.
-  useEffect(() => {
-    if (loaded && !loadError) {
-      setCounts({
-        planStatusCounts: getPlanStatusCounts(plans),
-      });
+  const planStatusCounts = useMemo(() => {
+    if (!loaded || loadError) {
+      return getPlanStatusCounts();
     }
+
+    return getPlanStatusCounts(plans);
   }, [plans, loaded, loadError]);
 
   return {
-    count: counts.planStatusCounts,
+    count: planStatusCounts,
     loaded,
     loadError,
   };

--- a/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
+++ b/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
@@ -1,5 +1,5 @@
 // Ignoring above eslint rule as onTimeChange signature from PF has 6 params
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, useCallback, useMemo, useState } from 'react';
 import { usePlanMigration } from 'src/plans/hooks/usePlanMigration';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
@@ -11,21 +11,19 @@ import { getName } from '@utils/crds/common/selectors';
 
 import type { PlanModalProps } from '../types';
 
-import { formatDateTo12Hours, patchMigrationCutover } from './utils/utils';
+import {
+  CUTOVER_MODE_ASAP,
+  CUTOVER_MODE_SCHEDULED,
+  useCutoverFormState,
+} from './hooks/useCutoverFormState';
+import { patchMigrationCutover } from './utils/utils';
 import ScheduledCutoverFields from './ScheduledCutoverFields';
 
 import './PlanCutoverMigrationModal.scss';
 
-const CUTOVER_MODE_ASAP = 'asap' as const;
-const CUTOVER_MODE_SCHEDULED = 'scheduled' as const;
-
-type CutoverMode = typeof CUTOVER_MODE_ASAP | typeof CUTOVER_MODE_SCHEDULED;
-
 const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
   const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
-  const [cutoverDate, setCutoverDate] = useState<string>();
-  const [time, setTime] = useState<string>();
   const [isDateValid, setIsDateValid] = useState<boolean>(true);
   const [isTimeValid, setIsTimeValid] = useState<boolean>(true);
 
@@ -33,17 +31,8 @@ const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...re
 
   const existingCutoverValue = activeMigration?.spec?.cutover;
   const hasExistingCutover = Boolean(existingCutoverValue);
-  const [cutoverMode, setCutoverMode] = useState<CutoverMode>(
-    hasExistingCutover ? CUTOVER_MODE_SCHEDULED : CUTOVER_MODE_ASAP,
-  );
-
-  useEffect(() => {
-    const migrationCutoverDate = existingCutoverValue ?? new Date().toISOString();
-
-    setCutoverDate(migrationCutoverDate);
-    setTime(formatDateTo12Hours(new Date(migrationCutoverDate)));
-    setCutoverMode(existingCutoverValue ? CUTOVER_MODE_SCHEDULED : CUTOVER_MODE_ASAP);
-  }, [existingCutoverValue]);
+  const { cutoverDate, cutoverMode, setCutoverDate, setCutoverMode, setTime, time } =
+    useCutoverFormState(existingCutoverValue);
 
   const onDateChange: (event: FormEvent<HTMLInputElement>, value: string, date?: Date) => void = (
     _event,

--- a/src/plans/actions/components/CutoverModal/hooks/useCutoverFormState.ts
+++ b/src/plans/actions/components/CutoverModal/hooks/useCutoverFormState.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+import { formatDateTo12Hours } from '../utils/utils';
+
+const CUTOVER_MODE_ASAP = 'asap' as const;
+const CUTOVER_MODE_SCHEDULED = 'scheduled' as const;
+
+type CutoverMode = typeof CUTOVER_MODE_ASAP | typeof CUTOVER_MODE_SCHEDULED;
+
+export { CUTOVER_MODE_ASAP, CUTOVER_MODE_SCHEDULED };
+
+const getInitialCutoverDate = (existingCutoverValue: string | undefined): string =>
+  existingCutoverValue ?? new Date().toISOString();
+
+type UseCutoverFormStateResult = {
+  cutoverDate: string;
+  cutoverMode: CutoverMode;
+  setCutoverDate: (value: string) => void;
+  setCutoverMode: (mode: CutoverMode) => void;
+  setTime: (value: string) => void;
+  time: string;
+};
+
+export const useCutoverFormState = (
+  existingCutoverValue: string | undefined,
+): UseCutoverFormStateResult => {
+  const hasExistingCutover = Boolean(existingCutoverValue);
+  const initialCutoverDate = getInitialCutoverDate(existingCutoverValue);
+
+  const [cutoverDate, setCutoverDate] = useState<string>(initialCutoverDate);
+  const [time, setTime] = useState<string>(() => formatDateTo12Hours(new Date(initialCutoverDate)));
+  const [cutoverMode, setCutoverMode] = useState<CutoverMode>(
+    hasExistingCutover ? CUTOVER_MODE_SCHEDULED : CUTOVER_MODE_ASAP,
+  );
+  const [prevExistingCutoverValue, setPrevExistingCutoverValue] = useState(existingCutoverValue);
+
+  if (existingCutoverValue !== prevExistingCutoverValue) {
+    setPrevExistingCutoverValue(existingCutoverValue);
+    const migrationCutoverDate = getInitialCutoverDate(existingCutoverValue);
+    setCutoverDate(migrationCutoverDate);
+    setTime(formatDateTo12Hours(new Date(migrationCutoverDate)));
+    setCutoverMode(existingCutoverValue ? CUTOVER_MODE_SCHEDULED : CUTOVER_MODE_ASAP);
+  }
+
+  return {
+    cutoverDate,
+    cutoverMode,
+    setCutoverDate,
+    setCutoverMode,
+    setTime,
+    time,
+  };
+};

--- a/src/plans/create/steps/migration-hooks/HooksStep.tsx
+++ b/src/plans/create/steps/migration-hooks/HooksStep.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useEffect, useState } from 'react';
+import { type FC, useCallback, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import WizardStepContainer from '@components/common/WizardStepContainer';
@@ -33,12 +33,14 @@ const HooksStep: FC = () => {
   });
 
   const [aapJobTemplates, setAapJobTemplates] = useState<AapJobTemplate[]>([]);
+  const [prevHookSource, setPrevHookSource] = useState(hookSource);
 
-  useEffect(() => {
+  if (hookSource !== prevHookSource) {
+    setPrevHookSource(hookSource);
     if (hookSource !== HOOK_SOURCE_AAP) {
       setAapJobTemplates([]);
     }
-  }, [hookSource]);
+  }
 
   const handleAapConnected = useCallback((templates: AapJobTemplate[]): void => {
     setAapJobTemplates(templates);

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/hooks/useEditLUKSState.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/hooks/useEditLUKSState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { SOURCE_SECRET_LABEL } from 'src/plans/create/utils/copyDecryptionSecret';
 
 import { type IoK8sApiCoreV1Secret, SecretModel } from '@forklift-ui/types';
@@ -23,6 +23,30 @@ export type DecryptionMode = typeof DECRYPTION_MODE_EXISTING | typeof DECRYPTION
 
 export { DECRYPTION_MODE_EXISTING, DECRYPTION_MODE_PASSPHRASES };
 
+const getNbdeClevisFromResource = (resource: EditLUKSState['resource']): boolean => {
+  const vms = getPlanVirtualMachines(resource) as EnhancedPlanSpecVms[];
+  if (isEmpty(vms)) {
+    return false;
+  }
+  return vms[0]?.nbdeClevis ?? false;
+};
+
+const decodeSecretPassphrases = (secretData: Record<string, string> | undefined): string[] => {
+  if (!secretData) {
+    return [];
+  }
+
+  return Object.values(secretData)
+    .map((secretValue) => {
+      try {
+        return atob(secretValue);
+      } catch {
+        return '';
+      }
+    })
+    .filter(Boolean);
+};
+
 export const useEditLUKSState = (resource: EditLUKSState['resource']): EditLUKSState => {
   const secretName = getLUKSSecretName(resource);
   const secretNamespace = getNamespace(resource);
@@ -44,52 +68,38 @@ export const useEditLUKSState = (resource: EditLUKSState['resource']): EditLUKSS
 
   const [secret] = useK8sWatchResource<IoK8sApiCoreV1Secret>(watchResource);
 
+  const derivedNbdeClevis = getNbdeClevisFromResource(resource);
   const [value, setValue] = useState<string[]>([]);
-  const [nbdeClevis, setNbdeClevis] = useState<boolean>(false);
+  const [nbdeClevis, setNbdeClevis] = useState<boolean>(derivedNbdeClevis);
   const [decryptionMode, setDecryptionMode] = useState<DecryptionMode>(DECRYPTION_MODE_PASSPHRASES);
   const [selectedSecret, setSelectedSecret] = useState<IoK8sApiCoreV1Secret | undefined>();
-  const [modeInitialized, setModeInitialized] = useState(false);
+  const [prevResource, setPrevResource] = useState(resource);
+  const [prevSecretDataKey, setPrevSecretDataKey] = useState<string | undefined>();
+  const modeInitializedRef = useRef(false);
 
-  useEffect(() => {
-    const vms = getPlanVirtualMachines(resource) as EnhancedPlanSpecVms[];
-    if (!isEmpty(vms)) {
-      setNbdeClevis(vms[0]?.nbdeClevis ?? false);
-    }
-  }, [resource]);
+  if (resource !== prevResource) {
+    setPrevResource(resource);
+    setNbdeClevis(getNbdeClevisFromResource(resource));
+  }
 
-  useEffect(() => {
-    if (modeInitialized || !secret?.metadata) {
-      return;
-    }
+  if (nbdeClevis && !isEmpty(value)) {
+    setValue([]);
+  }
 
-    const isFromExisting = Boolean(secret.metadata.labels?.[SOURCE_SECRET_LABEL]);
-    if (isFromExisting) {
+  if (!modeInitializedRef.current && secret?.metadata) {
+    modeInitializedRef.current = true;
+    if (secret.metadata.labels?.[SOURCE_SECRET_LABEL]) {
       setDecryptionMode(DECRYPTION_MODE_EXISTING);
     }
-    setModeInitialized(true);
-  }, [modeInitialized, secret?.metadata]);
+  }
 
-  useEffect(() => {
+  const secretDataKey = secretName && secret?.data ? JSON.stringify(secret.data) : undefined;
+  if (secretDataKey !== prevSecretDataKey) {
+    setPrevSecretDataKey(secretDataKey);
     if (secretName && secret?.data && !nbdeClevis) {
-      const decoded = Object.values(secret.data)
-        .map((secretData) => {
-          try {
-            return atob(secretData);
-          } catch {
-            return '';
-          }
-        })
-        .filter(Boolean);
-
-      setValue(decoded);
+      setValue(decodeSecretPassphrases(secret.data));
     }
-  }, [secretName, secret?.data, nbdeClevis]);
-
-  useEffect(() => {
-    if (nbdeClevis) {
-      setValue([]);
-    }
-  }, [nbdeClevis]);
+  }
 
   const handleConfirm = useCallback(async (): Promise<unknown> => {
     if (decryptionMode === DECRYPTION_MODE_EXISTING && selectedSecret) {

--- a/src/providers/hooks/useK8sWatchProviderNames.ts
+++ b/src/providers/hooks/useK8sWatchProviderNames.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useMemo } from 'react';
 
 import { ProviderModelGroupVersionKind, type V1beta1Provider } from '@forklift-ui/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -19,10 +19,6 @@ export const useK8sWatchProviderNames = ({
 }: {
   namespace: string;
 }): K8sProvidersWatchResult => {
-  const [names, setNames] = useState<string[] | undefined>(undefined);
-  const [namesLoaded, setLoaded] = useState(false);
-  const [namesLoadError, setLoadError] = useState<Error | null>(null);
-
   const [providers, providersLoaded, providersLoadError] = useK8sWatchResource<V1beta1Provider[]>({
     groupVersionKind: ProviderModelGroupVersionKind,
     isList: true,
@@ -30,33 +26,18 @@ export const useK8sWatchProviderNames = ({
     namespaced: true,
   });
 
-  const handleLoadError = useCallback((error: Error | null) => {
-    setLoadError(error);
-    setLoaded(true);
-  }, []);
+  const names = useMemo(() => {
+    if (!providersLoaded || providersLoadError) {
+      return undefined;
+    }
 
-  const handleLoadedProviders = useCallback((loadedProviders: V1beta1Provider[] | null) => {
-    setLoaded(true);
-
-    const loadedNames: string[] = (loadedProviders ?? []).reduce<string[]>((acc, nextProvider) => {
+    return (providers ?? []).reduce<string[]>((acc, nextProvider) => {
       if (nextProvider.metadata?.name) {
         acc.push(nextProvider.metadata.name);
       }
       return acc;
     }, []);
+  }, [providers, providersLoaded, providersLoadError]);
 
-    setNames(loadedNames);
-  }, []);
-
-  useEffect(() => {
-    if (providersLoaded) {
-      if (providersLoadError) {
-        handleLoadError(providersLoadError as Error);
-        return;
-      }
-      handleLoadedProviders(providers);
-    }
-  }, [providers, providersLoaded, providersLoadError, handleLoadError, handleLoadedProviders]);
-
-  return [names, namesLoaded, namesLoadError];
+  return [names, providersLoaded, (providersLoadError as Error | null) ?? null];
 };

--- a/src/providers/hooks/useK8sWatchProviderNames.ts
+++ b/src/providers/hooks/useK8sWatchProviderNames.ts
@@ -39,5 +39,13 @@ export const useK8sWatchProviderNames = ({
     }, []);
   }, [providers, providersLoaded, providersLoadError]);
 
-  return [names, providersLoaded, (providersLoadError as Error | null) ?? null];
+  let loadError: Error | null = null;
+  if (providersLoadError !== undefined && providersLoadError !== null) {
+    loadError =
+      providersLoadError instanceof Error
+        ? providersLoadError
+        : new Error(String(providersLoadError));
+  }
+
+  return [names, providersLoaded, loadError];
 };

--- a/src/storageMaps/create/fields/ProjectSelectField.tsx
+++ b/src/storageMaps/create/fields/ProjectSelectField.tsx
@@ -35,12 +35,13 @@ const ProjectSelectField: FC = () => {
 
   const defaultProject = useDefaultProject(projectNames);
   const [showDefaultProjects, setShowDefaultProjects] = useState<boolean>(false);
+  const effectiveShowDefaultProjects =
+    showDefaultProjects || Boolean(defaultProject && isSystemNamespace(defaultProject));
 
   // Automatically set the default project once it's resolved
   useEffect(() => {
     if (defaultProject) {
       setValue(StorageMapFieldId.Project, defaultProject);
-      setShowDefaultProjects((prev) => prev || isSystemNamespace(defaultProject));
     }
   }, [defaultProject, setValue]);
 
@@ -66,7 +67,7 @@ const ProjectSelectField: FC = () => {
         render={({ field }) => (
           <div ref={field.ref}>
             <ProjectSelect
-              showDefaultProjects={showDefaultProjects}
+              showDefaultProjects={effectiveShowDefaultProjects}
               setShowDefaultProjects={setShowDefaultProjects}
               isDisabled={isSubmitting}
               placeholder={t('Select project')}

--- a/src/utils/hooks/useIsDarkTheme.ts
+++ b/src/utils/hooks/useIsDarkTheme.ts
@@ -1,21 +1,17 @@
 import { useEffect, useState } from 'react';
 
+const getIsDarkTheme = (): boolean =>
+  document.documentElement.classList.contains('pf-v6-theme-dark');
+
 export const useIsDarkTheme = (): boolean => {
-  const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [isDarkTheme, setIsDarkTheme] = useState(getIsDarkTheme);
 
   useEffect(() => {
-    const checkDarkTheme = () => {
-      const hasDarkTheme = document.documentElement.classList.contains('pf-v6-theme-dark');
-      setIsDarkTheme(hasDarkTheme);
-    };
-
     const observer = new MutationObserver(() => {
-      checkDarkTheme();
+      setIsDarkTheme(getIsDarkTheme());
     });
 
     observer.observe(document.documentElement, { attributeFilter: ['class'], attributes: true });
-
-    checkDarkTheme();
 
     return () => {
       observer.disconnect();

--- a/src/utils/hooks/useProviderInventory.ts
+++ b/src/utils/hooks/useProviderInventory.ts
@@ -77,6 +77,13 @@ const useProviderInventory = <T>({
   const providerType = provider?.spec?.type;
   const providerUid = provider?.metadata?.uid;
   const isValidProvider = providerType !== undefined && providerUid !== undefined;
+  const fetchKey = `${providerType ?? ''}:${providerUid ?? ''}:${subPath}:${String(disabled)}:${String(onRefresh)}`;
+  const [prevFetchKey, setPrevFetchKey] = useState(fetchKey);
+
+  if (fetchKey !== prevFetchKey) {
+    setPrevFetchKey(fetchKey);
+    setLoading(true);
+  }
 
   const forceRefresh = useCallback(() => {
     setOnRefresh((prev) => !prev);
@@ -107,8 +114,6 @@ const useProviderInventory = <T>({
 
   // Fetch data from API
   useEffect(() => {
-    setLoading(true);
-
     const fetchData = async () => {
       if (disabled) {
         return;

--- a/src/utils/hooks/useProviderInventory.ts
+++ b/src/utils/hooks/useProviderInventory.ts
@@ -114,11 +114,16 @@ const useProviderInventory = <T>({
 
   // Fetch data from API
   useEffect(() => {
+    let active = true;
+
     const fetchData = async () => {
       if (disabled) {
         return;
       }
       if (!isValidProvider) {
+        if (!active) {
+          return;
+        }
         const fetchError = new Error('Invalid provider data');
         handleError(fetchError);
 
@@ -134,19 +139,29 @@ const useProviderInventory = <T>({
           fetchTimeout,
         )) as T;
 
+        if (!active) {
+          return;
+        }
+
         updateInventoryIfChanged(
           newInventory,
           fieldsToAvoidComparing ?? DEFAULT_FIELDS_TO_AVOID_COMPARING,
         );
         setError(null);
       } catch (e) {
+        if (!active) {
+          return;
+        }
+
         updateInventoryIfChanged(null, []);
 
         if (e instanceof Error) {
           handleError(e);
         }
       } finally {
-        setLoading(false);
+        if (active) {
+          setLoading(false);
+        }
       }
     };
 
@@ -156,6 +171,7 @@ const useProviderInventory = <T>({
 
     const intervalId = setInterval(fetchData, interval);
     return () => {
+      active = false;
       clearInterval(intervalId);
     };
   }, [


### PR DESCRIPTION
## Summary
- Fix all `@eslint-react` setState-in-useEffect violations (~39 across ~19 files)
- Prefer useMemo / render-time derivation over syncing derived values via useEffect
- Enable the rule as `error`

## Test plan
- [ ] `npx eslint src/ --quiet` has zero set-state-in-effect violations
- [ ] Unit tests for touched hooks/components pass
- [ ] CI passes (lint + unit tests + build)
- [ ] Spot-check LUKS modal, affinity inputs, pagination/selection, cutover modal, Overview settings for regressions

Resolves: MTV-6285

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation and state synchronization across affinity, encryption, hook, and cutover workflows.
  * Corrected pagination, filtering, selection, and overview data handling to prevent stale results and invalid page selections.
  * Ensured system-namespace projects remain visible when required and improved provider loading updates.
  * Improved theme detection and migration/plan summary accuracy during loading or error states.

* **Refactor**
  * Streamlined state handling for more consistent, responsive behavior across forms, filters, selections, and overview data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->