### PR TITLE
Resolves: MTV-6091 | Filter Migration resources to the latest Migration run

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -148,9 +148,11 @@ const id = (disk as unknown as { ID?: string }).ID ?? disk.id;
 - **Do:** Use GVK constants, useK8sWatchResource, k8s* for operations
 - **Do:** Check provider phase before plan creation; handle async statuses
 - **Do:** Verify actual API responses when investigating field-name bugs — type analysis alone is insufficient
+- **Do:** Scope Plan "Migration resources" watches by both `plan` and `migration` labels (`useMigrationResources` + `useLatestPlanMigration`) — plan-only matching mixes resources across restarts (MTV-6091)
 - **Don't:** Import from feature code in shared (`components/`, `utils/`)
 - **Don't:** Assume resources are always loaded — handle loading/error/empty
 - **Don't:** Assume `@forklift-ui/types` field names match API field names for OVA embedded objects
+- **Don't:** Reuse `usePlanMigration` to scope migration resources — it only returns `Running=True`; use `useLatestPlanMigration` for Failed/Succeeded/restartable views
 
 ---
 

--- a/src/plans/details/tabs/Details/components/MigrationsSection/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/MigrationsSection/utils/utils.ts
@@ -1,9 +1,1 @@
-import type { V1beta1Migration } from '@forklift-ui/types';
-
-export const sortMigrationsByStartedAtDate = (migrations: V1beta1Migration[]) =>
-  // Copy-then-sort: ES2022 target has no Array.prototype.toSorted (ES2023).
-  [...migrations].sort((migrationA, migrationB) => {
-    const dateA = new Date(migrationA?.status?.started ?? '');
-    const dateB = new Date(migrationB?.status?.started ?? '');
-    return dateB.getTime() - dateA.getTime();
-  });
+export { sortMigrationsByStartedAtDate } from 'src/plans/utils/sortMigrationsByStartedAtDate';

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
@@ -66,7 +66,7 @@ describe('useMigrationResources', () => {
     const watchCalls = mockUseK8sWatchResource.mock.calls.map((call) => call[0]);
     const nonNullWatches = watchCalls.filter(Boolean);
 
-    expect(nonNullWatches.length).toBe(4);
+    expect(nonNullWatches).toHaveLength(4);
     for (const watch of nonNullWatches) {
       expect(watch.selector.matchLabels).toEqual({
         migration: MIGRATION_UID,
@@ -92,5 +92,59 @@ describe('useMigrationResources', () => {
       namespace: 'openshift-mtv',
       selector: { matchLabels: { migration: MIGRATION_UID, plan: PLAN_UID } },
     });
+  });
+
+  it('stays unloaded while the latest migration watch is still loading', () => {
+    mockUseLatestPlanMigration.mockReturnValue([undefined, false, undefined]);
+
+    const { result } = renderHook(() => useMigrationResources(mockPlan));
+
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('stays unloaded until every enabled resource watch has loaded', () => {
+    mockUseLatestPlanMigration.mockReturnValue([
+      { metadata: { uid: MIGRATION_UID } },
+      true,
+      undefined,
+    ]);
+    mockUseK8sWatchResource
+      .mockReturnValueOnce([[], true, undefined])
+      .mockReturnValueOnce([[], true, undefined])
+      .mockReturnValueOnce([[], false, undefined])
+      .mockReturnValueOnce([[], true, undefined]);
+
+    const { result } = renderHook(() => useMigrationResources(mockPlan));
+
+    expect(result.current.loaded).toBe(false);
+  });
+
+  it('propagates errors from useLatestPlanMigration', () => {
+    const migrationError = new Error('migration watch failed');
+    mockUseLatestPlanMigration.mockReturnValue([undefined, true, migrationError]);
+
+    const { result } = renderHook(() => useMigrationResources(mockPlan));
+
+    expect(result.current.error).toBe(migrationError);
+    expect(result.current.loaded).toBe(true);
+  });
+
+  it('propagates errors from an enabled resource watch', () => {
+    const podsError = new Error('pods watch failed');
+    mockUseLatestPlanMigration.mockReturnValue([
+      { metadata: { uid: MIGRATION_UID } },
+      true,
+      undefined,
+    ]);
+    mockUseK8sWatchResource
+      .mockReturnValueOnce([[], true, podsError])
+      .mockReturnValueOnce([[], true, undefined])
+      .mockReturnValueOnce([[], true, undefined])
+      .mockReturnValueOnce([[], true, undefined]);
+
+    const { result } = renderHook(() => useMigrationResources(mockPlan));
+
+    expect(result.current.error).toBe(podsError);
+    expect(result.current.loaded).toBe(true);
   });
 });

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
@@ -1,0 +1,96 @@
+import type { V1beta1Plan } from '@forklift-ui/types';
+import { renderHook } from '@testing-library/react';
+
+import { useMigrationResources } from '../useMigrationResources';
+
+const mockUseK8sWatchResource = jest.fn();
+const mockUseLatestPlanMigration = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
+}));
+
+jest.mock('src/plans/hooks/useLatestPlanMigration', () => ({
+  useLatestPlanMigration: jest.fn((...args: unknown[]) => mockUseLatestPlanMigration(...args)),
+}));
+
+jest.mock('../../../utils/utils', () => ({
+  getPlanVirtualMachinesDict: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../utils/getPlanVirtualMachineIdByName', () => ({
+  getPlanVirtualMachineIdByName: jest.fn(),
+}));
+
+jest.mock('../../utils/utils', () => ({
+  groupByVmId: jest.fn(() => ({})),
+}));
+
+const PLAN_UID = 'plan-uid-abc';
+const MIGRATION_UID = 'migration-uid-xyz';
+const TARGET_NS = 'openshift-mtv';
+
+const mockPlan = {
+  metadata: { name: 'mtv-6091-offload', namespace: 'openshift-mtv', uid: PLAN_UID },
+  spec: {
+    targetNamespace: TARGET_NS,
+    vms: [{ id: 'vm-1008', name: 'mtv-tests-rhel8' }],
+  },
+} as unknown as V1beta1Plan;
+
+describe('useMigrationResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseK8sWatchResource.mockReturnValue([[], true, undefined]);
+  });
+
+  it('disables resource watches when no latest migration exists', () => {
+    mockUseLatestPlanMigration.mockReturnValue([undefined, true, undefined]);
+
+    const { result } = renderHook(() => useMigrationResources(mockPlan));
+
+    expect(mockUseK8sWatchResource).toHaveBeenCalledWith(null);
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.migrationListData).toHaveLength(1);
+  });
+
+  it('scopes Pod/PVC/DV watches to plan and latest migration UIDs', () => {
+    mockUseLatestPlanMigration.mockReturnValue([
+      { metadata: { uid: MIGRATION_UID } },
+      true,
+      undefined,
+    ]);
+
+    renderHook(() => useMigrationResources(mockPlan));
+
+    const watchCalls = mockUseK8sWatchResource.mock.calls.map((call) => call[0]);
+    const nonNullWatches = watchCalls.filter(Boolean);
+
+    expect(nonNullWatches.length).toBe(4);
+    for (const watch of nonNullWatches) {
+      expect(watch.selector.matchLabels).toEqual({
+        migration: MIGRATION_UID,
+        plan: PLAN_UID,
+      });
+    }
+  });
+
+  it('keeps Jobs watch in the plan namespace while still filtering by migration', () => {
+    mockUseLatestPlanMigration.mockReturnValue([
+      { metadata: { uid: MIGRATION_UID } },
+      true,
+      undefined,
+    ]);
+
+    renderHook(() => useMigrationResources(mockPlan));
+
+    const jobWatch = mockUseK8sWatchResource.mock.calls
+      .map((call) => call[0])
+      .find((watch) => watch?.groupVersionKind?.kind === 'Job');
+
+    expect(jobWatch).toMatchObject({
+      namespace: 'openshift-mtv',
+      selector: { matchLabels: { migration: MIGRATION_UID, plan: PLAN_UID } },
+    });
+  });
+});

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/__tests__/useMigrationResources.test.ts
@@ -28,12 +28,12 @@ jest.mock('../../utils/utils', () => ({
 
 const PLAN_UID = 'plan-uid-abc';
 const MIGRATION_UID = 'migration-uid-xyz';
-const TARGET_NS = 'openshift-mtv';
+const OPENSHIFT_MTV_NS = 'openshift-mtv';
 
 const mockPlan = {
-  metadata: { name: 'mtv-6091-offload', namespace: 'openshift-mtv', uid: PLAN_UID },
+  metadata: { name: 'mtv-6091-offload', namespace: OPENSHIFT_MTV_NS, uid: PLAN_UID },
   spec: {
-    targetNamespace: TARGET_NS,
+    targetNamespace: OPENSHIFT_MTV_NS,
     vms: [{ id: 'vm-1008', name: 'mtv-tests-rhel8' }],
   },
 } as unknown as V1beta1Plan;
@@ -89,7 +89,7 @@ describe('useMigrationResources', () => {
       .find((watch) => watch?.groupVersionKind?.kind === 'Job');
 
     expect(jobWatch).toMatchObject({
-      namespace: 'openshift-mtv',
+      namespace: OPENSHIFT_MTV_NS,
       selector: { matchLabels: { migration: MIGRATION_UID, plan: PLAN_UID } },
     });
   });

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useLatestPlanMigration } from 'src/plans/hooks/useLatestPlanMigration';
 
 import type {
   IoK8sApiBatchV1Job,
@@ -7,7 +8,7 @@ import type {
   V1beta1DataVolume,
   V1beta1Plan,
 } from '@forklift-ui/types';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource, type WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   DataVolumeModelGroupVersionKind,
   JobModelGroupVersionKind,
@@ -33,75 +34,95 @@ type MigrationResources = {
 };
 
 export const useMigrationResources = (plan: V1beta1Plan): MigrationResources => {
-  const watchOptions = {
-    isList: true,
-    namespace: getPlanTargetNamespace(plan),
-    namespaced: true,
-    selector: { matchLabels: { plan: getUID(plan) ?? '' } },
-  };
+  const [latestMigration, migrationLoaded, migrationError] = useLatestPlanMigration(plan);
+  const migrationUid = getUID(latestMigration);
+  const planUid = getUID(plan);
 
-  const [pods, podsLoaded, podsError] = useK8sWatchResource<IoK8sApiCoreV1Pod[]>({
-    ...watchOptions,
-    groupVersionKind: PodModelGroupVersionKind,
-  });
+  const watchOptions = useMemo((): WatchK8sResource | null => {
+    if (!migrationUid || !planUid) {
+      return null;
+    }
 
-  const [jobs, jobsLoaded, jobsError] = useK8sWatchResource<IoK8sApiBatchV1Job[]>({
-    ...watchOptions,
-    groupVersionKind: JobModelGroupVersionKind,
-    namespace: getNamespace(plan),
-  });
+    return {
+      isList: true,
+      namespace: getPlanTargetNamespace(plan),
+      namespaced: true,
+      selector: {
+        matchLabels: {
+          migration: migrationUid,
+          plan: planUid,
+        },
+      },
+    };
+  }, [migrationUid, plan, planUid]);
 
-  const [pvcs, pvcsLoaded, pvcsError] = useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>({
-    ...watchOptions,
-    groupVersionKind: PersistentVolumeClaimModelGroupVersionKind,
-  });
+  const [pods, podsLoaded, podsError] = useK8sWatchResource<IoK8sApiCoreV1Pod[]>(
+    watchOptions ? { ...watchOptions, groupVersionKind: PodModelGroupVersionKind } : null,
+  );
 
-  const [dvs, dvsLoaded, dvsError] = useK8sWatchResource<V1beta1DataVolume[]>({
-    ...watchOptions,
-    groupVersionKind: DataVolumeModelGroupVersionKind,
-  });
+  const [jobs, jobsLoaded, jobsError] = useK8sWatchResource<IoK8sApiBatchV1Job[]>(
+    watchOptions
+      ? {
+          ...watchOptions,
+          groupVersionKind: JobModelGroupVersionKind,
+          namespace: getNamespace(plan),
+        }
+      : null,
+  );
+
+  const [pvcs, pvcsLoaded, pvcsError] = useK8sWatchResource<IoK8sApiCoreV1PersistentVolumeClaim[]>(
+    watchOptions
+      ? { ...watchOptions, groupVersionKind: PersistentVolumeClaimModelGroupVersionKind }
+      : null,
+  );
+
+  const [dvs, dvsLoaded, dvsError] = useK8sWatchResource<V1beta1DataVolume[]>(
+    watchOptions ? { ...watchOptions, groupVersionKind: DataVolumeModelGroupVersionKind } : null,
+  );
 
   const virtualMachines = getPlanVirtualMachines(plan);
+  const resourcesReady = Boolean(migrationUid && planUid);
+  const resourcesLoaded = !resourcesReady || (podsLoaded && jobsLoaded && pvcsLoaded && dvsLoaded);
 
   const dvsDict = useMemo(
-    () => (dvsLoaded && !dvsError ? groupByVmId(dvs) : {}),
-    [dvs, dvsLoaded, dvsError],
+    () => (resourcesReady && dvsLoaded && !dvsError ? groupByVmId(dvs) : {}),
+    [resourcesReady, dvs, dvsLoaded, dvsError],
   );
   const jobsDict = useMemo(
-    () => (jobsLoaded && !jobsError ? groupByVmId(jobs) : {}),
-    [jobs, jobsLoaded, jobsError],
+    () => (resourcesReady && jobsLoaded && !jobsError ? groupByVmId(jobs) : {}),
+    [resourcesReady, jobs, jobsLoaded, jobsError],
   );
   const podsDict = useMemo(
-    () => (podsLoaded && !podsError ? groupByVmId(pods) : {}),
-    [pods, podsLoaded, podsError],
+    () => (resourcesReady && podsLoaded && !podsError ? groupByVmId(pods) : {}),
+    [resourcesReady, pods, podsLoaded, podsError],
   );
   const pvcsDict = useMemo(
-    () => (pvcsLoaded && !pvcsError ? groupByVmId(pvcs) : {}),
-    [pvcs, pvcsLoaded, pvcsError],
+    () => (resourcesReady && pvcsLoaded && !pvcsError ? groupByVmId(pvcs) : {}),
+    [resourcesReady, pvcs, pvcsLoaded, pvcsError],
   );
 
   const vmDict = getPlanVirtualMachinesDict(plan);
 
   const migrationListData = useMemo(() => {
     return virtualMachines.map((specVM) => {
-      const id = specVM?.id ?? getPlanVirtualMachineIdByName(plan, specVM?.name);
+      const id = specVM?.id ?? getPlanVirtualMachineIdByName(plan, specVM?.name) ?? '';
       return {
-        dvs: dvsDict[id ?? ''],
+        dvs: dvsDict[id],
         isWarm: getPlanIsWarm(plan),
-        jobs: jobsDict[id ?? ''],
+        jobs: jobsDict[id],
         plan,
-        pods: podsDict[id ?? ''],
-        pvcs: pvcsDict[id ?? ''],
+        pods: podsDict[id],
+        pvcs: pvcsDict[id],
         specVM,
-        statusVM: vmDict[id ?? ''],
+        statusVM: vmDict[id],
         targetNamespace: getPlanTargetNamespace(plan),
       };
     }) as MigrationStatusVirtualMachinePageData[];
   }, [virtualMachines, dvsDict, jobsDict, podsDict, pvcsDict, vmDict, plan]);
 
   return {
-    error: podsError ?? jobsError ?? pvcsError ?? dvsError,
-    loaded: podsLoaded && jobsLoaded && pvcsLoaded && dvsLoaded,
+    error: migrationError ?? podsError ?? jobsError ?? pvcsError ?? dvsError,
+    loaded: migrationLoaded && resourcesLoaded,
     migrationListData,
   };
 };

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
@@ -81,24 +81,24 @@ export const useMigrationResources = (plan: V1beta1Plan): MigrationResources => 
   );
 
   const virtualMachines = getPlanVirtualMachines(plan);
-  const resourcesReady = Boolean(migrationUid && planUid);
-  const resourcesLoaded = !resourcesReady || (podsLoaded && jobsLoaded && pvcsLoaded && dvsLoaded);
+  const hasWatchScope = Boolean(migrationUid && planUid);
+  const resourcesLoaded = !hasWatchScope || (podsLoaded && jobsLoaded && pvcsLoaded && dvsLoaded);
 
   const dvsDict = useMemo(
-    () => (resourcesReady && dvsLoaded && !dvsError ? groupByVmId(dvs) : {}),
-    [resourcesReady, dvs, dvsLoaded, dvsError],
+    () => (hasWatchScope && dvsLoaded && !dvsError ? groupByVmId(dvs) : {}),
+    [hasWatchScope, dvs, dvsLoaded, dvsError],
   );
   const jobsDict = useMemo(
-    () => (resourcesReady && jobsLoaded && !jobsError ? groupByVmId(jobs) : {}),
-    [resourcesReady, jobs, jobsLoaded, jobsError],
+    () => (hasWatchScope && jobsLoaded && !jobsError ? groupByVmId(jobs) : {}),
+    [hasWatchScope, jobs, jobsLoaded, jobsError],
   );
   const podsDict = useMemo(
-    () => (resourcesReady && podsLoaded && !podsError ? groupByVmId(pods) : {}),
-    [resourcesReady, pods, podsLoaded, podsError],
+    () => (hasWatchScope && podsLoaded && !podsError ? groupByVmId(pods) : {}),
+    [hasWatchScope, pods, podsLoaded, podsError],
   );
   const pvcsDict = useMemo(
-    () => (resourcesReady && pvcsLoaded && !pvcsError ? groupByVmId(pvcs) : {}),
-    [resourcesReady, pvcs, pvcsLoaded, pvcsError],
+    () => (hasWatchScope && pvcsLoaded && !pvcsError ? groupByVmId(pvcs) : {}),
+    [hasWatchScope, pvcs, pvcsLoaded, pvcsError],
   );
 
   const vmDict = getPlanVirtualMachinesDict(plan);

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationResources.ts
@@ -35,7 +35,7 @@ type MigrationResources = {
 
 export const useMigrationResources = (plan: V1beta1Plan): MigrationResources => {
   const [latestMigration, migrationLoaded, migrationError] = useLatestPlanMigration(plan);
-  const migrationUid = getUID(latestMigration);
+  const migrationUid = latestMigration ? getUID(latestMigration) : undefined;
   const planUid = getUID(plan);
 
   const watchOptions = useMemo((): WatchK8sResource | null => {

--- a/src/plans/hooks/__tests__/useLatestPlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/useLatestPlanMigration.test.ts
@@ -1,0 +1,141 @@
+import type { V1beta1Migration, V1beta1Plan } from '@forklift-ui/types';
+import { renderHook } from '@testing-library/react';
+
+import { useLatestPlanMigration } from '../useLatestPlanMigration';
+
+const mockUseK8sWatchResource = jest.fn();
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
+}));
+
+const PLAN_UID = 'plan-uid-123';
+const TEST_NAMESPACE = 'test-ns';
+
+const mockPlan = {
+  metadata: { name: 'test-plan', namespace: TEST_NAMESPACE, uid: PLAN_UID },
+} as unknown as V1beta1Plan;
+
+type MigrationTestOverrides = {
+  metadata?: {
+    creationTimestamp?: string;
+    name?: string;
+    namespace?: string;
+    ownerReferences?: { uid: string }[];
+  };
+  status?: {
+    conditions?: { status: string; type: string }[];
+    started?: string;
+  };
+};
+
+const buildMigration = (overrides: MigrationTestOverrides = {}): V1beta1Migration =>
+  ({
+    ...overrides,
+    metadata: {
+      creationTimestamp: '2026-08-05T17:00:00Z',
+      name: 'test-migration',
+      namespace: TEST_NAMESPACE,
+      ownerReferences: [{ uid: PLAN_UID }],
+      ...overrides.metadata,
+    },
+    status: {
+      conditions: [{ status: 'False', type: 'Running' }],
+      ...overrides.status,
+    },
+  }) as unknown as V1beta1Migration;
+
+describe('useLatestPlanMigration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined when migrations are not loaded yet', () => {
+    mockUseK8sWatchResource.mockReturnValue([undefined, false, undefined]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('returns undefined when there is a load error', () => {
+    const loadError = new Error('boom');
+    mockUseK8sWatchResource.mockReturnValue([[buildMigration()], true, loadError]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+    expect(result.current[2]).toBe(loadError);
+  });
+
+  it('ignores migrations owned by a different plan', () => {
+    const otherPlansMigration = buildMigration({
+      metadata: {
+        name: 'other',
+        namespace: TEST_NAMESPACE,
+        ownerReferences: [{ uid: 'some-other-uid' }],
+      },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[otherPlansMigration], true, undefined]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('returns a Failed owned migration (not only Running)', () => {
+    const failedMigration = buildMigration({
+      status: {
+        conditions: [{ status: 'True', type: 'Failed' }],
+        started: '2026-08-05T17:49:00Z',
+      },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[failedMigration], true, undefined]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBe(failedMigration);
+  });
+
+  it('picks the newest owned migration by status.started', () => {
+    const older = buildMigration({
+      metadata: { name: 'older', namespace: TEST_NAMESPACE, ownerReferences: [{ uid: PLAN_UID }] },
+      status: { started: '2026-08-05T17:49:00Z' },
+    });
+    const newer = buildMigration({
+      metadata: { name: 'newer', namespace: TEST_NAMESPACE, ownerReferences: [{ uid: PLAN_UID }] },
+      status: { started: '2026-08-05T17:51:00Z' },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[older, newer], true, undefined]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBe(newer);
+  });
+
+  it('falls back to creationTimestamp when status.started is missing', () => {
+    const olderByCreation = buildMigration({
+      metadata: {
+        creationTimestamp: '2026-08-05T17:49:00Z',
+        name: 'older-creation',
+        namespace: TEST_NAMESPACE,
+        ownerReferences: [{ uid: PLAN_UID }],
+      },
+      status: { conditions: [] },
+    });
+    const newerByCreation = buildMigration({
+      metadata: {
+        creationTimestamp: '2026-08-05T17:51:00Z',
+        name: 'newer-creation',
+        namespace: TEST_NAMESPACE,
+        ownerReferences: [{ uid: PLAN_UID }],
+      },
+      status: { conditions: [] },
+    });
+    mockUseK8sWatchResource.mockReturnValue([[olderByCreation, newerByCreation], true, undefined]);
+
+    const { result } = renderHook(() => useLatestPlanMigration(mockPlan));
+
+    expect(result.current[0]).toBe(newerByCreation);
+  });
+});

--- a/src/plans/hooks/__tests__/useLatestPlanMigration.test.ts
+++ b/src/plans/hooks/__tests__/useLatestPlanMigration.test.ts
@@ -10,6 +10,9 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 
 const PLAN_UID = 'plan-uid-123';
 const TEST_NAMESPACE = 'test-ns';
+const DEFAULT_CREATION_TIMESTAMP = '2026-08-05T17:00:00Z';
+const STARTED_NEWER = '2026-08-05T17:51:00Z';
+const STARTED_OLDER = '2026-08-05T17:49:00Z';
 
 const mockPlan = {
   metadata: { name: 'test-plan', namespace: TEST_NAMESPACE, uid: PLAN_UID },
@@ -32,7 +35,7 @@ const buildMigration = (overrides: MigrationTestOverrides = {}): V1beta1Migratio
   ({
     ...overrides,
     metadata: {
-      creationTimestamp: '2026-08-05T17:00:00Z',
+      creationTimestamp: DEFAULT_CREATION_TIMESTAMP,
       name: 'test-migration',
       namespace: TEST_NAMESPACE,
       ownerReferences: [{ uid: PLAN_UID }],
@@ -87,7 +90,7 @@ describe('useLatestPlanMigration', () => {
     const failedMigration = buildMigration({
       status: {
         conditions: [{ status: 'True', type: 'Failed' }],
-        started: '2026-08-05T17:49:00Z',
+        started: STARTED_OLDER,
       },
     });
     mockUseK8sWatchResource.mockReturnValue([[failedMigration], true, undefined]);
@@ -100,11 +103,11 @@ describe('useLatestPlanMigration', () => {
   it('picks the newest owned migration by status.started', () => {
     const older = buildMigration({
       metadata: { name: 'older', namespace: TEST_NAMESPACE, ownerReferences: [{ uid: PLAN_UID }] },
-      status: { started: '2026-08-05T17:49:00Z' },
+      status: { started: STARTED_OLDER },
     });
     const newer = buildMigration({
       metadata: { name: 'newer', namespace: TEST_NAMESPACE, ownerReferences: [{ uid: PLAN_UID }] },
-      status: { started: '2026-08-05T17:51:00Z' },
+      status: { started: STARTED_NEWER },
     });
     mockUseK8sWatchResource.mockReturnValue([[older, newer], true, undefined]);
 
@@ -116,7 +119,7 @@ describe('useLatestPlanMigration', () => {
   it('falls back to creationTimestamp when status.started is missing', () => {
     const olderByCreation = buildMigration({
       metadata: {
-        creationTimestamp: '2026-08-05T17:49:00Z',
+        creationTimestamp: STARTED_OLDER,
         name: 'older-creation',
         namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: PLAN_UID }],
@@ -125,7 +128,7 @@ describe('useLatestPlanMigration', () => {
     });
     const newerByCreation = buildMigration({
       metadata: {
-        creationTimestamp: '2026-08-05T17:51:00Z',
+        creationTimestamp: STARTED_NEWER,
         name: 'newer-creation',
         namespace: TEST_NAMESPACE,
         ownerReferences: [{ uid: PLAN_UID }],

--- a/src/plans/hooks/useLatestPlanMigration.ts
+++ b/src/plans/hooks/useLatestPlanMigration.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { sortMigrationsByStartedAtDate } from 'src/plans/utils/sortMigrationsByStartedAtDate';
+
+import {
+  MigrationModelGroupVersionKind,
+  type V1beta1Migration,
+  type V1beta1Plan,
+} from '@forklift-ui/types';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getNamespace, getOwnerReference, getUID } from '@utils/crds/common/selectors';
+import { isEmpty } from '@utils/helpers';
+
+/**
+ * Returns the most recent Migration CR owned by the plan (by status.started,
+ * falling back to creationTimestamp), regardless of Running/Failed/Succeeded.
+ * Used to scope migration-created resources (pods, PVCs, …) to a single run.
+ */
+export const useLatestPlanMigration = (
+  plan: V1beta1Plan,
+): [V1beta1Migration | undefined, boolean, Error | undefined] => {
+  const [migrations, migrationLoaded, migrationLoadError] = useK8sWatchResource<V1beta1Migration[]>(
+    {
+      groupVersionKind: MigrationModelGroupVersionKind,
+      isList: true,
+      namespace: getNamespace(plan),
+      namespaced: true,
+    },
+  );
+
+  const latestMigration = useMemo(() => {
+    if (!migrationLoaded || migrationLoadError || isEmpty(migrations)) {
+      return undefined;
+    }
+
+    const planMigrations = migrations.filter(
+      (migration) => getOwnerReference(migration)?.uid === getUID(plan),
+    );
+
+    if (isEmpty(planMigrations)) {
+      return undefined;
+    }
+
+    return sortMigrationsByStartedAtDate(planMigrations)[0];
+  }, [migrations, migrationLoaded, migrationLoadError, plan]);
+
+  return [latestMigration, migrationLoaded, migrationLoadError as Error | undefined];
+};

--- a/src/plans/utils/__tests__/sortMigrationsByStartedAtDate.test.ts
+++ b/src/plans/utils/__tests__/sortMigrationsByStartedAtDate.test.ts
@@ -1,0 +1,53 @@
+import type { V1beta1Migration } from '@forklift-ui/types';
+
+import { sortMigrationsByStartedAtDate } from '../sortMigrationsByStartedAtDate';
+
+const buildMigration = ({
+  creationTimestamp,
+  name,
+  started,
+}: {
+  creationTimestamp?: string;
+  name: string;
+  started?: string;
+}): V1beta1Migration =>
+  ({
+    metadata: { creationTimestamp, name },
+    status: started === undefined ? {} : { started },
+  }) as unknown as V1beta1Migration;
+
+describe('sortMigrationsByStartedAtDate', () => {
+  it('sorts by status.started descending', () => {
+    const older = buildMigration({ name: 'older', started: '2026-08-05T17:49:00Z' });
+    const newer = buildMigration({ name: 'newer', started: '2026-08-05T17:51:00Z' });
+
+    expect(
+      sortMigrationsByStartedAtDate([older, newer]).map((migration) => migration.metadata?.name),
+    ).toEqual(['newer', 'older']);
+  });
+
+  it('falls back to creationTimestamp when started is missing', () => {
+    const older = buildMigration({
+      creationTimestamp: '2026-08-05T17:49:00Z',
+      name: 'older',
+    });
+    const newer = buildMigration({
+      creationTimestamp: '2026-08-05T17:51:00Z',
+      name: 'newer',
+    });
+
+    expect(
+      sortMigrationsByStartedAtDate([older, newer]).map((migration) => migration.metadata?.name),
+    ).toEqual(['newer', 'older']);
+  });
+
+  it('does not mutate the input array', () => {
+    const older = buildMigration({ name: 'older', started: '2026-08-05T17:49:00Z' });
+    const newer = buildMigration({ name: 'newer', started: '2026-08-05T17:51:00Z' });
+    const input = [older, newer];
+
+    sortMigrationsByStartedAtDate(input);
+
+    expect(input.map((migration) => migration.metadata?.name)).toEqual(['older', 'newer']);
+  });
+});

--- a/src/plans/utils/sortMigrationsByStartedAtDate.ts
+++ b/src/plans/utils/sortMigrationsByStartedAtDate.ts
@@ -1,0 +1,16 @@
+import type { V1beta1Migration } from '@forklift-ui/types';
+import { getCreatedAt } from '@utils/crds/common/selectors';
+
+/**
+ * Sort migrations newest-first by status.started, falling back to creationTimestamp
+ * when started is missing (e.g. a Migration that has not been reconciled yet).
+ */
+export const sortMigrationsByStartedAtDate = (migrations: V1beta1Migration[]): V1beta1Migration[] =>
+  // Copy-then-sort: ES2022 target has no Array.prototype.toSorted (ES2023).
+  [...migrations].sort((migrationA, migrationB) => {
+    const startedA = migrationA?.status?.started;
+    const startedB = migrationB?.status?.started;
+    const dateA = new Date(startedA ?? getCreatedAt(migrationA) ?? '');
+    const dateB = new Date(startedB ?? getCreatedAt(migrationB) ?? '');
+    return dateB.getTime() - dateA.getTime();
+  });


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6091](https://redhat.atlassian.net/browse/MTV-6091)

## 📝 Description

Plan details → Virtual machines → Migration resources watched pods/PVCs/Jobs/DataVolumes by `plan` UID only, so resources from earlier failed or restarted Migration runs mixed into one list.

Scope those watches to both `plan` and the latest Migration UID (`useLatestPlanMigration`, sorted by `status.started` with `creationTimestamp` fallback). When no Migration exists yet, resource watches stay disabled instead of falling back to plan-only matching.

## 🎥 Demo

After restart/fail cycles, Migration resources shows only the current run’s `populate-*` pods/PVCs (previously mixed timestamps from multiple Migration UIDs). Details → Migration history remains the place to review prior runs.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6091]: https://redhat.atlassian.net/browse/MTV-6091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration status tracking by associating resources with both the selected plan and migration.
  * Resource lists now remain accurate while migration data is loading or unavailable.
  * Latest migrations are selected more reliably, including migrations without a recorded start time.
  * Migration views now better support failed, completed, and restartable migrations.

* **Refactor**
  * Standardized migration sorting across plan details views for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->