### PR TITLE
Resolves: MTV-6374 | Gate Inspect Select All exclusion E2E at MTV 5.0.0+

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-deep-inspection.spec.ts
@@ -12,7 +12,7 @@ import {
   isCompletedInspectionStatus,
 } from '../../../utils/inspection-status';
 import { requireVddk } from '../../../utils/requireVddk';
-import { V2_12_0 } from '../../../utils/version/constants';
+import { V2_12_0, V5_0_0 } from '../../../utils/version/constants';
 import { requireVersion } from '../../../utils/version/version';
 
 // Deep inspection creates vSphere snapshots — only inspect mtv-func-win2022 here.
@@ -262,46 +262,51 @@ test.describe('Plan Deep Inspection', { tag: '@downstream' }, () => {
     });
   });
 
-  test('should exclude VMs with active inspections from Select All', async ({
-    page,
-    testPlan,
-    testProvider: _testProvider,
-  }) => {
-    const { firstVmName, planDetailsPage, secondVmName } = await setupPlanDetailsPage(
+  // MTV-5569 Select All exclusion shipped on main / MTV 5.0.0+; still broken on 2.12.x.
+  test.describe('Select All excludes active inspections', () => {
+    requireVersion(test, V5_0_0);
+
+    test('should exclude VMs with active inspections from Select All', async ({
       page,
       testPlan,
-    );
-    const activeVmRow = planDetailsPage.virtualMachinesTab.getVmRow(firstVmName);
+      testProvider: _testProvider,
+    }) => {
+      const { firstVmName, planDetailsPage, secondVmName } = await setupPlanDetailsPage(
+        page,
+        testPlan,
+      );
+      const activeVmRow = planDetailsPage.virtualMachinesTab.getVmRow(firstVmName);
 
-    await test.step('ensure first VM has an active inspection', async () => {
-      const status = await planDetailsPage.virtualMachinesTab.getVmInspectionStatus(firstVmName);
-      if (!ACTIVE_STATUSES.test(status)) {
+      await test.step('ensure first VM has an active inspection', async () => {
+        const status = await planDetailsPage.virtualMachinesTab.getVmInspectionStatus(firstVmName);
+        if (!ACTIVE_STATUSES.test(status)) {
+          const inspectModal = await planDetailsPage.openInspectModal();
+          await inspectModal.selectVmByName(firstVmName);
+          await inspectModal.clickInspect();
+        }
+        await expect(activeVmRow.getByText(ACTIVE_STATUSES)).toBeVisible({ timeout: 30_000 });
+      });
+
+      await test.step('Select All includes only eligible VMs', async () => {
         const inspectModal = await planDetailsPage.openInspectModal();
-        await inspectModal.selectVmByName(firstVmName);
-        await inspectModal.clickInspect();
-      }
-      await expect(activeVmRow.getByText(ACTIVE_STATUSES)).toBeVisible({ timeout: 30_000 });
-    });
+        await inspectModal.waitForVmTableLoaded();
 
-    await test.step('Select All includes only eligible VMs', async () => {
-      const inspectModal = await planDetailsPage.openInspectModal();
-      await inspectModal.waitForVmTableLoaded();
+        expect(await inspectModal.getVmRowCount()).toBe(2);
+        expect(await inspectModal.isVmCheckboxDisabled(firstVmName)).toBe(true);
+        expect(await inspectModal.isVmCheckboxDisabled(secondVmName)).toBe(false);
 
-      expect(await inspectModal.getVmRowCount()).toBe(2);
-      expect(await inspectModal.isVmCheckboxDisabled(firstVmName)).toBe(true);
-      expect(await inspectModal.isVmCheckboxDisabled(secondVmName)).toBe(false);
+        await inspectModal.selectAllVms();
 
-      await inspectModal.selectAllVms();
+        const eligibleCount = await inspectModal.getEligibleVmCount();
+        expect(eligibleCount).toBe(1);
+        const buttonText = await inspectModal.getConfirmButtonText();
+        expect(buttonText).toContain(`Inspect ${eligibleCount} VM`);
 
-      const eligibleCount = await inspectModal.getEligibleVmCount();
-      expect(eligibleCount).toBe(1);
-      const buttonText = await inspectModal.getConfirmButtonText();
-      expect(buttonText).toContain(`Inspect ${eligibleCount} VM`);
+        expect(await inspectModal.isVmCheckboxChecked(firstVmName)).toBe(false);
+        expect(await inspectModal.isVmCheckboxChecked(secondVmName)).toBe(true);
 
-      expect(await inspectModal.isVmCheckboxChecked(firstVmName)).toBe(false);
-      expect(await inspectModal.isVmCheckboxChecked(secondVmName)).toBe(true);
-
-      await inspectModal.close();
+        await inspectModal.close();
+      });
     });
   });
 


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6374](https://redhat.atlassian.net/browse/MTV-6374)
- Related: [MTV-5569](https://redhat.atlassian.net/browse/MTV-5569) (product fix verified on MTV 5.0.0; still absent on 2.12.x)

## 📝 Description

Version-gate the deep-inspection Select All exclusion regression test at `V5_0_0`.

MTV-5569 fixed Select All so active inspections are excluded; that fix (and this E2E) land on main / MTV 5.0.0+. On MTV 2.12.x the product behavior is still wrong, so the assertion fails in downstream 2.12 CI (e.g. `dev-mtv-deploy-and-ui-tests` on qemtv-09). Other deep-inspection coverage stays gated at `V2_12_0`.

## 🎥 Demo

N/A — test-only version-gate change, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-5569]: https://redhat.atlassian.net/browse/MTV-5569
[MTV-6374]: https://redhat.atlassian.net/browse/MTV-6374