### PR TITLE
Resolves: MTV-6373 | Skip non-expandable leaf sections in Tips accordion E2E

### DIFF
--- a/testing/playwright/page-objects/LearningExperienceDrawer.ts
+++ b/testing/playwright/page-objects/LearningExperienceDrawer.ts
@@ -159,9 +159,18 @@ export class LearningExperienceDrawer {
     const count = await accordions.count();
     expect(count).toBeGreaterThanOrEqual(minimumCount);
 
-    const testCount = Math.min(3, count);
-    for (let i = 0; i < testCount; i += 1) {
-      const accordion = accordions.nth(i);
+    // Leaf steps (e.g. "Go to Providers") use m-non-expandable and no-op onToggle.
+    const expandableIndexes: number[] = [];
+    for (let i = 0; i < count; i += 1) {
+      const className = (await accordions.nth(i).getAttribute('class')) ?? '';
+      if (!className.includes('m-non-expandable')) {
+        expandableIndexes.push(i);
+      }
+    }
+
+    const testCount = Math.min(3, expandableIndexes.length);
+    for (let t = 0; t < testCount; t += 1) {
+      const accordion = accordions.nth(expandableIndexes[t]);
       const toggleButton = accordion.locator('button').first();
 
       await toggleButton.scrollIntoViewIfNeeded();


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6373](https://redhat.atlassian.net/browse/MTV-6373)

## 📝 Description

`testAccordionsStructure` was clicking the first N `help-topic-section` toggles, including leaf steps such as “Go to Providers” (`m-non-expandable`), which correctly keep `aria-expanded=false`. Only expand/collapse sections that are expandable. Affects both MTV 2.12 and 5.0.

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6373]: https://redhat.atlassian.net/browse/MTV-6373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ