### PR TITLE
Resolves: MTV-6280 | Enable no-deprecated — useOverlay migration and cleanups

### DIFF
--- a/.cursor/rules/frontend/providers.mdc
+++ b/.cursor/rules/frontend/providers.mdc
@@ -204,7 +204,7 @@ Uses `useProviderInventory` with `subPath: 'networkattachmentdefinitions?detail=
 |---|---|
 | **Edit** / **Edit YAML** | Navigates to details page (list) or YAML tab (details) |
 | **Edit provider credentials** | Navigates to `/credentials` tab (hidden for `ova`) |
-| **Delete provider** | Opens `DeleteModal` (shared component) via `useModal` |
+| **Delete provider** | Opens `DeleteModal` (shared component) via `useOverlay` |
 
 ---
 
@@ -300,7 +300,7 @@ OpenShift-only. Patches `forklift.konveyor.io/defaultTransferNetwork` annotation
 
 ### Changing provider actions
 1. Edit `ProviderActionsDropdownItems.tsx` — single file for all action items
-2. If adding a modal action, use `useModal` launcher from Console SDK
+2. If adding a modal action, use `useOverlay` launcher from Console SDK
 
 ### Modifying list columns
 1. Edit `src/providers/list/utils/providerFields.ts` for field definitions

--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -150,12 +150,16 @@ Always use the shared `ModalForm` component (`@components/ModalForm/ModalForm`) 
 - Loading state on confirm button
 - Error display (catches thrown errors automatically)
 - Confirm/Cancel buttons with proper variants
-- `closeModal` on success
+- `closeOverlay` on success
+
+Launch modals with Console SDK `useOverlay` and type them as `OverlayComponent`. Pass `closeOverlay` through to `ModalForm`:
 
 ```typescript
 import ModalForm from '@components/ModalForm/ModalForm';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
-const MyModal: ModalComponent<MyModalProps> = ({ myData, ...rest }) => {
+const MyModal: OverlayComponent<MyModalProps> = ({ closeOverlay, myData, ...rest }) => {
   const handleConfirm = useCallback(async () => {
     await doSomething(myData);
     // throw new Error('message') on failure -- ModalForm catches and displays it
@@ -163,6 +167,7 @@ const MyModal: ModalComponent<MyModalProps> = ({ myData, ...rest }) => {
 
   return (
     <ModalForm
+      closeOverlay={closeOverlay}
       title={t('My title')}
       onConfirm={handleConfirm}
       confirmLabel={t('Confirm')}
@@ -174,9 +179,14 @@ const MyModal: ModalComponent<MyModalProps> = ({ myData, ...rest }) => {
     </ModalForm>
   );
 };
+
+// Launcher:
+const launchOverlay = useOverlay();
+launchOverlay(MyModal, { myData });
 ```
 
 Do NOT use raw `Modal` + `ModalHeader` + `ModalBody` + `ModalFooter` + manual error/loading state.
+Do NOT use deprecated `useModal` / `ModalComponent`.
 
 ---
 

--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -159,7 +159,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
-const MyModal: OverlayComponent<MyModalProps> = ({ closeOverlay, myData, ...rest }) => {
+const MyModal: OverlayComponent<MyModalProps> = ({ closeOverlay, myData }) => {
   const handleConfirm = useCallback(async () => {
     await doSomething(myData);
     // throw new Error('message') on failure -- ModalForm catches and displays it
@@ -173,7 +173,6 @@ const MyModal: OverlayComponent<MyModalProps> = ({ closeOverlay, myData, ...rest
       confirmLabel={t('Confirm')}
       isDisabled={!isValid}
       variant={ModalVariant.large}
-      {...rest}
     >
       {/* Modal body content */}
     </ModalForm>
@@ -187,6 +186,8 @@ launchOverlay(MyModal, { myData });
 
 Do NOT use raw `Modal` + `ModalHeader` + `ModalBody` + `ModalFooter` + manual error/loading state.
 Do NOT use deprecated `useModal` / `ModalComponent`.
+
+**Exception — nested sub-views:** A modal may render a nested raw PatternFly `Modal` when Esc/close must mean “back to the parent view” rather than dismiss the overlay (e.g. `AffinityEditModal` inside `AffinityModal`). Pass `onCancel` to that nested modal’s `onClose`; do not wire it to `closeOverlay`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Example: if you remove `'no-ternary': 'off'`, the rule activates from `eslint.co
 ### Categories
 
 - **Permanently off (Category 3/4):** Rules intentionally rejected for this project (e.g., `no-ternary`, `prefer-readonly-parameter-types`, `strict-boolean-expressions`). Do not enable without team consensus.
-- **Deferred (has a Jira story):** Rules currently off with a plan to enable later (e.g., `explicit-function-return-type`, `naming-convention`, `no-deprecated`). Check the parent epic MTV-6268 for status.
+- **Deferred (has a Jira story):** Rules currently off with a plan to enable later (e.g., `explicit-function-return-type`, `naming-convention`). Check the parent epic MTV-6268 for status.
 - **Inherited from `.all` (no explicit entry):** If a rule isn't listed in the config, it's **on** from `.all`. To turn it off, add an explicit `'off'` entry.
 
 ### Adding a new rule

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -165,8 +165,7 @@ export const createEslintConfig = () =>
             selector: 'import',
           },
         ],
-        // Deferred to MTV-6280 (useModal → useOverlay + other deprecated cleanups)
-        '@typescript-eslint/no-deprecated': 'off',
+        '@typescript-eslint/no-deprecated': 'error',
         '@typescript-eslint/no-dynamic-delete': 'off',
         '@typescript-eslint/no-explicit-any': 'error',
         '@typescript-eslint/no-floating-promises': ['error', { ignoreIIFE: true }],

--- a/src/components/AffinityModal/AffinityEditModal.tsx
+++ b/src/components/AffinityModal/AffinityEditModal.tsx
@@ -1,6 +1,5 @@
-import { type Dispatch, type SetStateAction, useState } from 'react';
+import { type Dispatch, type FC, type SetStateAction, useState } from 'react';
 
-import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -17,8 +16,7 @@ type AffinityEditModalProps = {
   title: string;
 };
 
-const AffinityEditModal: OverlayComponent<AffinityEditModalProps> = ({
-  closeOverlay,
+const AffinityEditModal: FC<AffinityEditModalProps> = ({
   focusedAffinity,
   onCancel,
   onSubmit,
@@ -35,7 +33,7 @@ const AffinityEditModal: OverlayComponent<AffinityEditModalProps> = ({
       className="ocs-modal co-catalog-page__overlay"
       data-testid="affinity-edit-modal"
       isOpen
-      onClose={closeOverlay}
+      onClose={onCancel}
       position="top"
       variant={ModalVariant.medium}
     >

--- a/src/components/AffinityModal/AffinityEditModal.tsx
+++ b/src/components/AffinityModal/AffinityEditModal.tsx
@@ -1,6 +1,6 @@
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -17,8 +17,8 @@ type AffinityEditModalProps = {
   title: string;
 };
 
-const AffinityEditModal: ModalComponent<AffinityEditModalProps> = ({
-  closeModal,
+const AffinityEditModal: OverlayComponent<AffinityEditModalProps> = ({
+  closeOverlay,
   focusedAffinity,
   onCancel,
   onSubmit,
@@ -35,7 +35,7 @@ const AffinityEditModal: ModalComponent<AffinityEditModalProps> = ({
       className="ocs-modal co-catalog-page__overlay"
       data-testid="affinity-edit-modal"
       isOpen
-      onClose={closeModal}
+      onClose={closeOverlay}
       position="top"
       variant={ModalVariant.medium}
     >

--- a/src/components/AffinityModal/AffinityList.tsx
+++ b/src/components/AffinityModal/AffinityList.tsx
@@ -1,7 +1,15 @@
-import type { FC } from 'react';
+import { type FC, useMemo, useState } from 'react';
 
 import { Stack, StackItem } from '@patternfly/react-core';
-import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  SortByDirection,
+  Table,
+  Tbody,
+  Th,
+  Thead,
+  type ThProps,
+  Tr,
+} from '@patternfly/react-table';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import type { AffinityRowData } from './utils/types';
@@ -16,6 +24,28 @@ type AffinityListProps = {
   onEdit: (affinity: AffinityRowData) => void;
 };
 
+const AFFINITY_SORT_COLUMN = {
+  Condition: 1,
+  Type: 0,
+  Weight: 2,
+} as const;
+
+const getSortValue = (affinity: AffinityRowData, columnIndex: number): string | number => {
+  if (columnIndex === AFFINITY_SORT_COLUMN.Type) {
+    return affinity.type;
+  }
+
+  if (columnIndex === AFFINITY_SORT_COLUMN.Condition) {
+    return affinity.condition;
+  }
+
+  if (columnIndex === AFFINITY_SORT_COLUMN.Weight) {
+    return affinity.weight ?? 0;
+  }
+
+  return '';
+};
+
 const AffinityList: FC<AffinityListProps> = ({
   affinities,
   onAffinityClickAdd,
@@ -23,6 +53,40 @@ const AffinityList: FC<AffinityListProps> = ({
   onEdit,
 }) => {
   const { t } = useForkliftTranslation();
+  const [activeSortIndex, setActiveSortIndex] = useState<number | undefined>();
+  const [activeSortDirection, setActiveSortDirection] = useState<SortByDirection | undefined>();
+
+  const getSortParams = (columnIndex: number): ThProps['sort'] => ({
+    columnIndex,
+    onSort: (_event, index, direction) => {
+      setActiveSortIndex(index);
+      setActiveSortDirection(direction);
+    },
+    sortBy: {
+      direction: activeSortDirection,
+      index: activeSortIndex,
+    },
+  });
+
+  const sortedAffinities = useMemo(() => {
+    const rows = [...(affinities ?? [])];
+
+    if (activeSortIndex === undefined || activeSortDirection === undefined) {
+      return rows;
+    }
+
+    return rows.sort((a, b) => {
+      const aValue = getSortValue(a, activeSortIndex);
+      const bValue = getSortValue(b, activeSortIndex);
+
+      if (typeof aValue === 'number' && typeof bValue === 'number') {
+        return activeSortDirection === SortByDirection.asc ? aValue - bValue : bValue - aValue;
+      }
+
+      const comparison = String(aValue).localeCompare(String(bValue));
+      return activeSortDirection === SortByDirection.asc ? comparison : -comparison;
+    });
+  }, [activeSortDirection, activeSortIndex, affinities]);
 
   return (
     <Stack hasGutter>
@@ -33,15 +97,15 @@ const AffinityList: FC<AffinityListProps> = ({
         <Table aria-label={t('Affinity rules')} variant="compact">
           <Thead>
             <Tr>
-              <Th>{t('Type')}</Th>
-              <Th>{t('Condition')}</Th>
-              <Th>{t('Weight')}</Th>
+              <Th sort={getSortParams(AFFINITY_SORT_COLUMN.Type)}>{t('Type')}</Th>
+              <Th sort={getSortParams(AFFINITY_SORT_COLUMN.Condition)}>{t('Condition')}</Th>
+              <Th sort={getSortParams(AFFINITY_SORT_COLUMN.Weight)}>{t('Weight')}</Th>
               <Th>{t('Terms')}</Th>
               <Th className="pf-v6-c-table__action" />
             </Tr>
           </Thead>
           <Tbody>
-            {(affinities ?? []).map((affinity) => (
+            {sortedAffinities.map((affinity) => (
               <AffinityRow
                 affinity={affinity}
                 key={affinity.id}

--- a/src/components/AffinityModal/AffinityList.tsx
+++ b/src/components/AffinityModal/AffinityList.tsx
@@ -1,13 +1,13 @@
 import type { FC } from 'react';
 
-import { VirtualizedTable } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
+import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { useForkliftTranslation } from '@utils/i18n';
 
-import { affinityColumns } from './utils/constants';
 import type { AffinityRowData } from './utils/types';
 import AddAffinityRuleButton from './AddAffinityRuleButton';
 import AffinityDescriptionText from './AffinityDescriptionText';
-import AffinityRow, { type AffinityRowDataProps } from './AffinityRow';
+import AffinityRow from './AffinityRow';
 
 type AffinityListProps = {
   affinities: AffinityRowData[];
@@ -22,22 +22,35 @@ const AffinityList: FC<AffinityListProps> = ({
   onDelete,
   onEdit,
 }) => {
-  const columns = affinityColumns();
+  const { t } = useForkliftTranslation();
+
   return (
     <Stack hasGutter>
       <StackItem>
         <AffinityDescriptionText />
       </StackItem>
       <StackItem data-testid="affinity-rules-list">
-        <VirtualizedTable<AffinityRowData, AffinityRowDataProps>
-          columns={columns}
-          data={affinities ?? []}
-          loaded
-          loadError={false}
-          Row={AffinityRow}
-          rowData={{ onDelete, onEdit }}
-          unfilteredData={affinities || []}
-        />
+        <Table aria-label={t('Affinity rules')} variant="compact">
+          <Thead>
+            <Tr>
+              <Th>{t('Type')}</Th>
+              <Th>{t('Condition')}</Th>
+              <Th>{t('Weight')}</Th>
+              <Th>{t('Terms')}</Th>
+              <Th className="pf-v6-c-table__action" />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {(affinities ?? []).map((affinity) => (
+              <AffinityRow
+                affinity={affinity}
+                key={affinity.id}
+                onDelete={onDelete}
+                onEdit={onEdit}
+              />
+            ))}
+          </Tbody>
+        </Table>
       </StackItem>
       <StackItem>
         <AddAffinityRuleButton isLinkButton onAffinityClickAdd={onAffinityClickAdd} />
@@ -45,4 +58,5 @@ const AffinityList: FC<AffinityListProps> = ({
     </Stack>
   );
 };
+
 export default AffinityList;

--- a/src/components/AffinityModal/AffinityModal.tsx
+++ b/src/components/AffinityModal/AffinityModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { K8sIoApiCoreV1Affinity, K8sResourceCommon } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ModalVariant } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -22,7 +22,8 @@ export type AffinityModalProps = {
   title?: string;
 };
 
-const AffinityModal: ModalComponent<AffinityModalProps> = ({
+const AffinityModal: OverlayComponent<AffinityModalProps> = ({
+  closeOverlay,
   initialAffinity,
   onConfirm,
   title,
@@ -89,15 +90,16 @@ const AffinityModal: ModalComponent<AffinityModalProps> = ({
 
   return isEditing ? (
     <AffinityEditModal
+      closeOverlay={closeOverlay}
       focusedAffinity={focusedAffinity}
       onCancel={onCancel}
       onSubmit={onSaveAffinity}
       setFocusedAffinity={setFocusedAffinity}
       title={isCreating ? t('Add affinity rule') : t('Edit affinity rule')}
-      {...rest}
     />
   ) : (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Apply rules')}
       onConfirm={async () => onConfirm(rowsDataToAffinity(affinities) ?? {})}
       testId="affinity-modal"

--- a/src/components/AffinityModal/AffinityModal.tsx
+++ b/src/components/AffinityModal/AffinityModal.tsx
@@ -90,7 +90,6 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
 
   return isEditing ? (
     <AffinityEditModal
-      closeOverlay={closeOverlay}
       focusedAffinity={focusedAffinity}
       onCancel={onCancel}
       onSubmit={onSaveAffinity}
@@ -99,7 +98,7 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
     />
   ) : (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Apply rules')}
       onConfirm={async () => onConfirm(rowsDataToAffinity(affinities) ?? {})}
       testId="affinity-modal"

--- a/src/components/AffinityModal/AffinityModal.tsx
+++ b/src/components/AffinityModal/AffinityModal.tsx
@@ -27,7 +27,6 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
   initialAffinity,
   onConfirm,
   title,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -104,7 +103,6 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
       testId="affinity-modal"
       title={title ?? t('Affinity rules')}
       variant={ModalVariant.medium}
-      {...rest}
     >
       {list}
     </ModalForm>

--- a/src/components/AffinityModal/AffinityRow.tsx
+++ b/src/components/AffinityModal/AffinityRow.tsx
@@ -1,8 +1,7 @@
 import type { FC } from 'react';
 
-import type { RowProps } from '@openshift-console/dynamic-plugin-sdk';
 import { pluralize } from '@patternfly/react-core';
-import { Td } from '@patternfly/react-table';
+import { Td, Tr } from '@patternfly/react-table';
 import { EMPTY_MSG } from '@utils/constants';
 import { isEmpty } from '@utils/helpers';
 
@@ -10,23 +9,20 @@ import { AFFINITY_CONDITION_LABELS, AFFINITY_TYPE_LABELS } from './utils/constan
 import type { AffinityRowData } from './utils/types';
 import AffinityRowActionsDropdown from './AffinityRowActionsDropdown';
 
-export type AffinityRowDataProps = {
+type AffinityRowProps = {
+  affinity: AffinityRowData;
   onDelete: (affinity: AffinityRowData) => void;
   onEdit: (affinity: AffinityRowData) => void;
 };
 
-const AffinityRow: FC<
-  RowProps<
-    AffinityRowData,
-    { onDelete: (affinity: AffinityRowData) => void; onEdit: (affinity: AffinityRowData) => void }
-  >
-> = ({ obj: affinity, rowData: { onDelete, onEdit } }) => {
+const AffinityRow: FC<AffinityRowProps> = ({ affinity, onDelete, onEdit }) => {
   const expressionsLabel =
     !isEmpty(affinity?.expressions) && pluralize(affinity?.expressions?.length ?? 0, 'Expression');
   const fieldsLabel =
     !isEmpty(affinity?.fields) && pluralize(affinity?.fields?.length ?? 0, 'Node Field');
+
   return (
-    <>
+    <Tr>
       <Td dataLabel="type">{AFFINITY_TYPE_LABELS[affinity?.type]}</Td>
       <Td dataLabel="condition">{AFFINITY_CONDITION_LABELS[affinity?.condition]}</Td>
       <Td dataLabel="weight">{affinity?.weight ?? EMPTY_MSG}</Td>
@@ -36,7 +32,7 @@ const AffinityRow: FC<
       <Td className="pf-v6-c-table__action">
         <AffinityRowActionsDropdown affinity={affinity} onDelete={onDelete} onEdit={onEdit} />
       </Td>
-    </>
+    </Tr>
   );
 };
 

--- a/src/components/AffinityModal/utils/constants.ts
+++ b/src/components/AffinityModal/utils/constants.ts
@@ -1,5 +1,4 @@
-import { Operator, type TableColumn } from '@openshift-console/dynamic-plugin-sdk';
-import { sortable } from '@patternfly/react-table';
+import { Operator } from '@openshift-console/dynamic-plugin-sdk';
 import { t } from '@utils/i18n';
 
 import { AffinityCondition, type AffinityRowData, AffinityType } from './types';
@@ -32,39 +31,6 @@ export const AFFINITY_TYPE_LABELS = {
 export const AFFINITY_CONDITION_LABELS = {
   [AffinityCondition.Preferred]: t('Preferred during scheduling'),
   [AffinityCondition.Required]: t('Required during scheduling'),
-};
-
-export const affinityColumns = () => {
-  const columns: TableColumn<AffinityRowData>[] = [
-    {
-      id: 'type',
-      sort: 'type',
-      title: t('Type'),
-      transforms: [sortable],
-    },
-    {
-      id: 'condition',
-      sort: 'condition',
-      title: t('Condition'),
-      transforms: [sortable],
-    },
-    {
-      id: 'weight',
-      sort: 'weight',
-      title: t('Weight'),
-      transforms: [sortable],
-    },
-    {
-      id: 'terms',
-      title: t('Terms'),
-    },
-    {
-      id: '',
-      props: { className: 'dropdown-kebab-pf pf-v6-c-table__action' },
-      title: '',
-    },
-  ];
-  return columns;
 };
 
 export const operatorSelectOptions = [

--- a/src/components/DetailItems/OwnerReferencesItem.tsx
+++ b/src/components/DetailItems/OwnerReferencesItem.tsx
@@ -6,6 +6,8 @@ import {
   type OwnerReference,
   ResourceLink,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { getGroupVersionKindFromOwnerReference } from '@utils/crds/common/selectors';
+import { isEmpty } from '@utils/helpers';
 
 /**
  * React Component to display a list of owner references for a given Kubernetes resource.
@@ -17,21 +19,24 @@ import {
  */
 export const OwnerReferencesItem: FC<OwnerReferencesProps> = ({ resource }) => {
   const { t } = useForkliftTranslation();
-  const owners = (resource?.metadata?.ownerReferences ?? []).map(
-    (ownerReference: OwnerReference) => (
-      <ResourceLink
-        groupVersionKind={{
-          group: ownerReference.apiVersion.split('/')[0],
-          kind: ownerReference.kind,
-          version: ownerReference.apiVersion.split('/')[1],
-        }}
-        key={ownerReference.uid}
-        name={ownerReference.name}
-        namespace={resource.metadata?.namespace}
-      />
-    ),
+  const ownerReferences = resource?.metadata?.ownerReferences ?? [];
+
+  if (isEmpty(ownerReferences)) {
+    return <span className="text-muted">{t('No owner')}</span>;
+  }
+
+  return (
+    <>
+      {ownerReferences.map((ownerReference: OwnerReference) => (
+        <ResourceLink
+          groupVersionKind={getGroupVersionKindFromOwnerReference(ownerReference)}
+          key={ownerReference.uid}
+          name={ownerReference.name}
+          namespace={resource.metadata?.namespace}
+        />
+      ))}
+    </>
   );
-  return owners.length ? <>{owners}</> : <span className="text-muted">{t('No owner')}</span>;
 };
 
 /**

--- a/src/components/InspectVirtualMachines/InspectVirtualMachinesButton.tsx
+++ b/src/components/InspectVirtualMachines/InspectVirtualMachinesButton.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
 import type { V1beta1Plan, V1beta1Provider } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { TOOLTIP_TRIGGER_MANUAL } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -26,10 +26,10 @@ const InspectVirtualMachinesButton: FC<InspectVirtualMachinesButtonProps> = ({
   testId = 'plan-inspect-vms-button',
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const onClickInspectVms = (): void => {
-    launcher<InspectVirtualMachinesModalProps>(InspectVirtualMachinesModal, {
+    launchOverlay<InspectVirtualMachinesModalProps>(InspectVirtualMachinesModal, {
       plan,
       provider,
     });

--- a/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
+++ b/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
@@ -4,7 +4,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Plan, V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, AlertVariant, ModalVariant } from '@patternfly/react-core';
 import { getNamespace, getUID, getVddkInitImage } from '@utils/crds/common/selectors';
 import { CONVERSION_LABELS, CONVERSION_TYPE } from '@utils/crds/conversion/constants';
@@ -26,7 +26,8 @@ export type InspectVirtualMachinesModalProps = {
   provider: V1beta1Provider;
 };
 
-const InspectVirtualMachinesModal: ModalComponent<InspectVirtualMachinesModalProps> = ({
+const InspectVirtualMachinesModal: OverlayComponent<InspectVirtualMachinesModalProps> = ({
+  closeOverlay,
   plan,
   provider,
   ...rest
@@ -116,6 +117,7 @@ const InspectVirtualMachinesModal: ModalComponent<InspectVirtualMachinesModalPro
   return (
     <ModalForm
       className="forklift-inspect-vms-modal"
+      closeModal={closeOverlay}
       confirmLabel={confirmLabel}
       isDisabled={isSubmitDisabled}
       label={<TechPreviewLabel />}

--- a/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
+++ b/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
@@ -117,7 +117,7 @@ const InspectVirtualMachinesModal: OverlayComponent<InspectVirtualMachinesModalP
   return (
     <ModalForm
       className="forklift-inspect-vms-modal"
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={confirmLabel}
       isDisabled={isSubmitDisabled}
       label={<TechPreviewLabel />}

--- a/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
+++ b/src/components/InspectVirtualMachines/InspectVirtualMachinesModal.tsx
@@ -30,7 +30,6 @@ const InspectVirtualMachinesModal: OverlayComponent<InspectVirtualMachinesModalP
   closeOverlay,
   plan,
   provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -125,7 +124,6 @@ const InspectVirtualMachinesModal: OverlayComponent<InspectVirtualMachinesModalP
       testId="inspect-vms-modal"
       title={t('Inspect virtual machines')}
       variant={ModalVariant.large}
-      {...rest}
     >
       {!isVddkConfigured && (
         <Alert

--- a/src/components/InspectVirtualMachines/utils/types.ts
+++ b/src/components/InspectVirtualMachines/utils/types.ts
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { PfLabelStatus } from '@utils/constants';
 import type { InspectionStatus } from '@utils/crds/conversion/constants';
 import type { ObjectReference, V1beta1Conversion } from '@utils/crds/conversion/types';
@@ -37,7 +39,7 @@ export type VmOverrides = {
 export type CreateInspectionsFn = (vms: VmInspectionRef[]) => Promise<InspectionCreateResult>;
 
 export type PhaseConfig = {
-  icon: JSX.Element;
+  icon: ReactElement;
   label: string;
   labelStatus?: PfLabelStatus;
 };

--- a/src/components/LabelsModal/LabelsModal.tsx
+++ b/src/components/LabelsModal/LabelsModal.tsx
@@ -46,7 +46,6 @@ const LabelsModal: OverlayComponent<LabelsModalProps> = ({
   initialLabels,
   onConfirm,
   title,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [inputValue, setInputValue] = useState('');
@@ -115,7 +114,6 @@ const LabelsModal: OverlayComponent<LabelsModalProps> = ({
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="labels-modal"
       title={title ?? t('Edit labels')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>{description ?? LABELS_MODAL_DESCRIPTION}</StackItem>

--- a/src/components/LabelsModal/LabelsModal.tsx
+++ b/src/components/LabelsModal/LabelsModal.tsx
@@ -111,7 +111,7 @@ const LabelsModal: OverlayComponent<LabelsModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="labels-modal"
       title={title ?? t('Edit labels')}

--- a/src/components/LabelsModal/LabelsModal.tsx
+++ b/src/components/LabelsModal/LabelsModal.tsx
@@ -9,7 +9,7 @@ import TagsInput from 'react-tagsinput';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -40,7 +40,8 @@ export type LabelsModalProps = {
   title?: string;
 };
 
-const LabelsModal: ModalComponent<LabelsModalProps> = ({
+const LabelsModal: OverlayComponent<LabelsModalProps> = ({
+  closeOverlay,
   description,
   initialLabels,
   onConfirm,
@@ -110,6 +111,7 @@ const LabelsModal: ModalComponent<LabelsModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="labels-modal"
       title={title ?? t('Edit labels')}

--- a/src/components/MapProvidersDetails/MapProvidersEdit.tsx
+++ b/src/components/MapProvidersDetails/MapProvidersEdit.tsx
@@ -69,7 +69,7 @@ const MapProvidersEdit: OverlayComponent<MapProvidersEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit providers')}

--- a/src/components/MapProvidersDetails/MapProvidersEdit.tsx
+++ b/src/components/MapProvidersDetails/MapProvidersEdit.tsx
@@ -4,7 +4,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import ProviderSelect from '@components/ProviderSelect/ProviderSelect';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, FormGroup, ModalVariant } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { getObjectRef } from '@utils/helpers/getObjectRef';
@@ -16,8 +16,8 @@ import {
   type MapProvidersEditProps,
 } from './utils/types';
 
-const MapProvidersEdit: ModalComponent<MapProvidersEditProps> = ({
-  closeModal,
+const MapProvidersEdit: OverlayComponent<MapProvidersEditProps> = ({
+  closeOverlay,
   destinationProvider,
   model,
   namespace,
@@ -42,7 +42,7 @@ const MapProvidersEdit: ModalComponent<MapProvidersEditProps> = ({
 
   const onSubmit = async (formData: MapProvidersEditFormValues) => {
     if (!isDirty) {
-      closeModal();
+      closeOverlay();
       return;
     }
     const { destination, source } = formData;
@@ -69,7 +69,7 @@ const MapProvidersEdit: ModalComponent<MapProvidersEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit providers')}

--- a/src/components/ModalForm/ModalForm.tsx
+++ b/src/components/ModalForm/ModalForm.tsx
@@ -1,6 +1,5 @@
-import { type ReactNode, useCallback, useState } from 'react';
+import { type FC, type ReactNode, useCallback, useState } from 'react';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import {
   Alert,
   AlertVariant,
@@ -24,6 +23,7 @@ type ModalFormProps = {
   cancelLabel?: string;
   children: ReactNode;
   className?: string;
+  closeOverlay: () => void;
   confirmLabel?: string;
   confirmVariant?: ButtonVariant;
   description?: ReactNode;
@@ -36,12 +36,12 @@ type ModalFormProps = {
   variant?: ModalVariant;
 };
 
-const ModalForm: ModalComponent<ModalFormProps> = ({
+const ModalForm: FC<ModalFormProps> = ({
   additionalAction,
   cancelLabel,
   children,
   className,
-  closeModal,
+  closeOverlay,
   confirmLabel,
   confirmVariant,
   description,
@@ -63,13 +63,13 @@ const ModalForm: ModalComponent<ModalFormProps> = ({
 
     try {
       await onConfirm();
-      closeModal();
+      closeOverlay();
     } catch (err) {
       setError((err as Error)?.message ?? err?.toString());
     } finally {
       setIsLoading(false);
     }
-  }, [onConfirm, closeModal]);
+  }, [onConfirm, closeOverlay]);
 
   const headerTitle = label ? (
     <Flex alignItems={{ default: 'alignItemsBaseline' }} gap={{ default: 'gapXs' }}>
@@ -87,7 +87,7 @@ const ModalForm: ModalComponent<ModalFormProps> = ({
       className={className}
       data-testid={testId}
       isOpen
-      onClose={closeModal}
+      onClose={closeOverlay}
       position="top"
       variant={variant}
     >
@@ -123,7 +123,7 @@ const ModalForm: ModalComponent<ModalFormProps> = ({
         <Button
           data-testid="modal-cancel-button"
           key="cancel"
-          onClick={closeModal}
+          onClick={closeOverlay}
           variant={ButtonVariant.secondary}
         >
           {cancelLabel ?? t('Cancel')}

--- a/src/components/ModalForm/TextInputEditModal.tsx
+++ b/src/components/ModalForm/TextInputEditModal.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form';
 import { FormGroupWithHelpText } from 'src/components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import { type ValidationMsg, ValidationState } from 'src/utils/validation/Validation';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, ModalVariant, TextInput } from '@patternfly/react-core';
 
 import ModalForm from './ModalForm';
@@ -22,8 +22,8 @@ type TextInputEditModalProps = {
   validationHook?: (value: string) => ValidationMsg;
 };
 
-const TextInputEditModal: ModalComponent<TextInputEditModalProps> = ({
-  closeModal,
+const TextInputEditModal: OverlayComponent<TextInputEditModalProps> = ({
+  closeOverlay,
   description,
   helperText,
   initialValue,
@@ -51,7 +51,7 @@ const TextInputEditModal: ModalComponent<TextInputEditModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeModal}
+      closeModal={closeOverlay}
       isDisabled={!isValid || hasError}
       onConfirm={handleConfirm}
       title={title}

--- a/src/components/ModalForm/TextInputEditModal.tsx
+++ b/src/components/ModalForm/TextInputEditModal.tsx
@@ -51,7 +51,7 @@ const TextInputEditModal: OverlayComponent<TextInputEditModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={!isValid || hasError}
       onConfirm={handleConfirm}
       title={title}

--- a/src/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useMemo, useState } from 'react';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, Stack, StackItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -21,7 +21,8 @@ export type NodeSelectorModalProps = {
   title?: string;
 };
 
-const NodeSelectorModal: ModalComponent<NodeSelectorModalProps> = ({
+const NodeSelectorModal: OverlayComponent<NodeSelectorModalProps> = ({
+  closeOverlay,
   description,
   initialLabels,
   onConfirm,
@@ -58,6 +59,7 @@ const NodeSelectorModal: ModalComponent<NodeSelectorModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={isNotValid}
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="node-selector-modal"

--- a/src/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -59,7 +59,7 @@ const NodeSelectorModal: OverlayComponent<NodeSelectorModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={isNotValid}
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="node-selector-modal"

--- a/src/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -27,7 +27,6 @@ const NodeSelectorModal: OverlayComponent<NodeSelectorModalProps> = ({
   initialLabels,
   onConfirm,
   title,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [labels, setLabels] = useState<LabelFields[]>(labelsObjectToArray(initialLabels));
@@ -64,7 +63,6 @@ const NodeSelectorModal: OverlayComponent<NodeSelectorModalProps> = ({
       onConfirm={async () => onConfirm(labelsArrayToObject(labels))}
       testId="node-selector-modal"
       title={title ?? t('Edit node selectors')}
-      {...rest}
     >
       <Form>
         <Stack hasGutter>

--- a/src/components/PowerState/VirtualMachinePowerStateCell.tsx
+++ b/src/components/PowerState/VirtualMachinePowerStateCell.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import { TableIconCell } from 'src/components/TableCell/TableIconCell';
 import type { ProviderVmData } from 'src/utils/types';
 
@@ -11,7 +11,7 @@ const VirtualMachinePowerStateCell: FC<{ vmData: ProviderVmData }> = ({ vmData }
   const { t } = useForkliftTranslation();
 
   const powerState = getVmPowerState(vmData?.vm);
-  const states: Record<PowerState, [JSX.Element, string, string]> = {
+  const states: Record<PowerState, [ReactElement, string, string]> = {
     off: [<OffIcon color="grey" key="off" />, t('Powered off'), t('Off')],
     on: [<PowerOffIcon color="green" key="on" />, t('Powered on'), t('On')],
     unknown: [<UnknownIcon key="unknown" />, t('Unknown power state'), t('Unknown')],

--- a/src/components/common/Filter/__tests__/useUniqueEnums.test.tsx
+++ b/src/components/common/Filter/__tests__/useUniqueEnums.test.tsx
@@ -26,7 +26,7 @@ describe('aggregate filters with the same labels', () => {
     expect(uniqueEnumLabels).toStrictEqual(['FalseTranslated', 'TrueTranslated']);
     expect(selectedUniqueEnumLabels).toStrictEqual([]);
     onUniqueFilterUpdate(['TrueTranslated']);
-    expect(onSelectedEnumIdsChange).toBeCalledWith(['True', 'AlsoTrue']);
+    expect(onSelectedEnumIdsChange).toHaveBeenCalledWith(['True', 'AlsoTrue']);
   });
 
   it('selects a standard filter(one filter already selected)', () => {
@@ -46,6 +46,6 @@ describe('aggregate filters with the same labels', () => {
     expect(uniqueEnumLabels).toStrictEqual(['FalseTranslated', 'TrueTranslated']);
     expect(selectedUniqueEnumLabels).toStrictEqual(['TrueTranslated']);
     onUniqueFilterUpdate(['TrueTranslated', 'FalseTranslated']);
-    expect(onSelectedEnumIdsChange).toBeCalledWith(['True', 'AlsoTrue', 'False']);
+    expect(onSelectedEnumIdsChange).toHaveBeenCalledWith(['True', 'AlsoTrue', 'False']);
   });
 });

--- a/src/components/common/FilterGroup/FilterFromDef.tsx
+++ b/src/components/common/FilterGroup/FilterFromDef.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { type ReactElement, useMemo, useState } from 'react';
 
 import { isEmpty } from '@utils/helpers';
 
@@ -9,7 +9,7 @@ import type { GlobalFilters } from './types';
 
 type FilterFromDefProps = {
   filterDef: FilterDef;
-  FilterType: (props: FilterTypeProps) => JSX.Element;
+  FilterType: (props: FilterTypeProps) => ReactElement;
   label: string;
   onFilterUpdate: (filters: GlobalFilters) => void;
   resolvedLanguage: string;

--- a/src/components/common/FilterGroup/__tests__/useUrlFilters.test.tsx
+++ b/src/components/common/FilterGroup/__tests__/useUrlFilters.test.tsx
@@ -87,6 +87,6 @@ describe('display currently selected filters in the URL', () => {
       setSelectedFilters({ [NAME]: update });
     });
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(window.history.pushState).toBeCalledWith({}, '', pushedState);
+    expect(window.history.pushState).toHaveBeenCalledWith({}, '', pushedState);
   });
 });

--- a/src/components/common/FilterGroup/types.ts
+++ b/src/components/common/FilterGroup/types.ts
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { FilterTypeProps } from '../Filter/types';
 import type { FilterDef } from '../utils/types';
 
@@ -6,7 +8,7 @@ import type { FilterDef } from '../utils/types';
  *
  * Get the filter type, and render a top bar widget that match the filter.
  */
-export type FilterRenderer = (props: FilterTypeProps) => JSX.Element;
+export type FilterRenderer = (props: FilterTypeProps) => ReactElement;
 
 /**
  * Field ID to filter definition mapping.

--- a/src/components/common/Page/__tests__/ResultStates.test.tsx
+++ b/src/components/common/Page/__tests__/ResultStates.test.tsx
@@ -11,5 +11,5 @@ test('NoResultsMatchFilter', () => {
 
   fireEvent.click(screen.getByRole('button'));
 
-  expect(clear).toBeCalledTimes(1);
+  expect(clear).toHaveBeenCalledTimes(1);
 });

--- a/src/components/common/Page/__tests__/useFields.test.tsx
+++ b/src/components/common/Page/__tests__/useFields.test.tsx
@@ -155,7 +155,7 @@ describe('saves fields to user settings', () => {
         { isVisible: false, label: '', resourceFieldId: NAME },
       ]);
     });
-    expect(saveSettings).toBeCalledWith([
+    expect(saveSettings).toHaveBeenCalledWith([
       { isVisible: true, resourceFieldId: NAMESPACE },
       { isVisible: false, resourceFieldId: NAME },
     ]);
@@ -182,6 +182,6 @@ describe('saves fields to user settings', () => {
         { isVisible: true, label: '', resourceFieldId: NAMESPACE },
       ]);
     });
-    expect(clearSettings).toBeCalled();
+    expect(clearSettings).toHaveBeenCalled();
   });
 });

--- a/src/components/common/ProjectSelect/ProjectSelect.tsx
+++ b/src/components/common/ProjectSelect/ProjectSelect.tsx
@@ -9,7 +9,7 @@ import CreateProjectModal, {
 import {
   type K8sResourceCommon,
   useAccessReview,
-  useModal,
+  useOverlay,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ProjectModel } from '@openshift-console/dynamic-plugin-sdk/lib/models';
 import { Bullseye, Button, ButtonVariant, Divider, Spinner, Switch } from '@patternfly/react-core';
@@ -40,7 +40,7 @@ const ProjectSelect: FC<ProjectSelectProps> = ({
   value,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [canCreate, loadingCreate] = useAccessReview({
     group: ProjectModel.apiGroup,
@@ -72,7 +72,7 @@ const ProjectSelect: FC<ProjectSelectProps> = ({
   };
 
   const onNewProject = () => {
-    launcher<CreateProjectModalProps>(CreateProjectModal, { onCreated: onProjectCreated });
+    launchOverlay<CreateProjectModalProps>(CreateProjectModal, { onCreated: onProjectCreated });
   };
 
   return (

--- a/src/components/common/TableView/__tests__/sort.test.ts
+++ b/src/components/common/TableView/__tests__/sort.test.ts
@@ -93,7 +93,7 @@ describe('buildSort factory', () => {
     expect(columnIndex).toBe(0);
     expect(sortBy).toStrictEqual({ direction: 'asc', index: 0 });
     onSort?.({} as React.MouseEvent, 1, SortByDirection.asc, {});
-    expect(setActiveSort).toBeCalledWith({
+    expect(setActiveSort).toHaveBeenCalledWith({
       isAsc: true,
       label: NamespaceColumn.label,
       resourceFieldId: NAMESPACE,
@@ -116,7 +116,7 @@ describe('buildSort factory', () => {
     expect(columnIndex).toBe(1);
     expect(sortBy).toStrictEqual({ direction: 'desc', index: 0 });
     onSort?.({} as React.MouseEvent, 1, SortByDirection.desc, {});
-    expect(setActiveSort).toBeCalledWith({
+    expect(setActiveSort).toHaveBeenCalledWith({
       isAsc: false,
       label: NamespaceColumn.label,
       resourceFieldId: NAMESPACE,
@@ -153,6 +153,6 @@ describe('buildSort factory', () => {
         setActiveSort,
       }) ?? {};
     onSort?.({} as React.MouseEvent, 100, SortByDirection.desc, {});
-    expect(setActiveSort).toBeCalledTimes(0);
+    expect(setActiveSort).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/components/modals/CreateProjectModal.tsx
+++ b/src/components/modals/CreateProjectModal.tsx
@@ -3,7 +3,7 @@ import { type FormEvent, type MouseEvent, useState } from 'react';
 import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
 import ProjectNameHelp from '@components/modals/ProjectNameHelp';
 import { k8sCreate, type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ProjectModel } from '@openshift-console/dynamic-plugin-sdk/lib/models';
 import {
   Alert,
@@ -37,7 +37,10 @@ export type CreateProjectModalProps = {
   onCreated: (project: K8sResourceCommon) => void;
 };
 
-const CreateProjectModal: ModalComponent<CreateProjectModalProps> = ({ closeModal, onCreated }) => {
+const CreateProjectModal: OverlayComponent<CreateProjectModalProps> = ({
+  closeOverlay,
+  onCreated,
+}) => {
   const [inProgress, setInProgress] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [name, setName] = useState('');
@@ -63,7 +66,7 @@ const CreateProjectModal: ModalComponent<CreateProjectModalProps> = ({ closeModa
       .then((obj) => {
         setErrorMessage('');
         onCreated(obj);
-        closeModal();
+        closeOverlay();
       })
       .catch((error: Error) => {
         const err = error.message || t('An error occurred. Please try again.');
@@ -80,7 +83,7 @@ const CreateProjectModal: ModalComponent<CreateProjectModalProps> = ({ closeModa
       `${window.SERVER_FLAGS?.documentationBaseURL ?? ''}${workingWithProjectsURLs.downstream}`;
 
   return (
-    <Modal isOpen onClose={closeModal} variant={ModalVariant.small}>
+    <Modal isOpen onClose={closeOverlay} variant={ModalVariant.small}>
       <ModalHeader title={t('Create project')} />
       <ModalBody>
         <Form name="form" onSubmit={submit}>
@@ -159,7 +162,7 @@ const CreateProjectModal: ModalComponent<CreateProjectModalProps> = ({ closeModa
         <Button
           data-testid="create-project-modal-cancel-button"
           isDisabled={inProgress}
-          onClick={closeModal}
+          onClick={closeOverlay}
           type="button"
           variant={ButtonVariant.secondary}
         >

--- a/src/components/modals/DeleteModal/DeleteModal.tsx
+++ b/src/components/modals/DeleteModal/DeleteModal.tsx
@@ -9,7 +9,7 @@ import {
   type K8sModel,
   type K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Button,
   ButtonVariant,
@@ -47,8 +47,8 @@ export type DeleteModalProps = {
  * @param {DeleteModalProps} props - Props for DeleteModal
  * @returns {Element} The DeleteModal component
  */
-export const DeleteModal: ModalComponent<DeleteModalProps> = ({
-  closeModal,
+export const DeleteModal: OverlayComponent<DeleteModalProps> = ({
+  closeOverlay,
   model,
   redirectTo,
   resource,
@@ -84,7 +84,7 @@ export const DeleteModal: ModalComponent<DeleteModalProps> = ({
         navigate(getResourceUrl({ groupVersionKind, namespace }))?.catch(() => undefined);
       }
 
-      closeModal();
+      closeOverlay();
     } catch (err) {
       toggleIsLoading();
 
@@ -94,10 +94,10 @@ export const DeleteModal: ModalComponent<DeleteModalProps> = ({
         setAlertMessage(<AlertMessageForModals message={t('Unknown error')} title={t('Error')} />);
       }
     }
-  }, [resource, model, name, namespace, navigate, redirectTo, t, toggleIsLoading, closeModal]);
+  }, [resource, model, name, namespace, navigate, redirectTo, t, toggleIsLoading, closeOverlay]);
 
   return (
-    <Modal isOpen={true} onClose={closeModal} position="top" variant={ModalVariant.small}>
+    <Modal isOpen={true} onClose={closeOverlay} position="top" variant={ModalVariant.small}>
       <ModalHeader
         title={title ?? t('Delete {{model.label}}', { model })}
         titleIconVariant="warning"
@@ -133,7 +133,7 @@ export const DeleteModal: ModalComponent<DeleteModalProps> = ({
         >
           {t('Delete')}
         </Button>
-        <Button key="cancel" onClick={closeModal} variant={ButtonVariant.secondary}>
+        <Button key="cancel" onClick={closeOverlay} variant={ButtonVariant.secondary}>
           {t('Cancel')}
         </Button>
       </ModalFooter>

--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -1,4 +1,11 @@
-import { type FC, type MutableRefObject, type ReactNode, useMemo, useRef } from 'react';
+import {
+  type FC,
+  type MutableRefObject,
+  type ReactElement,
+  type ReactNode,
+  useMemo,
+  useRef,
+} from 'react';
 
 import type { FilterRenderer, ValueMatcher } from '@components/common/FilterGroup/types';
 import type { UserSettings } from '@components/common/Page/types';
@@ -10,14 +17,14 @@ import { useTableSortContext } from '@components/useTableSortContext';
 
 import StandardPageInner from './StandardPageInner';
 type StandardPageProps<T> = {
-  addButton?: JSX.Element;
+  addButton?: ReactElement;
   alerts?: ReactNode;
   canSelect?: (item: T) => boolean;
   cell?: FC<RowProps<T>>;
 
   className?: string;
-  customNoResultsFound?: JSX.Element;
-  customNoResultsMatchFilter?: JSX.Element;
+  customNoResultsFound?: ReactElement;
+  customNoResultsMatchFilter?: ReactElement;
   dataSource: [data: T[], loaded: boolean, error: unknown];
   expanded?: FC<RowProps<T>>;
   expandedIds?: string[];

--- a/src/components/page/components/PageHeader.tsx
+++ b/src/components/page/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import LearningExperienceButton from 'src/onlineHelp/learningExperienceDrawer/LearningExperienceButton';
 
 import {
@@ -14,7 +14,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 type PageHeaderProps = {
-  actionButton?: JSX.Element;
+  actionButton?: ReactElement;
   shouldShowLearningExperienceButton?: boolean;
   title?: string;
   titleHelpContent?: ReactNode;

--- a/src/components/page/components/PageTable.tsx
+++ b/src/components/page/components/PageTable.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import { useMemo } from 'react';
+import { type FC, type ReactElement, useMemo } from 'react';
 
 import {
   ErrorState,
@@ -16,8 +15,8 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 type PageTableProps<T> = {
   clearAllFilters: () => void;
-  customNoResultsFound?: JSX.Element;
-  customNoResultsMatchFilter?: JSX.Element;
+  customNoResultsFound?: ReactElement;
+  customNoResultsMatchFilter?: ReactElement;
   dataOnScreen: T[];
   error: unknown;
   expandedIds?: string[];

--- a/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
+++ b/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
@@ -4,7 +4,7 @@ import { useOwnerPlanActionGate } from 'src/plans/hooks/useOwnerPlanActionGate';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { NetworkMapModel, NetworkMapModelRef } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem } from '@patternfly/react-core';
 import type { NetworkMapData } from '@utils/crds/maps/types';
 import { getResourceUrl } from '@utils/getResourceUrl';
@@ -19,7 +19,7 @@ export const NetworkMapActionsDropdownItems = ({
   isDetailsPage,
 }: NetworkMapActionsDropdownItemsProps) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
 
   const { obj: networkMap } = data;
@@ -35,7 +35,7 @@ export const NetworkMapActionsDropdownItems = ({
     if (!networkMap) {
       return;
     }
-    launcher<DeleteModalProps>(DeleteModal, { model: NetworkMapModel, resource: networkMap });
+    launchOverlay<DeleteModalProps>(DeleteModal, { model: NetworkMapModel, resource: networkMap });
   };
 
   return [

--- a/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
+++ b/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
@@ -91,7 +91,7 @@ const NetworkMapEdit: OverlayComponent<NetworkMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-network-map-modal"

--- a/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
+++ b/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
@@ -14,7 +14,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { NetworkMapModel } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ModalVariant } from '@patternfly/react-core';
 import { NetworkMapFieldId } from '@utils/crds/maps/types';
 import { isEmpty } from '@utils/helpers';
@@ -24,8 +24,8 @@ import { defaultNetMapping } from '@utils/mappings/networkMap';
 import { PlanOwnerAlert } from './utils/PlanOwnerAlert';
 import type { NetworkEditFormValues, NetworkMapEditProps } from './utils/types';
 
-const NetworkMapEdit: ModalComponent<NetworkMapEditProps> = ({
-  closeModal,
+const NetworkMapEdit: OverlayComponent<NetworkMapEditProps> = ({
+  closeOverlay,
   destinationProvider,
   initialMappings,
   networkMap,
@@ -69,7 +69,7 @@ const NetworkMapEdit: ModalComponent<NetworkMapEditProps> = ({
 
   const onSubmit = async (formData: NetworkEditFormValues) => {
     if (!isDirty) {
-      closeModal();
+      closeOverlay();
       return;
     }
 
@@ -91,7 +91,7 @@ const NetworkMapEdit: ModalComponent<NetworkMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-network-map-modal"

--- a/src/networkMaps/details/tabs/Details/NetworkMapDetailsTab.tsx
+++ b/src/networkMaps/details/tabs/Details/NetworkMapDetailsTab.tsx
@@ -18,7 +18,7 @@ import {
   type V1beta1NetworkMap,
   type V1beta1Provider,
 } from '@forklift-ui/types';
-import { useK8sWatchResource, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource, useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection } from '@patternfly/react-core';
 import {
   getMapDestinationProviderName,
@@ -38,7 +38,7 @@ type NetworkMapDetailsTabProps = {
 
 const NetworkMapDetailsTab: FC<NetworkMapDetailsTabProps> = ({ name, namespace }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const [networkMap, loaded, loadError] = useK8sWatchResource<V1beta1NetworkMap>({
     groupVersionKind: NetworkMapModelGroupVersionKind,
@@ -88,7 +88,7 @@ const NetworkMapDetailsTab: FC<NetworkMapDetailsTabProps> = ({ name, namespace }
       <PageSection className="forklift-page-section" hasBodyWrapper={false}>
         <SectionHeadingWithEdit
           onClick={() => {
-            launcher<MapProvidersEditProps>(MapProvidersEdit, {
+            launchOverlay<MapProvidersEditProps>(MapProvidersEdit, {
               destinationProvider,
               model: NetworkMapModel,
               namespace,
@@ -105,7 +105,7 @@ const NetworkMapDetailsTab: FC<NetworkMapDetailsTabProps> = ({ name, namespace }
         <SectionHeadingWithEdit
           data-testid="network-map-edit-button"
           onClick={() => {
-            launcher<NetworkMapEditProps>(NetworkMapEdit, {
+            launchOverlay<NetworkMapEditProps>(NetworkMapEdit, {
               destinationProvider,
               initialMappings: currentMappings,
               networkMap,

--- a/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
+++ b/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
@@ -8,7 +8,8 @@ import type { IoK8sApiCoreV1Pod } from '@forklift-ui/types';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { HelperText, HelperTextItem, Pagination, Tooltip } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { getKind, getName, getNamespace, getOwnerReference } from '@utils/crds/common/selectors';
+import { PodModelGroupVersionKind } from '@utils/crds/common/models';
+import { getName, getNamespace, getOwnerReference } from '@utils/crds/common/selectors';
 import { getResourceUrl } from '@utils/getResourceUrl';
 import { isEmpty } from '@utils/helpers';
 
@@ -90,45 +91,57 @@ export const PodsTable: FC<PodsTableProps> = ({ limit, pods, showOwner }) => {
           </Tr>
         </Thead>
         <Tbody>
-          {paginatedPods.map((pod) => (
-            <Tr key={pod?.metadata?.uid}>
-              <Td modifier="fitContent">
-                <ResourceLink
-                  kind={getKind(pod)}
-                  name={getName(pod)}
-                  namespace={getNamespace(pod)}
-                />
-              </Td>
-              {showOwner && (
+          {paginatedPods.map((pod) => {
+            const ownerReference = getOwnerReference(pod);
+            const ownerApiVersion = ownerReference?.apiVersion ?? '';
+            const [ownerGroup, ownerVersion] = ownerApiVersion.includes('/')
+              ? ownerApiVersion.split('/')
+              : [undefined, ownerApiVersion];
+
+            return (
+              <Tr key={pod?.metadata?.uid}>
                 <Td modifier="fitContent">
-                  {getOwnerReference(pod) ? (
-                    <ResourceLink
-                      kind={getOwnerReference(pod)?.kind}
-                      name={getOwnerReference(pod)?.name}
-                      namespace={getNamespace(pod)}
-                    />
+                  <ResourceLink
+                    groupVersionKind={PodModelGroupVersionKind}
+                    name={getName(pod)}
+                    namespace={getNamespace(pod)}
+                  />
+                </Td>
+                {showOwner && (
+                  <Td modifier="fitContent">
+                    {ownerReference ? (
+                      <ResourceLink
+                        groupVersionKind={{
+                          group: ownerGroup,
+                          kind: ownerReference.kind,
+                          version: ownerVersion,
+                        }}
+                        name={ownerReference.name}
+                        namespace={getNamespace(pod)}
+                      />
+                    ) : (
+                      ''
+                    )}
+                  </Td>
+                )}
+                <Td modifier="fitContent">
+                  {pod?.status?.phase ? (
+                    <Tooltip content={pod.status.phase}>
+                      <StatusIcon phase={pod.status.phase} />
+                    </Tooltip>
                   ) : (
                     ''
                   )}
                 </Td>
-              )}
-              <Td modifier="fitContent">
-                {pod?.status?.phase ? (
-                  <Tooltip content={pod.status.phase}>
-                    <StatusIcon phase={pod.status.phase} />
-                  </Tooltip>
-                ) : (
-                  ''
-                )}
-              </Td>
-              <Td modifier="fitContent">
-                <Link to={`${getPodLogsLink(pod)}/logs`}>{t('Logs')}</Link>
-              </Td>
-              <Td modifier="fitContent">
-                <ConsoleTimestamp timestamp={pod?.metadata?.creationTimestamp ?? ''} />
-              </Td>
-            </Tr>
-          ))}
+                <Td modifier="fitContent">
+                  <Link to={`${getPodLogsLink(pod)}/logs`}>{t('Logs')}</Link>
+                </Td>
+                <Td modifier="fitContent">
+                  <ConsoleTimestamp timestamp={pod?.metadata?.creationTimestamp ?? ''} />
+                </Td>
+              </Tr>
+            );
+          })}
         </Tbody>
       </Table>
       {limitedPods.length > PAGINATION_THRESHOLD && (

--- a/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
+++ b/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
@@ -9,7 +9,12 @@ import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { HelperText, HelperTextItem, Pagination, Tooltip } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { PodModelGroupVersionKind } from '@utils/crds/common/models';
-import { getName, getNamespace, getOwnerReference } from '@utils/crds/common/selectors';
+import {
+  getGroupVersionKindFromOwnerReference,
+  getName,
+  getNamespace,
+  getOwnerReference,
+} from '@utils/crds/common/selectors';
 import { getResourceUrl } from '@utils/getResourceUrl';
 import { isEmpty } from '@utils/helpers';
 
@@ -93,10 +98,6 @@ export const PodsTable: FC<PodsTableProps> = ({ limit, pods, showOwner }) => {
         <Tbody>
           {paginatedPods.map((pod) => {
             const ownerReference = getOwnerReference(pod);
-            const ownerApiVersion = ownerReference?.apiVersion ?? '';
-            const [ownerGroup, ownerVersion] = ownerApiVersion.includes('/')
-              ? ownerApiVersion.split('/')
-              : [undefined, ownerApiVersion];
 
             return (
               <Tr key={pod?.metadata?.uid}>
@@ -111,11 +112,7 @@ export const PodsTable: FC<PodsTableProps> = ({ limit, pods, showOwner }) => {
                   <Td modifier="fitContent">
                     {ownerReference ? (
                       <ResourceLink
-                        groupVersionKind={{
-                          group: ownerGroup,
-                          kind: ownerReference.kind,
-                          version: ownerVersion,
-                        }}
+                        groupVersionKind={getGroupVersionKindFromOwnerReference(ownerReference)}
                         name={ownerReference.name}
                         namespace={getNamespace(pod)}
                       />

--- a/src/overview/tabs/Overview/cards/throughput/PlanSelectFilter.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/PlanSelectFilter.tsx
@@ -1,4 +1,4 @@
-import { type FC, type MouseEvent, type Ref, useMemo, useState } from 'react';
+import { type FC, type MouseEvent, type ReactElement, type Ref, useMemo, useState } from 'react';
 
 import {
   Badge,
@@ -68,7 +68,7 @@ const PlanSelectFilter: FC<PlanSelectFilterProps> = ({
     }
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>): JSX.Element => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       badge={
         disabled ? undefined : (

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo, useState } from 'react';
+import { type FC, type ReactElement, useMemo, useState } from 'react';
 
 import {
   Bullseye,
@@ -77,7 +77,7 @@ const ThroughputCard: FC<ThroughputCardProps> = ({ metricName, title }) => {
     }
   }
 
-  const renderBody = (): JSX.Element => {
+  const renderBody = (): ReactElement => {
     if (!loaded && !error) {
       return (
         <Bullseye>

--- a/src/overview/tabs/Overview/cards/throughput/ThroughputTimeRangeSelect.tsx
+++ b/src/overview/tabs/Overview/cards/throughput/ThroughputTimeRangeSelect.tsx
@@ -1,4 +1,4 @@
-import { type FC, type MouseEvent, type Ref, useState } from 'react';
+import { type FC, type MouseEvent, type ReactElement, type Ref, useState } from 'react';
 
 import { MenuToggle, type MenuToggleElement, Select, SelectOption } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -35,7 +35,7 @@ const ThroughputTimeRangeSelect: FC<ThroughputTimeRangeSelectProps> = ({
     setIsOpen(!isOpen);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>): JSX.Element => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       className="forklift-overview__cards-select"
       isExpanded={isOpen}

--- a/src/overview/tabs/Overview/components/MigrationAlertsCard/MigrationAlertsCard.tsx
+++ b/src/overview/tabs/Overview/components/MigrationAlertsCard/MigrationAlertsCard.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react';
+import { type FC, type ReactElement, useMemo } from 'react';
 import { Link } from 'react-router';
 
 import { STATUS_ICONS } from '@components/status/statusIcons';
@@ -41,7 +41,7 @@ const MigrationAlertsCard: FC = () => {
     [alerts],
   );
 
-  const renderAlertList = (): JSX.Element => {
+  const renderAlertList = (): ReactElement => {
     if (!loaded) {
       return (
         <Bullseye>

--- a/src/overview/tabs/Settings/components/SettingsCard.tsx
+++ b/src/overview/tabs/Settings/components/SettingsCard.tsx
@@ -5,7 +5,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import { DetailsItem } from '@components/DetailItems/DetailItem';
 import SectionHeadingWithEdit from '@components/headers/SectionHeadingWithEdit';
 import { ForkliftControllerModel, type V1beta1ForkliftController } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList } from '@patternfly/react-core';
 
 import {
@@ -39,7 +39,7 @@ type SettingsCardProps = {
 
 const SettingsCard: FC<SettingsCardProps> = ({ obj }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const { canPatch } = useGetDeleteAndEditAccessReview({
     model: ForkliftControllerModel,
@@ -61,7 +61,7 @@ const SettingsCard: FC<SettingsCardProps> = ({ obj }) => {
         editable={canPatch}
         headingLevel="h3"
         onClick={() => {
-          launcher<SettingsEditProps>(SettingsEdit, { controller });
+          launchOverlay<SettingsEditProps>(SettingsEdit, { controller });
         }}
         title={t('Settings')}
       />

--- a/src/overview/tabs/Settings/components/SettingsEdit.tsx
+++ b/src/overview/tabs/Settings/components/SettingsEdit.tsx
@@ -3,7 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { ForkliftControllerModel, type V1beta1ForkliftController } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ButtonVariant, Form, ModalVariant } from '@patternfly/react-core';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -29,7 +29,7 @@ import EditSnapshotPoolingInterval from './SnapshotPoolingInterval/EditSnapshotP
 import EditVirtV2vMemsize from './VirtV2vMemsize/EditVirtV2vMemsize';
 import EditVirtV2vSmp from './VirtV2vSmp/EditVirtV2vSmp';
 
-const SettingsEdit: ModalComponent<SettingsEditProps> = ({ closeModal, controller }) => {
+const SettingsEdit: OverlayComponent<SettingsEditProps> = ({ closeOverlay, controller }) => {
   const { t } = useForkliftTranslation();
 
   const methods = useForm<ForkliftSettingsValues>({
@@ -44,7 +44,7 @@ const SettingsEdit: ModalComponent<SettingsEditProps> = ({ closeModal, controlle
 
   const onSubmit = async (formData: ForkliftSettingsValues) => {
     if (!isDirty) {
-      closeModal();
+      closeOverlay();
       return;
     }
 
@@ -73,7 +73,7 @@ const SettingsEdit: ModalComponent<SettingsEditProps> = ({ closeModal, controlle
           },
           variant: ButtonVariant.secondary,
         }}
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="settings-edit-modal"

--- a/src/overview/tabs/Settings/components/SettingsEdit.tsx
+++ b/src/overview/tabs/Settings/components/SettingsEdit.tsx
@@ -73,7 +73,7 @@ const SettingsEdit: OverlayComponent<SettingsEditProps> = ({ closeOverlay, contr
           },
           variant: ButtonVariant.secondary,
         }}
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="settings-edit-modal"

--- a/src/plans/actions/PlanActionsDropdownItems.tsx
+++ b/src/plans/actions/PlanActionsDropdownItems.tsx
@@ -4,7 +4,7 @@ import useGetDeleteAndEditAccessReview from 'src/utils/hooks/useGetDeleteAndEdit
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem, DropdownList } from '@patternfly/react-core';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { getPlanIsWarm } from '@utils/crds/plans/selectors';
@@ -42,7 +42,7 @@ type PlanActionsDropdownItemsProps = {
 
 const PlanActionsDropdownItems: FC<PlanActionsDropdownItemsProps> = ({ isDetailsPage, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
 
   const { canDelete } = useGetDeleteAndEditAccessReview({
@@ -66,30 +66,30 @@ const PlanActionsDropdownItems: FC<PlanActionsDropdownItemsProps> = ({ isDetails
   const hasCutover = canScheduleCutover && Boolean(activeMigration?.spec?.cutover);
 
   const onClickPlanStart = () => {
-    launcher<PlanStartMigrationModalProps>(PlanStartMigrationModal, {
+    launchOverlay<PlanStartMigrationModalProps>(PlanStartMigrationModal, {
       plan,
       title: buttonStartLabel,
     });
   };
 
   const onClickResumeConversion = () => {
-    launcher<PlanResumeConversionModalProps>(PlanResumeConversionModal, { plan });
+    launchOverlay<PlanResumeConversionModalProps>(PlanResumeConversionModal, { plan });
   };
 
   const onClickPlanCutover = () => {
-    launcher<PlanModalProps>(PlanCutoverMigrationModal, { plan });
+    launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
   };
 
   const onClickDuplicate = () => {
-    launcher<PlanModalProps>(DuplicateModal, { plan });
+    launchOverlay<PlanModalProps>(DuplicateModal, { plan });
   };
 
   const onClickArchive = () => {
-    launcher<PlanModalProps>(ArchiveModal, { plan });
+    launchOverlay<PlanModalProps>(ArchiveModal, { plan });
   };
 
   const onClickPlanDelete = () => {
-    launcher<PlanModalProps>(PlanDeleteModal, { plan });
+    launchOverlay<PlanModalProps>(PlanDeleteModal, { plan });
   };
 
   return (

--- a/src/plans/actions/PlanEditCutoverButton.tsx
+++ b/src/plans/actions/PlanEditCutoverButton.tsx
@@ -4,7 +4,7 @@ import PlanCutoverMigrationModal from 'src/plans/actions/components/CutoverModal
 import { usePlanMigration } from 'src/plans/hooks/usePlanMigration';
 
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, type ButtonVariant, Tooltip } from '@patternfly/react-core';
 import { CalendarAltIcon } from '@patternfly/react-icons';
 import { getPlanIsWarm } from '@utils/crds/plans/selectors';
@@ -26,7 +26,7 @@ type PlanEditCutoverButtonProps = {
 
 const PlanEditCutoverButton: FC<PlanEditCutoverButtonProps> = ({ plan, variant }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const cutoverButtonRef = useRef<HTMLButtonElement>(null);
   const [activeMigration] = usePlanMigration(plan);
 
@@ -50,7 +50,7 @@ const PlanEditCutoverButton: FC<PlanEditCutoverButtonProps> = ({ plan, variant }
         iconPosition="left"
         isInline
         onClick={() => {
-          launcher<PlanModalProps>(PlanCutoverMigrationModal, { plan });
+          launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
         }}
         ref={cutoverButtonRef}
         variant={variant}

--- a/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
+++ b/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
@@ -16,7 +16,7 @@ jest.mock('src/plans/hooks/usePlanMigration', () => ({
 
 const mockLauncher = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useModal: () => mockLauncher,
+  useOverlay: () => mockLauncher,
 }));
 
 const buildPlan = (

--- a/src/plans/actions/components/ArchiveModal.tsx
+++ b/src/plans/actions/components/ArchiveModal.tsx
@@ -13,7 +13,7 @@ import { getPlanArchived } from '@utils/crds/plans/selectors';
 
 import type { PlanModalProps } from './types';
 
-const ArchiveModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
+const ArchiveModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan }) => {
   const { t } = useForkliftTranslation();
 
   const onArchive = useCallback(async () => {
@@ -36,7 +36,6 @@ const ArchiveModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ..
       confirmVariant={isPlanRunning ? ButtonVariant.danger : ButtonVariant.primary}
       onConfirm={onArchive}
       title={t('Archive migration plan')}
-      {...rest}
     >
       <ForkliftTrans>
         <Stack hasGutter>

--- a/src/plans/actions/components/ArchiveModal.tsx
+++ b/src/plans/actions/components/ArchiveModal.tsx
@@ -31,7 +31,7 @@ const ArchiveModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ..
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Archive')}
       confirmVariant={isPlanRunning ? ButtonVariant.danger : ButtonVariant.primary}
       onConfirm={onArchive}

--- a/src/plans/actions/components/ArchiveModal.tsx
+++ b/src/plans/actions/components/ArchiveModal.tsx
@@ -6,14 +6,14 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { PlanModel } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
 import { getName } from '@utils/crds/common/selectors';
 import { getPlanArchived } from '@utils/crds/plans/selectors';
 
 import type { PlanModalProps } from './types';
 
-const ArchiveModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
+const ArchiveModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
   const { t } = useForkliftTranslation();
 
   const onArchive = useCallback(async () => {
@@ -31,6 +31,7 @@ const ArchiveModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Archive')}
       confirmVariant={isPlanRunning ? ButtonVariant.danger : ButtonVariant.primary}
       onConfirm={onArchive}

--- a/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
+++ b/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
@@ -4,7 +4,7 @@ import { usePlanMigration } from 'src/plans/hooks/usePlanMigration';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ButtonVariant, Flex, FlexItem, Radio, Stack, StackItem } from '@patternfly/react-core';
 import { useForkliftAnalytics } from '@utils/analytics/hooks/useForkliftAnalytics';
 import { getName } from '@utils/crds/common/selectors';
@@ -21,7 +21,11 @@ import ScheduledCutoverFields from './ScheduledCutoverFields';
 
 import './PlanCutoverMigrationModal.scss';
 
-const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
+const PlanCutoverMigrationModal: OverlayComponent<PlanModalProps> = ({
+  closeOverlay,
+  plan,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
   const [isDateValid, setIsDateValid] = useState<boolean>(true);
@@ -118,6 +122,7 @@ const PlanCutoverMigrationModal: ModalComponent<PlanModalProps> = ({ plan, ...re
   return (
     <ModalForm
       additionalAction={additionalAction}
+      closeModal={closeOverlay}
       confirmLabel={t('Set cutover')}
       isDisabled={isScheduledInvalid}
       onConfirm={onCutover}

--- a/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
+++ b/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
@@ -122,7 +122,7 @@ const PlanCutoverMigrationModal: OverlayComponent<PlanModalProps> = ({
   return (
     <ModalForm
       additionalAction={additionalAction}
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Set cutover')}
       isDisabled={isScheduledInvalid}
       onConfirm={onCutover}

--- a/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
+++ b/src/plans/actions/components/CutoverModal/PlanCutoverMigrationModal.tsx
@@ -21,11 +21,7 @@ import ScheduledCutoverFields from './ScheduledCutoverFields';
 
 import './PlanCutoverMigrationModal.scss';
 
-const PlanCutoverMigrationModal: OverlayComponent<PlanModalProps> = ({
-  closeOverlay,
-  plan,
-  ...rest
-}) => {
+const PlanCutoverMigrationModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan }) => {
   const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
   const [isDateValid, setIsDateValid] = useState<boolean>(true);
@@ -127,7 +123,6 @@ const PlanCutoverMigrationModal: OverlayComponent<PlanModalProps> = ({
       isDisabled={isScheduledInvalid}
       onConfirm={onCutover}
       title={hasExistingCutover ? t('Edit cutover') : t('Schedule cutover')}
-      {...rest}
     >
       <ForkliftTrans>
         <Stack hasGutter>

--- a/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
+++ b/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
@@ -49,9 +49,11 @@ const mockMigrationWithoutCutover = {
   spec: {},
 } as unknown as V1beta1Migration;
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 const mockMigrationWithCutover = {
   metadata: { name: 'test-migration', namespace: 'test-ns' },
-  spec: { cutover: '2026-08-15T10:00:00.000Z' },
+  spec: { cutover: new Date(Date.now() + ONE_DAY_MS).toISOString() },
 } as unknown as V1beta1Migration;
 
 const closeOverlay = jest.fn();

--- a/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
+++ b/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
@@ -54,7 +54,7 @@ const mockMigrationWithCutover = {
   spec: { cutover: '2026-08-15T10:00:00.000Z' },
 } as unknown as V1beta1Migration;
 
-const closeModal = jest.fn();
+const closeOverlay = jest.fn();
 
 describe('PlanCutoverMigrationModal', () => {
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('renders with ASAP radio selected by default', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       const asapRadio = screen.getByTestId('cutover-mode-asap');
       const scheduledRadio = screen.getByTestId('cutover-mode-scheduled');
@@ -77,7 +77,7 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('hides date/time pickers when ASAP is selected', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.queryByLabelText('Cutover date')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Cutover time')).not.toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('PlanCutoverMigrationModal', () => {
 
     it('shows date/time pickers when scheduled is selected', async () => {
       const user = userEvent.setup();
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       await user.click(screen.getByTestId('cutover-mode-scheduled'));
 
@@ -98,7 +98,7 @@ describe('PlanCutoverMigrationModal', () => {
       const now = '2026-07-06T10:00:00.000Z';
       jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(now);
 
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       const confirmButton = screen.getByRole('button', { name: /set cutover/i });
       await user.click(confirmButton);
@@ -113,7 +113,7 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('does not show Remove cutover action when ASAP is selected', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.queryByRole('button', { name: /remove cutover/i })).not.toBeInTheDocument();
     });
@@ -125,7 +125,7 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('defaults to scheduled mode when cutover already exists', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       const asapRadio = screen.getByTestId('cutover-mode-asap');
       const scheduledRadio = screen.getByTestId('cutover-mode-scheduled');
@@ -135,21 +135,21 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('shows date/time pickers pre-filled in edit mode', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.getByLabelText('Cutover date')).toBeInTheDocument();
       expect(screen.getByLabelText('Cutover time')).toBeInTheDocument();
     });
 
     it('shows Remove cutover action in scheduled mode', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.getByRole('button', { name: /remove cutover/i })).toBeInTheDocument();
     });
 
     it('hides Remove cutover action when switching to ASAP', async () => {
       const user = userEvent.setup();
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       await user.click(screen.getByTestId('cutover-mode-asap'));
 
@@ -157,7 +157,7 @@ describe('PlanCutoverMigrationModal', () => {
     });
 
     it('shows Edit cutover as title when cutover exists', () => {
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.getByText('Edit cutover')).toBeInTheDocument();
     });
@@ -172,7 +172,7 @@ describe('PlanCutoverMigrationModal', () => {
     it('shows info alert when scheduled date is in the past', () => {
       mockUsePlanMigration.mockReturnValue([mockMigrationWithPastCutover, true, null]);
 
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(
         screen.getByText(
@@ -184,7 +184,7 @@ describe('PlanCutoverMigrationModal', () => {
     it('does not show info alert when scheduled date is in the future', () => {
       mockUsePlanMigration.mockReturnValue([mockMigrationWithCutover, true, null]);
 
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(
         screen.queryByText(
@@ -201,7 +201,7 @@ describe('PlanCutoverMigrationModal', () => {
 
     it('toggles between ASAP and scheduled modes', async () => {
       const user = userEvent.setup();
-      render(<PlanCutoverMigrationModal closeModal={closeModal} plan={mockPlan} />);
+      render(<PlanCutoverMigrationModal closeOverlay={closeOverlay} plan={mockPlan} />);
 
       expect(screen.getByTestId('cutover-mode-asap')).toBeChecked();
       expect(screen.queryByLabelText('Cutover date')).not.toBeInTheDocument();

--- a/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
+++ b/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
@@ -135,7 +135,7 @@ const DuplicateModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, 
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Duplicate')}
       onConfirm={onDuplicate}
       title={t('Duplicate migration plan')}

--- a/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
+++ b/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
@@ -14,7 +14,7 @@ import {
   type V1beta1StorageMap,
 } from '@forklift-ui/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack, StackItem, TextInput } from '@patternfly/react-core';
 import { getName, getNamespace } from '@utils/crds/common/selectors';
 import {
@@ -44,7 +44,7 @@ const getPlanHookNames = (plan: V1beta1Plan): { postHookName?: string; preHookNa
   return { postHookName, preHookName };
 };
 
-const DuplicateModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
+const DuplicateModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
   const { t } = useForkliftTranslation();
   const name = getName(plan);
   const [newName, setNewName] = useState<string>(`copy-of-${name}`);
@@ -135,6 +135,7 @@ const DuplicateModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Duplicate')}
       onConfirm={onDuplicate}
       title={t('Duplicate migration plan')}

--- a/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
+++ b/src/plans/actions/components/DuplicateModal/DuplicateModal.tsx
@@ -44,7 +44,7 @@ const getPlanHookNames = (plan: V1beta1Plan): { postHookName?: string; preHookNa
   return { postHookName, preHookName };
 };
 
-const DuplicateModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
+const DuplicateModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan }) => {
   const { t } = useForkliftTranslation();
   const name = getName(plan);
   const [newName, setNewName] = useState<string>(`copy-of-${name}`);
@@ -139,7 +139,6 @@ const DuplicateModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, 
       confirmLabel={t('Duplicate')}
       onConfirm={onDuplicate}
       title={t('Duplicate migration plan')}
-      {...rest}
     >
       <ForkliftTrans>
         <Stack hasGutter>

--- a/src/plans/actions/components/PlanDeleteModal.tsx
+++ b/src/plans/actions/components/PlanDeleteModal.tsx
@@ -15,7 +15,7 @@ import { getResourceUrl } from '@utils/getResourceUrl';
 
 import type { PlanModalProps } from './types';
 
-const PlanDeleteModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
+const PlanDeleteModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan }) => {
   const { t } = useForkliftTranslation();
   const navigate = useNavigate();
 
@@ -41,7 +41,6 @@ const PlanDeleteModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan,
       confirmVariant={ButtonVariant.danger}
       onConfirm={onDelete}
       title={t('Delete plan')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/actions/components/PlanDeleteModal.tsx
+++ b/src/plans/actions/components/PlanDeleteModal.tsx
@@ -36,7 +36,7 @@ const PlanDeleteModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan,
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       onConfirm={onDelete}

--- a/src/plans/actions/components/PlanDeleteModal.tsx
+++ b/src/plans/actions/components/PlanDeleteModal.tsx
@@ -8,14 +8,14 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { PlanModel } from '@forklift-ui/types';
 import { getGroupVersionKindForModel, k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, ButtonVariant, Stack, StackItem } from '@patternfly/react-core';
 import { getName, getNamespace, getOwnerReference } from '@utils/crds/common/selectors';
 import { getResourceUrl } from '@utils/getResourceUrl';
 
 import type { PlanModalProps } from './types';
 
-const PlanDeleteModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
+const PlanDeleteModal: OverlayComponent<PlanModalProps> = ({ closeOverlay, plan, ...rest }) => {
   const { t } = useForkliftTranslation();
   const navigate = useNavigate();
 
@@ -36,6 +36,7 @@ const PlanDeleteModal: ModalComponent<PlanModalProps> = ({ plan, ...rest }) => {
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       onConfirm={onDelete}

--- a/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
+++ b/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
@@ -4,7 +4,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { MigrationModel, type V1beta1Plan } from '@forklift-ui/types';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Alert,
   AlertVariant,
@@ -20,7 +20,8 @@ export type PlanResumeConversionModalProps = {
   plan: V1beta1Plan;
 };
 
-const PlanResumeConversionModal: ModalComponent<PlanResumeConversionModalProps> = ({
+const PlanResumeConversionModal: OverlayComponent<PlanResumeConversionModalProps> = ({
+  closeOverlay,
   plan,
   ...rest
 }) => {
@@ -54,6 +55,7 @@ const PlanResumeConversionModal: ModalComponent<PlanResumeConversionModalProps> 
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Resume')}
       onConfirm={onConfirm}
       title={t('Resume conversion')}

--- a/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
+++ b/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
@@ -23,7 +23,6 @@ export type PlanResumeConversionModalProps = {
 const PlanResumeConversionModal: OverlayComponent<PlanResumeConversionModalProps> = ({
   closeOverlay,
   plan,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const { name, namespace, uid } = getObjectRef(plan);
@@ -59,7 +58,6 @@ const PlanResumeConversionModal: OverlayComponent<PlanResumeConversionModalProps
       confirmLabel={t('Resume')}
       onConfirm={onConfirm}
       title={t('Resume conversion')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
+++ b/src/plans/actions/components/ResumeConversionModal/PlanResumeConversionModal.tsx
@@ -55,7 +55,7 @@ const PlanResumeConversionModal: OverlayComponent<PlanResumeConversionModalProps
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Resume')}
       onConfirm={onConfirm}
       title={t('Resume conversion')}

--- a/src/plans/actions/components/ResumeConversionModal/__tests__/PlanResumeConversionModal.test.tsx
+++ b/src/plans/actions/components/ResumeConversionModal/__tests__/PlanResumeConversionModal.test.tsx
@@ -42,7 +42,7 @@ const makePlan = (disksCopiedVMs: string[] = ['vm-1']): V1beta1Plan =>
     },
   }) as unknown as V1beta1Plan;
 
-const closeModal = jest.fn();
+const closeOverlay = jest.fn();
 
 describe('PlanResumeConversionModal', () => {
   beforeEach(() => {
@@ -50,14 +50,14 @@ describe('PlanResumeConversionModal', () => {
   });
 
   it('renders the modal with the correct title and confirm label', () => {
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan()} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan()} />);
 
     expect(screen.getByText('Resume conversion')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /resume/i })).toBeInTheDocument();
   });
 
   it('shows the info alert and safety warning', () => {
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan()} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan()} />);
 
     expect(screen.getByText('Disk copy will be skipped')).toBeInTheDocument();
     expect(
@@ -68,7 +68,9 @@ describe('PlanResumeConversionModal', () => {
   });
 
   it('displays the interpolated VM count in the confirmation message', () => {
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan(['vm-1', 'vm-2'])} />);
+    render(
+      <PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan(['vm-1', 'vm-2'])} />,
+    );
 
     expect(
       screen.getByText(
@@ -78,7 +80,7 @@ describe('PlanResumeConversionModal', () => {
   });
 
   it('displays the correct count for a single VM', () => {
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan(['vm-1'])} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan(['vm-1'])} />);
 
     expect(
       screen.getByText(
@@ -89,7 +91,7 @@ describe('PlanResumeConversionModal', () => {
 
   it('creates a Migration with resumeConversion: true on confirm', async () => {
     const user = userEvent.setup();
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan()} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan()} />);
 
     const confirmButton = screen.getByRole('button', { name: /resume/i });
     await user.click(confirmButton);
@@ -107,7 +109,7 @@ describe('PlanResumeConversionModal', () => {
 
   it('sets the correct ownerReference on the Migration', async () => {
     const user = userEvent.setup();
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan()} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan()} />);
 
     await user.click(screen.getByRole('button', { name: /resume/i }));
 
@@ -122,7 +124,7 @@ describe('PlanResumeConversionModal', () => {
 
   it('sets generateName with plan name prefix', async () => {
     const user = userEvent.setup();
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={makePlan()} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={makePlan()} />);
 
     await user.click(screen.getByRole('button', { name: /resume/i }));
 
@@ -147,7 +149,7 @@ describe('PlanResumeConversionModal', () => {
       },
     } as unknown as V1beta1Plan;
 
-    render(<PlanResumeConversionModal closeModal={closeModal} plan={plan} />);
+    render(<PlanResumeConversionModal closeOverlay={closeOverlay} plan={plan} />);
 
     expect(
       screen.getByText(

--- a/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
+++ b/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
@@ -45,7 +45,7 @@ const PlanStartMigrationModal: OverlayComponent<PlanStartMigrationModalProps> = 
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('{{title}}', { title })}
       isDisabled={!canPlanStart(plan) || Boolean(isMigrationStarted)}
       onConfirm={onStart}

--- a/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
+++ b/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
@@ -7,7 +7,7 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { useForkliftAnalytics } from '@utils/analytics/hooks/useForkliftAnalytics';
 import { getName } from '@utils/crds/common/selectors';
@@ -20,7 +20,8 @@ export type PlanStartMigrationModalProps = {
   title: string;
 };
 
-const PlanStartMigrationModal: ModalComponent<PlanStartMigrationModalProps> = ({
+const PlanStartMigrationModal: OverlayComponent<PlanStartMigrationModalProps> = ({
+  closeOverlay,
   plan,
   title,
   ...rest
@@ -44,6 +45,7 @@ const PlanStartMigrationModal: ModalComponent<PlanStartMigrationModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('{{title}}', { title })}
       isDisabled={!canPlanStart(plan) || Boolean(isMigrationStarted)}
       onConfirm={onStart}

--- a/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
+++ b/src/plans/actions/components/StartPlanModal/PlanStartMigrationModal.tsx
@@ -24,7 +24,6 @@ const PlanStartMigrationModal: OverlayComponent<PlanStartMigrationModalProps> = 
   closeOverlay,
   plan,
   title,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
@@ -50,7 +49,6 @@ const PlanStartMigrationModal: OverlayComponent<PlanStartMigrationModalProps> = 
       isDisabled={!canPlanStart(plan) || Boolean(isMigrationStarted)}
       onConfirm={onStart}
       title={t('{{title}} migration', { title })}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/details/components/PlanStatus/StatusPopover.tsx
+++ b/src/plans/details/components/PlanStatus/StatusPopover.tsx
@@ -4,7 +4,7 @@ import PlanCutoverMigrationModal from 'src/plans/actions/components/CutoverModal
 import type { PlanModalProps } from 'src/plans/actions/components/types';
 
 import { PlanModelRef, type V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   ButtonVariant,
@@ -37,13 +37,13 @@ type StatusPopoverProps = {
 };
 
 const StatusPopover: FC<StatusPopoverProps> = ({ count, plan, status, vms }) => {
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
 
   const { actionLabel, body, header } = getPopoverMessageByStatus(status, count);
 
   const openScheduleCutoverModal = () => {
-    launcher<PlanModalProps>(PlanCutoverMigrationModal, { plan });
+    launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
   };
 
   const navigateToVMsTab = () => {

--- a/src/plans/details/tabs/Automation/components/ScriptEdit/ScriptEdit.tsx
+++ b/src/plans/details/tabs/Automation/components/ScriptEdit/ScriptEdit.tsx
@@ -41,7 +41,7 @@ const ScriptEdit: OverlayComponent<ScriptEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="script-edit-modal"

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/DescriptionDetailItem.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/DescriptionDetailItem.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Truncate } from '@patternfly/react-core';
 import { getPlanDescription } from '@utils/crds/plans/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -15,7 +15,7 @@ import EditPlanDescription from './EditPlanDescription';
 
 const DescriptionDetailItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const description = getPlanDescription(plan) ?? '';
   const content = isEmpty(description) ? t('None') : description;
@@ -24,7 +24,7 @@ const DescriptionDetailItem: FC<EditableDetailsItemProps> = ({ canPatch, plan })
       canEdit={canPatch && isPlanEditable(plan)}
       content={<Truncate content={content} />}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanDescription, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanDescription, { resource: plan });
       }}
       testId="description-detail-item"
       title={t('Description')}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
@@ -10,11 +10,7 @@ import type { EditPlanProps } from '../../../SettingsSection/utils/types';
 
 import { onConfirmDescription } from './utils/utils';
 
-const EditPlanDescription: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditPlanDescription: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<string | undefined>(getPlanDescription(resource));
 
@@ -23,7 +19,6 @@ const EditPlanDescription: OverlayComponent<EditPlanProps> = ({
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmDescription({ newValue: value, resource })}
       title={t('Edit description')}
-      {...rest}
     >
       <Form>
         <FormGroup label={t('Description')}>

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
@@ -20,7 +20,7 @@ const EditPlanDescription: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmDescription({ newValue: value, resource })}
       title={t('Edit description')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/EditPlanDescription.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { getPlanDescription } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -10,12 +10,17 @@ import type { EditPlanProps } from '../../../SettingsSection/utils/types';
 
 import { onConfirmDescription } from './utils/utils';
 
-const EditPlanDescription: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanDescription: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<string | undefined>(getPlanDescription(resource));
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmDescription({ newValue: value, resource })}
       title={t('Edit description')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
@@ -56,7 +56,7 @@ const EditPlanMigrationType: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       description={t('Set the migration type for your migration plan.')}
       onConfirm={async () => onConfirmMigrationType({ newValue: selected, resource })}
       testId="edit-migration-type-modal"

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
@@ -13,7 +13,7 @@ import { useCbtDisabledVms } from 'src/plans/details/hooks/useCbtDisabledVms';
 import { getPlanMigrationType } from 'src/plans/details/utils/utils';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Flex, FlexItem, Radio } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -28,7 +28,8 @@ const VISIBLE_TYPES: MigrationTypeValue[] = [
   MigrationTypeValue.Live,
 ];
 
-const EditPlanMigrationType: ModalComponent<EditPlanProps> = ({
+const EditPlanMigrationType: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
   isVddkInitImageNotSet,
   resource,
   sourceProvider,
@@ -55,6 +56,7 @@ const EditPlanMigrationType: ModalComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       description={t('Set the migration type for your migration plan.')}
       onConfirm={async () => onConfirmMigrationType({ newValue: selected, resource })}
       testId="edit-migration-type-modal"

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/EditPlanMigrationType.tsx
@@ -33,7 +33,6 @@ const EditPlanMigrationType: OverlayComponent<EditPlanProps> = ({
   isVddkInitImageNotSet,
   resource,
   sourceProvider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [selected, setSelected] = useState<MigrationTypeValue>(getPlanMigrationType(resource));
@@ -61,7 +60,6 @@ const EditPlanMigrationType: OverlayComponent<EditPlanProps> = ({
       onConfirm={async () => onConfirmMigrationType({ newValue: selected, resource })}
       testId="edit-migration-type-modal"
       title={t('Edit migration type')}
-      {...rest}
     >
       <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsLg' }}>
         {VISIBLE_TYPES.filter(canShowType).map((type) => {

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/MigrationTypeDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/MigrationTypeDetailsItem.tsx
@@ -6,7 +6,7 @@ import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/Se
 import { getPlanMigrationType } from 'src/plans/details/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
 
@@ -20,7 +20,7 @@ const MigrationTypeDetailsItem: FC<EditableDetailsItemProps> = ({
   sourceProvider,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -35,7 +35,7 @@ const MigrationTypeDetailsItem: FC<EditableDetailsItemProps> = ({
       crumbs={['spec', 'type']}
       helpContent={t('The migration strategy used for this plan.')}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanMigrationType, {
+        launchOverlay<EditPlanProps>(EditPlanMigrationType, {
           isVddkInitImageNotSet,
           resource: plan,
           sourceProvider,

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack } from '@patternfly/react-core';
 import { getPlanTargetNamespace } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -15,7 +15,11 @@ import { onConfirmTargetNamespace } from './utils/utils';
 import LocalProviderNamespaceSelect from './LocalProviderNamespaceSelect';
 import RemoteProviderNamespaceSelect from './RemoteProviderNamespaceSelect';
 
-const EditPlanTargetNamespace: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanTargetNamespace: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const { destinationProvider } = usePlanDestinationProvider(resource);
   const [value, setValue] = useState<string>(getPlanTargetNamespace(resource) ?? '');
@@ -24,6 +28,7 @@ const EditPlanTargetNamespace: ModalComponent<EditPlanProps> = ({ resource, ...r
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmTargetNamespace({ newValue: value, resource })}
       title={t('Edit migration plan target project')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
@@ -15,11 +15,7 @@ import { onConfirmTargetNamespace } from './utils/utils';
 import LocalProviderNamespaceSelect from './LocalProviderNamespaceSelect';
 import RemoteProviderNamespaceSelect from './RemoteProviderNamespaceSelect';
 
-const EditPlanTargetNamespace: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditPlanTargetNamespace: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const { destinationProvider } = usePlanDestinationProvider(resource);
   const [value, setValue] = useState<string>(getPlanTargetNamespace(resource) ?? '');
@@ -31,7 +27,6 @@ const EditPlanTargetNamespace: OverlayComponent<EditPlanProps> = ({
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmTargetNamespace({ newValue: value, resource })}
       title={t('Edit migration plan target project')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(`You can select a migration target project for the migration virtual machines.`)}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/EditPlanTargetNamespace.tsx
@@ -28,7 +28,7 @@ const EditPlanTargetNamespace: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmTargetNamespace({ newValue: value, resource })}
       title={t('Edit migration plan target project')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/TargetNamespaceDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/TargetNamespaceDetailsItem.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { getPlanTargetNamespace } from '@utils/crds/plans/selectors';
 
@@ -15,7 +15,7 @@ import EditPlanTargetNamespace from './EditPlanTargetNamespace';
 
 const TargetNamespaceDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   return (
     <DetailsItem
@@ -32,7 +32,7 @@ const TargetNamespaceDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, pl
         'Projects, also known as namespaces, separate resources within clusters. The target project is the project, within your selected target provider, that your virtual machines will be migrated to. This is different from the project that your migration plan will be created in and where your provider was created.',
       )}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanTargetNamespace, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanTargetNamespace, { resource: plan });
       }}
       testId="target-project-detail-item"
       title={t('Target project')}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorAffinity/ConvertorAffinityDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorAffinity/ConvertorAffinityDetailsItem.tsx
@@ -5,7 +5,7 @@ import AffinityModal, { type AffinityModalProps } from '@components/AffinityModa
 import AffinityViewDetailsItemContent from '@components/AffinityViewDetailsItemContent/AffinityViewDetailsItemContent';
 import { DetailsItem } from '@components/DetailItems/DetailItem';
 import type { K8sIoApiCoreV1Affinity, V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { useForkliftTranslation } from '@utils/i18n';
 import { DOC_MAIN_HELP_LINK } from '@utils/links';
 
@@ -18,7 +18,7 @@ const ConvertorAffinityDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -46,7 +46,7 @@ const ConvertorAffinityDetailsItem: FC<EditableDetailsItemProps> = ({
       helpContent={description}
       moreInfoLink={DOC_MAIN_HELP_LINK}
       onEdit={() => {
-        launcher<AffinityModalProps>(AffinityModal, {
+        launchOverlay<AffinityModalProps>(AffinityModal, {
           initialAffinity,
           onConfirm,
           title: t('Edit convertor pod affinity rules'),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorLabels/ConvertorLabelsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorLabels/ConvertorLabelsDetailsItem.tsx
@@ -5,7 +5,7 @@ import { DetailsItem } from '@components/DetailItems/DetailItem';
 import LabelsModal, { type LabelsModalProps } from '@components/LabelsModal/LabelsModal';
 import LabelsViewDetailsItemContent from '@components/LabelsViewDetailsItemContent/LabelsViewDetailsItemContent';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
 import { DOC_MAIN_HELP_LINK } from '@utils/links';
@@ -19,7 +19,7 @@ const ConvertorLabelsDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -45,7 +45,7 @@ const ConvertorLabelsDetailsItem: FC<EditableDetailsItemProps> = ({
       helpContent={description}
       moreInfoLink={DOC_MAIN_HELP_LINK}
       onEdit={() => {
-        launcher<LabelsModalProps>(LabelsModal, {
+        launchOverlay<LabelsModalProps>(LabelsModal, {
           description: (
             <ForkliftTrans>
               <Stack hasGutter>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorNodeSelector/ConvertorNodeSelectorDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/ConvertorNodeSelector/ConvertorNodeSelectorDetailsItem.tsx
@@ -7,7 +7,7 @@ import NodeSelectorModal, {
 } from '@components/NodeSelectorModal/NodeSelectorModal';
 import NodeSelectorViewDetailsItemContent from '@components/NodeSelectorViewDetailsItemContent/NodeSelectorViewDetailsItemContent';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { ForkliftTrans, useForkliftTranslation } from '@utils/i18n';
@@ -22,7 +22,7 @@ const ConvertorNodeSelectorDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -48,7 +48,7 @@ const ConvertorNodeSelectorDetailsItem: FC<EditableDetailsItemProps> = ({
       helpContent={description}
       moreInfoLink={DOC_MAIN_HELP_LINK}
       onEdit={() => {
-        launcher<NodeSelectorModalProps>(NodeSelectorModal, {
+        launchOverlay<NodeSelectorModalProps>(NodeSelectorModal, {
           description: (
             <ForkliftTrans>
               <Stack hasGutter>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
@@ -44,7 +44,7 @@ const EditNameTemplate: OverlayComponent<EditNameTemplateProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={
         selected === NameTemplateOptions.CustomNameTemplate &&
         (inputValue === value || isEmpty(inputValue.trim()))

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
@@ -35,7 +35,6 @@ const EditNameTemplate: OverlayComponent<EditNameTemplateProps> = ({
   onConfirm,
   title,
   value,
-  ...rest
 }) => {
   const [selected, setSelected] = useState<NameTemplateOptions>(
     getSelectedOption(value, allowInherit),
@@ -58,7 +57,6 @@ const EditNameTemplate: OverlayComponent<EditNameTemplateProps> = ({
           : onConfirm(undefined);
       }}
       title={title}
-      {...rest}
     >
       {body}
       <Form>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/EditNameTemplate.tsx
@@ -3,7 +3,7 @@ import { type ReactNode, useState } from 'react';
 import Select from '@components/common/Select';
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, FormGroup, SelectList, SelectOption, TextInput } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -25,9 +25,10 @@ type EditNameTemplateProps = {
   value: string | undefined;
 };
 
-const EditNameTemplate: ModalComponent<EditNameTemplateProps> = ({
+const EditNameTemplate: OverlayComponent<EditNameTemplateProps> = ({
   allowInherit = true,
   body,
+  closeOverlay,
   fieldName,
   helperText,
   inheritValue,
@@ -43,6 +44,7 @@ const EditNameTemplate: ModalComponent<EditNameTemplateProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={
         selected === NameTemplateOptions.CustomNameTemplate &&
         (inputValue === value || isEmpty(inputValue.trim()))

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, Stack, StackItem } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -18,7 +18,7 @@ const GuestConversionDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -51,7 +51,7 @@ const GuestConversionDetailsItem: FC<EditableDetailsItemProps> = ({
       }
       crumbs={['spec', 'skipGuestConversion']}
       onEdit={() => {
-        launcher<EditPlanProps>(GuestConversionEditModal, { resource: plan });
+        launchOverlay<EditPlanProps>(GuestConversionEditModal, { resource: plan });
       }}
       testId="guest-conversion-mode-detail-item"
       title={t('Guest conversion mode')}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Alert,
   AlertVariant,
@@ -21,7 +21,11 @@ import type { EditPlanProps } from '../../utils/types';
 import { patchGuestConversion } from './utils/patchGuestConversion';
 import { getSkipGuestConversion, getUseCompatibilityMode } from './utils/utils';
 
-const GuestConversionEditModal: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const GuestConversionEditModal: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [skipGuestConversion, setSkipGuestConversion] = useState<boolean>(
     Boolean(getSkipGuestConversion(resource)),
@@ -32,6 +36,7 @@ const GuestConversionEditModal: ModalComponent<EditPlanProps> = ({ resource, ...
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () =>
         patchGuestConversion({
           newValue: skipGuestConversion,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
@@ -36,7 +36,7 @@ const GuestConversionEditModal: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () =>
         patchGuestConversion({
           newValue: skipGuestConversion,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/GuestConversionEditModal.tsx
@@ -21,11 +21,7 @@ import type { EditPlanProps } from '../../utils/types';
 import { patchGuestConversion } from './utils/patchGuestConversion';
 import { getSkipGuestConversion, getUseCompatibilityMode } from './utils/utils';
 
-const GuestConversionEditModal: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const GuestConversionEditModal: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const [skipGuestConversion, setSkipGuestConversion] = useState<boolean>(
     Boolean(getSkipGuestConversion(resource)),
@@ -46,7 +42,6 @@ const GuestConversionEditModal: OverlayComponent<EditPlanProps> = ({
       }
       testId="guest-conversion-mode-modal"
       title={t('Guest conversion mode')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/EditNetworkNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/EditNetworkNameTemplate.tsx
@@ -27,7 +27,6 @@ const EditNetworkNameTemplate: OverlayComponent<EditNetworkNameTemplateProps> = 
   onConfirmNetworkNameTemplate,
   resource,
   value,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -49,7 +48,6 @@ const EditNetworkNameTemplate: OverlayComponent<EditNetworkNameTemplateProps> = 
       onConfirm={async (newValue) => onConfirmNetworkNameTemplate({ newValue, resource })}
       title={t('Edit network name template')}
       value={value}
-      {...rest}
     />
   );
 };

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/EditNetworkNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/EditNetworkNameTemplate.tsx
@@ -1,5 +1,5 @@
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import NameTemplateBody from '../EditNameTemplate/components/NameTemplateBody';
@@ -21,8 +21,9 @@ export type EditNetworkNameTemplateProps = {
   value?: string;
 };
 
-const EditNetworkNameTemplate: ModalComponent<EditNetworkNameTemplateProps> = ({
+const EditNetworkNameTemplate: OverlayComponent<EditNetworkNameTemplateProps> = ({
   allowInherit = true,
+  closeOverlay,
   onConfirmNetworkNameTemplate,
   resource,
   value,
@@ -41,6 +42,7 @@ const EditNetworkNameTemplate: ModalComponent<EditNetworkNameTemplateProps> = ({
           )}
         />
       }
+      closeOverlay={closeOverlay}
       fieldName={allowInherit ? t('VM network name template') : t('Plan network name template')}
       helperText={<NameTemplateHelper examples={networkNameTemplateHelperExamples} />}
       inheritValue={resource?.spec?.networkNameTemplate}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/NetworkNameTemplateDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -19,7 +19,7 @@ const NetworkNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -37,7 +37,7 @@ const NetworkNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
       content={content}
       crumbs={['spec', 'networkNameTemplate']}
       onEdit={() => {
-        launcher<EditNetworkNameTemplateProps>(EditNetworkNameTemplate, {
+        launchOverlay<EditNetworkNameTemplateProps>(EditNetworkNameTemplate, {
           allowInherit: false,
           onConfirmNetworkNameTemplate: onConfirmPlanNetworkNameTemplate,
           resource: plan,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/EditPVCNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/EditPVCNameTemplate.tsx
@@ -1,5 +1,5 @@
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import NameTemplateBody from '../EditNameTemplate/components/NameTemplateBody';
@@ -18,8 +18,9 @@ export type EditPVCNameTemplateProps = {
   value?: string;
 };
 
-const EditPVCNameTemplate: ModalComponent<EditPVCNameTemplateProps> = ({
+const EditPVCNameTemplate: OverlayComponent<EditPVCNameTemplateProps> = ({
   allowInherit = true,
+  closeOverlay,
   onConfirmPVCNameTemplate,
   resource,
   value,
@@ -38,6 +39,7 @@ const EditPVCNameTemplate: ModalComponent<EditPVCNameTemplateProps> = ({
           )}
         />
       }
+      closeOverlay={closeOverlay}
       fieldName={allowInherit ? t('VM PVC name template') : t('Plan PVC name template')}
       helperText={<NameTemplateHelper examples={pvcNameTemplateHelperExamples} />}
       inheritValue={resource?.spec?.pvcNameTemplate}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/EditPVCNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/EditPVCNameTemplate.tsx
@@ -24,7 +24,6 @@ const EditPVCNameTemplate: OverlayComponent<EditPVCNameTemplateProps> = ({
   onConfirmPVCNameTemplate,
   resource,
   value,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -46,7 +45,6 @@ const EditPVCNameTemplate: OverlayComponent<EditPVCNameTemplateProps> = ({
       onConfirm={async (newValue) => onConfirmPVCNameTemplate({ newValue, resource })}
       title={t('Edit PVC name template')}
       value={value}
-      {...rest}
     />
   );
 };

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/PVCNameTemplateDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -17,7 +17,7 @@ const PVCNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -35,7 +35,7 @@ const PVCNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
       content={content}
       crumbs={['spec', 'pvcNameTemplate']}
       onEdit={() => {
-        launcher<EditPVCNameTemplateProps>(EditPVCNameTemplate, {
+        launchOverlay<EditPVCNameTemplateProps>(EditPVCNameTemplate, {
           allowInherit: false,
           onConfirmPVCNameTemplate,
           resource: plan,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
@@ -22,7 +22,7 @@ const EditMigrateSharedDisks: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       description={t('Choose whether to migrate shared disks with your migration.')}
       headerHelp={
         <HelpIconPopover header={t('Migrate shared disks')}>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
@@ -3,7 +3,7 @@ import PlanVddkForSharedDisksWarningAlert from 'src/plans/components/PlanVddkFor
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, AlertVariant, Checkbox, Stack, StackItem } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -11,7 +11,8 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { getMigrateSharedDisksValue, onConfirmMigrateSharedDisks } from './utils/utils';
 
-const EditMigrateSharedDisks: ModalComponent<EditPlanProps> = ({
+const EditMigrateSharedDisks: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
   isVddkInitImageNotSet,
   resource,
   ...rest
@@ -21,6 +22,7 @@ const EditMigrateSharedDisks: ModalComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       description={t('Choose whether to migrate shared disks with your migration.')}
       headerHelp={
         <HelpIconPopover header={t('Migrate shared disks')}>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditMigrateSharedDisks.tsx
@@ -15,7 +15,6 @@ const EditMigrateSharedDisks: OverlayComponent<EditPlanProps> = ({
   closeOverlay,
   isVddkInitImageNotSet,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(getMigrateSharedDisksValue(resource));
@@ -33,7 +32,6 @@ const EditMigrateSharedDisks: OverlayComponent<EditPlanProps> = ({
       }
       onConfirm={async () => onConfirmMigrateSharedDisks({ newValue: value, resource })}
       title={t('Edit shared disks')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
@@ -53,7 +53,7 @@ const EditVmMigrateSharedDisks: OverlayComponent<EditVmMigrateSharedDisksProps> 
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Save shared disks setting')}
       description={t(
         'Choose whether to migrate shared disks for {{vmName}}. Changing this will override the plan wide setting for only this VM.',

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
@@ -4,7 +4,7 @@ import usePlanSourceProvider from 'src/plans/details/hooks/usePlanSourceProvider
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, AlertVariant, Radio, Stack, StackItem } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -23,7 +23,8 @@ export type EditVmMigrateSharedDisksProps = EditPlanProps & {
   index: number;
 };
 
-const EditVmMigrateSharedDisks: ModalComponent<EditVmMigrateSharedDisksProps> = ({
+const EditVmMigrateSharedDisks: OverlayComponent<EditVmMigrateSharedDisksProps> = ({
+  closeOverlay,
   index,
   resource,
   ...rest
@@ -52,6 +53,7 @@ const EditVmMigrateSharedDisks: ModalComponent<EditVmMigrateSharedDisksProps> = 
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Save shared disks setting')}
       description={t(
         'Choose whether to migrate shared disks for {{vmName}}. Changing this will override the plan wide setting for only this VM.',

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/EditVmMigrateSharedDisks.tsx
@@ -27,7 +27,6 @@ const EditVmMigrateSharedDisks: OverlayComponent<EditVmMigrateSharedDisksProps> 
   closeOverlay,
   index,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const { sourceProvider } = usePlanSourceProvider(resource);
@@ -70,7 +69,6 @@ const EditVmMigrateSharedDisks: OverlayComponent<EditVmMigrateSharedDisksProps> 
       onConfirm={async () => onConfirmVmMigrateSharedDisks(index)({ newValue: value, resource })}
       testId="edit-vm-shared-disks-modal"
       title={t('Edit shared disks')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanMigrateSharedDisks/MigrateSharedDisksDetailsItem.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -19,7 +19,7 @@ const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -37,7 +37,10 @@ const SharedDisksDetailsItem: FC<EditableDetailsItemProps> = ({
       }
       crumbs={['spec', 'migrateSharedDisks']}
       onEdit={() => {
-        launcher<EditPlanProps>(EditMigrateSharedDisks, { isVddkInitImageNotSet, resource: plan });
+        launchOverlay<EditPlanProps>(EditMigrateSharedDisks, {
+          isVddkInitImageNotSet,
+          resource: plan,
+        });
       }}
       testId="shared-disks-detail-item"
       title={t('Shared disks')}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1PlanSpecTransferNetwork } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack } from '@patternfly/react-core';
 import { getPlanTransferNetwork } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -14,7 +14,11 @@ import type { EditPlanProps } from '../../utils/types';
 import { onConfirmTransferNetwork } from './utils/utils';
 import TransferNetworkDropdown from './TransferNetworkDropdown';
 
-const EditPlanTransferNetwork: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanTransferNetwork: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const { destinationProvider } = usePlanDestinationProvider(resource);
   const [value, setValue] = useState<V1beta1PlanSpecTransferNetwork | null>(
@@ -23,6 +27,7 @@ const EditPlanTransferNetwork: ModalComponent<EditPlanProps> = ({ resource, ...r
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmTransferNetwork({ newValue: value, resource })}
       title={t('Edit migration plan transfer network')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
@@ -27,7 +27,7 @@ const EditPlanTransferNetwork: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmTransferNetwork({ newValue: value, resource })}
       title={t('Edit migration plan transfer network')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/EditPlanTransferNetwork.tsx
@@ -14,11 +14,7 @@ import type { EditPlanProps } from '../../utils/types';
 import { onConfirmTransferNetwork } from './utils/utils';
 import TransferNetworkDropdown from './TransferNetworkDropdown';
 
-const EditPlanTransferNetwork: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditPlanTransferNetwork: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const { destinationProvider } = usePlanDestinationProvider(resource);
   const [value, setValue] = useState<V1beta1PlanSpecTransferNetwork | null>(
@@ -30,7 +26,6 @@ const EditPlanTransferNetwork: OverlayComponent<EditPlanProps> = ({
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmTransferNetwork({ newValue: value, resource })}
       title={t('Edit migration plan transfer network')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/TransferNetworkDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/TransferNetworkDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { getPlanTransferNetwork } from '@utils/crds/plans/selectors';
 
@@ -20,7 +20,7 @@ const TransferNetworkDetailItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -48,7 +48,7 @@ const TransferNetworkDetailItem: FC<EditableDetailsItemProps> = ({
         network for all migration plans. Otherwise, the pod network is used.`,
       )}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanTransferNetwork, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanTransferNetwork, { resource: plan });
       }}
       title={t('Transfer network')}
     />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { FormGroup, Stack } from '@patternfly/react-core';
 import { getPlanPreserveClusterCpuModel } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -11,12 +11,17 @@ import type { EditPlanProps } from '../../utils/types';
 import { onConfirmPreserveCpuModel } from './utils/utils';
 import PreserveCpuModelSwitch from './PreserveCpuModelSwitch';
 
-const EditPlanPreserveClusterCpuModel: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanPreserveClusterCpuModel: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanPreserveClusterCpuModel(resource)));
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmPreserveCpuModel({ newValue: value, resource })}
       title={t('Set to preserve the CPU model')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
@@ -14,7 +14,6 @@ import PreserveCpuModelSwitch from './PreserveCpuModelSwitch';
 const EditPlanPreserveClusterCpuModel: OverlayComponent<EditPlanProps> = ({
   closeOverlay,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanPreserveClusterCpuModel(resource)));
@@ -24,7 +23,6 @@ const EditPlanPreserveClusterCpuModel: OverlayComponent<EditPlanProps> = ({
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmPreserveCpuModel({ newValue: value, resource })}
       title={t('Set to preserve the CPU model')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(`Preserve the CPU model and flags the VM runs with in its oVirt cluster.`)}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/EditPlanPreserveClusterCpuModel.tsx
@@ -21,7 +21,7 @@ const EditPlanPreserveClusterCpuModel: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmPreserveCpuModel({ newValue: value, resource })}
       title={t('Set to preserve the CPU model')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveClusterCpuModelDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveClusterCpuModelDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { getPlanPreserveClusterCpuModel } from '@utils/crds/plans/selectors';
 
@@ -18,7 +18,7 @@ const PreserveClusterCpuModelDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -37,7 +37,7 @@ const PreserveClusterCpuModelDetailsItem: FC<EditableDetailsItemProps> = ({
       crumbs={['spec', 'preserveClusterCpuModel']}
       helpContent={t(`Preserve the CPU model and flags the VM runs with in its oVirt cluster.`)}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanPreserveClusterCpuModel, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanPreserveClusterCpuModel, { resource: plan });
       }}
       title={t('Preserve CPU model')}
     />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
@@ -21,7 +21,7 @@ const EditPlanPreserveStaticIPs: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       description={t('Use when VMs have static IPs that must remain unchanged after migration.')}
       headerHelp={
         <HelpIconPopover header={t('Preserve static IPs')}>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Checkbox } from '@patternfly/react-core';
 import { getPlanPreserveIP } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -11,12 +11,17 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { onConfirmPreserveStaticIPs } from './utils/utils';
 
-const EditPlanPreserveStaticIPs: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanPreserveStaticIPs: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanPreserveIP(resource)));
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       description={t('Use when VMs have static IPs that must remain unchanged after migration.')}
       headerHelp={
         <HelpIconPopover header={t('Preserve static IPs')}>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/EditPlanPreserveStaticIPs.tsx
@@ -11,11 +11,7 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { onConfirmPreserveStaticIPs } from './utils/utils';
 
-const EditPlanPreserveStaticIPs: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditPlanPreserveStaticIPs: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanPreserveIP(resource)));
 
@@ -32,7 +28,6 @@ const EditPlanPreserveStaticIPs: OverlayComponent<EditPlanProps> = ({
       }
       onConfirm={async () => onConfirmPreserveStaticIPs({ newValue: value, resource })}
       title={t('Edit static IPs')}
-      {...rest}
     >
       <Checkbox
         data-testid="preserve-static-ips-checkbox"

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/PreserveStaticIPsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/PreserveStaticIPsDetailsItem.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { getPlanPreserveIP } from '@utils/crds/plans/selectors';
 
@@ -18,7 +18,7 @@ const PreserveStaticIPsDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -37,7 +37,7 @@ const PreserveStaticIPsDetailsItem: FC<EditableDetailsItemProps> = ({
       crumbs={['spec', 'preserveStaticIPs']}
       helpContent={t(`Preserve the static IPs of virtual machines migrated from vSphere.`)}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanPreserveStaticIPs, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanPreserveStaticIPs, { resource: plan });
       }}
       title={t('Preserve static IPs')}
     />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack, TextInput } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -13,7 +13,7 @@ import EditRootDiskModalAlert from './components/EditRootDiskModalAlert';
 import EditRootDiskModalBody from './components/EditRootDiskModalBody';
 import { onConfirmRootDisk } from './utils/utils';
 
-const EditRootDisk: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditRootDisk: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource, ...rest }) => {
   const { t } = useForkliftTranslation();
 
   const vms = getPlanVirtualMachines(resource);
@@ -23,6 +23,7 @@ const EditRootDisk: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmRootDisk(resource, value)}
       title={t('Edit root device')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
@@ -13,7 +13,7 @@ import EditRootDiskModalAlert from './components/EditRootDiskModalAlert';
 import EditRootDiskModalBody from './components/EditRootDiskModalBody';
 import { onConfirmRootDisk } from './utils/utils';
 
-const EditRootDisk: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource, ...rest }) => {
+const EditRootDisk: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
 
   const vms = getPlanVirtualMachines(resource);
@@ -26,7 +26,6 @@ const EditRootDisk: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource,
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmRootDisk(resource, value)}
       title={t('Edit root device')}
-      {...rest}
     >
       <Stack hasGutter>
         <EditRootDiskModalBody />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/EditRootDisk.tsx
@@ -23,7 +23,7 @@ const EditRootDisk: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource,
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmRootDisk(resource, value)}
       title={t('Edit root device')}
       {...rest}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/RootDiskDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/RootDiskDetailsItem.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { getRootDisk } from '@utils/crds/plans/selectors';
 import { VIRT_V2V_HELP_LINK } from '@utils/links';
 
@@ -15,7 +15,7 @@ import EditRootDisk from './EditRootDisk';
 
 const RootDiskDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan, shouldRender }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -31,7 +31,7 @@ const RootDiskDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan, sho
       helpContent={t(`Choose the root filesystem to be converted.`)}
       moreInfoLink={VIRT_V2V_HELP_LINK}
       onEdit={() => {
-        launcher<EditPlanProps>(EditRootDisk, { resource: plan });
+        launchOverlay<EditPlanProps>(EditRootDisk, { resource: plan });
       }}
       title={t('Root device')}
     />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
@@ -39,7 +39,7 @@ const EditLUKSEncryptionPasswords: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={isDisabled}
       onConfirm={handleConfirm}
       testId="edit-disk-decryption-modal"

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
@@ -1,6 +1,6 @@
 import LUKSSecretSelect from '@components/LUKSSecretSelect/LUKSSecretSelect';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Checkbox, Flex, FlexItem, FormGroup, Radio, Stack } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -15,7 +15,11 @@ import {
 } from './hooks/useEditLUKSState';
 import LUKSPassphraseInputList from './LUKSPassphraseInputList';
 
-const EditLUKSEncryptionPasswords: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditLUKSEncryptionPasswords: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
 
   const {
@@ -35,6 +39,7 @@ const EditLUKSEncryptionPasswords: ModalComponent<EditPlanProps> = ({ resource, 
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={isDisabled}
       onConfirm={handleConfirm}
       testId="edit-disk-decryption-modal"

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/EditLUKSEncryptionPasswords.tsx
@@ -18,7 +18,6 @@ import LUKSPassphraseInputList from './LUKSPassphraseInputList';
 const EditLUKSEncryptionPasswords: OverlayComponent<EditPlanProps> = ({
   closeOverlay,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -44,7 +43,6 @@ const EditLUKSEncryptionPasswords: OverlayComponent<EditPlanProps> = ({
       onConfirm={handleConfirm}
       testId="edit-disk-decryption-modal"
       title={t('Disk decryption')}
-      {...rest}
     >
       <Stack hasGutter>
         <EditLUKSModalBody />

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/SetLUKSEncryptionPasswordsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/SetLUKSEncryptionPasswordsDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { VIRT_V2V_HELP_LINK } from '@utils/links';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -18,7 +18,7 @@ const SetLUKSEncryptionPasswordsDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -34,7 +34,7 @@ const SetLUKSEncryptionPasswordsDetailsItem: FC<EditableDetailsItemProps> = ({
       )}
       moreInfoLink={VIRT_V2V_HELP_LINK}
       onEdit={() => {
-        launcher<EditPlanProps>(EditLUKSEncryptionPasswords, { resource: plan });
+        launchOverlay<EditPlanProps>(EditLUKSEncryptionPasswords, { resource: plan });
       }}
       testId="disk-decryption-detail-item"
       title={t('Disk decryption')}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/EditLUKSEncryptionPasswords.test.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/EditLUKSEncryptionPasswords.test.tsx
@@ -53,7 +53,7 @@ const mockPlan = {
   spec: { vms: [] },
 } as unknown as V1beta1Plan;
 
-const closeModal = jest.fn();
+const closeOverlay = jest.fn();
 
 describe('EditLUKSEncryptionPasswords', () => {
   beforeEach(() => {
@@ -67,7 +67,7 @@ describe('EditLUKSEncryptionPasswords', () => {
   it('initializes NBDE state from VM data', () => {
     mockGetPlanVirtualMachines.mockReturnValue([{ nbdeClevis: true }]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     const checkbox = screen.getByLabelText('Use network-bound disk encryption (NBDE/Clevis)');
     expect(checkbox).toBeChecked();
@@ -75,7 +75,7 @@ describe('EditLUKSEncryptionPasswords', () => {
 
   it('toggles NBDE checkbox', async () => {
     const user = userEvent.setup();
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     const checkbox = screen.getByLabelText('Use network-bound disk encryption (NBDE/Clevis)');
     expect(checkbox).not.toBeChecked();
@@ -87,7 +87,7 @@ describe('EditLUKSEncryptionPasswords', () => {
   it('shows passphrase fields when NBDE is disabled', () => {
     mockGetPlanVirtualMachines.mockReturnValue([{ nbdeClevis: false }]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     expect(screen.getByText('Passphrases for LUKS encrypted devices')).toBeInTheDocument();
     expect(screen.getByTestId('luks-passphrase-input-list')).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe('EditLUKSEncryptionPasswords', () => {
 
   it('hides passphrase fields when NBDE is enabled', async () => {
     const user = userEvent.setup();
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     const checkbox = screen.getByLabelText('Use network-bound disk encryption (NBDE/Clevis)');
     await user.click(checkbox);
@@ -111,7 +111,7 @@ describe('EditLUKSEncryptionPasswords', () => {
       null,
     ]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     await waitFor(() => {
       expect(screen.getByText('Passphrases: test-pass-1, test-pass-2')).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('EditLUKSEncryptionPasswords', () => {
     const user = userEvent.setup();
     mockUseK8sWatchResource.mockReturnValue([{ data: { pass1: btoa('test-pass') } }, false, null]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     await waitFor(() => {
       expect(screen.getByText('Passphrases: test-pass')).toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('EditLUKSEncryptionPasswords', () => {
 
   it('submits form with correct NBDE state', async () => {
     const user = userEvent.setup();
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     const checkbox = screen.getByLabelText('Use network-bound disk encryption (NBDE/Clevis)');
     await user.click(checkbox);
@@ -161,7 +161,7 @@ describe('EditLUKSEncryptionPasswords', () => {
       { luks: { name: 'secret-2' } },
     ]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     expect(screen.getByTestId('luks-modal-alert')).toBeInTheDocument();
   });
@@ -170,7 +170,7 @@ describe('EditLUKSEncryptionPasswords', () => {
     mockGetLUKSSecretName.mockReturnValue('test-secret');
     mockUseK8sWatchResource.mockReturnValue([{ data: null }, false, null]);
 
-    render(<EditLUKSEncryptionPasswords closeModal={closeModal} resource={mockPlan} />);
+    render(<EditLUKSEncryptionPasswords closeOverlay={closeOverlay} resource={mockPlan} />);
 
     expect(screen.getByTestId('luks-modal-body')).toBeInTheDocument();
     expect(screen.getByTestId('luks-passphrase-input-list')).toHaveTextContent('Passphrases:');

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/SetLUKSEncryptionPasswordsDetailsItem.test.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/SetLUKSEncryptionPasswordsDetailsItem.test.tsx
@@ -17,7 +17,7 @@ const mockShowModal = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(),
   ResourceLink: ({ name }: { name: string }) => <span data-testid="resource-link">{name}</span>,
-  useModal: jest.fn(() => mockShowModal),
+  useOverlay: jest.fn(() => mockShowModal),
 }));
 
 jest.mock('../EditLUKSEncryptionPasswords', () => ({ resource }: { resource: V1beta1Plan }) => (

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetAffinity/TargetAffinityDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetAffinity/TargetAffinityDetailsItem.tsx
@@ -6,7 +6,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import AffinityModal, { type AffinityModalProps } from '@components/AffinityModal/AffinityModal';
 import AffinityViewDetailsItemContent from '@components/AffinityViewDetailsItemContent/AffinityViewDetailsItemContent';
 import type { K8sIoApiCoreV1Affinity, V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DOC_MAIN_HELP_LINK } from '@utils/links';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -14,7 +14,7 @@ import { patchPlanSpec } from '../../utils/patchPlanSpec';
 
 const TargetAffinityDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const TARGET_AFFINITY_DETAILS_ITEM_DESCRIPTION = t(
     `Specify affinity rules that will be applied after migration to all target virtual machines of the migration plan.
@@ -39,7 +39,7 @@ const TargetAffinityDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, pla
       helpContent={TARGET_AFFINITY_DETAILS_ITEM_DESCRIPTION}
       moreInfoLink={DOC_MAIN_HELP_LINK}
       onEdit={() => {
-        launcher<AffinityModalProps>(AffinityModal, {
+        launchOverlay<AffinityModalProps>(AffinityModal, {
           initialAffinity,
           onConfirm,
           title: t('Edit VM target affinity rules'),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetLabels/TargetLabelsDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetLabels/TargetLabelsDetailsItem.tsx
@@ -6,7 +6,7 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import LabelsModal, { type LabelsModalProps } from '@components/LabelsModal/LabelsModal';
 import LabelsViewDetailsItemContent from '@components/LabelsViewDetailsItemContent/LabelsViewDetailsItemContent';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { DOC_MAIN_HELP_LINK } from '@utils/links';
 
@@ -15,7 +15,7 @@ import { patchPlanSpec } from '../../utils/patchPlanSpec';
 
 const TargetLabelsDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const TARGET_LABELS_DETAILS_ITEM_DESCRIPTION = t(
     'Specify custom labels that will be applied after migration to all target virtual machines of the migration plan. This can apply organizational or operational labels to migrated virtual machines for further identification and management.',
@@ -37,7 +37,7 @@ const TargetLabelsDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan 
       helpContent={TARGET_LABELS_DETAILS_ITEM_DESCRIPTION}
       moreInfoLink={DOC_MAIN_HELP_LINK}
       onEdit={() => {
-        launcher<LabelsModalProps>(LabelsModal, {
+        launchOverlay<LabelsModalProps>(LabelsModal, {
           description: (
             <ForkliftTrans>
               <Stack hasGutter>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetNodeSelector/TargetNodeSelectorDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetNodeSelector/TargetNodeSelectorDetailsItem.tsx
@@ -8,7 +8,7 @@ import NodeSelectorModal, {
 } from '@components/NodeSelectorModal/NodeSelectorModal';
 import NodeSelectorViewDetailsItemContent from '@components/NodeSelectorViewDetailsItemContent/NodeSelectorViewDetailsItemContent';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -17,7 +17,7 @@ import { patchPlanSpec } from '../../utils/patchPlanSpec';
 
 const TargetNodeSelectorDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const TARGET_NODE_SELECTOR_DETAILS_ITEM_DESCRIPTION = t(
     'Specify node labels that will be applied after migration to all target virtual machines of the migration plan for constraining virtual machines scheduling to specific nodes, based on node labels. This will ensure that the migrated virtual machines will run on nodes with required capabilities (GPU, storage type, CPU architecture).',
@@ -38,7 +38,7 @@ const TargetNodeSelectorDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch,
       crumbs={['spec', 'targetNodeSelector']}
       helpContent={TARGET_NODE_SELECTOR_DETAILS_ITEM_DESCRIPTION}
       onEdit={() => {
-        launcher<NodeSelectorModalProps>(NodeSelectorModal, {
+        launchOverlay<NodeSelectorModalProps>(NodeSelectorModal, {
           description: (
             <ForkliftTrans>
               <Stack hasGutter>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
@@ -13,11 +13,7 @@ import type { EditPlanProps } from '../../utils/types';
 import { onConfirmTargetPowerState } from './utils/utils';
 import TargetPowerStateDropdown from './TargetPowerStateDropdown';
 
-const EditTargetPowerState: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditTargetPowerState: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<TargetPowerStateValue>(
     getPlanTargetPowerState(resource) ?? TargetPowerStates.AUTO,
@@ -31,7 +27,6 @@ const EditTargetPowerState: OverlayComponent<EditPlanProps> = ({
       onConfirm={async () => onConfirmTargetPowerState({ newValue: value, resource })}
       testId="edit-target-power-state-modal"
       title={t('Edit target power state')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(`Choose what state you'd like the VMs in your plan to be powered to after migration.`)}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, Stack } from '@patternfly/react-core';
 import { getPlanTargetPowerState } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -13,7 +13,11 @@ import type { EditPlanProps } from '../../utils/types';
 import { onConfirmTargetPowerState } from './utils/utils';
 import TargetPowerStateDropdown from './TargetPowerStateDropdown';
 
-const EditTargetPowerState: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditTargetPowerState: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<TargetPowerStateValue>(
     getPlanTargetPowerState(resource) ?? TargetPowerStates.AUTO,
@@ -21,6 +25,7 @@ const EditTargetPowerState: ModalComponent<EditPlanProps> = ({ resource, ...rest
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Save target power state')}
       isDisabled={value === getPlanTargetPowerState(resource)}
       onConfirm={async () => onConfirmTargetPowerState({ newValue: value, resource })}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditTargetPowerState.tsx
@@ -25,7 +25,7 @@ const EditTargetPowerState: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Save target power state')}
       isDisabled={value === getPlanTargetPowerState(resource)}
       onConfirm={async () => onConfirmTargetPowerState({ newValue: value, resource })}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
@@ -22,7 +22,6 @@ const EditVmTargetPowerState: OverlayComponent<EditVmTargetPowerStateProps> = ({
   closeOverlay,
   index,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const vm = getPlanVirtualMachines(resource)[index];
@@ -37,7 +36,6 @@ const EditVmTargetPowerState: OverlayComponent<EditVmTargetPowerStateProps> = ({
       onConfirm={async () => onConfirmVmTargetPowerState(index)({ newValue: value, resource })}
       testId="edit-target-power-state-modal"
       title={t('Edit target power state')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
@@ -31,7 +31,7 @@ const EditVmTargetPowerState: OverlayComponent<EditVmTargetPowerStateProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Save target power state')}
       isDisabled={value === getVmTargetPowerState(vm)}
       onConfirm={async () => onConfirmVmTargetPowerState(index)({ newValue: value, resource })}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/EditVmTargetPowerState.tsx
@@ -3,7 +3,7 @@ import { getVmTargetPowerState } from 'src/plans/details/components/PlanStatus/u
 
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, Stack } from '@patternfly/react-core';
 import { getPlanTargetPowerState, getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -18,7 +18,8 @@ export type EditVmTargetPowerStateProps = EditPlanProps & {
   index: number;
 };
 
-const EditVmTargetPowerState: ModalComponent<EditVmTargetPowerStateProps> = ({
+const EditVmTargetPowerState: OverlayComponent<EditVmTargetPowerStateProps> = ({
+  closeOverlay,
   index,
   resource,
   ...rest
@@ -30,6 +31,7 @@ const EditVmTargetPowerState: ModalComponent<EditVmTargetPowerStateProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Save target power state')}
       isDisabled={value === getVmTargetPowerState(vm)}
       onConfirm={async () => onConfirmVmTargetPowerState(index)({ newValue: value, resource })}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/TargetPowerStateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/TargetPowerStateDetailsItem.tsx
@@ -4,7 +4,7 @@ import { getTargetPowerStateLabel } from 'src/plans/constants';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { getPlanTargetPowerState } from '@utils/crds/plans/selectors';
 
@@ -15,7 +15,7 @@ import EditTargetPowerState from './EditTargetPowerState';
 
 const TargetPowerStateDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   return (
     <DetailsItem
@@ -30,7 +30,7 @@ const TargetPowerStateDetailsItem: FC<EditableDetailsItemProps> = ({ canPatch, p
         `Choose what state you'd like all of the VMs in your plan to be powered to after migration. You can change this setting for specific VMs in the Virtual machines tab.`,
       )}
       onEdit={() => {
-        launcher<EditPlanProps>(EditTargetPowerState, { resource: plan });
+        launchOverlay<EditPlanProps>(EditTargetPowerState, { resource: plan });
       }}
       testId="target-vm-power-state-detail-item"
       title={t('VM target power state')}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/EditVolumeNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/EditVolumeNameTemplate.tsx
@@ -27,7 +27,6 @@ const EditVolumeNameTemplate: OverlayComponent<EditVolumeNameTemplateProps> = ({
   onConfirmVolumeNameTemplate,
   resource,
   value,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -49,7 +48,6 @@ const EditVolumeNameTemplate: OverlayComponent<EditVolumeNameTemplateProps> = ({
       onConfirm={async (newValue) => onConfirmVolumeNameTemplate({ newValue, resource })}
       title={t('Edit volume name template')}
       value={value}
-      {...rest}
     />
   );
 };

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/EditVolumeNameTemplate.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/EditVolumeNameTemplate.tsx
@@ -1,5 +1,5 @@
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { useForkliftTranslation } from '@utils/i18n';
 
 import NameTemplateBody from '../EditNameTemplate/components/NameTemplateBody';
@@ -21,8 +21,9 @@ export type EditVolumeNameTemplateProps = {
   value?: string;
 };
 
-const EditVolumeNameTemplate: ModalComponent<EditVolumeNameTemplateProps> = ({
+const EditVolumeNameTemplate: OverlayComponent<EditVolumeNameTemplateProps> = ({
   allowInherit = true,
+  closeOverlay,
   onConfirmVolumeNameTemplate,
   resource,
   value,
@@ -41,6 +42,7 @@ const EditVolumeNameTemplate: ModalComponent<EditVolumeNameTemplateProps> = ({
           )}
         />
       }
+      closeOverlay={closeOverlay}
       fieldName={allowInherit ? t('VM volume name template') : t('Plan volume name template')}
       helperText={<NameTemplateHelper examples={volumeNameTemplateHelperExamples} />}
       inheritValue={resource?.spec?.volumeNameTemplate}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/VolumeNameTemplateDetailsItem.tsx
@@ -3,7 +3,7 @@ import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -17,7 +17,7 @@ const VolumeNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -35,7 +35,7 @@ const VolumeNameTemplateDetailsItem: FC<EditableDetailsItemProps> = ({
       content={content}
       crumbs={['spec', 'volumeNameTemplate']}
       onEdit={() => {
-        launcher<EditVolumeNameTemplateProps>(EditVolumeNameTemplate, {
+        launchOverlay<EditVolumeNameTemplateProps>(EditVolumeNameTemplate, {
           allowInherit: false,
           onConfirmVolumeNameTemplate,
           resource: plan,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
@@ -9,11 +9,7 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from './utils/utils';
 
-const EditPlanXfsCompatibility: OverlayComponent<EditPlanProps> = ({
-  closeOverlay,
-  resource,
-  ...rest
-}) => {
+const EditPlanXfsCompatibility: OverlayComponent<EditPlanProps> = ({ closeOverlay, resource }) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanXfsCompatibility(resource)));
 
@@ -25,7 +21,6 @@ const EditPlanXfsCompatibility: OverlayComponent<EditPlanProps> = ({
       )}
       onConfirm={async () => onConfirmXfsCompatibility({ newValue: value, resource })}
       title={t('Edit XFS v4 compatibility')}
-      {...rest}
     >
       <Checkbox
         data-testid="xfs-compatibility-checkbox"

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Checkbox } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 
@@ -9,12 +9,17 @@ import type { EditPlanProps } from '../../utils/types';
 
 import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from './utils/utils';
 
-const EditPlanXfsCompatibility: ModalComponent<EditPlanProps> = ({ resource, ...rest }) => {
+const EditPlanXfsCompatibility: OverlayComponent<EditPlanProps> = ({
+  closeOverlay,
+  resource,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [value, setValue] = useState<boolean>(Boolean(getPlanXfsCompatibility(resource)));
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       description={t(
         'XFS v4 and BTRFS support are mutually exclusive. Enable for XFS v4 filesystems; leave disabled for BTRFS.',
       )}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/EditPlanXfsCompatibility.tsx
@@ -19,7 +19,7 @@ const EditPlanXfsCompatibility: OverlayComponent<EditPlanProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       description={t(
         'XFS v4 and BTRFS support are mutually exclusive. Enable for XFS v4 filesystems; leave disabled for BTRFS.',
       )}

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/XfsCompatibilityDetailsItem.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/XfsCompatibilityDetailsItem.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import type { EditPlanProps } from 'src/plans/details/tabs/Details/components/SettingsSection/utils/types';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 
 import type { EditableDetailsItemProps } from '../../../utils/types';
@@ -18,7 +18,7 @@ const XfsCompatibilityDetailsItem: FC<EditableDetailsItemProps> = ({
   shouldRender,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   if (!shouldRender) {
     return null;
@@ -39,7 +39,7 @@ const XfsCompatibilityDetailsItem: FC<EditableDetailsItemProps> = ({
         'XFS v4 and BTRFS support are mutually exclusive. Enable for XFS v4 filesystems; leave disabled for BTRFS.',
       )}
       onEdit={() => {
-        launcher<EditPlanProps>(EditPlanXfsCompatibility, { resource: plan });
+        launchOverlay<EditPlanProps>(EditPlanXfsCompatibility, { resource: plan });
       }}
       title={t('XFS v4 compatibility')}
     />

--- a/src/plans/details/tabs/Hooks/components/HookEdit/HookEdit.tsx
+++ b/src/plans/details/tabs/Hooks/components/HookEdit/HookEdit.tsx
@@ -87,7 +87,7 @@ const HookEdit: OverlayComponent<HookEditProps> = ({ closeOverlay, hook, plan, s
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={title}

--- a/src/plans/details/tabs/Hooks/components/HookEdit/HookEdit.tsx
+++ b/src/plans/details/tabs/Hooks/components/HookEdit/HookEdit.tsx
@@ -9,7 +9,7 @@ import {
 import ModalForm from '@components/ModalForm/ModalForm';
 import TechPreviewLabel from '@components/PreviewLabels/TechPreviewLabel';
 import type { V1beta1Hook, V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Flex,
   FlexItem,
@@ -37,7 +37,7 @@ export type HookEditProps = {
   step: HookType;
 };
 
-const HookEdit: ModalComponent<HookEditProps> = ({ closeModal, hook, plan, step }) => {
+const HookEdit: OverlayComponent<HookEditProps> = ({ closeOverlay, hook, plan, step }) => {
   const { t } = useForkliftTranslation();
 
   const methods = useForm<HookEditFormValues>({
@@ -87,7 +87,7 @@ const HookEdit: ModalComponent<HookEditProps> = ({ closeModal, hook, plan, step 
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={title}

--- a/src/plans/details/tabs/Hooks/components/HookSection/HookSection.tsx
+++ b/src/plans/details/tabs/Hooks/components/HookSection/HookSection.tsx
@@ -4,7 +4,7 @@ import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/ut
 import { DetailsItem } from '@components/DetailItems/DetailItem';
 import SectionHeadingWithEdit from '@components/headers/SectionHeadingWithEdit';
 import type { V1beta1Hook, V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -27,7 +27,7 @@ type HookSectionProps = {
 
 const HookSection: FC<HookSectionProps> = ({ hook, plan, step, title }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const planEditable = isPlanEditable(plan);
   const hookExists = !isEmpty(hook);
@@ -41,7 +41,7 @@ const HookSection: FC<HookSectionProps> = ({ hook, plan, step, title }) => {
         editable={planEditable}
         headingLevel="h3"
         onClick={() => {
-          launcher<HookEditProps>(HookEdit, { hook, plan, step });
+          launchOverlay<HookEditProps>(HookEdit, { hook, plan, step });
         }}
         title={title}
       />

--- a/src/plans/details/tabs/Mappings/PlanMappingsPage.tsx
+++ b/src/plans/details/tabs/Mappings/PlanMappingsPage.tsx
@@ -14,7 +14,7 @@ import {
   NetworkMapModelGroupVersionKind,
   StorageMapModelGroupVersionKind,
 } from '@forklift-ui/types';
-import { ResourceLink, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { ResourceLink, useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, DescriptionList, PageSection } from '@patternfly/react-core';
 import { getName, getNamespace } from '@utils/crds/common/selectors';
 import { getPlanTargetNamespace } from '@utils/crds/plans/selectors';
@@ -38,7 +38,7 @@ import { getMappingPageMessage } from './utils/utils';
 // eslint-disable-next-line max-lines-per-function
 const PlanMappingsPage: FC<PlanPageProps> = ({ name, namespace }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const { plan } = usePlan(name, namespace);
   const { sourceProvider, targetProvider } = usePlanProviders(plan);
@@ -134,7 +134,7 @@ const PlanMappingsPage: FC<PlanPageProps> = ({ name, namespace }) => {
         data-testid="network-map-edit-button"
         editable={isPlanEditable(plan)}
         onClick={() => {
-          launcher<PlanNetworkMapEditProps>(PlanNetworkMapEdit, {
+          launchOverlay<PlanNetworkMapEditProps>(PlanNetworkMapEdit, {
             initialMappings: networkMappings,
             isLoading,
             loadError: sourceNetworksError ?? targetNetworksError,
@@ -170,7 +170,7 @@ const PlanMappingsPage: FC<PlanPageProps> = ({ name, namespace }) => {
         data-testid="storage-map-edit-button"
         editable={isPlanEditable(plan)}
         onClick={() => {
-          launcher<PlanStorageMapEditProps>(PlanStorageMapEdit, {
+          launchOverlay<PlanStorageMapEditProps>(PlanStorageMapEdit, {
             isLoading: sourceStoragesLoading || targetStoragesLoading,
             loadError: sourceStoragesLoadError ?? targetStoragesLoadError,
             otherSourceStorages,

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
@@ -1,7 +1,7 @@
 import { FormProvider, useForm } from 'react-hook-form';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, AlertVariant, ModalVariant, Stack } from '@patternfly/react-core';
 import { NetworkMapFieldId } from '@utils/crds/maps/types';
 import { isEmpty } from '@utils/helpers';
@@ -11,8 +11,8 @@ import PlanNetworkMapFieldsTable from './components/PlanNetworkMapFieldsTable';
 import type { PlanNetworkEditFormValues, PlanNetworkMapEditProps } from './utils/types';
 import { patchNetworkMappingValues } from './utils/utils';
 
-const PlanNetworkMapEdit: ModalComponent<PlanNetworkMapEditProps> = ({
-  closeModal,
+const PlanNetworkMapEdit: OverlayComponent<PlanNetworkMapEditProps> = ({
+  closeOverlay,
   initialMappings,
   isLoading,
   loadError,
@@ -43,7 +43,7 @@ const PlanNetworkMapEdit: ModalComponent<PlanNetworkMapEditProps> = ({
 
   const onSubmit = async (formData: PlanNetworkEditFormValues) => {
     if (!isDirty) {
-      closeModal();
+      closeOverlay();
       return;
     }
 
@@ -53,7 +53,7 @@ const PlanNetworkMapEdit: ModalComponent<PlanNetworkMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-network-map-modal"

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
@@ -53,7 +53,7 @@ const PlanNetworkMapEdit: OverlayComponent<PlanNetworkMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-network-map-modal"

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
@@ -53,7 +53,7 @@ const PlanStorageMapEdit: OverlayComponent<PlanStorageMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-storage-map-modal"

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
@@ -3,7 +3,7 @@ import { isHypervIscsiProvider } from 'src/providers/utils/helpers/isHypervIscsi
 import StorageMapStatusAlerts from 'src/storageMaps/components/StorageMapStatusAlerts';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, AlertVariant, ModalVariant, Stack } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
 import { StorageMapFieldId } from '@utils/storage/types';
@@ -12,8 +12,8 @@ import PlanStorageMapFieldsTable from './components/PlanStorageMapFieldsTable';
 import type { PlanStorageEditFormValues, PlanStorageMapEditProps } from './utils/types';
 import { patchStorageMappingValues } from './utils/utils';
 
-const PlanStorageMapEdit: ModalComponent<PlanStorageMapEditProps> = ({
-  closeModal,
+const PlanStorageMapEdit: OverlayComponent<PlanStorageMapEditProps> = ({
+  closeOverlay,
   isLoading,
   loadError,
   otherSourceStorages,
@@ -53,7 +53,7 @@ const PlanStorageMapEdit: ModalComponent<PlanStorageMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-storage-map-modal"

--- a/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesButton.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesButton.tsx
@@ -2,7 +2,7 @@ import { type FC, useMemo } from 'react';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { ToolbarItem } from '@patternfly/react-core';
 
 import VMsActionButton from '../VMsActionButton';
@@ -12,10 +12,10 @@ import AddVirtualMachinesModal from './AddVirtualMachinesModal';
 
 const AddVirtualMachinesButton: FC<AddVirtualMachineProps> = ({ plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const onClick = (): void => {
-    launcher<AddVirtualMachineProps>(AddVirtualMachinesModal, { plan });
+    launchOverlay<AddVirtualMachineProps>(AddVirtualMachinesModal, { plan });
   };
 
   const reason = useMemo((): string | null => {

--- a/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
@@ -54,7 +54,7 @@ const AddVirtualMachinesModal: OverlayComponent<AddVirtualMachineProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Add virtual machines')}
       isDisabled={!hasSelection}
       onConfirm={handleSave}

--- a/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
@@ -19,7 +19,6 @@ import type { AddVirtualMachineProps } from './utils/types';
 const AddVirtualMachinesModal: OverlayComponent<AddVirtualMachineProps> = ({
   closeOverlay,
   plan,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const { sourceProvider } = usePlanSourceProvider(plan);
@@ -60,7 +59,6 @@ const AddVirtualMachinesModal: OverlayComponent<AddVirtualMachineProps> = ({
       onConfirm={handleSave}
       title={t('Add virtual machines to migration plan')}
       variant={ModalVariant.large}
-      {...rest}
     >
       <AddVirtualMachinesTable
         onSelect={handleSelect}

--- a/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/AddVirtualMachines/AddVirtualMachinesModal.tsx
@@ -7,7 +7,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { REPLACE } from '@components/ModalForm/utils/constants';
 import { PlanModel, type V1beta1PlanSpecVms } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ModalVariant } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -16,7 +16,11 @@ import { PROVIDER_TYPES } from '@utils/providers/constants';
 import AddVirtualMachinesTable from './components/AddVirtualMachinesTable';
 import type { AddVirtualMachineProps } from './utils/types';
 
-const AddVirtualMachinesModal: ModalComponent<AddVirtualMachineProps> = ({ plan, ...rest }) => {
+const AddVirtualMachinesModal: OverlayComponent<AddVirtualMachineProps> = ({
+  closeOverlay,
+  plan,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const { sourceProvider } = usePlanSourceProvider(plan);
   const selectedVmsRef = useRef<VmData[]>([]);
@@ -50,6 +54,7 @@ const AddVirtualMachinesModal: ModalComponent<AddVirtualMachineProps> = ({ plan,
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Add virtual machines')}
       isDisabled={!hasSelection}
       onConfirm={handleSave}

--- a/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesButton.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesButton.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { ToolbarItem } from '@patternfly/react-core';
 
 import VMsActionButton from '../VMsActionButton';
@@ -14,9 +14,9 @@ const CancelMigrationVirtualMachinesButton: FC<CancelMigrationVirtualMachinesPro
   selectedIds,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const onClick = () => {
-    launcher<CancelMigrationVirtualMachinesProps>(CancelMigrationVirtualMachinesModal, {
+    launchOverlay<CancelMigrationVirtualMachinesProps>(CancelMigrationVirtualMachinesModal, {
       migration,
       selectedIds,
     });

--- a/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
@@ -12,7 +12,7 @@ import type { CancelMigrationVirtualMachinesProps } from './utils/types';
 
 const CancelMigrationVirtualMachinesModal: OverlayComponent<
   CancelMigrationVirtualMachinesProps
-> = ({ closeOverlay, migration, selectedIds, ...rest }) => {
+> = ({ closeOverlay, migration, selectedIds }) => {
   const { t } = useForkliftTranslation();
 
   const handleSave = useCallback(async () => {
@@ -32,7 +32,6 @@ const CancelMigrationVirtualMachinesModal: OverlayComponent<
       closeOverlay={closeOverlay}
       onConfirm={handleSave}
       title={t('Cancel virtual machines migration?')}
-      {...rest}
     >
       <Stack hasGutter>
         {t('You can cancel the migration of virtual machines in a running migration plan.')}

--- a/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
@@ -29,7 +29,7 @@ const CancelMigrationVirtualMachinesModal: OverlayComponent<
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={handleSave}
       title={t('Cancel virtual machines migration?')}
       {...rest}

--- a/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesModal.tsx
@@ -5,16 +5,14 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { MigrationModel } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack } from '@patternfly/react-core';
 
 import type { CancelMigrationVirtualMachinesProps } from './utils/types';
 
-const CancelMigrationVirtualMachinesModal: ModalComponent<CancelMigrationVirtualMachinesProps> = ({
-  migration,
-  selectedIds,
-  ...rest
-}) => {
+const CancelMigrationVirtualMachinesModal: OverlayComponent<
+  CancelMigrationVirtualMachinesProps
+> = ({ closeOverlay, migration, selectedIds, ...rest }) => {
   const { t } = useForkliftTranslation();
 
   const handleSave = useCallback(async () => {
@@ -30,7 +28,12 @@ const CancelMigrationVirtualMachinesModal: ModalComponent<CancelMigrationVirtual
   }, [migration, selectedIds]);
 
   return (
-    <ModalForm onConfirm={handleSave} title={t('Cancel virtual machines migration?')} {...rest}>
+    <ModalForm
+      closeModal={closeOverlay}
+      onConfirm={handleSave}
+      title={t('Cancel virtual machines migration?')}
+      {...rest}
+    >
       <Stack hasGutter>
         {t('You can cancel the migration of virtual machines in a running migration plan.')}
       </Stack>

--- a/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesButton.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesButton.tsx
@@ -2,7 +2,7 @@ import { type FC, useMemo } from 'react';
 import { isPlanEditable } from 'src/plans/details/components/PlanStatus/utils/utils';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { ToolbarItem } from '@patternfly/react-core';
 
 import VMsActionButton from '../VMsActionButton';
@@ -12,10 +12,10 @@ import DeleteVirtualMachinesModal from './DeleteVirtualMachinesModal';
 
 const DeleteVirtualMachinesButton: FC<DeleteVirtualMachineProps> = ({ plan, selectedIds }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const onClick = () => {
-    launcher<DeleteVirtualMachineProps>(DeleteVirtualMachinesModal, { plan, selectedIds });
+    launchOverlay<DeleteVirtualMachineProps>(DeleteVirtualMachinesModal, { plan, selectedIds });
   };
 
   const reason = useMemo(() => {

--- a/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
@@ -34,7 +34,7 @@ const PlanVMsDeleteModal: OverlayComponent<DeleteVirtualMachineProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       onConfirm={handleSave}

--- a/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
@@ -5,13 +5,14 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { PlanModel } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ButtonVariant } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 
 import type { DeleteVirtualMachineProps } from './utils/types';
 
-const PlanVMsDeleteModal: ModalComponent<DeleteVirtualMachineProps> = ({
+const PlanVMsDeleteModal: OverlayComponent<DeleteVirtualMachineProps> = ({
+  closeOverlay,
   plan,
   selectedIds,
   ...rest
@@ -33,6 +34,7 @@ const PlanVMsDeleteModal: ModalComponent<DeleteVirtualMachineProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       onConfirm={handleSave}

--- a/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesModal.tsx
@@ -15,7 +15,6 @@ const PlanVMsDeleteModal: OverlayComponent<DeleteVirtualMachineProps> = ({
   closeOverlay,
   plan,
   selectedIds,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -39,7 +38,6 @@ const PlanVMsDeleteModal: OverlayComponent<DeleteVirtualMachineProps> = ({
       confirmVariant={ButtonVariant.danger}
       onConfirm={handleSave}
       title={t('Delete virtual machines from migration plan?')}
-      {...rest}
     >
       {t('The virtual machines will be permanently deleted from your migration plan.')}
     </ModalForm>

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationProgressTable/MigrationProgressTable.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationProgressTable/MigrationProgressTable.tsx
@@ -7,7 +7,7 @@ import { ConsoleTimestamp } from '@components/ConsoleTimestamp/ConsoleTimestamp'
 import { useDrawer } from '@components/DrawerContext/useDrawer';
 import HelpText from '@components/HelpText';
 import type { V1beta1Plan, V1beta1PlanStatusMigrationVms } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertVariant,
@@ -55,7 +55,7 @@ const MigrationProgressTable: FC<MigrationProgressTableProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
   const { openDrawer } = useDrawer();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
   const pipeline = statusVM?.pipeline ?? [];
   const inPostMigrationSetup = isVmInPostMigrationSetup(statusVM);
@@ -159,7 +159,7 @@ const MigrationProgressTable: FC<MigrationProgressTableProps> = ({
                       <Button
                         className="forklift-progress-table__schedule-cutover"
                         onClick={() => {
-                          launcher<PlanModalProps>(PlanCutoverMigrationModal, { plan });
+                          launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
                         }}
                         variant={ButtonVariant.link}
                       >

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
@@ -36,7 +36,7 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Save instance type')}
       isDisabled={value === vm?.instanceType}
       onConfirm={async () => onConfirmVmInstanceType(index)({ newValue: value, resource })}

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/InstanceType/EditVmInstanceType.tsx
@@ -21,7 +21,6 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
   closeOverlay,
   index,
   resource,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const vm = getPlanVirtualMachines(resource)[index];
@@ -42,7 +41,6 @@ const EditVmInstanceType: OverlayComponent<EditVmInstanceTypeProps> = ({
       onConfirm={async () => onConfirmVmInstanceType(index)({ newValue: value, resource })}
       testId="edit-instance-type-modal"
       title={t('Edit instance type')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/SpecVirtualMachinesActionsDropdownItems.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/SpecVirtualMachinesActionsDropdownItems.tsx
@@ -19,7 +19,7 @@ import useGetDeleteAndEditAccessReview from 'src/utils/hooks/useGetDeleteAndEdit
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { PlanModel, type ProviderType, type V1beta1Plan } from '@forklift-ui/types';
-import { useModal, useOverlay } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem, DropdownList } from '@patternfly/react-core';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
@@ -49,7 +49,6 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
   vmIndex,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
   const launchOverlay = useOverlay();
 
   const { canPatch } = useGetDeleteAndEditAccessReview({
@@ -69,7 +68,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
         isDisabled={!canEdit}
         key="edit-vm-target-name"
         onClick={() => {
-          launcher<EditVirtualMachineTargetNameProps>(EditVirtualMachineTargetName, {
+          launchOverlay<EditVirtualMachineTargetNameProps>(EditVirtualMachineTargetName, {
             plan,
             vmIndex,
           });
@@ -83,7 +82,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
             isDisabled={!canEdit}
             key="edit-pvc-name-template"
             onClick={() => {
-              launcher<EditPVCNameTemplateProps>(EditPVCNameTemplate, {
+              launchOverlay<EditPVCNameTemplateProps>(EditPVCNameTemplate, {
                 onConfirmPVCNameTemplate: onConfirmVirtualMachinePVCNameTemplate(vmIndex),
                 resource: plan,
                 value: vm?.pvcNameTemplate,
@@ -96,7 +95,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
             isDisabled={!canEdit}
             key="edit-volume-name-template"
             onClick={() => {
-              launcher<EditVolumeNameTemplateProps>(EditVolumeNameTemplate, {
+              launchOverlay<EditVolumeNameTemplateProps>(EditVolumeNameTemplate, {
                 onConfirmVolumeNameTemplate: onConfirmVirtualMachineVolumeNameTemplate(vmIndex),
                 resource: plan,
                 value: vm?.volumeNameTemplate,
@@ -109,7 +108,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
             isDisabled={!canEdit}
             key="edit-network-name-template"
             onClick={() => {
-              launcher<EditNetworkNameTemplateProps>(EditNetworkNameTemplate, {
+              launchOverlay<EditNetworkNameTemplateProps>(EditNetworkNameTemplate, {
                 onConfirmNetworkNameTemplate: onConfirmVirtualMachineNetworkNameTemplate(vmIndex),
                 resource: plan,
                 value: vm?.networkNameTemplate,
@@ -123,7 +122,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
             isDisabled={!canEdit}
             key="edit-vm-shared-disks"
             onClick={() => {
-              launcher<EditVmMigrateSharedDisksProps>(EditVmMigrateSharedDisks, {
+              launchOverlay<EditVmMigrateSharedDisksProps>(EditVmMigrateSharedDisks, {
                 index: vmIndex,
                 resource: plan,
               });
@@ -138,7 +137,7 @@ const SpecVirtualMachinesActionsDropdownItems: FC<SpecVirtualMachinesActionsDrop
         isDisabled={!canEdit}
         key="edit-target-power-state"
         onClick={() => {
-          launcher<EditVmTargetPowerStateProps>(EditVmTargetPowerState, {
+          launchOverlay<EditVmTargetPowerStateProps>(EditVmTargetPowerState, {
             index: vmIndex,
             resource: plan,
           });

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
@@ -36,7 +36,7 @@ const EditVirtualMachineTargetName: OverlayComponent<EditVirtualMachineTargetNam
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={
         Boolean(validateVMTargetName(inputValue, vms ?? [])) ||
         (isEmpty(vm.targetName) && isEmpty(inputValue)) ||

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Plan } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack, StackItem, TextInput, ValidatedOptions } from '@patternfly/react-core';
 import { getPlanVirtualMachines } from '@utils/crds/plans/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -17,7 +17,8 @@ export type EditVirtualMachineTargetNameProps = {
   vmIndex: number;
 };
 
-const EditVirtualMachineTargetName: ModalComponent<EditVirtualMachineTargetNameProps> = ({
+const EditVirtualMachineTargetName: OverlayComponent<EditVirtualMachineTargetNameProps> = ({
+  closeOverlay,
   plan,
   vmIndex,
   ...rest
@@ -35,6 +36,7 @@ const EditVirtualMachineTargetName: ModalComponent<EditVirtualMachineTargetNameP
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={
         Boolean(validateVMTargetName(inputValue, vms ?? [])) ||
         (isEmpty(vm.targetName) && isEmpty(inputValue)) ||

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/VirtualMachineTargetName/EditVirtualMachineTargetName.tsx
@@ -21,7 +21,6 @@ const EditVirtualMachineTargetName: OverlayComponent<EditVirtualMachineTargetNam
   closeOverlay,
   plan,
   vmIndex,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const vms = getPlanVirtualMachines(plan);
@@ -44,7 +43,6 @@ const EditVirtualMachineTargetName: OverlayComponent<EditVirtualMachineTargetNam
       }
       onConfirm={async () => patchVMTargetName({ newValue: inputValue, resource: plan, vmIndex })}
       title={t('Edit target name')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/list/components/BulkPlanActions/BulkArchivePlansDropdownItem.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkArchivePlansDropdownItem.tsx
@@ -2,7 +2,7 @@ import { type FC, useCallback, useMemo } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -21,7 +21,7 @@ const BulkArchivePlansDropdownItem: FC<BulkArchivePlansDropdownItemProps> = ({
   selectedIds,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const selectedPlans = useMemo(() => getSelectedPlans(plans, selectedIds), [plans, selectedIds]);
   const eligiblePlans = useMemo(() => getPlansEligibleForArchive(selectedPlans), [selectedPlans]);
@@ -45,11 +45,11 @@ const BulkArchivePlansDropdownItem: FC<BulkArchivePlansDropdownItemProps> = ({
       return;
     }
 
-    launcher<BulkArchivePlansModalProps>(BulkArchivePlansModal, {
+    launchOverlay<BulkArchivePlansModalProps>(BulkArchivePlansModal, {
       plans: eligiblePlans,
       skippedArchivedCount,
     });
-  }, [disabledReason, eligiblePlans, launcher, skippedArchivedCount]);
+  }, [disabledReason, eligiblePlans, launchOverlay, skippedArchivedCount]);
 
   return (
     <DropdownItem

--- a/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
@@ -37,7 +37,6 @@ const BulkArchivePlansModal: OverlayComponent<BulkArchivePlansModalProps> = ({
   closeOverlay,
   plans,
   skippedArchivedCount = 0,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [actionFailures, setActionFailures] = useState<BulkPlanActionFailure[]>([]);
@@ -76,7 +75,6 @@ const BulkArchivePlansModal: OverlayComponent<BulkArchivePlansModalProps> = ({
       onConfirm={onArchive}
       testId="bulk-archive-plans-modal"
       title={t('Archive migration plans')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
@@ -4,7 +4,7 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Alert,
   AlertVariant,
@@ -33,7 +33,8 @@ export type BulkArchivePlansModalProps = {
   skippedArchivedCount?: number;
 };
 
-const BulkArchivePlansModal: ModalComponent<BulkArchivePlansModalProps> = ({
+const BulkArchivePlansModal: OverlayComponent<BulkArchivePlansModalProps> = ({
+  closeOverlay,
   plans,
   skippedArchivedCount = 0,
   ...rest
@@ -68,6 +69,7 @@ const BulkArchivePlansModal: ModalComponent<BulkArchivePlansModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Archive')}
       confirmVariant={ButtonVariant.primary}
       isDisabled={isEmpty(plans)}

--- a/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkArchivePlansModal.tsx
@@ -69,7 +69,7 @@ const BulkArchivePlansModal: OverlayComponent<BulkArchivePlansModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Archive')}
       confirmVariant={ButtonVariant.primary}
       isDisabled={isEmpty(plans)}

--- a/src/plans/list/components/BulkPlanActions/BulkDeletePlansDropdownItem.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkDeletePlansDropdownItem.tsx
@@ -2,7 +2,7 @@ import { type FC, useCallback, useMemo } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import type { V1beta1Plan } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -21,7 +21,7 @@ const BulkDeletePlansDropdownItem: FC<BulkDeletePlansDropdownItemProps> = ({
   selectedIds,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const selectedPlans = useMemo(() => getSelectedPlans(plans, selectedIds), [plans, selectedIds]);
   const eligiblePlans = useMemo(() => getPlansEligibleForDelete(selectedPlans), [selectedPlans]);
@@ -51,10 +51,10 @@ const BulkDeletePlansDropdownItem: FC<BulkDeletePlansDropdownItemProps> = ({
       return;
     }
 
-    launcher<BulkDeletePlansModalProps>(BulkDeletePlansModal, {
+    launchOverlay<BulkDeletePlansModalProps>(BulkDeletePlansModal, {
       plans: eligiblePlans,
     });
-  }, [disabledReason, eligiblePlans, launcher]);
+  }, [disabledReason, eligiblePlans, launchOverlay]);
 
   return (
     <DropdownItem

--- a/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
@@ -65,7 +65,7 @@ const BulkDeletePlansModal: OverlayComponent<BulkDeletePlansModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       isDisabled={isEmpty(plans)}

--- a/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
@@ -34,7 +34,6 @@ export type BulkDeletePlansModalProps = {
 const BulkDeletePlansModal: OverlayComponent<BulkDeletePlansModalProps> = ({
   closeOverlay,
   plans,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [actionFailures, setActionFailures] = useState<BulkPlanActionFailure[]>([]);
@@ -72,7 +71,6 @@ const BulkDeletePlansModal: OverlayComponent<BulkDeletePlansModalProps> = ({
       onConfirm={onDelete}
       testId="bulk-delete-plans-modal"
       title={t('Delete migration plans')}
-      {...rest}
     >
       <Stack hasGutter>
         <StackItem>

--- a/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
+++ b/src/plans/list/components/BulkPlanActions/BulkDeletePlansModal.tsx
@@ -4,7 +4,7 @@ import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 import ModalForm from '@components/ModalForm/ModalForm';
 import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
 import { k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import {
   Alert,
   AlertVariant,
@@ -31,7 +31,11 @@ export type BulkDeletePlansModalProps = {
   plans: V1beta1Plan[];
 };
 
-const BulkDeletePlansModal: ModalComponent<BulkDeletePlansModalProps> = ({ plans, ...rest }) => {
+const BulkDeletePlansModal: OverlayComponent<BulkDeletePlansModalProps> = ({
+  closeOverlay,
+  plans,
+  ...rest
+}) => {
   const { t } = useForkliftTranslation();
   const [actionFailures, setActionFailures] = useState<BulkPlanActionFailure[]>([]);
 
@@ -61,6 +65,7 @@ const BulkDeletePlansModal: ModalComponent<BulkDeletePlansModalProps> = ({ plans
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       confirmLabel={t('Delete')}
       confirmVariant={ButtonVariant.danger}
       isDisabled={isEmpty(plans)}

--- a/src/plans/list/components/PlanRowFields/PlanStatus/PlanStatus.tsx
+++ b/src/plans/list/components/PlanRowFields/PlanStatus/PlanStatus.tsx
@@ -19,7 +19,7 @@ import VMStatusIconsRow from 'src/plans/details/components/PlanStatus/VMStatusIc
 import { usePlanMigration } from 'src/plans/hooks/usePlanMigration';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Flex, FlexItem, Spinner, Split } from '@patternfly/react-core';
 import { PlayIcon as StartIcon, RedoIcon } from '@patternfly/react-icons';
 import {
@@ -36,7 +36,7 @@ import './PlanStatus.style.scss';
 
 const PlanStatus: FC<PlanFieldProps> = ({ plan }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const pipelinesProgressPercentage = usePipelineTaskProgress(plan);
   const planStatus = getPlanStatus(plan);
   const [activeMigration, loaded] = usePlanMigration(plan);
@@ -52,7 +52,7 @@ const PlanStatus: FC<PlanFieldProps> = ({ plan }) => {
           isDisabled={hasActiveMigration}
           isInline
           onClick={() => {
-            launcher<PlanStartMigrationModalProps>(PlanStartMigrationModal, {
+            launchOverlay<PlanStartMigrationModalProps>(PlanStartMigrationModal, {
               plan,
               title: t('Start'),
             });
@@ -104,7 +104,7 @@ const PlanStatus: FC<PlanFieldProps> = ({ plan }) => {
             icon={<RedoIcon />}
             isInline
             onClick={() => {
-              launcher<PlanResumeConversionModalProps>(PlanResumeConversionModal, { plan });
+              launchOverlay<PlanResumeConversionModalProps>(PlanResumeConversionModal, { plan });
             }}
             variant={ButtonVariant.link}
           >

--- a/src/plans/list/components/PlanRowFields/PlanStatus/__tests__/PlanStatusResumeButton.test.tsx
+++ b/src/plans/list/components/PlanRowFields/PlanStatus/__tests__/PlanStatusResumeButton.test.tsx
@@ -5,7 +5,7 @@ mockI18n();
 
 const mockLauncher = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useModal: () => mockLauncher,
+  useOverlay: () => mockLauncher,
 }));
 
 const mockUsePlanMigration = jest.fn();

--- a/src/providers/actions/ProviderActionsDropdownItems.tsx
+++ b/src/providers/actions/ProviderActionsDropdownItems.tsx
@@ -4,7 +4,7 @@ import { DeleteModal, type DeleteModalProps } from 'src/components/modals/Delete
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ProviderModel } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem, DropdownList } from '@patternfly/react-core';
 import { getName, getNamespace } from '@utils/crds/common/selectors';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
@@ -22,7 +22,7 @@ const ProviderActionsDropdownItems: FC<ProviderActionsDropdownItemsProps> = ({
   isDetailsPage,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
 
   const { provider } = data;
@@ -34,7 +34,7 @@ const ProviderActionsDropdownItems: FC<ProviderActionsDropdownItemsProps> = ({
   const providerURL = getProviderDetailsPageUrl(provider);
 
   const onProviderDelete = () => {
-    launcher<DeleteModalProps>(DeleteModal, { model: ProviderModel, resource: provider });
+    launchOverlay<DeleteModalProps>(DeleteModal, { model: ProviderModel, resource: provider });
   };
 
   return (

--- a/src/providers/components/CertificateUpload/CertificateUpload.tsx
+++ b/src/providers/components/CertificateUpload/CertificateUpload.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEvent, FC } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Button,
   ButtonVariant,
@@ -36,7 +36,7 @@ const CertificateUpload: FC<CertificateUploadProps> = ({
   validated,
   value,
 }) => {
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const { t } = useForkliftTranslation();
   const isText = !type || type === 'text';
   const onClick = () => {
@@ -44,7 +44,7 @@ const CertificateUpload: FC<CertificateUploadProps> = ({
       target: { value },
     } as ChangeEvent<HTMLTextAreaElement>;
 
-    launcher<FetchCertificateModalProps>(FetchCertificateModal, {
+    launchOverlay<FetchCertificateModalProps>(FetchCertificateModal, {
       existingCert: (value as string) ?? '',
       handleSave: (saved) => {
         onTextChange?.(syntheticEvent, saved);

--- a/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
+++ b/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
@@ -38,7 +38,7 @@ const FetchCertificateModal: OverlayComponent<FetchCertificateModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={!isTrusted}
       onConfirm={onConfirm}
       title={t('Verify certificate')}

--- a/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
+++ b/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
@@ -21,7 +21,6 @@ const FetchCertificateModal: OverlayComponent<FetchCertificateModalProps> = ({
   existingCert,
   handleSave,
   url,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [isTrusted, setIsTrusted] = useState(false);
@@ -43,7 +42,6 @@ const FetchCertificateModal: OverlayComponent<FetchCertificateModalProps> = ({
       onConfirm={onConfirm}
       title={t('Verify certificate')}
       variant={ModalVariant.small}
-      {...rest}
     >
       {loading && <Loading title={t('Loading...')} />}
 

--- a/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
+++ b/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
@@ -4,7 +4,7 @@ import { calculateThumbprint, useTlsCertificate } from 'src/providers/hooks/useT
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Alert, ModalVariant } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -16,7 +16,8 @@ export type FetchCertificateModalProps = {
   url: string;
 };
 
-const FetchCertificateModal: ModalComponent<FetchCertificateModalProps> = ({
+const FetchCertificateModal: OverlayComponent<FetchCertificateModalProps> = ({
+  closeOverlay,
   existingCert,
   handleSave,
   url,
@@ -37,6 +38,7 @@ const FetchCertificateModal: ModalComponent<FetchCertificateModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={!isTrusted}
       onConfirm={onConfirm}
       title={t('Verify certificate')}

--- a/src/providers/components/InventoryCell.tsx
+++ b/src/providers/components/InventoryCell.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import { getResourceFieldValue } from 'src/components/common/FilterGroup/matchers';
 import { TableEmptyCell } from 'src/components/TableCell/TableEmptyCell';
 import { TableIconCell } from 'src/components/TableCell/TableIconCell';
@@ -13,7 +13,7 @@ import OpenshiftNetworkCell from './OpenshiftNetworkCell';
 import VSphereHostCell from './VSphereHostCell';
 
 type InventoryCellProps = {
-  icon?: JSX.Element;
+  icon?: ReactElement;
   inventoryValue?: number | string;
 } & CellProps;
 

--- a/src/providers/create/__tests__/setup-provider-form-mocks.tsx
+++ b/src/providers/create/__tests__/setup-provider-form-mocks.tsx
@@ -55,7 +55,7 @@ jest.mock('../CreateProviderFormContextProvider', () => {
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   useActiveNamespace: () => ['test-namespace', jest.fn()],
   useK8sWatchResource: () => [[], true, null],
-  useModal: () => ({ isOpen: false, showModal: jest.fn(), hideModal: jest.fn() }),
+  useOverlay: () => ({ isOpen: false, showModal: jest.fn(), hideModal: jest.fn() }),
   useAccessReview: () => [true, false],
   ProjectModel: {
     apiGroup: 'project.openshift.io',

--- a/src/providers/create/__tests__/test-utils.tsx
+++ b/src/providers/create/__tests__/test-utils.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 export const mockNavigate = jest.fn();
 export const mockCreateProvider = jest.fn();
 export const mockCreateProviderSecret = jest.fn();
@@ -15,7 +17,7 @@ export const clearAllProviderMocks = (): void => {
 export const mockCreateProviderTypeField = (
   optionValue: string,
   optionLabel: string,
-): { __esModule: true; default: () => JSX.Element } => {
+): { __esModule: true; default: () => ReactElement } => {
   const { useController } = jest.requireActual('react-hook-form');
   const { useCreateProviderFormContext } = jest.requireActual(
     '../hooks/useCreateProviderFormContext',

--- a/src/providers/details/components/DetailsSection/components/ExternalManagementLinkDetailsItem.tsx
+++ b/src/providers/details/components/DetailsSection/components/ExternalManagementLinkDetailsItem.tsx
@@ -8,7 +8,7 @@ import {
 import { providerUiAnnotation } from 'src/providers/utils/constants';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionListDescription } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -40,7 +40,7 @@ export const ExternalManagementLinkDetailsItem: FC<ExternalManagementLinkDetails
   webUILinkText,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const canEdit = !isEmpty(provider?.metadata) && canPatch;
   const defaultHelpContent = (
@@ -71,7 +71,7 @@ export const ExternalManagementLinkDetailsItem: FC<ExternalManagementLinkDetails
         helpContent={helpContent ?? defaultHelpContent}
         moreInfoLink={moreInfoLink}
         onEdit={() => {
-          launcher<EditProviderUIModalProps>(EditProviderUIModal, {
+          launchOverlay<EditProviderUIModalProps>(EditProviderUIModal, {
             resource: provider,
           });
         }}

--- a/src/providers/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
+++ b/src/providers/details/components/DetailsSection/components/TransferNetworkDetailsItem.tsx
@@ -6,7 +6,7 @@ import EditProviderDefaultTransferNetwork, {
 import { DEFAULT_TRANSFER_NETWORK_ANNOTATION } from 'src/providers/utils/constants';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { DEFAULT_NETWORK } from '@utils/constants';
 
@@ -19,7 +19,7 @@ export const TransferNetworkDetailsItem: FC<ProviderDetailsItemProps> = ({
   resource: provider,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   // TODO: Update URL when AEM documentation migration to new platform is complete
   const defaultMoreInfoLink = ''; // was: 'https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.10/html-single/planning_your_migration_to_red_hat_openshift_virtualization/index#selecting-migration-network-for-virt-provider_dest_cnv'
@@ -44,7 +44,7 @@ export const TransferNetworkDetailsItem: FC<ProviderDetailsItemProps> = ({
       helpContent={helpContent ?? defaultHelpContent}
       moreInfoLink={moreInfoLink ?? defaultMoreInfoLink}
       onEdit={() => {
-        launcher<EditProviderDefaultTransferNetworkProps>(EditProviderDefaultTransferNetwork, {
+        launchOverlay<EditProviderDefaultTransferNetworkProps>(EditProviderDefaultTransferNetwork, {
           resource: provider,
         });
       }}

--- a/src/providers/details/components/DetailsSection/components/URLDetailsItem.tsx
+++ b/src/providers/details/components/DetailsSection/components/URLDetailsItem.tsx
@@ -7,7 +7,7 @@ import {
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import type { IoK8sApiCoreV1Secret } from '@forklift-ui/types';
-import { useK8sWatchResource, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource, useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 
 import type { ProviderDetailsItemProps } from './ProviderDetailsItem';
 
@@ -18,7 +18,7 @@ export const URLDetailsItem: FC<ProviderDetailsItemProps> = ({
   resource: provider,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const [secret] = useK8sWatchResource<IoK8sApiCoreV1Secret>({
     groupVersionKind: { kind: 'Secret', version: 'v1' },
@@ -44,7 +44,7 @@ export const URLDetailsItem: FC<ProviderDetailsItemProps> = ({
       helpContent={helpContent ?? defaultHelpContent}
       moreInfoLink={moreInfoLink ?? defaultMoreInfoLink}
       onEdit={() => {
-        launcher<EditProviderURLModalProps>(EditProviderURLModal, {
+        launchOverlay<EditProviderURLModalProps>(EditProviderURLModal, {
           insecureSkipVerify: secret?.data?.insecureSkipVerify,
           resource: provider,
         });

--- a/src/providers/details/tabs/Credentials/ProviderCredentialsTabPage.tsx
+++ b/src/providers/details/tabs/Credentials/ProviderCredentialsTabPage.tsx
@@ -8,7 +8,7 @@ import {
   getGroupVersionKindForModel,
   useAccessReview,
   useK8sWatchResource,
-  useModal,
+  useOverlay,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection, Stack } from '@patternfly/react-core';
 import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
@@ -23,7 +23,7 @@ import EditProviderCredentials, {
 const ProviderCredentialsTabPage: FC<ProviderDetailsPageProps> = ({ name, namespace }) => {
   const { t } = useForkliftTranslation();
   const [reveal, setReveal] = useState(false);
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const { loaded, loadError, provider } = useProvider(name, namespace);
 
@@ -69,7 +69,10 @@ const ProviderCredentialsTabPage: FC<ProviderDetailsPageProps> = ({ name, namesp
             data-testid="credentials-edit-button"
             editable={canPatch}
             onClick={() => {
-              launcher<EditProviderCredentialsProps>(EditProviderCredentials, { provider, secret });
+              launchOverlay<EditProviderCredentialsProps>(EditProviderCredentials, {
+                provider,
+                secret,
+              });
             }}
             title={t('Credentials')}
           />

--- a/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
+++ b/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
@@ -2,7 +2,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { IoK8sApiCoreV1Secret, V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, ModalVariant } from '@patternfly/react-core';
 import { getType } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -21,8 +21,8 @@ export type EditProviderCredentialsProps = {
   secret: IoK8sApiCoreV1Secret;
 };
 
-const EditProviderCredentials: ModalComponent<EditProviderCredentialsProps> = ({
-  closeModal,
+const EditProviderCredentials: OverlayComponent<EditProviderCredentialsProps> = ({
+  closeOverlay,
   provider,
   secret,
 }) => {
@@ -58,7 +58,7 @@ const EditProviderCredentials: ModalComponent<EditProviderCredentialsProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit provider credentials')}

--- a/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
+++ b/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
@@ -58,7 +58,7 @@ const EditProviderCredentials: OverlayComponent<EditProviderCredentialsProps> = 
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isEmpty(errors) || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit provider credentials')}

--- a/src/providers/details/tabs/Details/components/DetailsSection/ApplianceManagementDetailsItem.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/ApplianceManagementDetailsItem.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 import { OVA_APPLIANCE_MANAGEMENT_DESCRIPTION } from 'src/providers/utils/constants';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { PF_LABEL_STATUS } from '@utils/constants';
 import { isApplianceManagementEnabled } from '@utils/crds/common/selectors';
@@ -19,7 +19,7 @@ const ApplianceManagementDetailsItem: FC<ProviderDetailsItemProps> = ({
   resource: provider,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const isEnabled = isApplianceManagementEnabled(provider);
 
@@ -38,7 +38,7 @@ const ApplianceManagementDetailsItem: FC<ProviderDetailsItemProps> = ({
       crumbs={['Provider', 'spec', 'settings', 'applianceManagement']}
       helpContent={helpContent ?? OVA_APPLIANCE_MANAGEMENT_DESCRIPTION}
       onEdit={() => {
-        launcher<EditApplianceManagementProps>(EditApplianceManagement, { provider });
+        launchOverlay<EditApplianceManagementProps>(EditApplianceManagement, { provider });
       }}
       testId="appliance-management-detail-item"
       title={t('Appliance management')}

--- a/src/providers/details/tabs/Details/components/DetailsSection/EditApplianceManagement.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/EditApplianceManagement.tsx
@@ -31,7 +31,7 @@ const EditApplianceManagement: OverlayComponent<EditApplianceManagementProps> = 
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={onSubmit}
       title={t('Edit appliance management')}
     >

--- a/src/providers/details/tabs/Details/components/DetailsSection/EditApplianceManagement.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/EditApplianceManagement.tsx
@@ -7,7 +7,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Checkbox, Form, FormGroup } from '@patternfly/react-core';
 import { isApplianceManagementEnabled } from '@utils/crds/common/selectors';
 
@@ -17,8 +17,8 @@ export type EditApplianceManagementProps = {
   provider: V1beta1Provider;
 };
 
-const EditApplianceManagement: ModalComponent<EditApplianceManagementProps> = ({
-  closeModal,
+const EditApplianceManagement: OverlayComponent<EditApplianceManagementProps> = ({
+  closeOverlay,
   provider,
 }) => {
   const { t } = useForkliftTranslation();
@@ -30,7 +30,11 @@ const EditApplianceManagement: ModalComponent<EditApplianceManagementProps> = ({
   };
 
   return (
-    <ModalForm closeModal={closeModal} onConfirm={onSubmit} title={t('Edit appliance management')}>
+    <ModalForm
+      closeModal={closeOverlay}
+      onConfirm={onSubmit}
+      title={t('Edit appliance management')}
+    >
       <Form>
         <FormGroup fieldId="appliance-management">
           <Checkbox

--- a/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
@@ -46,7 +46,7 @@ const EditProviderVDDKImage: OverlayComponent<EditProviderVDDKImageProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit VDDK image')}
       >

--- a/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
@@ -7,7 +7,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form } from '@patternfly/react-core';
 import { getUseVddkAioOptimization, getVddkInitImage } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -18,8 +18,8 @@ export type EditProviderVDDKImageProps = {
   provider: V1beta1Provider;
 };
 
-const EditProviderVDDKImage: ModalComponent<EditProviderVDDKImageProps> = ({
-  closeModal,
+const EditProviderVDDKImage: OverlayComponent<EditProviderVDDKImageProps> = ({
+  closeOverlay,
   provider,
 }) => {
   const { t } = useForkliftTranslation();
@@ -40,13 +40,13 @@ const EditProviderVDDKImage: ModalComponent<EditProviderVDDKImageProps> = ({
 
   const onSubmit = async (data: EditProviderVDDKImageFormData) => {
     await onUpdateVddkImageSettings(provider, data);
-    closeModal();
+    closeOverlay();
   };
 
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         onConfirm={handleSubmit(onSubmit)}
         title={t('Edit VDDK image')}
       >

--- a/src/providers/details/tabs/Details/components/DetailsSection/VDDKDetailsItem.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/VDDKDetailsItem.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { DetailsItem } from 'src/components/DetailItems/DetailItem';
 
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Label } from '@patternfly/react-core';
 import { CREATE_VDDK_HELP_LINK, PF_LABEL_STATUS } from '@utils/constants';
 import { getVddkInitImage } from '@utils/crds/common/selectors';
@@ -18,7 +18,7 @@ export const VDDKDetailsItem: FC<ProviderDetailsItemProps> = ({
   resource: provider,
 }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const defaultHelpContent = (
     <ForkliftTrans>
@@ -48,7 +48,7 @@ export const VDDKDetailsItem: FC<ProviderDetailsItemProps> = ({
       helpContent={helpContent ?? defaultHelpContent}
       moreInfoLink={moreInfoLink ?? CREATE_VDDK_HELP_LINK}
       onEdit={() => {
-        launcher<EditProviderVDDKImageProps>(EditProviderVDDKImage, { provider });
+        launchOverlay<EditProviderVDDKImageProps>(EditProviderVDDKImage, { provider });
       }}
       testId="vddk-detail-item"
       title={t('VDDK init image')}

--- a/src/providers/details/tabs/Hosts/components/SelectNetworkForHostButton.tsx
+++ b/src/providers/details/tabs/Hosts/components/SelectNetworkForHostButton.tsx
@@ -2,7 +2,7 @@ import { type FC, useCallback } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import type { V1beta1Provider } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, ToolbarItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -15,15 +15,15 @@ const SelectNetworkForHostButton: FC<{
   selectedIds: string[];
 }> = ({ hostsData, provider, selectedIds }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const onClick = useCallback(() => {
-    launcher<VSphereNetworkModalProps>(VSphereNetworkModal, {
+    launchOverlay<VSphereNetworkModalProps>(VSphereNetworkModal, {
       data: hostsData,
       provider,
       selectedIds,
     });
-  }, [hostsData, provider, selectedIds, launcher]);
+  }, [hostsData, provider, selectedIds, launchOverlay]);
 
   return (
     <ToolbarItem>

--- a/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
+++ b/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
@@ -70,7 +70,7 @@ const VSphereNetworkModal: OverlayComponent<VSphereNetworkModalProps> = ({
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       isDisabled={shouldDisableSave}
       onConfirm={handleSave}
       title={t('Select migration network')}

--- a/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
+++ b/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
@@ -29,7 +29,6 @@ const VSphereNetworkModal: OverlayComponent<VSphereNetworkModalProps> = ({
   data,
   provider,
   selectedIds,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
   const [network, setNetwork] = useState<NetworkAdapters | undefined>();
@@ -75,7 +74,6 @@ const VSphereNetworkModal: OverlayComponent<VSphereNetworkModalProps> = ({
       onConfirm={handleSave}
       title={t('Select migration network')}
       variant={ModalVariant.small}
-      {...rest}
     >
       <Stack hasGutter>
         <div className="forklift-edit-modal-body">

--- a/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
+++ b/src/providers/details/tabs/Hosts/components/VSphereNetworkModal.tsx
@@ -5,7 +5,7 @@ import { validateNoSpaces } from 'src/utils/validation/common';
 
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { NetworkAdapters, V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, ModalVariant, Stack } from '@patternfly/react-core';
 import { getSdkEndpoint } from '@utils/crds/common/selectors';
 
@@ -24,7 +24,8 @@ export type VSphereNetworkModalProps = {
   selectedIds: string[];
 };
 
-const VSphereNetworkModal: ModalComponent<VSphereNetworkModalProps> = ({
+const VSphereNetworkModal: OverlayComponent<VSphereNetworkModalProps> = ({
+  closeOverlay,
   data,
   provider,
   selectedIds,
@@ -69,6 +70,7 @@ const VSphereNetworkModal: ModalComponent<VSphereNetworkModalProps> = ({
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       isDisabled={shouldDisableSave}
       onConfirm={handleSave}
       title={t('Select migration network')}

--- a/src/providers/details/tabs/Networks/ProviderNetworksTabPage.tsx
+++ b/src/providers/details/tabs/Networks/ProviderNetworksTabPage.tsx
@@ -10,7 +10,7 @@ import {
   type OpenShiftNetworkAttachmentDefinition,
   ProviderModel,
 } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, PageSection } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { DEFAULT_NETWORK, EMPTY_MSG } from '@utils/constants';
@@ -27,7 +27,7 @@ const ProviderNetworksTabPage: FC<ProviderDetailsPageProps> = ({ name, namespace
   const { t } = useForkliftTranslation();
   const { provider } = useProvider(name, namespace);
 
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const {
     error,
@@ -62,7 +62,7 @@ const ProviderNetworksTabPage: FC<ProviderDetailsPageProps> = ({ name, namespace
   );
 
   const onClick = () => {
-    launcher<EditProviderDefaultTransferNetworkProps>(EditProviderDefaultTransferNetwork, {
+    launchOverlay<EditProviderDefaultTransferNetworkProps>(EditProviderDefaultTransferNetwork, {
       defaultNetworkName,
       resource: provider,
     });

--- a/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
+++ b/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
@@ -29,7 +29,7 @@ const EditProviderDefaultTransferNetwork: OverlayComponent<
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmProviderDefaultTransferNetwork({ resource, value })}
       title={t('Set default Transfer Network')}
       {...rest}

--- a/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
+++ b/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
@@ -4,7 +4,7 @@ import { useForkliftTranslation } from 'src/utils/i18n';
 import { FormGroupWithHelpText } from '@components/common/FormGroupWithHelpText/FormGroupWithHelpText';
 import ModalForm from '@components/ModalForm/ModalForm';
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Stack } from '@patternfly/react-core';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 
@@ -16,9 +16,9 @@ export type EditProviderDefaultTransferNetworkProps = {
   resource: V1beta1Provider;
 };
 
-const EditProviderDefaultTransferNetwork: ModalComponent<
+const EditProviderDefaultTransferNetwork: OverlayComponent<
   EditProviderDefaultTransferNetworkProps
-> = ({ defaultNetworkName, resource, ...rest }) => {
+> = ({ closeOverlay, defaultNetworkName, resource, ...rest }) => {
   const { t } = useForkliftTranslation();
 
   const [value, setValue] = useState<string | number>(defaultNetworkName ?? 0);
@@ -29,6 +29,7 @@ const EditProviderDefaultTransferNetwork: ModalComponent<
 
   return (
     <ModalForm
+      closeModal={closeOverlay}
       onConfirm={async () => onConfirmProviderDefaultTransferNetwork({ resource, value })}
       title={t('Set default Transfer Network')}
       {...rest}

--- a/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
+++ b/src/providers/details/tabs/Networks/components/EditProviderDefaultTransferNetwork.tsx
@@ -18,7 +18,7 @@ export type EditProviderDefaultTransferNetworkProps = {
 
 const EditProviderDefaultTransferNetwork: OverlayComponent<
   EditProviderDefaultTransferNetworkProps
-> = ({ closeOverlay, defaultNetworkName, resource, ...rest }) => {
+> = ({ closeOverlay, defaultNetworkName, resource }) => {
   const { t } = useForkliftTranslation();
 
   const [value, setValue] = useState<string | number>(defaultNetworkName ?? 0);
@@ -32,7 +32,6 @@ const EditProviderDefaultTransferNetwork: OverlayComponent<
       closeOverlay={closeOverlay}
       onConfirm={async () => onConfirmProviderDefaultTransferNetwork({ resource, value })}
       title={t('Set default Transfer Network')}
-      {...rest}
     >
       <Stack hasGutter>
         {t(

--- a/src/providers/details/tabs/VirtualMachines/components/PowerStateCellRenderer.tsx
+++ b/src/providers/details/tabs/VirtualMachines/components/PowerStateCellRenderer.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import { TableIconCell } from 'src/components/TableCell/TableIconCell';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -11,7 +11,7 @@ import type { VMCellProps } from './VMCellProps';
 export const PowerStateCellRenderer: FC<VMCellProps> = ({ data }) => {
   const { t } = useForkliftTranslation();
   const powerState = getVmPowerState(data?.vm);
-  const states: Record<PowerState, [JSX.Element, string, string]> = {
+  const states: Record<PowerState, [ReactElement, string, string]> = {
     off: [<OffIcon color="grey" key="off" />, t('Powered off'), t('Off')],
     on: [<PowerOffIcon color="green" key="on" />, t('Powered on'), t('On')],
     unknown: [<UnknownIcon key="unknown" />, t('Unknown power state'), t('Unknown')],

--- a/src/providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
+++ b/src/providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
@@ -54,7 +54,7 @@ const EditProviderDefaultTransferNetwork: OverlayComponent<
 
   return (
     <ModalForm
-      closeModal={closeOverlay}
+      closeOverlay={closeOverlay}
       onConfirm={onConfirm}
       title={t('Edit default transfer network')}
     >

--- a/src/providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
+++ b/src/providers/modals/EditProviderDefaultTransferNetwork/EditProviderDefaultTransferNetwork.tsx
@@ -7,7 +7,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { ProviderModel, type V1beta1Provider } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { Form, Stack, StackItem } from '@patternfly/react-core';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 
@@ -17,9 +17,9 @@ export type EditProviderDefaultTransferNetworkProps = {
   resource: V1beta1Provider;
 };
 
-const EditProviderDefaultTransferNetwork: ModalComponent<
+const EditProviderDefaultTransferNetwork: OverlayComponent<
   EditProviderDefaultTransferNetworkProps
-> = ({ closeModal, resource: provider }) => {
+> = ({ closeOverlay, resource: provider }) => {
   const { t } = useForkliftTranslation();
 
   const initialValue =
@@ -54,7 +54,7 @@ const EditProviderDefaultTransferNetwork: ModalComponent<
 
   return (
     <ModalForm
-      closeModal={closeModal}
+      closeModal={closeOverlay}
       onConfirm={onConfirm}
       title={t('Edit default transfer network')}
     >

--- a/src/providers/modals/EditProviderUI/EditProviderUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/EditProviderUIModal.tsx
@@ -1,5 +1,5 @@
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { OpenshiftEditUIModal } from './OpenshiftEditUIModal';
 import { OpenstackEditUIModal } from './OpenstackEditUIModal';
@@ -10,7 +10,7 @@ export type EditProviderUIModalProps = {
   resource: V1beta1Provider;
 };
 
-export const EditProviderUIModal: ModalComponent<EditProviderUIModalProps> = (props) => {
+export const EditProviderUIModal: OverlayComponent<EditProviderUIModalProps> = (props) => {
   switch (props.resource?.spec?.type) {
     case 'vsphere':
       return <VSphereEditUIModal {...props} />;

--- a/src/providers/modals/EditProviderUI/OpenshiftEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OpenshiftEditUIModal.tsx
@@ -12,7 +12,6 @@ import type { EditProviderUIModalProps } from './EditProviderUIModal';
 export const OpenshiftEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OpenshiftEditUIModal: OverlayComponent<EditProviderUIModalProps> = 
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t(
         'Link for OpenShift Virtualization web console UI. For example, https://console-openshift-console.apps.openshift-domain.com.',

--- a/src/providers/modals/EditProviderUI/OpenshiftEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OpenshiftEditUIModal.tsx
@@ -2,14 +2,15 @@ import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { providerUiAnnotation } from 'src/providers/utils/constants';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOpenshiftUILink } from '../../utils/validators/provider/openshift/validateOpenshiftUILink';
 
 import { patchProviderUI } from './utils/patchProviderUI';
 import type { EditProviderUIModalProps } from './EditProviderUIModal';
 
-export const OpenshiftEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
+export const OpenshiftEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OpenshiftEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t(

--- a/src/providers/modals/EditProviderUI/OpenstackEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OpenstackEditUIModal.tsx
@@ -2,14 +2,15 @@ import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { providerUiAnnotation } from 'src/providers/utils/constants';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOpenstackUILink } from '../../utils/validators/provider/openstack/validateOpenstackUILink';
 
 import { patchProviderUI } from './utils/patchProviderUI';
 import type { EditProviderUIModalProps } from './EditProviderUIModal';
 
-export const OpenstackEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
+export const OpenstackEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OpenstackEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t(

--- a/src/providers/modals/EditProviderUI/OpenstackEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OpenstackEditUIModal.tsx
@@ -12,7 +12,6 @@ import type { EditProviderUIModalProps } from './EditProviderUIModal';
 export const OpenstackEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OpenstackEditUIModal: OverlayComponent<EditProviderUIModalProps> = 
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t(
         'Link for the OpenStack dashboard. For example, https://identity_service.com/dashboard.',

--- a/src/providers/modals/EditProviderUI/OvirtEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OvirtEditUIModal.tsx
@@ -2,14 +2,15 @@ import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { providerUiAnnotation } from 'src/providers/utils/constants';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOvirtUILink } from '../../utils/validators/provider/ovirt/validateOvirtUILink';
 
 import { patchProviderUI } from './utils/patchProviderUI';
 import type { EditProviderUIModalProps } from './EditProviderUIModal';
 
-export const OvirtEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
+export const OvirtEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OvirtEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t(

--- a/src/providers/modals/EditProviderUI/OvirtEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/OvirtEditUIModal.tsx
@@ -12,7 +12,6 @@ import type { EditProviderUIModalProps } from './EditProviderUIModal';
 export const OvirtEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OvirtEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t(
         'Link for the Red Hat Virtualization Manager landing page. For example, https://rhv-host-example.com/ovirt-engine.',

--- a/src/providers/modals/EditProviderUI/VSphereEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/VSphereEditUIModal.tsx
@@ -2,14 +2,15 @@ import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { providerUiAnnotation } from 'src/providers/utils/constants';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateVSphereUILink } from '../../utils/validators/provider/vsphere/validateVSphereUILink';
 
 import { patchProviderUI } from './utils/patchProviderUI';
 import type { EditProviderUIModalProps } from './EditProviderUIModal';
 
-export const VSphereEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
+export const VSphereEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const VSphereEditUIModal: ModalComponent<EditProviderUIModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t(

--- a/src/providers/modals/EditProviderUI/VSphereEditUIModal.tsx
+++ b/src/providers/modals/EditProviderUI/VSphereEditUIModal.tsx
@@ -12,7 +12,6 @@ import type { EditProviderUIModalProps } from './EditProviderUIModal';
 export const VSphereEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const VSphereEditUIModal: OverlayComponent<EditProviderUIModalProps> = ({
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t(
         'Link for the VMware vSphere UI. For example, https://vSphere-host-example.com/ui.',

--- a/src/providers/modals/EditProviderURL/EditProviderURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/EditProviderURLModal.tsx
@@ -1,5 +1,5 @@
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { OpenshiftEditURLModal } from './OpenshiftEditURLModal';
 import { OpenstackEditURLModal } from './OpenstackEditURLModal';
@@ -11,7 +11,7 @@ export type EditProviderURLModalProps = {
   resource: V1beta1Provider;
 };
 
-export const EditProviderURLModal: ModalComponent<EditProviderURLModalProps> = (props) => {
+export const EditProviderURLModal: OverlayComponent<EditProviderURLModalProps> = (props) => {
   switch (props.resource?.spec?.type) {
     case 'ovirt':
       return <OvirtEditURLModal {...props} />;

--- a/src/providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
@@ -1,14 +1,15 @@
 import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOpenshiftURL } from '../../utils/validators/provider/openshift/validateOpenshiftURL';
 
 import { patchProviderURL } from './utils/patchProviderURL';
 import type { EditProviderURLModalProps } from './EditProviderURLModal';
 
-export const OpenshiftEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
+export const OpenshiftEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OpenshiftEditURLModal: ModalComponent<EditProviderURLModalProps> = 
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t('URL of the Openshift Virtualization API endpoint.')}

--- a/src/providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OpenshiftEditURLModal.tsx
@@ -11,7 +11,6 @@ import type { EditProviderURLModalProps } from './EditProviderURLModal';
 export const OpenshiftEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OpenshiftEditURLModal: OverlayComponent<EditProviderURLModalProps> 
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t('URL of the Openshift Virtualization API endpoint.')}
       initialValue={provider?.spec?.url ?? ''}

--- a/src/providers/modals/EditProviderURL/OpenstackEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OpenstackEditURLModal.tsx
@@ -11,7 +11,6 @@ import type { EditProviderURLModalProps } from './EditProviderURLModal';
 export const OpenstackEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OpenstackEditURLModal: OverlayComponent<EditProviderURLModalProps> 
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t('The URL of the OpenStack Identity endpoint.')}
       initialValue={provider?.spec?.url ?? ''}

--- a/src/providers/modals/EditProviderURL/OpenstackEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OpenstackEditURLModal.tsx
@@ -1,14 +1,15 @@
 import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOpenstackURL } from '../../utils/validators/provider/openstack/validateOpenstackURL';
 
 import { patchProviderURL } from './utils/patchProviderURL';
 import type { EditProviderURLModalProps } from './EditProviderURLModal';
 
-export const OpenstackEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
+export const OpenstackEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OpenstackEditURLModal: ModalComponent<EditProviderURLModalProps> = 
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t('The URL of the OpenStack Identity endpoint.')}

--- a/src/providers/modals/EditProviderURL/OvirtEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OvirtEditURLModal.tsx
@@ -11,7 +11,6 @@ import type { EditProviderURLModalProps } from './EditProviderURLModal';
 export const OvirtEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
   closeOverlay,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -37,7 +36,6 @@ export const OvirtEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t('The URL of the Red Hat Virtualization Manager API endpoint.')}
       initialValue={provider?.spec?.url ?? ''}

--- a/src/providers/modals/EditProviderURL/OvirtEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/OvirtEditURLModal.tsx
@@ -1,14 +1,15 @@
 import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateOvirtURL } from '../../utils/validators/provider/ovirt/validateOvirtURL';
 
 import { patchProviderURL } from './utils/patchProviderURL';
 import type { EditProviderURLModalProps } from './EditProviderURLModal';
 
-export const OvirtEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
+export const OvirtEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
+  closeOverlay,
   resource: provider,
   ...rest
 }) => {
@@ -35,6 +36,7 @@ export const OvirtEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t('The URL of the Red Hat Virtualization Manager API endpoint.')}

--- a/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
@@ -13,7 +13,6 @@ export const VSphereEditURLModal: OverlayComponent<EditProviderURLModalProps> = 
   closeOverlay,
   insecureSkipVerify,
   resource: provider,
-  ...rest
 }) => {
   const { t } = useForkliftTranslation();
 
@@ -45,7 +44,6 @@ export const VSphereEditURLModal: OverlayComponent<EditProviderURLModalProps> = 
   return (
     <TextInputEditModal
       closeOverlay={closeOverlay}
-      {...rest}
       description={description}
       helperText={t('The URL of the vCenter API endpoint.')}
       initialValue={provider?.spec?.url ?? ''}

--- a/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
@@ -1,7 +1,7 @@
 import TextInputEditModal from 'src/components/ModalForm/TextInputEditModal';
 import { ForkliftTrans, useForkliftTranslation } from 'src/utils/i18n';
 
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 
 import { validateEsxiURL } from '../../utils/validators/provider/vsphere/validateEsxiURL';
 import { validateVCenterURL } from '../../utils/validators/provider/vsphere/validateVCenterURL';
@@ -9,7 +9,8 @@ import { validateVCenterURL } from '../../utils/validators/provider/vsphere/vali
 import { patchProviderURL } from './utils/patchProviderURL';
 import type { EditProviderURLModalProps } from './EditProviderURLModal';
 
-export const VSphereEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
+export const VSphereEditURLModal: OverlayComponent<EditProviderURLModalProps> = ({
+  closeOverlay,
   insecureSkipVerify,
   resource: provider,
   ...rest
@@ -43,6 +44,7 @@ export const VSphereEditURLModal: ModalComponent<EditProviderURLModalProps> = ({
 
   return (
     <TextInputEditModal
+      closeOverlay={closeOverlay}
       {...rest}
       description={description}
       helperText={t('The URL of the vCenter API endpoint.')}

--- a/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
+++ b/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
@@ -4,7 +4,7 @@ import { useOwnerPlanActionGate } from 'src/plans/hooks/useOwnerPlanActionGate';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { StorageMapModel, StorageMapModelRef } from '@forklift-ui/types';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { DropdownItem } from '@patternfly/react-core';
 import { getResourceUrl } from '@utils/getResourceUrl';
 import type { StorageMapData } from '@utils/storage/types';
@@ -19,7 +19,7 @@ export const StorageMapActionsDropdownItems = ({
   isDetailsPage,
 }: StorageMapActionsDropdownItemsProps) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
   const navigate = useNavigate();
 
   const { obj: storageMap } = data;
@@ -35,7 +35,7 @@ export const StorageMapActionsDropdownItems = ({
     if (!storageMap) {
       return;
     }
-    launcher<DeleteModalProps>(DeleteModal, { model: StorageMapModel, resource: storageMap });
+    launchOverlay<DeleteModalProps>(DeleteModal, { model: StorageMapModel, resource: storageMap });
   };
 
   return [

--- a/src/storageMaps/components/GroupedSourceStorageField.tsx
+++ b/src/storageMaps/components/GroupedSourceStorageField.tsx
@@ -6,17 +6,14 @@ import Select from '@components/common/Select';
 import { SelectGroup, SelectList, SelectOption } from '@patternfly/react-core';
 import { getDuplicateValues, isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
-import {
-  StorageMapFieldId,
-  type StorageMapping,
-  type StorageMappingValue,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 type GroupedSourceStorageFieldProps = {
   fieldId: string;
-  otherSourceStorages: StorageMappingValue[];
+  otherSourceStorages: MappingValue[];
   storageMappings: StorageMapping[];
-  usedSourceStorages: StorageMappingValue[];
+  usedSourceStorages: MappingValue[];
 };
 
 /**
@@ -55,7 +52,7 @@ const GroupedSourceStorageField: FC<GroupedSourceStorageFieldProps> = ({
           placeholder={t('Select source storage')}
           ref={field.ref}
           testId={`source-storage-${fieldId}`}
-          value={(field.value as StorageMappingValue).name}
+          value={(field.value as MappingValue).name}
         >
           <SelectGroup label={t('Storages used by the selected VMs')}>
             <SelectList>

--- a/src/storageMaps/components/OffloadStorageIndexedForm/OffloadStorageRow.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/OffloadStorageRow.tsx
@@ -4,11 +4,8 @@ import { getStorageMapFieldId } from 'src/storageMaps/utils/getStorageMapFieldId
 
 import type { V1beta1Provider } from '@forklift-ui/types';
 import type { InventoryStorage } from '@utils/hooks/useStorages';
-import {
-  StorageMapFieldId,
-  type StorageMappingValue,
-  type TargetStorage,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type TargetStorage } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import { useDatastoreVendor } from '../../hooks/useDatastoreVendor';
 import type { DatastoreWithBacking } from '../../utils/vendorLookupTables';
@@ -43,9 +40,9 @@ const OffloadStorageRow: FC<OffloadStorageRowProps> = ({
     name: [sourceFieldId, targetFieldId],
   });
 
-  const sourceId = (sourceValue as StorageMappingValue | undefined)?.id;
-  const sourceName = (sourceValue as StorageMappingValue | undefined)?.name;
-  const targetName = (targetValue as StorageMappingValue | undefined)?.name;
+  const sourceId = (sourceValue as MappingValue | undefined)?.id;
+  const sourceName = (sourceValue as MappingValue | undefined)?.name;
+  const targetName = (targetValue as MappingValue | undefined)?.name;
 
   const matchedDatastore = sourceStorages.find(
     (ds) => ds.id === sourceId || ds.name === sourceName,

--- a/src/storageMaps/components/SourceStorageField.tsx
+++ b/src/storageMaps/components/SourceStorageField.tsx
@@ -5,15 +5,12 @@ import Select from '@components/common/Select';
 import { SelectList, SelectOption } from '@patternfly/react-core';
 import { getDuplicateValues, isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
-import {
-  StorageMapFieldId,
-  type StorageMapping,
-  type StorageMappingValue,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 type SourceStorageFieldProps = {
   fieldId: string;
-  sourceStorages: StorageMappingValue[];
+  sourceStorages: MappingValue[];
   storageMappings: StorageMapping[];
 };
 
@@ -50,7 +47,7 @@ const SourceStorageField: FC<SourceStorageFieldProps> = ({
           placeholder={t('Select source storage')}
           ref={field.ref}
           testId={`source-storage-${fieldId}`}
-          value={(field.value as StorageMappingValue).name}
+          value={(field.value as MappingValue).name}
         >
           <SelectList>
             {isEmpty(sourceStorages) ? (

--- a/src/storageMaps/components/TargetStorageField.tsx
+++ b/src/storageMaps/components/TargetStorageField.tsx
@@ -16,7 +16,8 @@ import {
 } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
-import type { StorageMappingValue, TargetStorage } from '@utils/storage/types';
+import type { TargetStorage } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import type { StorageVendorProduct } from '../utils/types';
 import { resolveProductFromCsiProvisioner } from '../utils/vendorLookupTables';
@@ -105,7 +106,7 @@ const TargetStorageField: FC<TargetStorageFieldProps> = ({
             placeholder={t('Select target storage')}
             ref={field.ref}
             testId={testId}
-            value={(field.value as StorageMappingValue).name}
+            value={(field.value as MappingValue).name}
           >
             {hasRecommended ? (
               <>

--- a/src/storageMaps/components/TargetStorageWithSuggestion.tsx
+++ b/src/storageMaps/components/TargetStorageWithSuggestion.tsx
@@ -3,11 +3,8 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { getStorageMapFieldId } from 'src/storageMaps/utils/getStorageMapFieldId';
 
 import type { InventoryStorage } from '@utils/hooks/useStorages';
-import {
-  StorageMapFieldId,
-  type StorageMappingValue,
-  type TargetStorage,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type TargetStorage } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import { resolveProductFromDatastoreName } from '../utils/vendorLookupTables';
 
@@ -36,7 +33,7 @@ const TargetStorageWithSuggestion: FC<TargetStorageWithSuggestionProps> = ({
   const { control } = useFormContext();
 
   const sourceFieldId = getStorageMapFieldId(StorageMapFieldId.SourceStorage, index);
-  const sourceValue = useWatch({ control, name: sourceFieldId }) as StorageMappingValue | undefined;
+  const sourceValue = useWatch({ control, name: sourceFieldId }) as MappingValue | undefined;
 
   const matchedDatastore = sourceStorages.find(
     (ds) => ds.id === sourceValue?.id || ds.name === sourceValue?.name,

--- a/src/storageMaps/create/fields/InventorySourceStorageField.tsx
+++ b/src/storageMaps/create/fields/InventorySourceStorageField.tsx
@@ -8,11 +8,8 @@ import Select from '@components/common/Select';
 import { SelectList, SelectOption } from '@patternfly/react-core';
 import { getDuplicateValues, isEmpty } from '@utils/helpers';
 import { useForkliftTranslation } from '@utils/i18n';
-import {
-  StorageMapFieldId,
-  type StorageMapping,
-  type StorageMappingValue,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import type { CreateStorageMapFormData } from '../types';
 
@@ -53,7 +50,7 @@ const InventorySourceStorageField: FC<InventorySourceStorageFieldProps> = ({
             placeholder={t('Select source storage')}
             ref={field.ref}
             testId={`source-storage-${fieldId}`}
-            value={(field.value as StorageMappingValue).name}
+            value={(field.value as MappingValue).name}
           >
             <SelectList>
               {isEmpty(sourceStorages) ? (
@@ -63,7 +60,7 @@ const InventorySourceStorageField: FC<InventorySourceStorageFieldProps> = ({
               ) : (
                 sourceStorages.map((storage) => {
                   const storageLabel = getMapResourceLabel(storage);
-                  const storageValue: StorageMappingValue = {
+                  const storageValue: MappingValue = {
                     id: storage.id,
                     name: storageLabel,
                   };

--- a/src/storageMaps/create/utils/buildStorageMappings.ts
+++ b/src/storageMaps/create/utils/buildStorageMappings.ts
@@ -9,11 +9,8 @@ import type {
 } from '@forklift-ui/types';
 import { STORAGE_NAMES } from '@utils/constants';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
-import {
-  StorageMapFieldId,
-  type StorageMapping,
-  type StorageMappingValue,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import type { CustomStorageMapSpecMap, OffloadPluginConfig } from '../types';
 
@@ -123,7 +120,7 @@ const getSourceStorage = (
   source: V1beta1StorageMapSpecMapSource,
   sourceProvider: V1beta1Provider | undefined,
   sourceStorages: Map<string, InventoryStorage>,
-): StorageMappingValue => {
+): MappingValue => {
   const isOpenShiftProvider = sourceProvider?.spec?.type === PROVIDER_TYPES.openshift;
   const isEc2Provider = sourceProvider?.spec?.type === PROVIDER_TYPES.ec2;
   const isGlanceStorage = source.name === STORAGE_NAMES.GLANCE;
@@ -164,13 +161,9 @@ export const getStorageMappingValues = (
   return specMappings.map((specMapping) => {
     const { destination, offloadPlugin, source } = specMapping;
 
-    const sourceStorage: StorageMappingValue = getSourceStorage(
-      source,
-      sourceProvider,
-      sourceStorages,
-    );
+    const sourceStorage: MappingValue = getSourceStorage(source, sourceProvider, sourceStorages);
 
-    const targetStorage: StorageMappingValue = {
+    const targetStorage: MappingValue = {
       name: destination.storageClass,
     };
 

--- a/src/storageMaps/details/components/StorageMapEdit.tsx
+++ b/src/storageMaps/details/components/StorageMapEdit.tsx
@@ -112,7 +112,7 @@ const StorageMapEdit: OverlayComponent<StorageMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeOverlay}
+        closeOverlay={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-storage-map-modal"

--- a/src/storageMaps/details/components/StorageMapEdit.tsx
+++ b/src/storageMaps/details/components/StorageMapEdit.tsx
@@ -8,7 +8,7 @@ import ModalForm from '@components/ModalForm/ModalForm';
 import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { StorageMapModel, type V1beta1Provider, type V1beta1StorageMap } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import type { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
+import type { OverlayComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/OverlayProvider';
 import { ModalVariant } from '@patternfly/react-core';
 import { getNamespace } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
@@ -28,8 +28,8 @@ export type StorageMapEditProps = {
   storageMap: V1beta1StorageMap;
 };
 
-const StorageMapEdit: ModalComponent<StorageMapEditProps> = ({
-  closeModal,
+const StorageMapEdit: OverlayComponent<StorageMapEditProps> = ({
+  closeOverlay,
   destinationProvider,
   sourceProvider,
   storageMap,
@@ -112,7 +112,7 @@ const StorageMapEdit: ModalComponent<StorageMapEditProps> = ({
   return (
     <FormProvider {...methods}>
       <ModalForm
-        closeModal={closeModal}
+        closeModal={closeOverlay}
         isDisabled={!isValid || !isDirty}
         onConfirm={handleSubmit(onSubmit)}
         testId="edit-storage-map-modal"

--- a/src/storageMaps/details/components/UpdateStorageMapFieldTable.tsx
+++ b/src/storageMaps/details/components/UpdateStorageMapFieldTable.tsx
@@ -9,11 +9,8 @@ import { FEATURE_NAMES } from '@utils/constants';
 import { useFeatureFlags } from '@utils/hooks/useFeatureFlags';
 import type { InventoryStorage } from '@utils/hooks/useStorages';
 import { useForkliftTranslation } from '@utils/i18n';
-import {
-  StorageMapFieldId,
-  type StorageMappingValue,
-  type TargetStorage,
-} from '@utils/storage/types';
+import { StorageMapFieldId, type TargetStorage } from '@utils/storage/types';
+import type { MappingValue } from '@utils/types';
 
 import AccessModeField from '../../components/AccessModeField';
 import OffloadStorageRow from '../../components/OffloadStorageIndexedForm/OffloadStorageRow';
@@ -31,7 +28,7 @@ type UpdateStorageMapFieldTableProps = {
   isVsphere: boolean;
   loadError: Error | null;
   sourceProvider: V1beta1Provider | undefined;
-  sourceStorages: StorageMappingValue[];
+  sourceStorages: MappingValue[];
   targetStorages: TargetStorage[];
 };
 

--- a/src/storageMaps/details/tabs/Details/StorageMapDetailsTab.tsx
+++ b/src/storageMaps/details/tabs/Details/StorageMapDetailsTab.tsx
@@ -18,7 +18,7 @@ import {
   type V1beta1Provider,
   type V1beta1StorageMap,
 } from '@forklift-ui/types';
-import { useK8sWatchResource, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource, useOverlay } from '@openshift-console/dynamic-plugin-sdk';
 import { PageSection } from '@patternfly/react-core';
 import {
   getMapDestinationProviderName,
@@ -37,7 +37,7 @@ type StorageMapDetailsTabProps = {
 
 export const StorageMapDetailsTab: FC<StorageMapDetailsTabProps> = ({ name, namespace }) => {
   const { t } = useForkliftTranslation();
-  const launcher = useModal();
+  const launchOverlay = useOverlay();
 
   const [storageMap, storageMapLoaded, storageMapLoadError] =
     useK8sWatchResource<V1beta1StorageMap>({
@@ -77,7 +77,7 @@ export const StorageMapDetailsTab: FC<StorageMapDetailsTabProps> = ({ name, name
       <PageSection className="forklift-page-section" hasBodyWrapper={false}>
         <SectionHeadingWithEdit
           onClick={() => {
-            launcher<MapProvidersEditProps>(MapProvidersEdit, {
+            launchOverlay<MapProvidersEditProps>(MapProvidersEdit, {
               destinationProvider,
               model: StorageMapModel,
               namespace,
@@ -94,7 +94,7 @@ export const StorageMapDetailsTab: FC<StorageMapDetailsTabProps> = ({ name, name
         <SectionHeadingWithEdit
           data-testid="storage-map-edit-button"
           onClick={() => {
-            launcher<StorageMapEditProps>(StorageMapEdit, {
+            launchOverlay<StorageMapEditProps>(StorageMapEdit, {
               destinationProvider,
               sourceProvider,
               storageMap,

--- a/src/utils/crds/common/__tests__/selectors.test.ts
+++ b/src/utils/crds/common/__tests__/selectors.test.ts
@@ -1,0 +1,35 @@
+import type { OwnerReference } from '@openshift-console/dynamic-plugin-sdk';
+
+import { getGroupVersionKindFromOwnerReference } from '../selectors';
+
+describe('getGroupVersionKindFromOwnerReference', () => {
+  it('parses grouped apiVersion', () => {
+    const ownerReference = {
+      apiVersion: 'apps/v1',
+      kind: 'ReplicaSet',
+      name: 'example',
+      uid: '1',
+    } as OwnerReference;
+
+    expect(getGroupVersionKindFromOwnerReference(ownerReference)).toEqual({
+      group: 'apps',
+      kind: 'ReplicaSet',
+      version: 'v1',
+    });
+  });
+
+  it('parses core apiVersion without a group', () => {
+    const ownerReference = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      name: 'example',
+      uid: '2',
+    } as OwnerReference;
+
+    expect(getGroupVersionKindFromOwnerReference(ownerReference)).toEqual({
+      group: undefined,
+      kind: 'Secret',
+      version: 'v1',
+    });
+  });
+});

--- a/src/utils/crds/common/selectors.ts
+++ b/src/utils/crds/common/selectors.ts
@@ -15,8 +15,6 @@ export const getLabels = (resource: K8sResourceCommon) => resource?.metadata?.la
 export const getOwnerReference = (resource: K8sResourceCommon) =>
   resource?.metadata?.ownerReferences?.[0];
 
-export const getKind = (resource: K8sResourceCommon) => resource?.kind;
-
 const getSettings = (provider: V1beta1Provider) => provider?.spec?.settings;
 
 export const getVddkInitImage = (provider: V1beta1Provider) => getSettings(provider)?.vddkInitImage;

--- a/src/utils/crds/common/selectors.ts
+++ b/src/utils/crds/common/selectors.ts
@@ -1,5 +1,9 @@
 import type { V1beta1Provider } from '@forklift-ui/types';
-import type { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import type {
+  K8sGroupVersionKind,
+  K8sResourceCommon,
+  OwnerReference,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 export const getName = (resource: K8sResourceCommon | undefined) => resource?.metadata?.name;
 
@@ -14,6 +18,21 @@ export const getLabels = (resource: K8sResourceCommon) => resource?.metadata?.la
 
 export const getOwnerReference = (resource: K8sResourceCommon) =>
   resource?.metadata?.ownerReferences?.[0];
+
+export const getGroupVersionKindFromOwnerReference = (
+  ownerReference: OwnerReference,
+): K8sGroupVersionKind => {
+  const apiVersion = ownerReference.apiVersion ?? '';
+  const [group, version] = apiVersion.includes('/')
+    ? apiVersion.split('/')
+    : [undefined, apiVersion];
+
+  return {
+    group,
+    kind: ownerReference.kind,
+    version,
+  };
+};
 
 const getSettings = (provider: V1beta1Provider) => provider?.spec?.settings;
 

--- a/src/utils/storage/types.ts
+++ b/src/utils/storage/types.ts
@@ -21,9 +21,6 @@ export enum StorageClassAnnotation {
   NetAppShiftStorageClassType = 'shift.netapp.io/storage-class-type',
 }
 
-/** @deprecated Use MappingValue from @utils/types instead */
-export type StorageMappingValue = MappingValue;
-
 export type OVirtVMWithDisks = OVirtVM & {
   disks?: {
     id: string;
@@ -58,8 +55,8 @@ export type StorageMapping = {
   [StorageMapFieldId.AccessMode]?: AccessMode;
   [StorageMapFieldId.DedicatedMigrationHosts]?: string[];
   [StorageMapFieldId.OffloadPlugin]?: string;
-  [StorageMapFieldId.SourceStorage]: StorageMappingValue;
+  [StorageMapFieldId.SourceStorage]: MappingValue;
   [StorageMapFieldId.StorageProduct]?: string;
   [StorageMapFieldId.StorageSecret]?: string;
-  [StorageMapFieldId.TargetStorage]: StorageMappingValue;
+  [StorageMapFieldId.TargetStorage]: MappingValue;
 };


### PR DESCRIPTION
## Summary
- Migrate Console `useModal` / `ModalComponent` call sites to `useOverlay` / `OverlayComponent` across plans, providers, maps, and shared modals
- Replace other deprecated APIs flagged by `@typescript-eslint/no-deprecated`: `StorageMappingValue` → `MappingValue`, global `JSX.Element` → `ReactElement`, Jest `toBeCalled*` matchers, ResourceLink `kind` → `groupVersionKind`, Affinity `VirtualizedTable` → PatternFly `Table`
- Enable `@typescript-eslint/no-deprecated` as error in `eslint.config.ts`

## Test plan
- [x] `npm run lint` passes with `no-deprecated` enabled
- [x] Spot-check overlay modals: plan settings edit, provider URL/UI/credentials, delete/archive/start plan, network/storage map edit, create project
- [x] Affinity rules modal still lists/edit/delete rules correctly
- [x] Controller health pods table ResourceLinks still navigate
- [x] Unit tests for touched areas (cutover/resume mocks, storage mapping utils, Jest matcher tests)

Resolves: MTV-6280

Made with [Cursor](https://cursor.com)