### PR TITLE
Resolves: MTV-6121 | Filter offload storage secret dropdown to Opaque secrets

### DIFF
--- a/locales/en/plugin__forklift-console-plugin.json
+++ b/locales/en/plugin__forklift-console-plugin.json
@@ -947,7 +947,6 @@
   "No results found": "No results found",
   "No results match the filter criteria. Clear all filters and try again.": "No results match the filter criteria. Clear all filters and try again.",
   "No secret": "No secret",
-  "No secrets available for this provider": "No secrets available for this provider",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "No source networks are available for the selected VMs.",
   "No source storages are available for the selected VMs.": "No source storages are available for the selected VMs.",

--- a/locales/es/plugin__forklift-console-plugin.json
+++ b/locales/es/plugin__forklift-console-plugin.json
@@ -957,7 +957,6 @@
   "No results found": "No se encontraron resultados",
   "No results match the filter criteria. Clear all filters and try again.": "No hay resultados que coincidan con los criterios de búsqueda. Borre todos los filtros y vuelva a intentarlo.",
   "No secret": "Sin secretos",
-  "No secrets available for this provider": "No hay secretos disponibles para este proveedor",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "No hay redes de origen disponibles para las máquinas virtuales seleccionadas.",
   "No source storages are available for the selected VMs.": "No hay almacenamientos de origen disponibles para las máquinas virtuales seleccionadas.",

--- a/locales/fr/plugin__forklift-console-plugin.json
+++ b/locales/fr/plugin__forklift-console-plugin.json
@@ -957,7 +957,6 @@
   "No results found": "Aucun résultat trouvé",
   "No results match the filter criteria. Clear all filters and try again.": "Aucun résultat ne correspond aux critères de filtrage. Supprimez tous les filtres et réessayez.",
   "No secret": "Aucun secret",
-  "No secrets available for this provider": "Aucun secret n'est disponible pour ce fournisseur.",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "Aucun réseau source n'est disponible pour les machines virtuelles sélectionnées.",
   "No source storages are available for the selected VMs.": "Aucun stockage source n'est disponible pour les machines virtuelles sélectionnées.",

--- a/locales/ja/plugin__forklift-console-plugin.json
+++ b/locales/ja/plugin__forklift-console-plugin.json
@@ -944,7 +944,6 @@
   "No results found": "結果が見つかりません",
   "No results match the filter criteria. Clear all filters and try again.": "フィルター条件に一致する結果が見つかりません。すべてのフィルターをクリアして再試行してください。",
   "No secret": "シークレットがありません",
-  "No secrets available for this provider": "このプロバイダーにはシークレットがありません",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "選択した仮想マシンに使用できるソースネットワークがありません。",
   "No source storages are available for the selected VMs.": "選択した仮想マシンに使用できるソースストレージがありません。",

--- a/locales/ko/plugin__forklift-console-plugin.json
+++ b/locales/ko/plugin__forklift-console-plugin.json
@@ -944,7 +944,6 @@
   "No results found": "결과 없음",
   "No results match the filter criteria. Clear all filters and try again.": "필터 조건과 일치하는 결과가 없습니다. 모든 필터를 지우고 다시 시도하세요.",
   "No secret": "시크릿 없음",
-  "No secrets available for this provider": "이 공급자에 사용할 수 있는 시크릿이 없습니다.",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "선택한 VM에 사용할 수 있는 소스 네트워크가 없습니다.",
   "No source storages are available for the selected VMs.": "선택한 VM에 사용할 수 있는 소스 스토리지가 없습니다.",

--- a/locales/zh/plugin__forklift-console-plugin.json
+++ b/locales/zh/plugin__forklift-console-plugin.json
@@ -944,7 +944,6 @@
   "No results found": "未找到结果",
   "No results match the filter criteria. Clear all filters and try again.": "没有与过滤条件匹配的结果。清除所有过滤并重试。",
   "No secret": "没有 Secret",
-  "No secrets available for this provider": "此提供程序没有可用的 secret",
   "No selected plans can be deleted.": "No selected plans can be deleted.",
   "No source networks are available for the selected VMs.": "所选虚拟机没有可用的源网络。",
   "No source storages are available for the selected VMs.": "所选虚拟机没有源存储。",

--- a/src/components/LUKSSecretSelect/LUKSSecretSelect.tsx
+++ b/src/components/LUKSSecretSelect/LUKSSecretSelect.tsx
@@ -5,6 +5,7 @@ import type { IoK8sApiCoreV1Secret } from '@forklift-ui/types';
 import { getName } from '@utils/crds/common/selectors';
 import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 import { useForkliftTranslation } from '@utils/i18n';
+import { filterOpaqueSecrets } from '@utils/secrets/opaqueSecrets';
 
 import type { TypeaheadSelectOption } from '../common/TypeaheadSelect/utils/types';
 
@@ -37,13 +38,10 @@ const LUKSSecretSelect: FC<LUKSSecretSelectProps> = ({
     namespace,
   });
 
-  const opaqueSecrets = useMemo((): IoK8sApiCoreV1Secret[] => {
-    if (!allSecrets) {
-      return [];
-    }
-
-    return allSecrets.filter((secret) => secret.type === 'Opaque');
-  }, [allSecrets]);
+  const opaqueSecrets = useMemo(
+    (): IoK8sApiCoreV1Secret[] => filterOpaqueSecrets(allSecrets),
+    [allSecrets],
+  );
 
   const options: TypeaheadSelectOption[] = useMemo(
     () =>

--- a/src/components/LUKSSecretSelect/__tests__/LUKSSecretSelect.test.tsx
+++ b/src/components/LUKSSecretSelect/__tests__/LUKSSecretSelect.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import LUKSSecretSelect from '../LUKSSecretSelect';
 
 const mockUseK8sWatchResource = jest.fn();
-jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useK8sWatchResource: jest.fn((...args) => mockUseK8sWatchResource(...args)),
+jest.mock('@utils/hooks/useK8sWatchResource', () => ({
+  useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
 }));
 
 const onSelect = jest.fn();
@@ -26,23 +27,19 @@ describe('LUKSSecretSelect', () => {
     expect(screen.getByPlaceholderText('Select a secret')).toBeInTheDocument();
   });
 
-  it('includes secrets with missing type (K8s default Opaque)', () => {
+  it('includes secrets with missing type (K8s default Opaque) in options', async () => {
+    const user = userEvent.setup();
     mockUseK8sWatchResource.mockReturnValue([
       [{ metadata: { name: 'default-type-secret' } }],
       true,
       null,
     ]);
 
-    render(
-      <LUKSSecretSelect
-        id="test"
-        namespace="test-ns"
-        onSelect={onSelect}
-        value="default-type-secret"
-      />,
-    );
+    render(<LUKSSecretSelect id="test" namespace="test-ns" onSelect={onSelect} value="" />);
 
-    expect(screen.getByDisplayValue('default-type-secret')).toBeInTheDocument();
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('option', { name: 'default-type-secret' })).toBeInTheDocument();
   });
 
   it('renders no-options message when no Opaque secrets exist', () => {

--- a/src/components/LUKSSecretSelect/__tests__/LUKSSecretSelect.test.tsx
+++ b/src/components/LUKSSecretSelect/__tests__/LUKSSecretSelect.test.tsx
@@ -26,6 +26,25 @@ describe('LUKSSecretSelect', () => {
     expect(screen.getByPlaceholderText('Select a secret')).toBeInTheDocument();
   });
 
+  it('includes secrets with missing type (K8s default Opaque)', () => {
+    mockUseK8sWatchResource.mockReturnValue([
+      [{ metadata: { name: 'default-type-secret' } }],
+      true,
+      null,
+    ]);
+
+    render(
+      <LUKSSecretSelect
+        id="test"
+        namespace="test-ns"
+        onSelect={onSelect}
+        value="default-type-secret"
+      />,
+    );
+
+    expect(screen.getByDisplayValue('default-type-secret')).toBeInTheDocument();
+  });
+
   it('renders no-options message when no Opaque secrets exist', () => {
     mockUseK8sWatchResource.mockReturnValue([
       [{ metadata: { name: 'tls-secret' }, type: 'kubernetes.io/tls' }],

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react';
+import { type FC, useEffect, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { storageMapFieldLabels } from 'src/storageMaps/utils/constants';
 
@@ -26,6 +26,8 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
   const {
     control,
     formState: { isSubmitting },
+    setValue,
+    watch,
   } = useFormContext();
 
   const [secrets, loaded, error] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>({
@@ -40,7 +42,27 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     [secrets],
   );
 
-  const isWatchPending = !loaded || Boolean(error);
+  const selectedSecret = watch(fieldId) as string | undefined;
+  const isWatchUnavailable = !loaded || Boolean(error);
+
+  useEffect(() => {
+    if (isWatchUnavailable || !selectedSecret) {
+      return;
+    }
+
+    const isSelectedOpaque = opaqueSecrets.some((secret) => getName(secret) === selectedSecret);
+
+    if (!isSelectedOpaque) {
+      setValue(fieldId, '', { shouldDirty: true, shouldValidate: true });
+    }
+  }, [fieldId, isWatchUnavailable, opaqueSecrets, selectedSecret, setValue]);
+
+  let placeholder = t('Loading secrets...');
+  if (error) {
+    placeholder = t('Failed to load secrets.');
+  } else if (loaded) {
+    placeholder = t('Select storage secret');
+  }
 
   return (
     <FormGroup
@@ -69,11 +91,11 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
         render={({ field }) => (
           <Select
             id={fieldId}
-            isDisabled={isSubmitting || isWatchPending}
+            isDisabled={isSubmitting || isWatchUnavailable}
             onSelect={(_e, value) => {
               field.onChange(value);
             }}
-            placeholder={loaded ? t('Select storage secret') : t('Loading secrets...')}
+            placeholder={placeholder}
             ref={field.ref}
             testId={fieldId}
             value={field.value as string | undefined}

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -108,7 +108,7 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
             placeholder={placeholder}
             ref={field.ref}
             testId={fieldId}
-            value={field.value as string | undefined}
+            value={typeof field.value === 'string' ? field.value : undefined}
           >
             <SelectList>
               {isEmpty(opaqueSecrets) ? (

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -30,12 +30,17 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     watch,
   } = useFormContext();
 
-  const [secrets, loaded, error] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>({
-    groupVersionKind: getGroupVersionKindForModel(SecretModel),
-    isList: true,
-    namespace: getNamespace(sourceProvider),
-    namespaced: true,
-  });
+  const namespace = getNamespace(sourceProvider);
+  const [secrets, loaded, error] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>(
+    namespace
+      ? {
+          groupVersionKind: getGroupVersionKindForModel(SecretModel),
+          isList: true,
+          namespace,
+          namespaced: true,
+        }
+      : null,
+  );
 
   const opaqueSecrets = useMemo(
     (): IoK8sApiCoreV1Secret[] => filterOpaqueSecrets(secrets),
@@ -43,10 +48,13 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
   );
 
   const selectedSecret = watch(fieldId) as string | undefined;
-  const isWatchUnavailable = !loaded || Boolean(error);
+  const hasOpaqueSecrets = !isEmpty(opaqueSecrets);
+  // Keep the select usable when the list returned Opaque secrets even if a later
+  // watch/stream error is set (common in e2e mocks without a secrets watch WS).
+  const isSelectDisabled = isSubmitting || !loaded || (Boolean(error) && !hasOpaqueSecrets);
 
   useEffect(() => {
-    if (isWatchUnavailable || !selectedSecret) {
+    if (!loaded || !selectedSecret || !hasOpaqueSecrets) {
       return;
     }
 
@@ -55,10 +63,12 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     if (!isSelectedOpaque) {
       setValue(fieldId, '', { shouldDirty: true, shouldValidate: true });
     }
-  }, [fieldId, isWatchUnavailable, opaqueSecrets, selectedSecret, setValue]);
+  }, [fieldId, hasOpaqueSecrets, loaded, opaqueSecrets, selectedSecret, setValue]);
 
   let placeholder = t('Loading secrets...');
-  if (error) {
+  if (loaded && hasOpaqueSecrets) {
+    placeholder = t('Select storage secret');
+  } else if (loaded && error) {
     placeholder = t('Failed to load secrets.');
   } else if (loaded) {
     placeholder = t('Select storage secret');
@@ -91,7 +101,7 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
         render={({ field }) => (
           <Select
             id={fieldId}
-            isDisabled={isSubmitting || isWatchUnavailable}
+            isDisabled={isSelectDisabled}
             onSelect={(_e, value) => {
               field.onChange(value);
             }}

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -11,11 +11,10 @@ import { getName, getNamespace, getUID } from '@utils/crds/common/selectors';
 import { isEmpty } from '@utils/helpers';
 import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 import { useForkliftTranslation } from '@utils/i18n';
+import { filterOpaqueSecrets } from '@utils/secrets/opaqueSecrets';
 import { StorageMapFieldId } from '@utils/storage/types';
 
 import { offloadNestedFieldRules } from '../../utils/offloadNestedFieldRules';
-
-const OPAQUE_SECRET_TYPE = 'Opaque';
 
 type StorageSecretFieldProps = {
   fieldId: string;
@@ -29,7 +28,7 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     formState: { isSubmitting },
   } = useFormContext();
 
-  const [secrets] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>({
+  const [secrets, loaded, error] = useK8sWatchResource<IoK8sApiCoreV1Secret[]>({
     groupVersionKind: getGroupVersionKindForModel(SecretModel),
     isList: true,
     namespace: getNamespace(sourceProvider),
@@ -37,9 +36,11 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
   });
 
   const opaqueSecrets = useMemo(
-    () => (secrets ?? []).filter((secret) => secret.type === OPAQUE_SECRET_TYPE),
+    (): IoK8sApiCoreV1Secret[] => filterOpaqueSecrets(secrets),
     [secrets],
   );
+
+  const isWatchPending = !loaded || Boolean(error);
 
   return (
     <FormGroup
@@ -68,11 +69,11 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
         render={({ field }) => (
           <Select
             id={fieldId}
-            isDisabled={isSubmitting}
+            isDisabled={isSubmitting || isWatchPending}
             onSelect={(_e, value) => {
               field.onChange(value);
             }}
-            placeholder={t('Select storage secret')}
+            placeholder={loaded ? t('Select storage secret') : t('Loading secrets...')}
             ref={field.ref}
             testId={fieldId}
             value={field.value as string | undefined}
@@ -80,7 +81,9 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
             <SelectList>
               {isEmpty(opaqueSecrets) ? (
                 <SelectOption isDisabled key="empty">
-                  {t('No secrets available for this provider')}
+                  {error
+                    ? t('Failed to load secrets.')
+                    : t('No Opaque secrets found in this project.')}
                 </SelectOption>
               ) : (
                 opaqueSecrets.map((secret) => {

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -47,9 +47,8 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     [secrets],
   );
 
-  const selectedSecretValue = watch(fieldId);
-  const selectedSecret =
-    typeof selectedSecretValue === 'string' ? selectedSecretValue : undefined;
+  const selectedSecretValue: unknown = watch(fieldId) as unknown;
+  const selectedSecret = typeof selectedSecretValue === 'string' ? selectedSecretValue : undefined;
   const hasOpaqueSecrets = !isEmpty(opaqueSecrets);
   // Keep the select usable when the list returned Opaque secrets even if a later
   // watch/stream error is set (common in e2e mocks without a secrets watch WS).

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -47,14 +47,21 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     [secrets],
   );
 
-  const selectedSecret = watch(fieldId) as string | undefined;
+  const selectedSecretValue = watch(fieldId);
+  const selectedSecret =
+    typeof selectedSecretValue === 'string' ? selectedSecretValue : undefined;
   const hasOpaqueSecrets = !isEmpty(opaqueSecrets);
   // Keep the select usable when the list returned Opaque secrets even if a later
   // watch/stream error is set (common in e2e mocks without a secrets watch WS).
   const isSelectDisabled = isSubmitting || !loaded || (Boolean(error) && !hasOpaqueSecrets);
 
   useEffect(() => {
-    if (!loaded || !selectedSecret || !hasOpaqueSecrets) {
+    if (!loaded || !selectedSecret) {
+      return;
+    }
+
+    // Preserve the selection only while loading failed and we have no Opaque list to trust.
+    if (error && !hasOpaqueSecrets) {
       return;
     }
 
@@ -63,7 +70,7 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     if (!isSelectedOpaque) {
       setValue(fieldId, '', { shouldDirty: true, shouldValidate: true });
     }
-  }, [fieldId, hasOpaqueSecrets, loaded, opaqueSecrets, selectedSecret, setValue]);
+  }, [error, fieldId, hasOpaqueSecrets, loaded, opaqueSecrets, selectedSecret, setValue]);
 
   let placeholder = t('Loading secrets...');
   if (loaded && hasOpaqueSecrets) {

--- a/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/StorageSecretField.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import { type FC, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { storageMapFieldLabels } from 'src/storageMaps/utils/constants';
 
@@ -14,6 +14,8 @@ import { useForkliftTranslation } from '@utils/i18n';
 import { StorageMapFieldId } from '@utils/storage/types';
 
 import { offloadNestedFieldRules } from '../../utils/offloadNestedFieldRules';
+
+const OPAQUE_SECRET_TYPE = 'Opaque';
 
 type StorageSecretFieldProps = {
   fieldId: string;
@@ -33,6 +35,11 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
     namespace: getNamespace(sourceProvider),
     namespaced: true,
   });
+
+  const opaqueSecrets = useMemo(
+    () => (secrets ?? []).filter((secret) => secret.type === OPAQUE_SECRET_TYPE),
+    [secrets],
+  );
 
   return (
     <FormGroup
@@ -71,12 +78,12 @@ const StorageSecretField: FC<StorageSecretFieldProps> = ({ fieldId, sourceProvid
             value={field.value as string | undefined}
           >
             <SelectList>
-              {isEmpty(secrets) ? (
+              {isEmpty(opaqueSecrets) ? (
                 <SelectOption isDisabled key="empty">
                   {t('No secrets available for this provider')}
                 </SelectOption>
               ) : (
-                secrets.map((secret) => {
+                opaqueSecrets.map((secret) => {
                   const secretName = getName(secret);
 
                   return (

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -152,4 +152,21 @@ describe('StorageSecretField', () => {
     );
     expect(screen.queryByText('tls-secret')).not.toBeInTheDocument();
   });
+
+  it('clears a stale selection when the loaded list has no Opaque secrets', () => {
+    mockUseK8sWatchResource.mockReturnValue([
+      [{ metadata: { name: 'tls-secret', uid: 'uid-2' }, type: 'kubernetes.io/tls' }],
+      true,
+      null,
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />, {
+      defaultValues: { storageSecret: 'tls-secret' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Select menu toggle' })).toHaveTextContent(
+      'Select storage secret',
+    );
+    expect(screen.queryByText('tls-secret')).not.toBeInTheDocument();
+  });
 });

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -52,6 +52,21 @@ describe('StorageSecretField', () => {
     expect(screen.queryByRole('option', { name: 'sa-token' })).not.toBeInTheDocument();
   });
 
+  it('includes secrets with missing type (K8s default Opaque)', async () => {
+    const user = userEvent.setup();
+    mockUseK8sWatchResource.mockReturnValue([
+      [{ metadata: { name: 'default-type-secret', uid: 'uid-5' } }],
+      true,
+      null,
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select menu toggle' }));
+
+    expect(screen.getByRole('option', { name: 'default-type-secret' })).toBeInTheDocument();
+  });
+
   it('shows empty message when only non-Opaque secrets exist', async () => {
     const user = userEvent.setup();
     mockUseK8sWatchResource.mockReturnValue([
@@ -64,6 +79,26 @@ describe('StorageSecretField', () => {
 
     await user.click(screen.getByRole('button', { name: 'Select menu toggle' }));
 
-    expect(screen.getByText('No secrets available for this provider')).toBeInTheDocument();
+    expect(screen.getByText('No Opaque secrets found in this project.')).toBeInTheDocument();
+  });
+
+  it('shows empty message when secrets list is empty', async () => {
+    const user = userEvent.setup();
+    mockUseK8sWatchResource.mockReturnValue([[], true, null]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select menu toggle' }));
+
+    expect(screen.getByText('No Opaque secrets found in this project.')).toBeInTheDocument();
+  });
+
+  it('disables the select while secrets are loading', () => {
+    mockUseK8sWatchResource.mockReturnValue([undefined, false, null]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    expect(screen.getByRole('button', { name: 'Select menu toggle' })).toBeDisabled();
+    expect(screen.getByText('Loading secrets...')).toBeInTheDocument();
   });
 });

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -101,4 +101,33 @@ describe('StorageSecretField', () => {
     expect(screen.getByRole('button', { name: 'Select menu toggle' })).toBeDisabled();
     expect(screen.getByText('Loading secrets...')).toBeInTheDocument();
   });
+
+  it('disables the select and shows failure copy when watch errors', () => {
+    mockUseK8sWatchResource.mockReturnValue([[], true, new Error('watch failed')]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    expect(screen.getByRole('button', { name: 'Select menu toggle' })).toBeDisabled();
+    expect(screen.getByText('Failed to load secrets.')).toBeInTheDocument();
+  });
+
+  it('clears a stale non-Opaque secret value from the form', () => {
+    mockUseK8sWatchResource.mockReturnValue([
+      [
+        { metadata: { name: 'storage-creds', uid: 'uid-1' }, type: 'Opaque' },
+        { metadata: { name: 'tls-secret', uid: 'uid-2' }, type: 'kubernetes.io/tls' },
+      ],
+      true,
+      null,
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />, {
+      defaultValues: { storageSecret: 'tls-secret' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Select menu toggle' })).toHaveTextContent(
+      'Select storage secret',
+    );
+    expect(screen.queryByText('tls-secret')).not.toBeInTheDocument();
+  });
 });

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -102,13 +102,32 @@ describe('StorageSecretField', () => {
     expect(screen.getByText('Loading secrets...')).toBeInTheDocument();
   });
 
-  it('disables the select and shows failure copy when watch errors', () => {
+  it('disables the select and shows failure copy when watch errors with no secrets', () => {
     mockUseK8sWatchResource.mockReturnValue([[], true, new Error('watch failed')]);
 
     renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
 
     expect(screen.getByRole('button', { name: 'Select menu toggle' })).toBeDisabled();
     expect(screen.getByText('Failed to load secrets.')).toBeInTheDocument();
+  });
+
+  it('keeps the select enabled when Opaque secrets loaded despite watch error', async () => {
+    const user = userEvent.setup();
+    mockUseK8sWatchResource.mockReturnValue([
+      [{ metadata: { name: 'storage-creds', uid: 'uid-1' }, type: 'Opaque' }],
+      true,
+      new Error('watch stream failed'),
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    const toggle = screen.getByRole('button', { name: 'Select menu toggle' });
+    expect(toggle).toBeEnabled();
+    expect(toggle).toHaveTextContent('Select storage secret');
+
+    await user.click(toggle);
+
+    expect(screen.getByRole('option', { name: 'storage-creds' })).toBeInTheDocument();
   });
 
   it('clears a stale non-Opaque secret value from the form', () => {

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -12,6 +12,9 @@ const mockUseK8sWatchResource = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(() => ({ group: '', kind: 'Secret', version: 'v1' })),
+}));
+
+jest.mock('@utils/hooks/useK8sWatchResource', () => ({
   useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
 }));
 

--- a/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
+++ b/src/storageMaps/components/OffloadStorageIndexedForm/__tests__/StorageSecretField.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { mockI18n } from '@test-utils/mockI18n';
+import { renderWithForm } from '@test-utils/renderWithForm';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import StorageSecretField from '../StorageSecretField';
+
+mockI18n();
+
+const mockUseK8sWatchResource = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  getGroupVersionKindForModel: jest.fn(() => ({ group: '', kind: 'Secret', version: 'v1' })),
+  useK8sWatchResource: jest.fn((...args: unknown[]) => mockUseK8sWatchResource(...args)),
+}));
+
+const sourceProvider = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Provider',
+  metadata: { name: 'vsphere-provider', namespace: 'openshift-mtv' },
+};
+
+describe('StorageSecretField', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists only Opaque secrets in the dropdown', async () => {
+    const user = userEvent.setup();
+    mockUseK8sWatchResource.mockReturnValue([
+      [
+        { metadata: { name: 'storage-creds', uid: 'uid-1' }, type: 'Opaque' },
+        { metadata: { name: 'tls-secret', uid: 'uid-2' }, type: 'kubernetes.io/tls' },
+        { metadata: { name: 'pull-secret', uid: 'uid-3' }, type: 'kubernetes.io/dockercfg' },
+        {
+          metadata: { name: 'sa-token', uid: 'uid-4' },
+          type: 'kubernetes.io/service-account-token',
+        },
+      ],
+      true,
+      null,
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select menu toggle' }));
+
+    expect(screen.getByRole('option', { name: 'storage-creds' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'tls-secret' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'pull-secret' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'sa-token' })).not.toBeInTheDocument();
+  });
+
+  it('shows empty message when only non-Opaque secrets exist', async () => {
+    const user = userEvent.setup();
+    mockUseK8sWatchResource.mockReturnValue([
+      [{ metadata: { name: 'tls-secret', uid: 'uid-2' }, type: 'kubernetes.io/tls' }],
+      true,
+      null,
+    ]);
+
+    renderWithForm(<StorageSecretField fieldId="storageSecret" sourceProvider={sourceProvider} />);
+
+    await user.click(screen.getByRole('button', { name: 'Select menu toggle' }));
+
+    expect(screen.getByText('No secrets available for this provider')).toBeInTheDocument();
+  });
+});

--- a/src/utils/secrets/__tests__/opaqueSecrets.test.ts
+++ b/src/utils/secrets/__tests__/opaqueSecrets.test.ts
@@ -1,0 +1,24 @@
+import type { IoK8sApiCoreV1Secret } from '@forklift-ui/types';
+
+import { filterOpaqueSecrets, isOpaqueSecret, OPAQUE_SECRET_TYPE } from '../opaqueSecrets';
+
+describe('opaqueSecrets', () => {
+  it('treats missing type as Opaque', () => {
+    expect(isOpaqueSecret({})).toBe(true);
+    expect(isOpaqueSecret({ type: undefined })).toBe(true);
+    expect(isOpaqueSecret({ type: OPAQUE_SECRET_TYPE })).toBe(true);
+    expect(isOpaqueSecret({ type: 'kubernetes.io/tls' })).toBe(false);
+  });
+
+  it('filters Opaque secrets including unset type', () => {
+    const secrets = [
+      { metadata: { name: 'a' }, type: OPAQUE_SECRET_TYPE },
+      { metadata: { name: 'b' } },
+      { metadata: { name: 'c' }, type: 'kubernetes.io/tls' },
+    ] as IoK8sApiCoreV1Secret[];
+
+    expect(filterOpaqueSecrets(secrets).map((secret) => secret.metadata?.name)).toEqual(['a', 'b']);
+    expect(filterOpaqueSecrets(undefined)).toEqual([]);
+    expect(filterOpaqueSecrets([])).toEqual([]);
+  });
+});

--- a/src/utils/secrets/opaqueSecrets.ts
+++ b/src/utils/secrets/opaqueSecrets.ts
@@ -1,0 +1,14 @@
+import type { IoK8sApiCoreV1Secret } from '@forklift-ui/types';
+
+export const OPAQUE_SECRET_TYPE = 'Opaque';
+
+/**
+ * Kubernetes defaults Secret.type to Opaque when unset.
+ * @param secret
+ */
+export const isOpaqueSecret = (secret: Pick<IoK8sApiCoreV1Secret, 'type'>): boolean =>
+  (secret.type ?? OPAQUE_SECRET_TYPE) === OPAQUE_SECRET_TYPE;
+
+export const filterOpaqueSecrets = (
+  secrets: IoK8sApiCoreV1Secret[] | undefined,
+): IoK8sApiCoreV1Secret[] => (secrets ?? []).filter(isOpaqueSecret);

--- a/src/utils/secrets/opaqueSecrets.ts
+++ b/src/utils/secrets/opaqueSecrets.ts
@@ -4,7 +4,7 @@ export const OPAQUE_SECRET_TYPE = 'Opaque';
 
 /**
  * Kubernetes defaults Secret.type to Opaque when unset.
- * @param secret
+ * @param secret Secret-like object; missing `type` is treated as Opaque.
  */
 export const isOpaqueSecret = (secret: Pick<IoK8sApiCoreV1Secret, 'type'>): boolean =>
   (secret.type ?? OPAQUE_SECRET_TYPE) === OPAQUE_SECRET_TYPE;

--- a/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
+++ b/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
@@ -38,6 +38,39 @@ const setupSecretsIntercept = async (page: Page): Promise<void> => {
               },
               type: 'Opaque',
             },
+            {
+              apiVersion: 'v1',
+              kind: 'Secret',
+              metadata: {
+                name: 'tls-secret',
+                namespace: MTV_NAMESPACE,
+                resourceVersion: '1',
+                uid: 'test-secret-uid-2',
+              },
+              type: 'kubernetes.io/tls',
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Secret',
+              metadata: {
+                name: 'pull-secret',
+                namespace: MTV_NAMESPACE,
+                resourceVersion: '1',
+                uid: 'test-secret-uid-3',
+              },
+              type: 'kubernetes.io/dockercfg',
+            },
+            {
+              apiVersion: 'v1',
+              kind: 'Secret',
+              metadata: {
+                name: 'sa-token',
+                namespace: MTV_NAMESPACE,
+                resourceVersion: '1',
+                uid: 'test-secret-uid-4',
+              },
+              type: 'kubernetes.io/service-account-token',
+            },
           ],
           kind: 'SecretList',
           metadata: {
@@ -149,6 +182,11 @@ test.describe(
       await test.step('configure offload with dedicated hosts', async () => {
         await storageMapCreatePage.offload.expandOffloadOptions(0);
         await storageMapCreatePage.offload.selectOffloadPlugin(0, 'vSphere XCOPY');
+        await storageMapCreatePage.offload.verifyStorageSecretOptions(
+          0,
+          ['test-storage-secret'],
+          ['tls-secret', 'pull-secret', 'sa-token'],
+        );
         await storageMapCreatePage.offload.selectStorageSecret(0, 'test-storage-secret');
         await storageMapCreatePage.offload.selectStorageProduct(0, 'NetApp ONTAP');
         await storageMapCreatePage.offload.selectDedicatedMigrationHost(0, TEST_DATA.hosts[0].name);

--- a/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
+++ b/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
@@ -7,27 +7,38 @@ import { StorageMapsListPage } from '../../page-objects/StorageMapsListPage';
 import { MTV_NAMESPACE } from '../../utils/resource-manager/constants';
 
 const setupSecretsIntercept = async (page: Page): Promise<void> => {
-  await page.route(`**/api/v1/namespaces/${MTV_NAMESPACE}/secrets?limit=250`, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        apiVersion: 'v1',
-        items: [
-          {
-            apiVersion: 'v1',
-            kind: 'Secret',
-            metadata: {
-              name: 'test-storage-secret',
-              namespace: MTV_NAMESPACE,
-              uid: 'test-secret-uid-1',
+  // Playwright globs treat "?" as a single-char wildcard, so avoid "?limit=250".
+  // Match list/watch secret requests under the provider project namespace.
+  await page.route(
+    new RegExp(`/api/(?:kubernetes/)?api/v1/namespaces/${MTV_NAMESPACE}/secrets(?:\\?.*)?$`),
+    async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          apiVersion: 'v1',
+          items: [
+            {
+              apiVersion: 'v1',
+              kind: 'Secret',
+              metadata: {
+                name: 'test-storage-secret',
+                namespace: MTV_NAMESPACE,
+                uid: 'test-secret-uid-1',
+              },
+              type: 'Opaque',
             },
-            type: 'Opaque',
-          },
-        ],
-      }),
-    });
-  });
+          ],
+          kind: 'SecretList',
+        }),
+      });
+    },
+  );
 };
 
 test.describe(

--- a/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
+++ b/testing/playwright/e2e/upstream/storage-map-create-offload.spec.ts
@@ -12,7 +12,11 @@ const setupSecretsIntercept = async (page: Page): Promise<void> => {
   await page.route(
     new RegExp(`/api/(?:kubernetes/)?api/v1/namespaces/${MTV_NAMESPACE}/secrets(?:\\?.*)?$`),
     async (route) => {
-      if (route.request().method() !== 'GET') {
+      const request = route.request();
+      const url = request.url();
+      // Only mock the list call. Watch/stream requests fail without a WS mock; the UI
+      // must remain usable when Opaque secrets were already returned by list.
+      if (request.method() !== 'GET' || url.includes('watch=true')) {
         await route.continue();
         return;
       }
@@ -29,12 +33,18 @@ const setupSecretsIntercept = async (page: Page): Promise<void> => {
               metadata: {
                 name: 'test-storage-secret',
                 namespace: MTV_NAMESPACE,
+                resourceVersion: '1',
                 uid: 'test-secret-uid-1',
               },
               type: 'Opaque',
             },
           ],
           kind: 'SecretList',
+          metadata: {
+            continue: '',
+            remainingItemCount: 0,
+            resourceVersion: '1',
+          },
         }),
       });
     },

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -162,6 +162,29 @@ export class OffloadOptions {
     await this.selectFromDropdown(OFFLOAD_FIELD.storageSecret(mappingIndex), secretName);
   }
 
+  async verifyStorageSecretOptions(
+    mappingIndex: number,
+    expected: string[],
+    unexpected: string[],
+  ): Promise<void> {
+    const toggle = this.fieldToggleButton(OFFLOAD_FIELD.storageSecret(mappingIndex));
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const listbox = this.page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    for (const name of expected) {
+      await expect(listbox.getByRole('option', { name })).toBeVisible();
+    }
+    for (const name of unexpected) {
+      await expect(listbox.getByRole('option', { name })).toHaveCount(0);
+    }
+
+    // Close the dropdown without selecting.
+    await toggle.click();
+  }
+
   async verifyAllDropdownsVisible(mappingIndex: number): Promise<void> {
     const pluginBtn = this.fieldToggleButton(OFFLOAD_FIELD.offloadPlugin(mappingIndex));
     const secretBtn = this.fieldToggleButton(OFFLOAD_FIELD.storageSecret(mappingIndex));

--- a/testing/playwright/page-objects/common/OffloadOptions.ts
+++ b/testing/playwright/page-objects/common/OffloadOptions.ts
@@ -162,29 +162,6 @@ export class OffloadOptions {
     await this.selectFromDropdown(OFFLOAD_FIELD.storageSecret(mappingIndex), secretName);
   }
 
-  async verifyStorageSecretOptions(
-    mappingIndex: number,
-    expected: string[],
-    unexpected: string[],
-  ): Promise<void> {
-    const toggle = this.fieldToggleButton(OFFLOAD_FIELD.storageSecret(mappingIndex));
-    await expect(toggle).toBeVisible();
-    await toggle.click();
-
-    const listbox = this.page.getByRole('listbox');
-    await expect(listbox).toBeVisible();
-
-    for (const name of expected) {
-      await expect(listbox.getByRole('option', { name })).toBeVisible();
-    }
-    for (const name of unexpected) {
-      await expect(listbox.getByRole('option', { name })).toHaveCount(0);
-    }
-
-    // Close the dropdown without selecting.
-    await toggle.click();
-  }
-
   async verifyAllDropdownsVisible(mappingIndex: number): Promise<void> {
     const pluginBtn = this.fieldToggleButton(OFFLOAD_FIELD.offloadPlugin(mappingIndex));
     const secretBtn = this.fieldToggleButton(OFFLOAD_FIELD.storageSecret(mappingIndex));
@@ -263,6 +240,29 @@ export class OffloadOptions {
   async verifyOffloadToggleVisible(mappingIndex: number): Promise<void> {
     const toggle = this.expandableToggle(mappingIndex);
     await expect(toggle).toBeVisible();
+  }
+
+  async verifyStorageSecretOptions(
+    mappingIndex: number,
+    expected: string[],
+    unexpected: string[],
+  ): Promise<void> {
+    const toggle = this.fieldToggleButton(OFFLOAD_FIELD.storageSecret(mappingIndex));
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const listbox = this.page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+
+    for (const name of expected) {
+      await expect(listbox.getByRole('option', { exact: true, name })).toBeVisible();
+    }
+    for (const name of unexpected) {
+      await expect(listbox.getByRole('option', { exact: true, name })).toHaveCount(0);
+    }
+
+    // Close the dropdown without selecting.
+    await toggle.click();
   }
 
   async verifyValidationError(partialText: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Filter the offload StorageMap **Storage secret** dropdown to Secrets with `type: Opaque`, matching the LUKS secret picker pattern.
- Excludes system/non-credential secrets (`kubernetes.io/tls`, `dockercfg`, `service-account-token`) that cluttered the list in namespaces with many Secrets.
- Adds unit tests covering Opaque-only listing and the empty state when no Opaque secrets exist.

## Demo
<img width="2506" height="938" alt="Screenshot (83)" src="https://github.com/user-attachments/assets/3ed57fcd-a558-4870-90ff-ae813dc303a1" />
<img width="1116" height="616" alt="Screenshot (82)" src="https://github.com/user-attachments/assets/0c6664e0-a5ad-46d1-9484-f992d137ffe7" />



## Test plan
- [x] Unit: `npm test -- --testPathPattern=StorageSecretField.test`
- [x] Create/edit a StorageMap with vSphere source and copy-offload enabled
- [x] Open the Storage secret dropdown — Opaque vendor credential secrets appear
- [x] Confirm TLS / dockercfg / SA-token secrets do not appear

Resolves: MTV-6121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved secret selection by recognizing Kubernetes Opaque secrets, including secrets without an explicit type.
  * Added clearer loading, error, and empty-state messages when selecting storage secrets.
  * Invalid or unavailable secret selections are now cleared automatically.

* **Bug Fixes**
  * Prevented non-Opaque secrets from appearing as selectable credentials.
  * Removed obsolete localization entries across supported languages.

* **Tests**
  * Added coverage for secret filtering, default types, empty states, loading errors, and stale selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->