### PR TITLE
Resolves: MTV-6385 | Keep local env out of UI test image and preserve version auto-detect

### DIFF
--- a/testing/.dockerignore
+++ b/testing/.dockerignore
@@ -1,4 +1,12 @@
+# Local credentials and provider config (injected at runtime via PROVIDERS_JSON)
 .providers.json
+
+# Local env files — baking these pins FORKLIFT_VERSION/CNV_VERSION and breaks
+# cluster auto-detect in Jenkins (e.g. FORKLIFT_VERSION=latest skips no gates)
+e2e.env
+e2e*.env
+playwright/.env-relay.json
+playwright/.auth/
 
 # Test artifacts
 playwright-report/

--- a/testing/.dockerignore
+++ b/testing/.dockerignore
@@ -8,6 +8,16 @@ e2e*.env
 playwright/.env-relay.json
 playwright/.auth/
 
+# Local-only / experimental specs (often listed in developers' .git/info/exclude).
+# Without these entries, `podman build … ./testing` COPY-bakes them into CI images
+# and Jenkins --grep=@downstream may run them (e.g. plan-cutover-asap on #391).
+**/plan-cutover-asap.spec.ts
+**/warm-migration-example.spec.ts
+**/plan-deep-inspection-seed.spec.ts
+**/seed-*.spec.ts
+**/temp-log-providers.spec.ts
+**/testdocs.txt
+
 # Test artifacts
 playwright-report/
 test-results/

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -70,10 +70,10 @@ export VSPHERE_PROVIDER=${VSPHERE_PROVIDER}
 # Only export when non-empty so Playwright global.setup can auto-detect from the
 # cluster. `export VAR=${VAR}` with VAR unset exports an empty string, which the
 # suite treats as user-set and disables version auto-detect / gating.
-if [ -n "${FORKLIFT_VERSION:-}" ]; then
+if [[ -n "${FORKLIFT_VERSION:-}" ]]; then
   export FORKLIFT_VERSION
 fi
-if [ -n "${CNV_VERSION:-}" ]; then
+if [[ -n "${CNV_VERSION:-}" ]]; then
   export CNV_VERSION
 fi
 

--- a/testing/run-tests.sh
+++ b/testing/run-tests.sh
@@ -66,8 +66,16 @@ export NODE_TLS_REJECT_UNAUTHORIZED=0
 export CLUSTER_USERNAME="kubeadmin"
 export CLUSTER_PASSWORD=${CLUSTER_PASSWORD}
 export VSPHERE_PROVIDER=${VSPHERE_PROVIDER}
-export FORKLIFT_VERSION=${FORKLIFT_VERSION}
-export CNV_VERSION=${CNV_VERSION}
+
+# Only export when non-empty so Playwright global.setup can auto-detect from the
+# cluster. `export VAR=${VAR}` with VAR unset exports an empty string, which the
+# suite treats as user-set and disables version auto-detect / gating.
+if [ -n "${FORKLIFT_VERSION:-}" ]; then
+  export FORKLIFT_VERSION
+fi
+if [ -n "${CNV_VERSION:-}" ]; then
+  export CNV_VERSION
+fi
 
 log "Running Playwright tests..."
 echo "  Cluster: ${CLUSTER_NAME}"


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6385](https://redhat.atlassian.net/browse/MTV-6385)
- Related: [MTV-6386](https://redhat.atlassian.net/browse/MTV-6386) (exclude local experimental specs from image bake-in)

## 📝 Description

Exclude local `e2e*.env` / Playwright env relay / `.auth` from the UI test image, and only export `FORKLIFT_VERSION` / `CNV_VERSION` when set.

Also exclude local-only experimental Playwright specs (e.g. `plan-cutover-asap`) that live in developers' `.git/info/exclude` but were previously COPY-baked into Quay images and run under Jenkins `--grep=@downstream`.

Empty exports and baked `FORKLIFT_VERSION=latest` previously disabled version auto-detect and gates in Jenkins (e.g. #390). Verified on [Jenkins #392](https://jenkins-csb-mtv-qe-main.dno.corp.redhat.com/job/dev-mtv-2.9-ocp-4.19-ui-tests/392/console): auto-detect 2.12.5, 14 passed / 4 skipped (V5_0_0 gates).

## 🎥 Demo

N/A — test infrastructure only; no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6385]: https://redhat.atlassian.net/browse/MTV-6385
[MTV-6386]: https://redhat.atlassian.net/browse/MTV-6386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved automatic version detection when optional version settings are not provided.
  * Prevented empty version values from overriding detected versions during test execution.

* **Chores**
  * Improved test image builds by excluding local credentials, environment files, authentication data, temporary logs, and local-only test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->