### PR TITLE
Resolves: MTV-6386 | Exclude local experimental Playwright specs from UI test images

### DIFF
--- a/testing/.dockerignore
+++ b/testing/.dockerignore
@@ -6,3 +6,13 @@ test-results/
 
 # IDE and local config
 .cursor/
+
+# Local-only / experimental specs (often listed in developers' .git/info/exclude).
+# Without these entries, `podman build … ./testing` COPY-bakes them into CI images
+# and Jenkins --grep=@downstream may run them (e.g. plan-cutover-asap on #391).
+**/plan-cutover-asap.spec.ts
+**/warm-migration-example.spec.ts
+**/plan-deep-inspection-seed.spec.ts
+**/seed-*.spec.ts
+**/temp-log-providers.spec.ts
+**/testdocs.txt


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6386](https://redhat.atlassian.net/browse/MTV-6386)
- Related: [MTV-6385](https://redhat.atlassian.net/browse/MTV-6385) (Phase 3 env/version auto-detect image hygiene)

## 📝 Description

`plan-cutover-asap.spec.ts` (and similar experimental specs) are local-only via `.git/info/exclude`, but `podman build -f PlaywrightContainerFile ./testing` still COPY-bakes them into Quay images. Jenkins then runs them under `--grep=@downstream` (seen on #391: `VMHasSnapshots` / Cannot start).

Exclude those paths in `testing/.dockerignore` so they never enter CI images.

## 🎥 Demo

N/A — test image build context only; no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6385]: https://redhat.atlassian.net/browse/MTV-6385
[MTV-6386]: https://redhat.atlassian.net/browse/MTV-6386