### PR TITLE
Resolves: MTV-6387 | Ensure plan-target NADs and harden multi-NIC network map selection

### DIFF
--- a/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/mapCreationHelpers.ts
@@ -53,6 +53,35 @@ export const createTestNad = async (
   };
 };
 
+const E2E_PLAN_NAD_COUNT = 3;
+const E2E_PLAN_NAD_PREFIX = 'e2e-plan-nad';
+
+/**
+ * Multi-NIC source networks hide Default/Ignore targets and require distinct NADs
+ * in the plan target namespace. Creates a fixed set when missing so plan-wizard
+ * network map steps can complete on empty target projects.
+ */
+export const ensurePlanTargetNads = async (
+  resourceManager: ResourceManager,
+  namespace: string,
+  count = E2E_PLAN_NAD_COUNT,
+): Promise<string[]> => {
+  const createdNames: string[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const name = `${E2E_PLAN_NAD_PREFIX}-${index}`;
+    try {
+      await createTestNad(resourceManager, { name, namespace });
+    } catch {
+      // Already present from a prior run or parallel setup — still track for cleanup.
+      resourceManager.addNad(name, namespace);
+    }
+    createdNames.push(name);
+  }
+
+  return createdNames;
+};
+
 // Network Map types and creation
 export type TestNetworkMap = {
   mappings: Mapping[];

--- a/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
+++ b/testing/playwright/fixtures/helpers/resourceCreationHelpers.ts
@@ -14,6 +14,8 @@ import {
 } from '../../utils/resource-manager/ResourceCreator';
 import type { ResourceManager } from '../../utils/resource-manager/ResourceManager';
 
+import { ensurePlanTargetNads } from './mapCreationHelpers';
+
 // Re-export map creation helpers
 export type {
   CreateNetworkMapOptions,
@@ -21,7 +23,12 @@ export type {
   TestNetworkMap,
   TestStorageMap,
 } from './mapCreationHelpers';
-export { createNetworkMap, createStorageMap, createTestNad } from './mapCreationHelpers';
+export {
+  createNetworkMap,
+  createStorageMap,
+  createTestNad,
+  ensurePlanTargetNads,
+} from './mapCreationHelpers';
 
 export const createSecretObject = (
   name: string,
@@ -233,6 +240,12 @@ export const createPlan = async (
   }
 
   const testPlanData = buildPlanTestData(sourceName, customPlanData);
+
+  // Preexisting targets need NADs before the wizard; new projects get them in
+  // GeneralInformationStep after the Create Project modal succeeds.
+  if (testPlanData.targetProject.isPreexisting && !testPlanData.networkMap.isPreexisting) {
+    await ensurePlanTargetNads(resourceManager, testPlanData.targetProject.name);
+  }
 
   const createWizard = new CreatePlanWizardPage(page, resourceManager);
   const planDetailsPage = new PlanDetailsPage(page);

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/GeneralInformationStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/GeneralInformationStep.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 
+import { ensurePlanTargetNads } from '../../../fixtures/helpers/mapCreationHelpers';
 import type { PlanTestData, TargetProject } from '../../../types/test-data';
 import type { ResourceManager } from '../../../utils/resource-manager/ResourceManager';
 import { V2_11_0, V2_12_0 } from '../../../utils/version/constants';
@@ -118,6 +119,7 @@ export class GeneralInformationStep {
 
       if (this.resourceManager) {
         this.resourceManager.addProject(targetProject.name, true);
+        await ensurePlanTargetNads(this.resourceManager, targetProject.name);
       }
     }
   }

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/NetworkMapStep.ts
@@ -5,6 +5,14 @@ import { isEmpty } from '../../../utils/utils';
 import { V2_11_0 } from '../../../utils/version/constants';
 import { isVersionAtLeast } from '../../../utils/version/version';
 
+const EMPTY_NAD_OPTION_PREFIX = 'No network attachment definitions';
+const NAD_OPTION_INVENTORY_TIMEOUT_MS = 60_000;
+
+type TargetOption = {
+  disabled: boolean;
+  name: string;
+};
+
 export class NetworkMapStep {
   private readonly page: Page;
 
@@ -57,7 +65,26 @@ export class NetworkMapStep {
     };
   }
 
-  private async mapRemainingDefaultRowsToIgnore(alreadyConfiguredSources: string[]): Promise<void> {
+  private async listTargetOptions(): Promise<TargetOption[]> {
+    const listbox = this.page.getByRole('listbox');
+    const options = listbox.getByRole('option');
+    const count = await options.count();
+    const available: TargetOption[] = [];
+
+    for (let i = 0; i < count; i += 1) {
+      const option = options.nth(i);
+      const name = ((await option.textContent()) ?? '').trim();
+      const disabled = await option.isDisabled();
+      available.push({ disabled, name });
+    }
+
+    return available;
+  }
+
+  private async mapRemainingDefaultRowsToIgnore(
+    alreadyConfiguredSources: string[],
+    usedTargets: Set<string>,
+  ): Promise<void> {
     const { rows, getRowText, getTargetSelect } = this.getMappingRowLocators();
     const rowCount = await rows.count();
 
@@ -71,13 +98,59 @@ export class NetworkMapStep {
       if (!alreadyConfigured) {
         const targetSelect = getTargetSelect(row);
         const currentText = await targetSelect.textContent();
-        if (currentText?.includes('Default network')) {
+        const needsRemap =
+          Boolean(currentText?.includes('Default network')) ||
+          Boolean(currentText?.includes('Select target network'));
+
+        if (needsRemap) {
           await targetSelect.click();
-          await this.waitForNetworkOptions();
-          await this.page.getByRole('option', { name: 'Ignore network' }).click();
+          await this.selectTargetNetworkOption('Ignore network', usedTargets);
         }
       }
     }
+  }
+
+  /**
+   * Prefer the requested target; when multi-NIC rows hide Default/Ignore, fall
+   * back to the next unused enabled NAD (`namespace/name`).
+   */
+  private async selectTargetNetworkOption(
+    preferredName: string,
+    usedTargets: Set<string>,
+  ): Promise<void> {
+    await this.waitForSelectableNetworkOptions();
+    const available = await this.listTargetOptions();
+
+    const preferred = available.find(
+      (option) =>
+        !option.disabled &&
+        (option.name === preferredName || option.name.endsWith(`/${preferredName}`)),
+    );
+    if (preferred) {
+      await this.page.getByRole('option', { name: preferred.name, exact: true }).click();
+      usedTargets.add(preferred.name);
+      return;
+    }
+
+    const fallback = available.find(
+      (option) =>
+        !option.disabled &&
+        !option.name.startsWith(EMPTY_NAD_OPTION_PREFIX) &&
+        option.name.includes('/') &&
+        !usedTargets.has(option.name),
+    );
+    if (fallback) {
+      await this.page.getByRole('option', { name: fallback.name, exact: true }).click();
+      usedTargets.add(fallback.name);
+      return;
+    }
+
+    const optionsList = available
+      .map((option) => `  - ${option.name}${option.disabled ? ' (disabled)' : ''}`)
+      .join('\n');
+    throw new Error(
+      `Could not select target network "${preferredName}". Available options:\n${optionsList}`,
+    );
   }
 
   private async waitForAtLeastOneRow(): Promise<void> {
@@ -85,10 +158,34 @@ export class NetworkMapStep {
     await expect(rows.first()).toBeVisible({ timeout: 15_000 });
   }
 
-  async configureMappings(mappings: { source: string; target: string }[]): Promise<void> {
+  private async waitForSelectableNetworkOptions(): Promise<void> {
+    await this.waitForNetworkOptions();
+
+    await expect
+      .poll(
+        async () => {
+          const available = await this.listTargetOptions();
+          return available.some(
+            (option) => !option.disabled && !option.name.startsWith(EMPTY_NAD_OPTION_PREFIX),
+          );
+        },
+        {
+          timeout: NAD_OPTION_INVENTORY_TIMEOUT_MS,
+          message:
+            'Timed out waiting for selectable target networks (NADs). Multi-NIC rows hide Default/Ignore until NADs exist in the target namespace.',
+        },
+      )
+      .toBe(true);
+  }
+
+  async configureMappings(
+    mappings: { source: string; target: string }[],
+    usedTargets: Set<string> = new Set<string>(),
+  ): Promise<Set<string>> {
     for (const mapping of mappings) {
-      await this.selectTargetNetworkForSource(mapping.source, mapping.target);
+      await this.selectTargetNetworkForSource(mapping.source, mapping.target, usedTargets);
     }
+    return usedTargets;
   }
 
   async fillAndComplete(networkMap: {
@@ -122,19 +219,24 @@ export class NetworkMapStep {
       // Wait for auto-detected rows to load before configuring or mapping
       await this.waitForAtLeastOneRow();
 
+      const usedTargets = new Set<string>();
       if (!isEmpty(networkMap.mappings)) {
-        await this.configureMappings(networkMap.mappings);
+        await this.configureMappings(networkMap.mappings, usedTargets);
       }
 
-      // Map any rows still on "Default network" to "Ignore network" to
-      // prevent the "more than one interface mapped to Default" wizard error.
-      // Rows already handled by the caller's explicit mappings are skipped.
+      // Map any rows still on "Default network" (or unselected) away from Default
+      // to prevent the "more than one interface mapped to Default" wizard error.
+      // Prefer Ignore; fall back to distinct NADs when multi-NIC hides Ignore.
       const configuredSources = networkMap.mappings?.map((mapping) => mapping.source) ?? [];
-      await this.mapRemainingDefaultRowsToIgnore(configuredSources);
+      await this.mapRemainingDefaultRowsToIgnore(configuredSources, usedTargets);
     }
   }
 
-  async selectTargetNetworkForSource(sourceNetwork: string, targetNetwork: string): Promise<void> {
+  async selectTargetNetworkForSource(
+    sourceNetwork: string,
+    targetNetwork: string,
+    usedTargets: Set<string> = new Set<string>(),
+  ): Promise<void> {
     const { rows, getRowText, getTargetSelect } = this.getMappingRowLocators();
     const rowCount = await rows.count();
 
@@ -169,8 +271,7 @@ export class NetworkMapStep {
     await expect(targetNetworkSelect).toBeVisible();
     await targetNetworkSelect.click();
 
-    await this.waitForNetworkOptions();
-    await this.page.getByRole('option', { name: targetNetwork }).click();
+    await this.selectTargetNetworkOption(targetNetwork, usedTargets);
   }
 
   async verifyStepVisible(): Promise<void> {


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6387](https://redhat.atlassian.net/browse/MTV-6387)
- Related: [MTV-6385](https://redhat.atlassian.net/browse/MTV-6385) / [#2671](https://github.com/kubev2v/forklift-console-plugin/pull/2671) (Phase 3 image hygiene — no file overlap; safe to merge independently)

## 📝 Description

Multi-NIC source networks hide Default/Ignore targets. Empty plan target projects had no NADs, so Jenkins timed out waiting for `Ignore network` in `plan-add-virtual-machines` and `plan-vm-concerns`.

- Ensure ≥3 fixture NADs in the plan target project (new projects after Create Project; preexisting before the wizard)
- Harden `NetworkMapStep` to prefer the requested target, fall back to distinct NAD options, and fail with a clear option list when nothing is selectable

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!-- @tag as needed -->

[MTV-6387]: https://redhat.atlassian.net/browse/MTV-6387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6385]: https://redhat.atlassian.net/browse/MTV-6385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ