### PR TITLE
Resolves: MTV-6273 | Enforce explicit-function-return-type on src

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Example: if you remove `'no-ternary': 'off'`, the rule activates from `eslint.co
 ### Categories
 
 - **Permanently off (Category 3/4):** Rules intentionally rejected for this project (e.g., `no-ternary`, `prefer-readonly-parameter-types`, `strict-boolean-expressions`). Do not enable without team consensus.
-- **Deferred (has a Jira story):** Rules currently off with a plan to enable later (e.g., `explicit-function-return-type`, `naming-convention`). Check the parent epic MTV-6268 for status.
+- **Deferred (has a Jira story):** Rules currently off with a plan to enable later. Check the parent epic MTV-6268 for status.
 - **Inherited from `.all` (no explicit entry):** If a rule isn't listed in the config, it's **on** from `.all`. To turn it off, add an explicit `'off'` entry.
 
 ### Adding a new rule

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -425,6 +425,14 @@ export const createEslintConfig = () =>
       rules: {
         ...eslintReact.configs['recommended-typescript'].rules,
         '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'error',
+        '@eslint-react/hooks-extra/prefer-use-state-lazy-initialization': 'off',
+      },
+    },
+    // MTV-6273: enforce explicit return types on src/
+    {
+      files: ['src/**/*.{ts,tsx}'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'error',
       },
     },
     {

--- a/src/__mocks__/console_components.tsx
+++ b/src/__mocks__/console_components.tsx
@@ -1,14 +1,18 @@
+import type { ReactElement } from 'react';
+
 import type { ResourceLinkProps } from '@openshift-console/dynamic-plugin-sdk';
 
 export const ResourceLink = ({
   groupVersionKind: { group = '', kind = '', version = '' } = { kind: '', version: '' },
   name,
   namespace: ns,
-}: ResourceLinkProps) => (
+}: ResourceLinkProps): ReactElement => (
   <div className="ResourceLink_mock">
     {`name: ${name}, gvk: ${[group, version, kind].join('~')}, ns: ${ns}`}
   </div>
 );
 
-export const ActionService = () => <div data-test-element-name="ActionService" />;
-export const ActionServiceProvider = () => <div data-test-element-name="ActionServiceProvider" />;
+export const ActionService = (): ReactElement => <div data-test-element-name="ActionService" />;
+export const ActionServiceProvider = (): ReactElement => (
+  <div data-test-element-name="ActionServiceProvider" />
+);

--- a/src/__mocks__/react-i18next.tsx
+++ b/src/__mocks__/react-i18next.tsx
@@ -1,17 +1,22 @@
+import type { ReactElement } from 'react';
+
 /**
  * Mock translation utility
  *
  * @returns {{ t: (k: string) => string; }}
  */
-export const useTranslation = () => ({
+export const useTranslation = (): {
+  i18n: { resolvedLanguage: string };
+  t: (key: string) => string;
+} => ({
   i18n: {
     resolvedLanguage: 'en',
   },
-  t: (key: string) => key,
+  t: (key: string): string => key,
 });
 
-export const getI18n = () => ({
-  t: (key: string) => key,
+export const getI18n = (): { t: (key: string) => string } => ({
+  t: (key: string): string => key,
 });
 
-export const Trans = () => <div data-test-element-name="Trans" />;
+export const Trans = (): ReactElement => <div data-test-element-name="Trans" />;

--- a/src/components/AffinityModal/AffinityConditionSelect.tsx
+++ b/src/components/AffinityModal/AffinityConditionSelect.tsx
@@ -26,13 +26,16 @@ const AffinityConditionSelect: FC<AffinityConditionSelectProps> = ({
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleChange = (event: ReactMouseEvent | undefined, value: string | number | undefined) => {
+  const handleChange = (
+    event: ReactMouseEvent | undefined,
+    value: string | number | undefined,
+  ): void => {
     event?.preventDefault();
     setFocusedAffinity({ ...focusedAffinity, condition: value as AffinityCondition });
     setIsOpen(false);
   };
 
-  const onToggle = () => {
+  const onToggle = (): void => {
     setIsOpen((prevIsOpen) => !prevIsOpen);
   };
 

--- a/src/components/AffinityModal/AffinityList.tsx
+++ b/src/components/AffinityModal/AffinityList.tsx
@@ -58,7 +58,7 @@ const AffinityList: FC<AffinityListProps> = ({
 
   const getSortParams = (columnIndex: number): ThProps['sort'] => ({
     columnIndex,
-    onSort: (_event, index, direction) => {
+    onSort: (_event, index, direction): void => {
       setActiveSortIndex(index);
       setActiveSortDirection(direction);
     },

--- a/src/components/AffinityModal/AffinityModal.tsx
+++ b/src/components/AffinityModal/AffinityModal.tsx
@@ -37,19 +37,19 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
   const [isCreating, setIsCreating] = useState(false);
   const [focusedAffinity, setFocusedAffinity] = useState<AffinityRowData>(defaultNewAffinity);
 
-  const onAffinityClickAdd = () => {
+  const onAffinityClickAdd = (): void => {
     setIsEditing(true);
     setIsCreating(true);
     setFocusedAffinity({ ...defaultNewAffinity, id: getAvailableAffinityID(affinities) });
   };
 
-  const onAffinityAdd = (affinity: AffinityRowData) => {
+  const onAffinityAdd = (affinity: AffinityRowData): void => {
     setAffinities((prevAffinities) => [...(prevAffinities || []), affinity]);
     setIsEditing(false);
     setIsCreating(false);
   };
 
-  const onAffinityChange = (updatedAffinity: AffinityRowData) => {
+  const onAffinityChange = (updatedAffinity: AffinityRowData): void => {
     setAffinities((prevAffinities) =>
       prevAffinities.map((affinity) => {
         if (affinity.id === updatedAffinity.id) {
@@ -62,16 +62,16 @@ const AffinityModal: OverlayComponent<AffinityModalProps> = ({
   };
   const onSaveAffinity = isCreating ? onAffinityAdd : onAffinityChange;
 
-  const onAffinityDelete = (affinity: AffinityRowData) => {
+  const onAffinityDelete = (affinity: AffinityRowData): void => {
     setAffinities((prevAffinities) => prevAffinities.filter(({ id }) => id !== affinity.id));
   };
 
-  const onAffinityClickEdit = (affinity: AffinityRowData) => {
+  const onAffinityClickEdit = (affinity: AffinityRowData): void => {
     setFocusedAffinity(affinity);
     setIsEditing(true);
   };
 
-  const onCancel = () => {
+  const onCancel = (): void => {
     setIsEditing(false);
     setIsCreating(false);
   };

--- a/src/components/AffinityModal/AffinityRowActionsDropdown.tsx
+++ b/src/components/AffinityModal/AffinityRowActionsDropdown.tsx
@@ -29,15 +29,15 @@ const AffinityRowActionsDropdown: FC<AffinityRowActionsDropdownProps> = ({
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((prevIsOpen) => !prevIsOpen);
   };
 
-  const onSelect = () => {
+  const onSelect = (): void => {
     setIsOpen(false);
   };
 
-  const handleDelete = () => {
+  const handleDelete = (): void => {
     onDelete(affinity);
     setIsOpen(false);
   };

--- a/src/components/AffinityModal/AffinityTypeSelect.tsx
+++ b/src/components/AffinityModal/AffinityTypeSelect.tsx
@@ -26,13 +26,16 @@ const AffinityTypeSelect: FC<AffinityTypeSelectProps> = ({
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleChange = (event: ReactMouseEvent | undefined, value: string | number | undefined) => {
+  const handleChange = (
+    event: ReactMouseEvent | undefined,
+    value: string | number | undefined,
+  ): void => {
     event?.preventDefault();
     setFocusedAffinity({ ...focusedAffinity, type: value as AffinityType });
     setIsOpen(false);
   };
 
-  const onToggle = () => {
+  const onToggle = (): void => {
     setIsOpen((prevIsOpen) => !prevIsOpen);
   };
   return (

--- a/src/components/AffinityModal/PreferredAffinityWeightInput.tsx
+++ b/src/components/AffinityModal/PreferredAffinityWeightInput.tsx
@@ -23,7 +23,7 @@ const PreferredAffinityWeightInput: FC<PreferredAffinityWeightInputProps> = ({
   const isInvalid = !weight || weight < 1 || weight > 100;
   const validated = isInvalid ? ValidatedOptions.error : ValidatedOptions.default;
 
-  const onChange = (_event: FormEvent<HTMLInputElement>, value: string) => {
+  const onChange = (_event: FormEvent<HTMLInputElement>, value: string): void => {
     setFocusedAffinity({ ...focusedAffinity, weight: Number(value) });
   };
 

--- a/src/components/AffinityModal/TopologyKeyInput.tsx
+++ b/src/components/AffinityModal/TopologyKeyInput.tsx
@@ -24,7 +24,7 @@ const TopologyKeyInput: FC<TopologyKeyInputProps> = ({
   const isInvalid = !topologyKey || isEmpty(topologyKey);
   const validated = isInvalid ? ValidatedOptions.error : ValidatedOptions.default;
 
-  const onChange = (value: string) => {
+  const onChange = (value: string): void => {
     setFocusedAffinity({ ...focusedAffinity, topologyKey: value });
   };
 

--- a/src/components/AffinityModal/hooks/useIDEntities.ts
+++ b/src/components/AffinityModal/hooks/useIDEntities.ts
@@ -1,8 +1,19 @@
-import { useCallback, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 
 import type { IDEntity } from '../utils/types';
 
-export const useIDEntities = <T extends IDEntity = IDEntity>(initialEntities: T[] = []) => {
+type UseIDEntitiesReturn<T extends IDEntity> = {
+  entities: T[];
+  initialEntitiesChanged: boolean;
+  onEntityAdd: (newEntity: T) => void;
+  onEntityChange: (updatedEntity: T) => void;
+  onEntityDelete: (idToDelete: number) => void;
+  setEntities: Dispatch<SetStateAction<T[]>>;
+};
+
+export const useIDEntities = <T extends IDEntity = IDEntity>(
+  initialEntities: T[] = [],
+): UseIDEntitiesReturn<T> => {
   const [entities, setEntities] = useState<T[]>(initialEntities);
   const [initialEntitiesChanged, setInitialEntitiesChanged] = useState<boolean>(false);
 

--- a/src/components/AffinityModal/utils/affinityToRowsData.ts
+++ b/src/components/AffinityModal/utils/affinityToRowsData.ts
@@ -6,11 +6,17 @@ import type {
   K8sIoApimachineryPkgApisMetaV1LabelSelectorRequirement,
 } from '@forklift-ui/types';
 
-import { AffinityCondition, type AffinityRowData, AffinityType } from './types';
+import { AffinityCondition, type AffinityLabel, type AffinityRowData, AffinityType } from './types';
 
 const setIDsToEntity = (
   entity: K8sIoApimachineryPkgApisMetaV1LabelSelectorRequirement[] | undefined,
-) => entity?.map((elm, index) => ({ ...elm, id: index }));
+): AffinityLabel[] | undefined =>
+  entity?.map((elm, index) => ({
+    id: index,
+    key: elm.key,
+    operator: elm.operator,
+    values: elm.values ?? [],
+  }));
 
 const getNodeAffinityRows = (
   nodeAffinity: K8sIoApiCoreV1NodeAffinity | undefined,

--- a/src/components/AffinityModal/utils/getAvailableAffinityID.ts
+++ b/src/components/AffinityModal/utils/getAvailableAffinityID.ts
@@ -1,6 +1,6 @@
 import type { AffinityRowData } from './types';
 
-export const getAvailableAffinityID = (affinities: AffinityRowData[]) => {
+export const getAvailableAffinityID = (affinities: AffinityRowData[]): string => {
   const idSet = new Set(affinities.map((aff) => aff.id));
   let id = 1;
   while (idSet.has(id.toString())) {

--- a/src/components/AffinityModal/utils/isTermsInvalid.ts
+++ b/src/components/AffinityModal/utils/isTermsInvalid.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '@utils/helpers';
 
 import type { AffinityLabel } from './types';
 
-export const isTermsInvalid = (terms: AffinityLabel[]) =>
+export const isTermsInvalid = (terms: AffinityLabel[]): boolean =>
   terms?.some(
     ({ key, operator, values }) =>
       !key ||

--- a/src/components/AffinityModal/utils/rowsDataToAffinity.ts
+++ b/src/components/AffinityModal/utils/rowsDataToAffinity.ts
@@ -94,7 +94,9 @@ const getPreferredPodTermFromRowData = ({
   weight,
 });
 
-export const rowsDataToAffinity = (affinityRows: AffinityRowData[]) => {
+export const rowsDataToAffinity = (
+  affinityRows: AffinityRowData[],
+): K8sIoApiCoreV1Affinity | null => {
   if (isEmpty(affinityRows)) {
     return null;
   }

--- a/src/components/BreadCrumb/utils.ts
+++ b/src/components/BreadCrumb/utils.ts
@@ -3,7 +3,17 @@ import { MODEL_KIND } from '@utils/constants';
 import { getResourceUrl } from '@utils/getResourceUrl';
 import { t } from '@utils/i18n';
 
-const getBreadcrumbLabels = (kind: string, model: K8sModel) => {
+type BreadcrumbLabels = {
+  detailsPage: string;
+  listPage: string;
+};
+
+type ModelBreadcrumb = {
+  name: string;
+  path?: string;
+};
+
+const getBreadcrumbLabels = (kind: string, model: K8sModel): BreadcrumbLabels => {
   switch (kind) {
     case MODEL_KIND.NETWORK_MAP:
       return {
@@ -33,7 +43,7 @@ const getBreadcrumbLabels = (kind: string, model: K8sModel) => {
   }
 };
 
-export const breadcrumbsForModel = (model: K8sModel, namespace: string) => {
+export const breadcrumbsForModel = (model: K8sModel, namespace: string): ModelBreadcrumb[] => {
   const groupVersionKind: K8sGroupVersionKind = {
     group: model.apiGroup,
     kind: model.kind,

--- a/src/components/ConditionsSection/ConditionsSection.tsx
+++ b/src/components/ConditionsSection/ConditionsSection.tsx
@@ -26,7 +26,7 @@ export const ConditionsSection: FC<ConditionsSectionProps> = ({ conditions }) =>
     );
   }
 
-  const getStatusLabel = (status: string) => {
+  const getStatusLabel = (status: string): string => {
     switch (status) {
       case 'True':
         return t('True');

--- a/src/components/DrawerContext/DrawerProvider.tsx
+++ b/src/components/DrawerContext/DrawerProvider.tsx
@@ -20,13 +20,13 @@ export const DrawerProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [drawerTitle, setDrawerTitle] = useState<ReactNode>(null);
   const focusRef = useRef<HTMLDivElement>(null);
 
-  const openDrawer = (content: ReactNode, title?: ReactNode) => {
+  const openDrawer = (content: ReactNode, title?: ReactNode): void => {
     setDrawerContent(content);
     setDrawerTitle(title ?? null);
     setIsOpen(true);
   };
 
-  const closeDrawer = () => {
+  const closeDrawer = (): void => {
     setIsOpen(false);
   };
 

--- a/src/components/DrawerContext/useDrawer.ts
+++ b/src/components/DrawerContext/useDrawer.ts
@@ -1,8 +1,8 @@
-import { useContext } from 'react';
+import { type ContextType, useContext } from 'react';
 
 import { DrawerContext } from './DrawerContext';
 
-export const useDrawer = () => {
+export const useDrawer = (): ContextType<typeof DrawerContext> => {
   const ctx = useContext(DrawerContext);
 
   return ctx;

--- a/src/components/FilterableSelect/FilterableSelect.tsx
+++ b/src/components/FilterableSelect/FilterableSelect.tsx
@@ -1,6 +1,7 @@
 import {
   type FunctionComponent,
   type MouseEvent,
+  type ReactElement,
   type ReactNode,
   type Ref,
   useMemo,
@@ -86,7 +87,7 @@ export const FilterableSelect: FunctionComponent<FilterableSelectProps> = ({
    *
    * @param {string} newValue The value to set as selected.
    */
-  const setSelected = (newValue: string) => {
+  const setSelected = (newValue: string): void => {
     setSelectedItem(newValue);
     setFilterValue('');
 
@@ -116,7 +117,10 @@ export const FilterableSelect: FunctionComponent<FilterableSelectProps> = ({
    * @param {MouseEvent<Element, MouseEvent> | undefined} _event The click event.
    * @param {string | number | undefined} itemId The id of the selected item.
    */
-  const onItemSelect = (_event: MouseEvent | undefined, itemId: string | number | undefined) => {
+  const onItemSelect = (
+    _event: MouseEvent | undefined,
+    itemId: string | number | undefined,
+  ): void => {
     if (itemId !== undefined) {
       setInputValue(itemId as string);
       setFilterValue(itemId as string);
@@ -126,7 +130,7 @@ export const FilterableSelect: FunctionComponent<FilterableSelectProps> = ({
     setFocusedItemIndex(null);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <FilterableSelectMenuToggle
       filterValue={filterValue}
       focusedItemIndex={focusedItemIndex}

--- a/src/components/FilterableSelect/FilterableSelectMenuToggle.tsx
+++ b/src/components/FilterableSelect/FilterableSelectMenuToggle.tsx
@@ -52,7 +52,7 @@ const FilterableSelectMenuToggle: FunctionComponent<FilterableSelectMenuTogglePr
 }) => {
   const textInputRef = useRef<HTMLInputElement>();
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen(!isOpen);
   };
 
@@ -64,7 +64,7 @@ const FilterableSelectMenuToggle: FunctionComponent<FilterableSelectMenuTogglePr
     setFilterValue(value);
   };
 
-  const handleMenuArrowKeys = (key: string) => {
+  const handleMenuArrowKeys = (key: string): void => {
     let indexToFocus = null;
 
     if (isOpen) {

--- a/src/components/InputList/InputList.tsx
+++ b/src/components/InputList/InputList.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState } from 'react';
+import { type FC, type ReactElement, useState } from 'react';
 
 import {
   Button,
@@ -26,7 +26,7 @@ let idCounter = 0;
  *
  * @returns {string} New unique ID.
  */
-const generateUniqueId = () => {
+const generateUniqueId = (): string => {
   idCounter += 1;
   return `item-${idCounter}`;
 };
@@ -86,13 +86,13 @@ export const InputList = <T,>({
   items,
   onChange,
   removeIconContent = 'Remove',
-}: InputListProps<T>) => {
+}: InputListProps<T>): ReactElement => {
   const initialStateItems = isEmpty(items) ? [null as unknown as T] : items;
   const [localItems, setLocalItems] = useState<InputListItem<T>[]>(
     assignIdsToItems(initialStateItems),
   );
 
-  const handleItemChange = (id: string, newContent: T) => {
+  const handleItemChange = (id: string, newContent: T): void => {
     const updatedItems = localItems.map(({ content, id: itemId }) => ({
       content: id === itemId ? newContent : content,
       id: itemId,
@@ -102,14 +102,14 @@ export const InputList = <T,>({
     onChange(extractContent<T>(updatedItems));
   };
 
-  const handleItemDelete = (id: string) => {
+  const handleItemDelete = (id: string): void => {
     const updatedItems = localItems.filter(({ id: itemId }) => id !== itemId);
 
     setLocalItems(updatedItems);
     onChange(extractContent<T>(updatedItems));
   };
 
-  const handleAddItem = () => {
+  const handleAddItem = (): void => {
     const newItem: InputListItem<T> = { content: null as unknown as T, id: generateUniqueId() };
     const updatedItems = [...localItems, newItem];
 

--- a/src/components/InputList/LazyTextInput.tsx
+++ b/src/components/InputList/LazyTextInput.tsx
@@ -37,13 +37,13 @@ export const LazyTextInput: FunctionComponent<LazyTextInputProps> = ({
 }) => {
   const [value, setValue] = useState(propValue);
 
-  const handleBlur = () => {
+  const handleBlur = (): void => {
     if (value !== propValue) {
       onChange(value);
     }
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === 'Enter' && value !== propValue) {
       onChange(value);
     }

--- a/src/components/LabelsModal/LabelsModal.tsx
+++ b/src/components/LabelsModal/LabelsModal.tsx
@@ -59,7 +59,7 @@ const LabelsModal: OverlayComponent<LabelsModalProps> = ({
   // Backspace deletes tags, but not if there is text being edited in the input field
   const removeKeys = inputValue.length ? [] : [8];
 
-  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const { value } = e.target;
 
     if (value === '') {
@@ -80,7 +80,7 @@ const LabelsModal: OverlayComponent<LabelsModalProps> = ({
     value: inputValue,
   };
 
-  const handleLabelsChange = (newLabels: string[], changed: string[]) => {
+  const handleLabelsChange = (newLabels: string[], changed: string[]): void => {
     const { 0: newLabel } = changed;
 
     if (!isLabelValid(newLabel)) {

--- a/src/components/LabelsModal/utils/isLabelValid.ts
+++ b/src/components/LabelsModal/utils/isLabelValid.ts
@@ -1,4 +1,4 @@
-export const isLabelValid = (label: string) => {
+export const isLabelValid = (label: string): boolean => {
   const LABEL_REGEX = /^[a-zA-Z0-9-_./]+=[a-zA-Z0-9-_./]+$/u;
   const LABEL_NO_WHITESPACE_REGEX = /^[^\s]+$/u;
   return LABEL_REGEX.test(label) && LABEL_NO_WHITESPACE_REGEX.test(label);

--- a/src/components/LabelsModal/utils/renderTag.tsx
+++ b/src/components/LabelsModal/utils/renderTag.tsx
@@ -1,11 +1,15 @@
+import type { ReactElement } from 'react';
+
 import { Label } from '@patternfly/react-core';
 
-export const renderTag = (props: {
+type RenderTagProps = {
   getTagDisplayValue: (tag: string) => string;
   key: number;
   onRemove: (key: number) => void;
   tag: string;
-}) => {
+};
+
+export const renderTag = (props: RenderTagProps): ReactElement => {
   const { getTagDisplayValue, key, onRemove, tag } = props;
 
   return (

--- a/src/components/MapProvidersDetails/MapProvidersEdit.tsx
+++ b/src/components/MapProvidersDetails/MapProvidersEdit.tsx
@@ -40,7 +40,7 @@ const MapProvidersEdit: OverlayComponent<MapProvidersEditProps> = ({
     handleSubmit,
   } = methods;
 
-  const onSubmit = async (formData: MapProvidersEditFormValues) => {
+  const onSubmit = async (formData: MapProvidersEditFormValues): Promise<void> => {
     if (!isDirty) {
       closeOverlay();
       return;

--- a/src/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -52,7 +52,7 @@ const NodeSelectorModal: OverlayComponent<NodeSelectorModalProps> = ({
     setLabels(labels.filter(({ id }) => id !== idToDelete));
   };
 
-  const onSelectorLabelAdd = () => {
+  const onSelectorLabelAdd = (): void => {
     onLabelAdd({ id: -1, key: '', value: '' });
   };
 

--- a/src/components/OvaFileUploader/OvaFileUploader.tsx
+++ b/src/components/OvaFileUploader/OvaFileUploader.tsx
@@ -30,7 +30,7 @@ const OvaFileUploader: FC<OvaFileUploaderProps> = ({ provider }) => {
   const [uploading, setUploading] = useState(false);
   const [validation, setValidation] = useState<OvaValidationVariant>(OvaValidationVariant.Default);
 
-  const handleUpload = async () => {
+  const handleUpload = async (): Promise<void> => {
     if (!file) {
       return;
     }

--- a/src/components/OvaFileUploader/utils/utils.ts
+++ b/src/components/OvaFileUploader/utils/utils.ts
@@ -25,7 +25,7 @@ export const uploadOva = async (
   return response.json() as Promise<UploadOvaResponse>;
 };
 
-export const getUploadButtonLabel = (uploading: boolean) =>
+export const getUploadButtonLabel = (uploading: boolean): string =>
   uploading ? t('Uploading...') : t('Upload');
 
 export const validateOvaFileName = (fileName: string): OvaValidationVariant => {

--- a/src/components/ProviderSelect/ProviderSelect.tsx
+++ b/src/components/ProviderSelect/ProviderSelect.tsx
@@ -1,4 +1,11 @@
-import { type ComponentProps, type ForwardedRef, forwardRef, type ReactNode, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  type ReactNode,
+  useMemo,
+} from 'react';
 import { getProviderTypeIcon } from 'src/utils/providers/getProviderTypeIcon';
 
 import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
@@ -56,7 +63,7 @@ const ProviderSelect = (
     value,
   }: ProviderSelectProps,
   ref: ForwardedRef<HTMLButtonElement>,
-) => {
+): ReactElement => {
   const isDarkTheme = useIsDarkTheme();
   const { isAwsPlatform } = useClusterIsAwsPlatform();
   const { trackEvent } = useForkliftAnalytics();

--- a/src/components/TableSortContext.tsx
+++ b/src/components/TableSortContext.tsx
@@ -10,8 +10,8 @@ export type TableSortContextProps = {
 
 const defaultTableSortContext = {
   activeSort: { isAsc: true, label: '', resourceFieldId: '' },
-  compareFn: () => 0,
-  setActiveSort: () => undefined,
+  compareFn: (): number => 0,
+  setActiveSort: (): void => undefined,
 };
 
 export const TableSortContext = createContext<TableSortContextProps>(defaultTableSortContext);

--- a/src/components/VddkUploader/VddkUploader.tsx
+++ b/src/components/VddkUploader/VddkUploader.tsx
@@ -37,7 +37,7 @@ const VddkUploader: FC<VddkUploaderProps> = ({ onChangeVddk }) => {
     }
   }, [body, isBuildSucceeded, onChangeVddk]);
 
-  const handleUpload = async () => {
+  const handleUpload = async (): Promise<void> => {
     if (!file) {
       return;
     }

--- a/src/components/VddkUploader/hooks/useVddkBuildImage.ts
+++ b/src/components/VddkUploader/hooks/useVddkBuildImage.ts
@@ -4,10 +4,10 @@ import { isEmpty } from '@utils/helpers';
 import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 import { getDefaultNamespace } from '@utils/namespaces';
 
-import type { VddkBuild } from '../utils/types';
+import type { VddkBuild, VddkBuildResponse } from '../utils/types';
 import { getVddkImageBuildResponse } from '../utils/utils';
 
-export const useVddkBuildImage = (buildName: string) => {
+export const useVddkBuildImage = (buildName: string): VddkBuildResponse | null => {
   const [activeNamespace] = useActiveNamespace();
   const namespace =
     activeNamespace === Namespace.AllProjects ? getDefaultNamespace() : activeNamespace;

--- a/src/components/VddkUploader/utils/utils.ts
+++ b/src/components/VddkUploader/utils/utils.ts
@@ -51,7 +51,7 @@ export const getVddkImageBuildResponse = (status: VddkBuild['status']): VddkBuil
   };
 };
 
-export const getUploadButtonText = (uploading: boolean, buildingImage?: boolean) => {
+export const getUploadButtonText = (uploading: boolean, buildingImage?: boolean): string => {
   if (uploading) {
     return t('Uploading...');
   }

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/AttributeFilter.tsx
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/AttributeFilter.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { COLUMN_IDS } from '@components/VsphereFoldersTable/utils/types';
 import {
   SearchInput,
@@ -31,7 +33,7 @@ export const AttributeFiltersToolbar = <T,>({
   setTextValue,
   text,
   toggleCheck,
-}: AttributeFiltersToolbarProps<T>) => {
+}: AttributeFiltersToolbarProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
   const active = attributes.find((attr) => attr.id === activeId) ?? attributes[0];
 

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterAttributeSelect.tsx
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterAttributeSelect.tsx
@@ -1,4 +1,4 @@
-import { type Ref, useMemo, useState } from 'react';
+import { type ReactElement, type Ref, useMemo, useState } from 'react';
 
 import {
   MenuToggle,
@@ -22,7 +22,7 @@ const FilterAttributeSelect = <T,>({
   activeId,
   attributes,
   onChange,
-}: FilterAttributeSelectProps<T>) => {
+}: FilterAttributeSelectProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
   const [isOpen, setOpen] = useState(false);
 

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterValueMultiSelect.tsx
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/components/FilterValueMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { type Ref, useMemo, useState } from 'react';
+import { type ReactElement, type Ref, useMemo, useState } from 'react';
 
 import {
   Badge,
@@ -29,7 +29,7 @@ const FilterValueMultiSelect = <T,>({
   onToggle,
   selected,
   width = 220,
-}: FilterValueMultiSelectProps<T>) => {
+}: FilterValueMultiSelectProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
   const [isOpen, setOpen] = useState(false);
   const [prevCloseKey, setPrevCloseKey] = useState(closeKey);

--- a/src/components/VsphereFoldersTable/components/AttributeFilter/hooks/useAttributeFilters.ts
+++ b/src/components/VsphereFoldersTable/components/AttributeFilter/hooks/useAttributeFilters.ts
@@ -63,7 +63,7 @@ export const useAttributeFilters = <T>(attributes: AttributeConfig<T>[]): Attrib
           const needle = (text[attr.id] ?? '').trim();
           if (needle) {
             const hay = attr.getValue(item) ?? '';
-            const def = (filter: string, data: string) => {
+            const def = (filter: string, data: string): boolean => {
               try {
                 return new RegExp(filter, 'iu').test(data);
               } catch {

--- a/src/components/VsphereFoldersTable/hooks/useSelectedTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useSelectedTreeRows.ts
@@ -45,30 +45,31 @@ const useSelectedTreeRows: UseSelectedTreeRows = (controls) => {
   );
 
   const onCheckChange = useCallback(
-    (keys: string | string[]) => (_event: FormEvent<HTMLInputElement>, isChecked: boolean) => {
-      setSelectedVmKeys((prev) => {
-        const next = new Set(prev);
-        if (Array.isArray(keys)) {
-          if (isChecked) {
-            for (const id of keys) next.add(id);
-          } else {
-            for (const id of keys) next.delete(id);
+    (keys: string | string[]) =>
+      (_event: FormEvent<HTMLInputElement>, isChecked: boolean): void => {
+        setSelectedVmKeys((prev) => {
+          const next = new Set(prev);
+          if (Array.isArray(keys)) {
+            if (isChecked) {
+              for (const id of keys) next.add(id);
+            } else {
+              for (const id of keys) next.delete(id);
+            }
+
+            return Array.from(next);
+          }
+
+          if (typeof keys === 'string') {
+            if (isChecked) {
+              next.add(keys);
+            } else {
+              next.delete(keys);
+            }
           }
 
           return Array.from(next);
-        }
-
-        if (typeof keys === 'string') {
-          if (isChecked) {
-            next.add(keys);
-          } else {
-            next.delete(keys);
-          }
-        }
-
-        return Array.from(next);
-      });
-    },
+        });
+      },
     [setSelectedVmKeys],
   );
 

--- a/src/components/VsphereFoldersTable/hooks/useSlug.ts
+++ b/src/components/VsphereFoldersTable/hooks/useSlug.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 
-export const useSlug = () => {
+export const useSlug = (): ((value: string) => string) => {
   const cacheRef = useRef(new Map<string, string>());
   return useCallback((value: string) => {
     const cached = cacheRef.current.get(value);

--- a/src/components/VsphereFoldersTable/hooks/useToggleTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useToggleTreeRows.ts
@@ -1,6 +1,14 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 
-const useToggleTreeRows = () => {
+type UseToggleTreeRowsReturn = {
+  expandedFolders: Set<string>;
+  expandedVMs: Set<string>;
+  setExpandedFolders: Dispatch<SetStateAction<Set<string>>>;
+  setExpandedVMs: Dispatch<SetStateAction<Set<string>>>;
+  toggleSet: <T extends string>(setFn: Dispatch<SetStateAction<Set<T>>>, id: T) => void;
+};
+
+const useToggleTreeRows = (): UseToggleTreeRowsReturn => {
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
   const [expandedVMs, setExpandedVMs] = useState<Set<string>>(new Set());
 

--- a/src/components/VsphereFoldersTable/hooks/useTreeFilterAttributes.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeFilterAttributes.ts
@@ -36,7 +36,10 @@ const inspectionStatusFilterOptions = INSPECTION_STATUS_FILTER_VALUES.map((value
   label: value,
 }));
 
-export const useTreeFilterAttributes = (rows: RowNode[], conversions: V1beta1Conversion[]) => {
+export const useTreeFilterAttributes = (
+  rows: RowNode[],
+  conversions: V1beta1Conversion[],
+): AttributeConfig<VmRow>[] => {
   const { t } = useForkliftTranslation();
   const getVmInspectionStatus = useVmInspectionStatus(conversions);
 
@@ -70,7 +73,7 @@ export const useTreeFilterAttributes = (rows: RowNode[], conversions: V1beta1Con
         options: getConcernLabelFilterOptions(rows),
       },
       {
-        getValues: (row) => {
+        getValues: (row): string[] => {
           const vmStatus = getVmInspectionStatus(row.vmData.vm?.id ?? '');
           return [vmStatus?.status ?? INSPECTION_STATUS_NOT_INSPECTED];
         },

--- a/src/components/VsphereFoldersTable/hooks/useTreeRows.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeRows.ts
@@ -66,13 +66,13 @@ export const useTreeRows: UseTreeRows = ({
   const slug = useSlug();
 
   const rows = useMemo(() => {
-    const isVmSelected = (id: string) => selectedSet.has(id);
+    const isVmSelected = (id: string): boolean => selectedSet.has(id);
     const result: RowNode[] = [];
 
     for (const [folderIdx, [folderName, vmIdsInFolder]] of realFolderEntries.entries()) {
       const isExpanded = expandedFolders.has(folderName);
 
-      const getVisibleVmsInFolder = () => {
+      const getVisibleVmsInFolder = (): string[] => {
         const visibleSet = visibleVmIdsRef?.current;
         if (!visibleSet || visibleSet.size === 0) {
           return vmIdsInFolder;
@@ -93,7 +93,7 @@ export const useTreeRows: UseTreeRows = ({
         isExpanded,
         level1SetSize,
         onCheckChange: canSelect
-          ? (_event, isChecked) => {
+          ? (_event, isChecked): void => {
               const currentlyVisibleVms = getVisibleVmsInFolder();
               onCheckChange(currentlyVisibleVms)(_event, isChecked);
             }

--- a/src/components/VsphereFoldersTable/hooks/useTreeVMFilters.ts
+++ b/src/components/VsphereFoldersTable/hooks/useTreeVMFilters.ts
@@ -61,9 +61,9 @@ const useTreeFilters = ({ filters, rows, showAll }: UseTreeFilters): UseTreeFilt
       return rows;
     }
 
-    const isVisibleFolder = (row: FolderRow) => visibleFolderKeySet.has(row.key);
+    const isVisibleFolder = (row: FolderRow): boolean => visibleFolderKeySet.has(row.key);
 
-    const isVisibleVm = (row: VmRow) => visibleVmKeySet.has(row.key);
+    const isVisibleVm = (row: VmRow): boolean => visibleVmKeySet.has(row.key);
 
     const shouldAttachConcerns = (vm: VmRow, next: RowNode): next is ConcernsRow =>
       next.type === ROW_TYPE.Concerns &&

--- a/src/components/VsphereFoldersTable/hooks/utils/treeUtils.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/treeUtils.ts
@@ -35,13 +35,13 @@ const INSPECTION_STATUS_SEVERITY_RANK: Record<InspectionStatus, number> = {
 
 type Counts = { Critical: number; Information: number; Warning: number };
 
-export const getVmName = (row: VmRow) => row.vmData.name ?? '';
-export const getVmGuestOSValue = (row: VmRow) => getVmGuestOS(row.vmData.vm);
-export const getVmHost = (row: VmRow) => row.vmData.hostName ?? '';
-export const getVmPath = (row: VmRow) => (row.vmData.vm as VSphereVM)?.path ?? '';
-export const getVmPower = (row: VmRow) => getVmPowerState(row?.vmData?.vm) ?? '';
+export const getVmName = (row: VmRow): string => row.vmData.name ?? '';
+export const getVmGuestOSValue = (row: VmRow): string => getVmGuestOS(row.vmData.vm);
+export const getVmHost = (row: VmRow): string => row.vmData.hostName ?? '';
+export const getVmPath = (row: VmRow): string => (row.vmData.vm as VSphereVM)?.path ?? '';
+export const getVmPower = (row: VmRow): string => getVmPowerState(row?.vmData?.vm) ?? '';
 
-export const getVmRowsId = (rows: RowNode[]) => {
+export const getVmRowsId = (rows: RowNode[]): string[] => {
   return rows
     .filter((row): row is VmRow => row.type === ROW_TYPE.Vm)
     .map((row) => row.vmData.vm.id);
@@ -70,10 +70,10 @@ export const getVmConcernCategories = (row: VmRow): ConcernCategory[] => {
   return Array.from(out);
 };
 
-export const cmpStr = (a: string, b: string) =>
+export const cmpStr = (a: string, b: string): number =>
   a.localeCompare(b, undefined, { sensitivity: 'base' });
 
-export const getFolderNameFromFolderRow = (row: RowNode) =>
+export const getFolderNameFromFolderRow = (row: RowNode): string =>
   row.type === ROW_TYPE.Folder ? (row.folderName ?? '') : '';
 
 const getConcernCounts = (row: VmRow): Counts => {
@@ -88,7 +88,7 @@ const getConcernCounts = (row: VmRow): Counts => {
   return counts;
 };
 
-const cmpCountsQuantityAsc = (first: Counts, second: Counts) => {
+const cmpCountsQuantityAsc = (first: Counts, second: Counts): number => {
   // Desc by Critical, then Warning, then Information
   if (first.Critical !== second.Critical) {
     return second.Critical - first.Critical;
@@ -104,25 +104,31 @@ const cmpCountsQuantityAsc = (first: Counts, second: Counts) => {
 
 type GetVmInspectionStatusFn = (vmId: string) => VmInspectionStatus | undefined;
 
+type VmComparator = (first: VmRow, second: VmRow) => number;
+
 export const buildVmComparator = (
   sort: SortState,
   getVmInspectionStatus?: GetVmInspectionStatusFn,
-) => {
+): VmComparator => {
   const dir = sort.direction === 'asc' ? 1 : -1;
   switch (sort.column) {
     case COLUMN_IDS.Name:
-      return (first: VmRow, second: VmRow) => dir * cmpStr(getVmName(first), getVmName(second));
+      return (first: VmRow, second: VmRow): number =>
+        dir * cmpStr(getVmName(first), getVmName(second));
     case COLUMN_IDS.GuestOS:
-      return (first: VmRow, second: VmRow) =>
+      return (first: VmRow, second: VmRow): number =>
         dir * cmpStr(getVmGuestOSValue(first), getVmGuestOSValue(second));
     case COLUMN_IDS.Host:
-      return (first: VmRow, second: VmRow) => dir * cmpStr(getVmHost(first), getVmHost(second));
+      return (first: VmRow, second: VmRow): number =>
+        dir * cmpStr(getVmHost(first), getVmHost(second));
     case COLUMN_IDS.Path:
-      return (first: VmRow, second: VmRow) => dir * cmpStr(getVmPath(first), getVmPath(second));
+      return (first: VmRow, second: VmRow): number =>
+        dir * cmpStr(getVmPath(first), getVmPath(second));
     case COLUMN_IDS.Power:
-      return (first: VmRow, second: VmRow) => dir * cmpStr(getVmPower(first), getVmPower(second));
+      return (first: VmRow, second: VmRow): number =>
+        dir * cmpStr(getVmPower(first), getVmPower(second));
     case COLUMN_IDS.Concerns:
-      return (a: VmRow, b: VmRow) => {
+      return (a: VmRow, b: VmRow): number => {
         const ca = getConcernCounts(a);
         const cb = getConcernCounts(b);
         const base = cmpCountsQuantityAsc(ca, cb);
@@ -132,7 +138,7 @@ export const buildVmComparator = (
         return cmpStr(getVmName(a), getVmName(b)) * dir;
       };
     case COLUMN_IDS.InspectionStatus:
-      return (first: VmRow, second: VmRow) => {
+      return (first: VmRow, second: VmRow): number => {
         const statusA =
           getVmInspectionStatus?.(first.vmData.vm?.id ?? '')?.status ??
           INSPECTION_STATUS.NOT_INSPECTED;
@@ -147,7 +153,7 @@ export const buildVmComparator = (
         return cmpStr(getVmName(first), getVmName(second)) * dir;
       };
     default:
-      return () => 0;
+      return (): number => 0;
   }
 };
 
@@ -179,7 +185,7 @@ export const getVmConcernLabels = (
   return { categoryMapper: outCategories, labelIconMapper: outIcons, labels: Array.from(out) };
 };
 
-export const getConcernLabelFilterOptions = (rows: RowNode[]) => {
+export const getConcernLabelFilterOptions = (rows: RowNode[]): CheckboxOption[] => {
   const seen = new Map<string, string>();
   const iconMapper: Record<string, ReactNode> = {};
   const catMapper: Record<string, ConcernCategory> = {};
@@ -208,7 +214,7 @@ export const getConcernLabelFilterOptions = (rows: RowNode[]) => {
   return opts;
 };
 
-export const getHostnameFilterOptions = (rows: RowNode[]) => {
+export const getHostnameFilterOptions = (rows: RowNode[]): CheckboxOption[] => {
   const seen = new Map<string, string>();
   for (const row of rows) {
     if (row.type === ROW_TYPE.Vm) {

--- a/src/components/common/Filter/DateFilter.tsx
+++ b/src/components/common/Filter/DateFilter.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, type ReactElement, useState } from 'react';
 
 import { DatePicker, InputGroup, ToolbarFilter } from '@patternfly/react-core';
 
@@ -23,14 +23,14 @@ export const DateFilter = ({
   selectedFilters = [],
   showFilter = true,
   title,
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const isString = (value: string | undefined): value is string => value !== undefined;
   const validFilters = selectedFilters?.map(changeFormatToISODate)?.filter(isString) ?? [];
 
   // internal state - stored as ISO date string (no time)
   const [date, setDate] = useState<string | undefined>();
 
-  const clearSingleDate = (option: string) => {
+  const clearSingleDate = (option: string): void => {
     onFilterUpdate([...validFilters.filter((filter) => filter !== option)]);
   };
 

--- a/src/components/common/Filter/DateRangeFilter.tsx
+++ b/src/components/common/Filter/DateRangeFilter.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, type ReactElement, useState } from 'react';
 import { DateTime } from 'luxon';
 
 import {
@@ -37,16 +37,16 @@ export const DateRangeFilter = ({
   helperText,
   onFilterUpdate,
   placeholderLabel,
-  selectedFilters = [],
+  selectedFilters,
   showFilter = true,
   title,
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const validFilters = selectedFilters?.filter(isValidInterval) ?? [];
 
   const [from, setFrom] = useState<Date>();
   const [to, setTo] = useState<Date>();
 
-  const rangeToOption = (range: string) => {
+  const rangeToOption = (range: string): { key: string; node: ReactElement } => {
     const formatted = localizeInterval(range);
     return {
       key: range,
@@ -59,7 +59,7 @@ export const DateRangeFilter = ({
   };
   const optionToRange = (option: ToolbarLabel): string => option?.key;
 
-  const clearSingleRange = (option: ToolbarLabel) => {
+  const clearSingleRange = (option: ToolbarLabel): void => {
     const target = optionToRange(option);
     onFilterUpdate([...validFilters.filter((range) => range !== target)]);
   };

--- a/src/components/common/Filter/EnumFilter.tsx
+++ b/src/components/common/Filter/EnumFilter.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent as ReactMouseEvent, type Ref, useState } from 'react';
+import { type MouseEvent as ReactMouseEvent, type ReactElement, type Ref, useState } from 'react';
 
 import { useUniqueEnums } from '@components/common/Filter/useUniqueEnums';
 import {
@@ -41,7 +41,7 @@ export const EnumFilter = ({
   showFilter = true,
   supportedValues: supportedEnumValues = [],
   title = '',
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
   const { onUniqueFilterUpdate, selectedUniqueEnumLabels } = useUniqueEnums({
     onSelectedEnumIdsChange,
@@ -62,11 +62,14 @@ export const EnumFilter = ({
     }
   };
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((prev) => !prev);
   };
 
-  const onSelect = (_event: ReactMouseEvent | undefined, value: string | number | undefined) => {
+  const onSelect = (
+    _event: ReactMouseEvent | undefined,
+    value: string | number | undefined,
+  ): void => {
     if (hasFilter(value as string)) {
       deleteFilter(value as string);
       return;
@@ -74,7 +77,7 @@ export const EnumFilter = ({
     addFilter(value as string);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       data-testid={`filter-toggle-${filterId}`}
       isExpanded={isOpen}
@@ -91,7 +94,7 @@ export const EnumFilter = ({
     </MenuToggle>
   );
 
-  const renderOptions = () => {
+  const renderOptions = (): ReactElement[] => {
     return supportedEnumValues.map((label) => (
       <SelectOption
         data-testid={`filter-value-${label.id}`}

--- a/src/components/common/Filter/FreetextFilter.tsx
+++ b/src/components/common/Filter/FreetextFilter.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, type SyntheticEvent, useState } from 'react';
+import { type FormEvent, type ReactElement, type SyntheticEvent, useState } from 'react';
 
 import { InputGroup, SearchInput, ToolbarFilter } from '@patternfly/react-core';
 
@@ -22,7 +22,7 @@ export const FreetextFilter = ({
   selectedFilters,
   showFilter = true,
   title,
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const [inputValue, setInputValue] = useState('');
 
   const onTextInput: (

--- a/src/components/common/Filter/GroupedEnumFilter.tsx
+++ b/src/components/common/Filter/GroupedEnumFilter.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent as ReactMouseEvent, type Ref, useState } from 'react';
+import { type MouseEvent as ReactMouseEvent, type ReactElement, type Ref, useState } from 'react';
 
 import type { EnumGroup, EnumValue } from '@components/common/utils/types';
 import {
@@ -20,7 +20,7 @@ const renderOptions = (
   supportedGroups: EnumGroup[],
   supportedEnumValues: EnumValue[],
   selectedEnumIds: string[],
-) =>
+): ReactElement[] =>
   supportedGroups.map(({ groupId, label }) => (
     <SelectGroup key={groupId} label={label}>
       <SelectList>
@@ -69,7 +69,7 @@ export const GroupedEnumFilter = ({
   showFilterIcon,
   supportedGroups,
   supportedValues: supportedEnumValues = [],
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
 
   // simplify lookup
@@ -131,7 +131,10 @@ export const GroupedEnumFilter = ({
     );
   };
 
-  const onSelect = (_event: ReactMouseEvent | undefined, value: string | number | undefined) => {
+  const onSelect = (
+    _event: ReactMouseEvent | undefined,
+    value: string | number | undefined,
+  ): void => {
     const label = value?.toString();
     if (label) {
       const labelId = label2enum?.[label] ? label2enum[label]?.id : label;
@@ -143,11 +146,11 @@ export const GroupedEnumFilter = ({
     }
   };
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((prev) => !prev);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       isExpanded={isOpen}
       isFullWidth

--- a/src/components/common/Filter/SwitchFilter.tsx
+++ b/src/components/common/Filter/SwitchFilter.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { Switch, ToolbarItem } from '@patternfly/react-core';
 import { isEmpty } from '@utils/helpers';
 
@@ -18,7 +20,7 @@ export const SwitchFilter = ({
   onFilterUpdate,
   placeholderLabel,
   selectedFilters,
-}: FilterTypeProps) => {
+}: FilterTypeProps): ReactElement => {
   const onChange: (checked: boolean) => void = (checked) => {
     onFilterUpdate(checked ? [checked.toString()] : []);
   };

--- a/src/components/common/FilterGroup/AttributeValueFilter.tsx
+++ b/src/components/common/FilterGroup/AttributeValueFilter.tsx
@@ -1,4 +1,4 @@
-import { type Ref, useState } from 'react';
+import { type ReactElement, type Ref, useState } from 'react';
 
 import {
   MenuToggle,
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 
 import { FilterFromDef } from './FilterFromDef';
-import type { MetaFilterProps } from './types';
+import type { FieldFilter, MetaFilterProps } from './types';
 
 /**
  * This is an implementation of [<font>``PatternFly 4`` attribute-value filter</font>](https://www.patternfly.org/v4/demos/filters/design-guidelines/#attribute-value-filter) pattern,
@@ -28,20 +28,20 @@ export const AttributeValueFilter = ({
   resolvedLanguage = 'en',
   selectedFilters,
   supportedFilterTypes,
-}: MetaFilterProps) => {
+}: MetaFilterProps): ReactElement => {
   const [currentFilter, setCurrentFilter] = useState(fieldFilters?.[0]);
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectOptionToFilter = (selectedValue: string) =>
+  const selectOptionToFilter = (selectedValue: string): FieldFilter =>
     fieldFilters.find(
       ({ filterDef, label }) => filterDef.fieldLabel === selectedValue || label === selectedValue,
     ) ?? currentFilter;
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((prev) => !prev);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       data-testid="attribute-filter-toggle"
       isExpanded={isOpen}
@@ -53,14 +53,14 @@ export const AttributeValueFilter = ({
     </MenuToggle>
   );
 
-  const onSelect = (value?: string) => {
+  const onSelect = (value?: string): void => {
     if (value) {
       setCurrentFilter(selectOptionToFilter(value));
     }
     setIsOpen((prev) => !prev);
   };
 
-  const renderOptions = () => {
+  const renderOptions = (): ReactElement[] => {
     return fieldFilters.map(({ filterDef, label, resourceFieldId }) => (
       <SelectOption
         data-testid={`filter-option-${resourceFieldId}`}

--- a/src/components/common/FilterGroup/FilterFromDef.tsx
+++ b/src/components/common/FilterGroup/FilterFromDef.tsx
@@ -27,7 +27,7 @@ export const FilterFromDef = ({
   resourceFieldId,
   selectedFilters,
   showFilter = true,
-}: FilterFromDefProps) => {
+}: FilterFromDefProps): ReactElement | null => {
   const [filterId, setFilterId] = useState(resourceFieldId);
 
   const selectedFilterValues = useMemo(() => {
@@ -49,7 +49,7 @@ export const FilterFromDef = ({
     return selectedFilters[filterId] ?? [];
   }, [def.groups, filterId, resourceFieldId, selectedFilters]);
 
-  const setSelectedFilters = (values: string[], selectedResourceId?: string) => {
+  const setSelectedFilters = (values: string[], selectedResourceId?: string): void => {
     if (selectedResourceId) {
       setFilterId(selectedResourceId);
     }

--- a/src/components/common/FilterGroup/FilterGroup.tsx
+++ b/src/components/common/FilterGroup/FilterGroup.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { ToolbarGroup } from '@patternfly/react-core';
 
 import { FilterFromDef } from './FilterFromDef';
@@ -18,7 +20,7 @@ export const FilterGroup = ({
   resolvedLanguage = 'en',
   selectedFilters,
   supportedFilterTypes,
-}: MetaFilterProps) => (
+}: MetaFilterProps): ReactElement => (
   <ToolbarGroup variant="filter-group">
     {fieldFilters.map(({ filterDef, label, resourceFieldId }) => (
       <FilterFromDef

--- a/src/components/common/FilterGroup/__tests__/matchers.test.ts
+++ b/src/components/common/FilterGroup/__tests__/matchers.test.ts
@@ -9,7 +9,7 @@ const matchFreetext = (
     placeholderLabel: NAME,
     type: 'freetext',
   },
-) =>
+): ReturnType<typeof createMatcher> =>
   createMatcher({
     selectedFilters,
     ...freetextMatcher,
@@ -65,7 +65,7 @@ describe('standard matchers', () => {
   });
 });
 
-const matchBothFieldsFreetext = () =>
+const matchBothFieldsFreetext = (): ((resourceData: unknown) => boolean) =>
   createMetaMatcher(
     {
       [NAME]: ['oo'],

--- a/src/components/common/FilterGroup/helpers.ts
+++ b/src/components/common/FilterGroup/helpers.ts
@@ -10,5 +10,5 @@ export const toFieldFilter =
     resourceFieldId: resourceFieldId ?? '',
   });
 
-export const enumToTuple = (i18nEnum: Record<string, string>) =>
+export const enumToTuple = (i18nEnum: Record<string, string>): { id: string; label: string }[] =>
   Object.entries(i18nEnum).map(([type, label]) => ({ id: type, label }));

--- a/src/components/common/FilterGroup/matchers.ts
+++ b/src/components/common/FilterGroup/matchers.ts
@@ -105,8 +105,10 @@ export const createMatcher =
  */
 export const freetextMatcher = {
   filterType: 'freetext',
-  matchValue: (value: string) => (filter: string) =>
-    value?.toLowerCase()?.includes(filter?.toLowerCase()?.trim()),
+  matchValue:
+    (value: string): ((filter: string) => boolean) =>
+    (filter: string) =>
+      value?.toLowerCase()?.includes(filter?.toLowerCase()?.trim()),
 };
 
 /**
@@ -114,7 +116,10 @@ export const freetextMatcher = {
  */
 const enumMatcher = {
   filterType: 'enum',
-  matchValue: (value: string) => (filter: string) => value === filter,
+  matchValue:
+    (value: string): ((filter: string) => boolean) =>
+    (filter: string) =>
+      value === filter,
 };
 
 const searchableEnumMatcher = {
@@ -134,17 +139,26 @@ const searchableGroupedEnumMatcher = {
 
 const dateMatcher = {
   filterType: 'date',
-  matchValue: (value: string) => (filter: string) => areSameDayInUTCZero(value, filter),
+  matchValue:
+    (value: string): ((filter: string) => boolean) =>
+    (filter: string) =>
+      areSameDayInUTCZero(value, filter),
 };
 
 const dateRangeMatcher = {
   filterType: 'dateRange',
-  matchValue: (value: string) => (filter: string) => isInClosedRange(filter, value),
+  matchValue:
+    (value: string): ((filter: string) => boolean) =>
+    (filter: string) =>
+      isInClosedRange(filter, value),
 };
 
 const sliderMatcher = {
   filterType: 'slider',
-  matchValue: (value: string) => (filter: string) => Boolean(value).toString() === filter || !value,
+  matchValue:
+    (value: string): ((filter: string) => boolean) =>
+    (filter: string) =>
+      Boolean(value).toString() === filter || !value,
 };
 
 export const defaultValueMatchers: ValueMatcher<string>[] = [

--- a/src/components/common/FilterGroup/useUrlFilters.ts
+++ b/src/components/common/FilterGroup/useUrlFilters.ts
@@ -93,8 +93,8 @@ const createSetStateAndUrl = (
   updateUserSettings: ((filters: GlobalFilters) => void) | undefined,
   persistentFieldIds: string[],
   fields: { resourceFieldId: string | null }[],
-) => {
-  return (filters: Record<string, string[]>) => {
+): ((filters: Record<string, string[]>) => void) => {
+  return (filters: Record<string, string[]>): void => {
     if (updateUserSettings) {
       const persistentFilters: GlobalFilters = Object.fromEntries(
         Object.entries(filters || {}).filter(([key]) => persistentFieldIds.includes(key)),
@@ -106,7 +106,7 @@ const createSetStateAndUrl = (
   };
 };
 
-const getIdsFromFields = (fields: ResourceField[]) =>
+const getIdsFromFields = (fields: ResourceField[]): string[] =>
   fields.reduce<string[]>((acc, nextField) => {
     if (nextField?.isPersistent && nextField.resourceFieldId) {
       acc.push(nextField.resourceFieldId);
@@ -118,7 +118,7 @@ const getInitialFilters = (
   fields: ResourceField[],
   searchParams: Record<string, string>,
   userSettings?: UserSettings,
-) => {
+): GlobalFilters => {
   const initialFieldIds = getIdsFromFields(fields);
 
   const persistentFilters = Object.fromEntries(

--- a/src/components/common/FormGroupWithErrorText.tsx
+++ b/src/components/common/FormGroupWithErrorText.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { FormErrorHelperText } from '@components/FormErrorHelperText';
@@ -14,7 +14,7 @@ const FormGroupWithErrorText = ({
   fieldId,
   helperText,
   ...props
-}: FormGroupWithErrorTextProps) => {
+}: FormGroupWithErrorTextProps): ReactElement => {
   const { getFieldState } = useFormContext();
   const { error } = getFieldState(fieldId);
 

--- a/src/components/common/FormGroupWithHelpText/FormGroupWithHelpText.tsx
+++ b/src/components/common/FormGroupWithHelpText/FormGroupWithHelpText.tsx
@@ -36,7 +36,9 @@ type FormGroupWithHelpTextProps = {
  * If validated mode was not set or if it's the 'default', use 'default' variant which shows
  * plain text without icons for informational helper text
  */
-const validatedToVariant = (validated: 'success' | 'warning' | 'error' | 'default' | undefined) =>
+const validatedToVariant = (
+  validated: 'success' | 'warning' | 'error' | 'default' | undefined,
+): 'success' | 'warning' | 'error' | 'default' =>
   !validated || validated === 'default' ? 'default' : validated;
 
 /**
@@ -67,7 +69,7 @@ export const FormGroupWithHelpText: FC<FormGroupWithHelpTextProps> = ({
     validated === ValidationState.Error && helperTextInvalid ? helperTextInvalid : helperText;
   const variant = validatedToVariant(validated);
   const isError = validated === ValidationState.Error;
-  const getHelperTextTestId = () => {
+  const getHelperTextTestId = (): string => {
     if (testId) {
       return isError ? `${testId}-error` : testId;
     }

--- a/src/components/common/Page/PageStates.tsx
+++ b/src/components/common/Page/PageStates.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactElement } from 'react';
 
 import {
   Button,
@@ -17,17 +17,19 @@ import { ExclamationCircleIcon, SearchIcon } from '@patternfly/react-icons';
  * [<img src="static/media/src/components-stories/assets/github-logo.svg"><i class="fi fi-brands-github">
  * <font color="green">View component source on GitHub</font>](https://github.com/kubev2v/forklift-console-plugin/blob/main/packages/common/src/components/Page/PageStates.tsx)
  */
-const BaseState = ({ icon, title }: { icon?: ComponentType; title?: string }) => {
+const BaseState = ({ icon, title }: { icon?: ComponentType; title?: string }): ReactElement => {
   return <EmptyState headingLevel="h4" icon={icon} titleText={title}></EmptyState>;
 };
 
-export const ErrorState = ({ title }: { title: string }) => (
+export const ErrorState = ({ title }: { title: string }): ReactElement => (
   <BaseState icon={ExclamationCircleIcon} title={title} />
 );
 
-export const Loading = ({ title }: { title: string }) => <BaseState icon={Spinner} title={title} />;
+export const Loading = ({ title }: { title: string }): ReactElement => (
+  <BaseState icon={Spinner} title={title} />
+);
 
-export const NoResultsFound = ({ title }: { title: string }) => (
+export const NoResultsFound = ({ title }: { title: string }): ReactElement => (
   <BaseState icon={SearchIcon} title={title} />
 );
 
@@ -47,7 +49,7 @@ export const NoResultsMatchFilter = ({
   clearAllLabel?: string;
   description?: string;
   title?: string;
-}) => {
+}): ReactElement => {
   return (
     <EmptyState headingLevel="h4" icon={SearchIcon} titleText={title}>
       <EmptyStateBody>{description}</EmptyStateBody>

--- a/src/components/common/Page/useFields.tsx
+++ b/src/components/common/Page/useFields.tsx
@@ -40,9 +40,9 @@ export const useFields = (
   userSettings?: FieldSettings,
 ): [ResourceField[], (newFields: ResourceField[]) => void] => {
   const {
-    clear: clearSettings = () => undefined,
+    clear: clearSettings = (): void => undefined,
     data: fieldsFromSettings = [],
-    save: saveFieldsInSettings = () => undefined,
+    save: saveFieldsInSettings = (): void => undefined,
   } = userSettings ?? {};
 
   const [fields, setFields] = useState<ResourceField[]>(() => {
@@ -88,25 +88,26 @@ export const useFields = (
   );
 
   const setInternalStateAndSaveUserSettings = useMemo(
-    () => (newFields: ResourceField[]) => {
-      setFields(newFields);
-      if (sameOrderAndVisibility(newFields, defaultFields)) {
-        // don't store settings if equal to default settings
-        clearSettings();
-      } else {
-        saveFieldsInSettings(
-          newFields.reduce<{ isVisible: boolean | undefined; resourceFieldId: string }[]>(
-            (acc, { isVisible, resourceFieldId }) => {
-              if (resourceFieldId) {
-                acc.push({ isVisible, resourceFieldId });
-              }
-              return acc;
-            },
-            [],
-          ),
-        );
-      }
-    },
+    () =>
+      (newFields: ResourceField[]): void => {
+        setFields(newFields);
+        if (sameOrderAndVisibility(newFields, defaultFields)) {
+          // don't store settings if equal to default settings
+          clearSettings();
+        } else {
+          saveFieldsInSettings(
+            newFields.reduce<{ isVisible: boolean | undefined; resourceFieldId: string }[]>(
+              (acc, { isVisible, resourceFieldId }) => {
+                if (resourceFieldId) {
+                  acc.push({ isVisible, resourceFieldId });
+                }
+                return acc;
+              },
+              [],
+            ),
+          );
+        }
+      },
     [defaultFields, clearSettings, saveFieldsInSettings],
   );
 

--- a/src/components/common/Page/usePagination.tsx
+++ b/src/components/common/Page/usePagination.tsx
@@ -21,23 +21,24 @@ export const usePagination = ({
   userSettings,
 }: PaginationHookProps): PaginationHookResult => {
   const {
-    clear: clearSavedPerPage = () => undefined,
+    clear: clearSavedPerPage = (): void => undefined,
     perPage: defaultPerPage = DEFAULT_PER_PAGE,
-    save: savePerPage = () => undefined,
+    save: savePerPage = (): void => undefined,
   } = userSettings ?? {};
   const [perPage, setPerPage] = useState(defaultPerPage);
 
   const lastPage = Math.ceil(filteredDataLength / perPage);
 
   const setPerPageInStateAndSettings = useMemo(
-    () => (perPageArg: number) => {
-      setPerPage(perPageArg);
-      if (perPageArg === DEFAULT_PER_PAGE) {
-        clearSavedPerPage();
-      } else {
-        savePerPage(perPageArg);
-      }
-    },
+    () =>
+      (perPageArg: number): void => {
+        setPerPage(perPageArg);
+        if (perPageArg === DEFAULT_PER_PAGE) {
+          clearSavedPerPage();
+        } else {
+          savePerPage(perPageArg);
+        }
+      },
     [clearSavedPerPage, savePerPage],
   );
 

--- a/src/components/common/Page/userSettings.ts
+++ b/src/components/common/Page/userSettings.ts
@@ -44,7 +44,7 @@ const toField = ({
 }: {
   isVisible?: boolean;
   resourceFieldId: string;
-}) => ({ isVisible, resourceFieldId });
+}): { isVisible?: boolean; resourceFieldId: string } => ({ isVisible, resourceFieldId });
 
 const sanitizeFields = (fields: unknown): { isVisible?: boolean; resourceFieldId: string }[] =>
   Array.isArray(fields)
@@ -71,12 +71,12 @@ export const loadUserSettings = ({ pageId }: { pageId: string }): UserSettings =
 
   return {
     fields: {
-      clear: () => {
+      clear: (): void => {
         const { fields: _keyFields, ...rest } = parseOrClean(key);
         saveRestOrRemoveKey(key, rest);
       },
       data: sanitizeFields(fields),
-      save: (newFields) => {
+      save: (newFields): void => {
         saveToLocalStorage(
           key,
           JSON.stringify({ ...parseOrClean(key), fields: newFields.map(toField) }),
@@ -84,22 +84,22 @@ export const loadUserSettings = ({ pageId }: { pageId: string }): UserSettings =
       },
     },
     filters: {
-      clear: () => {
+      clear: (): void => {
         const { filters: _keyFilters, ...rest } = parseOrClean(key);
         saveRestOrRemoveKey(key, rest);
       },
       data: filters ?? {},
-      save: (newFilters) => {
+      save: (newFilters): void => {
         saveToLocalStorage(key, JSON.stringify({ ...parseOrClean(key), filters: newFilters }));
       },
     },
     pagination: {
-      clear: () => {
+      clear: (): void => {
         const { perPage: _keyPerPage, ...rest } = parseOrClean(key);
         saveRestOrRemoveKey(key, rest);
       },
       perPage: typeof perPage === 'number' ? perPage : DEFAULT_PER_PAGE,
-      save: (newPerPage) => {
+      save: (newPerPage): void => {
         saveToLocalStorage(key, JSON.stringify({ ...parseOrClean(key), perPage: newPerPage }));
       },
     },

--- a/src/components/common/ProjectSelect/ProjectSelect.tsx
+++ b/src/components/common/ProjectSelect/ProjectSelect.tsx
@@ -64,14 +64,14 @@ const ProjectSelect: FC<ProjectSelectProps> = ({
     return defaultProject ? [{ content: defaultProject, value: defaultProject }] : [];
   }, [projectNames, defaultProject, showDefaultProjects, value]);
 
-  const onProjectCreated = (newProject: K8sResourceCommon) => {
+  const onProjectCreated = (newProject: K8sResourceCommon): void => {
     const projectName = getName(newProject);
     if (onNewValue && projectName) {
       onNewValue(projectName);
     }
   };
 
-  const onNewProject = () => {
+  const onNewProject = (): void => {
     launchOverlay<CreateProjectModalProps>(CreateProjectModal, { onCreated: onProjectCreated });
   };
 

--- a/src/components/common/RoutedTabs/__tests__/RoutedTabs.test.tsx
+++ b/src/components/common/RoutedTabs/__tests__/RoutedTabs.test.tsx
@@ -1,7 +1,7 @@
 import { MemoryRouter } from 'react-router';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, type RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import RoutedTabs from '../RoutedTabs';
@@ -10,10 +10,10 @@ const mockNavigate = jest.fn();
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
-  useNavigate: () => mockNavigate,
+  useNavigate: (): typeof mockNavigate => mockNavigate,
 }));
 
-const renderWithRouter = (tabs: any[], initialPath = '/overview') =>
+const renderWithRouter = (tabs: any[], initialPath = '/overview'): RenderResult =>
   render(
     <MemoryRouter initialEntries={[initialPath]}>
       <RoutedTabs tabs={tabs} />

--- a/src/components/common/Select.tsx
+++ b/src/components/common/Select.tsx
@@ -2,6 +2,7 @@ import {
   type ForwardedRef,
   forwardRef,
   type MutableRefObject,
+  type ReactElement,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -55,7 +56,7 @@ const Select = (
     value,
   }: SelectProps,
   ref: ForwardedRef<HTMLButtonElement>,
-) => {
+): ReactElement => {
   const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const toggleRef = useRef<HTMLButtonElement>();

--- a/src/components/common/TableView/DefaultHeader.tsx
+++ b/src/components/common/TableView/DefaultHeader.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { Th } from '@patternfly/react-table';
 
 import { buildSort } from './sort';
@@ -13,7 +15,7 @@ export const DefaultHeader = <T,>({
   activeSort,
   setActiveSort,
   visibleColumns,
-}: TableViewHeaderProps<T>) => {
+}: TableViewHeaderProps<T>): ReactElement => {
   return (
     <>
       {visibleColumns.map(

--- a/src/components/common/TableView/DefaultRow.tsx
+++ b/src/components/common/TableView/DefaultRow.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import { Td, Tr } from '@patternfly/react-table';
 
@@ -9,7 +9,7 @@ import type { RowProps } from './types';
 /**
  * Renders the value for each field as string.
  */
-export const DefaultRow = <T,>({ resourceData, resourceFields }: RowProps<T>) => {
+export const DefaultRow = <T,>({ resourceData, resourceFields }: RowProps<T>): ReactElement => {
   return (
     <Tr>
       {resourceFields?.reduce<ReactNode[]>((acc, { label, resourceFieldId }) => {

--- a/src/components/common/TableView/DefaultSelectHeader.tsx
+++ b/src/components/common/TableView/DefaultSelectHeader.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import { Th } from '@patternfly/react-table';
 
 import { buildSort } from './sort';
@@ -8,7 +10,7 @@ const DefaultSelectHeader = <T,>({
   canSelect,
   setActiveSort,
   visibleColumns,
-}: TableViewHeaderProps<T>) => {
+}: TableViewHeaderProps<T>): ReactElement => {
   return (
     <>
       {canSelect && <Th screenReaderText="Row select" />}

--- a/src/components/common/TableView/ManageColumnsModal.tsx
+++ b/src/components/common/TableView/ManageColumnsModal.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react';
+import { type FormEvent, type ReactElement, useState } from 'react';
 
 import {
   Button,
@@ -63,7 +63,7 @@ type ManagedColumnsProps = {
   title?: string;
 };
 
-const filterActionsAndHidden = (resourceFields: ResourceField[]) =>
+const filterActionsAndHidden = (resourceFields: ResourceField[]): ResourceField[] =>
   resourceFields.filter((col) => !col.isAction && !col.isHidden && col.resourceFieldId !== null);
 
 /**
@@ -88,14 +88,14 @@ export const ManageColumnsModal = ({
   saveLabel = 'Save',
   showModal,
   title = 'Manage columns',
-}: ManagedColumnsProps) => {
+}: ManagedColumnsProps): ReactElement => {
   const [editedColumns, setEditedColumns] = useState(filterActionsAndHidden(resourceFields));
 
-  const restoreDefaults = () => {
+  const restoreDefaults = (): void => {
     setEditedColumns([...filterActionsAndHidden(defaultColumns)]);
   };
 
-  const onDrop = (_event: unknown, newItems: DraggableObject[]) => {
+  const onDrop = (_event: unknown, newItems: DraggableObject[]): void => {
     const columnsMap = new Map(editedColumns.map((col) => [col.resourceFieldId, col]));
     const updatedColumns = newItems.flatMap((item) => {
       const col = columnsMap.get(String(item.id));
@@ -114,7 +114,7 @@ export const ManageColumnsModal = ({
     );
   };
 
-  const onSave = () => {
+  const onSave = (): void => {
     // assume that action resourceFields are always at the end
     onChange([
       ...editedColumns,

--- a/src/components/common/TableView/ManageColumnsToolbarItem.tsx
+++ b/src/components/common/TableView/ManageColumnsToolbarItem.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import {
   Button,
@@ -32,7 +32,7 @@ export const ManageColumnsToolbarItem = ({
   children,
   showDialog,
   tooltip,
-}: ManageColumnsToolbarItemProps) => {
+}: ManageColumnsToolbarItemProps): ReactElement => {
   const { t } = useForkliftTranslation();
   const manageColumnsText = t('Manage columns');
   return (

--- a/src/components/common/TableView/TableView.tsx
+++ b/src/components/common/TableView/TableView.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { FC, ReactElement, ReactNode } from 'react';
 
 import { Bullseye } from '@patternfly/react-core';
 import { InnerScrollContainer, Table, Tbody, Td, Thead, Tr } from '@patternfly/react-table';
@@ -38,7 +38,7 @@ export const TableView = <T,>({
   toId,
   uidFieldId = UID,
   visibleColumns,
-}: TableViewProps<T>) => {
+}: TableViewProps<T>): ReactElement => {
   const hasChildren = !isEmpty(children?.filter(Boolean));
   const columnSignature = visibleColumns.map(({ resourceFieldId: id }) => id).join();
 

--- a/src/components/common/TableView/sort.ts
+++ b/src/components/common/TableView/sort.ts
@@ -128,7 +128,7 @@ export const buildSort = ({
   setActiveSort: (sort: SortType) => void;
 }): ThProps['sort'] => ({
   columnIndex,
-  onSort: (_event, index, direction) => {
+  onSort: (_event, index, direction): void => {
     const { label, resourceFieldId } = resourceFields[index] ?? {};
     if (resourceFieldId) {
       setActiveSort({

--- a/src/components/common/TableView/withTr.tsx
+++ b/src/components/common/TableView/withTr.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 
 import { ExpandableRowContent, Td, Tr } from '@patternfly/react-table';
 
@@ -8,7 +8,7 @@ export const withTr = <T,>(
   Component: FC<RowProps<T>>,
   ExpandedComponent?: FC<RowProps<T>>,
 ): FC<RowProps<T>> => {
-  const Enhanced = (props: RowProps<T>) => {
+  const Enhanced = (props: RowProps<T>): ReactElement => {
     const { isExpanded, length } = props;
 
     if (ExpandedComponent) {

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadSelect.tsx
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadSelect.tsx
@@ -1,4 +1,10 @@
-import { type ForwardedRef, forwardRef, type ReactNode, useImperativeHandle } from 'react';
+import {
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  type ReactNode,
+  useImperativeHandle,
+} from 'react';
 
 import {
   MenuFooter,
@@ -65,7 +71,7 @@ const MultiTypeaheadSelect = (
     ...selectProps
   }: MultiTypeaheadSelectProps,
   ref: ForwardedRef<HTMLInputElement>,
-) => {
+): ReactElement => {
   const {
     activeItemId,
     displayOptions,

--- a/src/components/common/TypeaheadSelect/TypeaheadSelect.tsx
+++ b/src/components/common/TypeaheadSelect/TypeaheadSelect.tsx
@@ -1,6 +1,7 @@
 import {
   type ForwardedRef,
   forwardRef,
+  type ReactElement,
   type ReactNode,
   useImperativeHandle,
   useMemo,
@@ -87,7 +88,7 @@ const TypeaheadSelect = (
     ...selectProps
   }: TypeaheadSelectProps,
   ref: ForwardedRef<HTMLInputElement>,
-) => {
+): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
   const [isFiltering, setIsFiltering] = useState(false);
   const [inputValue, setInputValue] = useState('');

--- a/src/components/common/TypeaheadSelect/__tests__/TypeaheadSelect.test.tsx
+++ b/src/components/common/TypeaheadSelect/__tests__/TypeaheadSelect.test.tsx
@@ -216,7 +216,10 @@ describe('TypeaheadSelect', () => {
 
     test('applies custom filter function when provided', async () => {
       const user = userEvent.setup();
-      const customFilter = (filterValue: string, options: TypeaheadSelectOption[]) =>
+      const customFilter = (
+        filterValue: string,
+        options: TypeaheadSelectOption[],
+      ): TypeaheadSelectOption[] =>
         options.filter((option) => String(option.value).includes(filterValue));
 
       render(<TypeaheadSelect {...defaultProps} filterFunction={customFilter} />);
@@ -265,7 +268,7 @@ describe('TypeaheadSelect', () => {
 
     test('shows custom create option message when provided', async () => {
       const user = userEvent.setup();
-      const customMessage = (value: string) => `Add new: ${value}`;
+      const customMessage = (value: string): string => `Add new: ${value}`;
       render(<TypeaheadSelect {...defaultProps} createOptionMessage={customMessage} isCreatable />);
 
       const input = screen.getByRole('combobox');
@@ -310,7 +313,7 @@ describe('TypeaheadSelect', () => {
 
     test('shows custom no results message when filtering returns no results', async () => {
       const user = userEvent.setup();
-      const customMessage = (filter: string) => `Custom no results for "${filter}"`;
+      const customMessage = (filter: string): string => `Custom no results for "${filter}"`;
       render(<TypeaheadSelect {...defaultProps} noResultsMessage={customMessage} />);
 
       const input = screen.getByRole('combobox');

--- a/src/components/common/utils/dates.ts
+++ b/src/components/common/utils/dates.ts
@@ -33,7 +33,8 @@ export const toISODate = (date: Date): string | undefined => {
   return dt.isValid ? dt.toISODate() : undefined;
 };
 
-export const isValidDate = (isoDateString: string) => DateTime.fromISO(isoDateString).isValid;
+export const isValidDate = (isoDateString: string): boolean =>
+  DateTime.fromISO(isoDateString).isValid;
 
 /**
  *

--- a/src/components/common/utils/localStorage.ts
+++ b/src/components/common/utils/localStorage.ts
@@ -1,11 +1,11 @@
-export const saveToLocalStorage = (key: string, value: string) => {
+export const saveToLocalStorage = (key: string, value: string): void => {
   window?.localStorage?.setItem(key, value);
 };
 
-export const loadFromLocalStorage = (key: string) => {
+export const loadFromLocalStorage = (key: string): string | null | undefined => {
   return window?.localStorage?.getItem(key);
 };
 
-export const removeFromLocalStorage = (key: string) => {
+export const removeFromLocalStorage = (key: string): void => {
   window?.localStorage?.removeItem(key);
 };

--- a/src/components/images/logos.tsx
+++ b/src/components/images/logos.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import ec2Img from './resources/aws-ec2.svg';
 import hypervImg from './resources/hyperv.svg';
 import ovaImg from './resources/open-virtual-appliance.png';
@@ -73,4 +75,5 @@ const vmLogoDark = (
   />
 );
 
-export const getVmwareLogo = (isDarkTheme: boolean) => (isDarkTheme ? vmLogoLight : vmLogoDark);
+export const getVmwareLogo = (isDarkTheme: boolean): ReactElement =>
+  isDarkTheme ? vmLogoLight : vmLogoDark;

--- a/src/components/mappings/network-mappings/SourceNetworkField.tsx
+++ b/src/components/mappings/network-mappings/SourceNetworkField.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { type ReactElement, useMemo } from 'react';
 import {
   type Control,
   Controller,
@@ -28,7 +28,7 @@ const SourceNetworkField = <T extends FieldValues>({
   otherSourceNetworks,
   trigger,
   usedSourceNetworks,
-}: SourceNetworkFieldProps<T>) => {
+}: SourceNetworkFieldProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
 
   const allNetworks = useMemo(

--- a/src/components/modals/CreateProjectModal.tsx
+++ b/src/components/modals/CreateProjectModal.tsx
@@ -48,7 +48,7 @@ const CreateProjectModal: OverlayComponent<CreateProjectModalProps> = ({
   const [description, setDescription] = useState('');
   const { t } = useForkliftTranslation();
 
-  const submit = (event: MouseEvent<HTMLButtonElement> | FormEvent<HTMLFormElement>) => {
+  const submit = (event: MouseEvent<HTMLButtonElement> | FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
     setInProgress(true);
 

--- a/src/components/modals/DeleteModal/DeleteModal.tsx
+++ b/src/components/modals/DeleteModal/DeleteModal.tsx
@@ -63,7 +63,7 @@ export const DeleteModal: OverlayComponent<DeleteModalProps> = ({
   const owner = resource?.metadata?.ownerReferences?.[0];
 
   const onDelete = useCallback(async () => {
-    const isOnResourcePage = () => {
+    const isOnResourcePage = (): boolean => {
       const re = new RegExp(`/${name}(/|$)`, 'u');
       return re.test(window.location.pathname);
     };

--- a/src/components/page/ManageColumnsToolbar.tsx
+++ b/src/components/page/ManageColumnsToolbar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type ReactElement, useState } from 'react';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
 import { ManageColumnsModal } from '../common/TableView/ManageColumnsModal';
@@ -21,7 +21,7 @@ export const ManageColumnsToolbar = ({
   defaultColumns,
   resourceFields,
   setColumns,
-}: ManageColumnsToolbarProps) => {
+}: ManageColumnsToolbarProps): ReactElement => {
   const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
   return (

--- a/src/components/page/StandardPage.tsx
+++ b/src/components/page/StandardPage.tsx
@@ -56,7 +56,7 @@ type StandardPageProps<T> = {
   userSettings?: UserSettings;
 };
 
-const StandardPage = <T,>(pageProps: StandardPageProps<T>) => {
+const StandardPage = <T,>(pageProps: StandardPageProps<T>): ReactElement => {
   const sortContext = useTableSortContext();
   const internalPageRef = useRef(pageProps.page ?? 1);
   const pageRef = pageProps.pageRef ?? internalPageRef;

--- a/src/components/page/StandardPageInner.tsx
+++ b/src/components/page/StandardPageInner.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines-per-function */
-import { type ComponentProps, useMemo } from 'react';
+import { type ComponentProps, type ReactElement, useMemo } from 'react';
 
 import { useFields } from '@components/common/Page/useFields';
 import { DefaultHeader } from '@components/common/TableView/DefaultHeader';
@@ -59,7 +59,7 @@ const StandardPageInner = <T,>({
   titleHelpContent,
   toId,
   userSettings,
-}: StandardPageInnerProps<T>) => {
+}: StandardPageInnerProps<T>): ReactElement => {
   const { clearAllFilters, metaMatcher, selectedFilters, setSelectedFilters, supportedFilters } =
     usePageFilters({
       extraSupportedFilters,

--- a/src/components/page/StandardPageWithSelection.tsx
+++ b/src/components/page/StandardPageWithSelection.tsx
@@ -1,5 +1,4 @@
-import type { ComponentProps, FC } from 'react';
-import { useMemo, useRef } from 'react';
+import { type ComponentProps, type FC, type ReactElement, useMemo, useRef } from 'react';
 
 import DefaultSelectHeader from '@components/common/TableView/DefaultSelectHeader';
 import type { GlobalActionToolbarProps } from '@components/common/utils/types';
@@ -15,7 +14,7 @@ const wrapActionWithSelection = <T,>(
   Action: FC<GlobalActionToolbarProps<T>>,
   selectedIds: string[],
 ): FC<GlobalActionToolbarProps<T>> => {
-  const ActionWithSelection = (actionProps: ComponentProps<typeof Action>) => (
+  const ActionWithSelection = (actionProps: ComponentProps<typeof Action>): ReactElement => (
     <Action {...actionProps} selectedIds={selectedIds} />
   );
   ActionWithSelection.displayName = `${Action.displayName ?? 'Action'}WithSelection`;
@@ -62,9 +61,11 @@ type StandardPageWithSelectionProps<T> = ComponentProps<typeof StandardPage<T>> 
       }
   );
 
-export const StandardPageWithSelection = <T,>(props: StandardPageWithSelectionProps<T>) => {
+export const StandardPageWithSelection = <T,>(
+  props: StandardPageWithSelectionProps<T>,
+): ReactElement => {
   const {
-    canSelect = () => true,
+    canSelect = (): boolean => true,
     cell,
     expanded,
     expandedIds,

--- a/src/components/page/__tests__/StandardPage.test.tsx
+++ b/src/components/page/__tests__/StandardPage.test.tsx
@@ -1,13 +1,14 @@
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router';
 
 import type { ResourceField } from '@components/common/utils/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, type RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import StandardPage from '../StandardPage';
 
-const renderWithRouter = (component: React.ReactElement) =>
+const renderWithRouter = (component: ReactElement): RenderResult =>
   render(<MemoryRouter>{component}</MemoryRouter>);
 
 describe('StandardPage', () => {

--- a/src/components/page/__tests__/StandardPageWithSelection.test.tsx
+++ b/src/components/page/__tests__/StandardPageWithSelection.test.tsx
@@ -1,13 +1,14 @@
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router';
 
 import type { ResourceField } from '@components/common/utils/types';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { render, screen } from '@testing-library/react';
+import { render, type RenderResult, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { StandardPageWithSelection } from '../StandardPageWithSelection';
 
-const renderWithRouter = (component: React.ReactElement) =>
+const renderWithRouter = (component: ReactElement): RenderResult =>
   render(<MemoryRouter>{component}</MemoryRouter>);
 
 describe('StandardPageWithSelection', () => {
@@ -35,7 +36,7 @@ describe('StandardPageWithSelection', () => {
     },
   ];
 
-  const toId = (item: { id: string }) => item.id;
+  const toId = (item: { id: string }): string => item.id;
 
   beforeEach(() => {
     window.history.replaceState({}, '', '/');
@@ -150,7 +151,7 @@ describe('StandardPageWithSelection', () => {
   });
 
   describe('Expansion', () => {
-    const ExpandedContent = () => <div>Expanded details</div>;
+    const ExpandedContent = (): ReactElement => <div>Expanded details</div>;
 
     it('should render expansion toggle when expanded content is provided', () => {
       renderWithRouter(
@@ -217,7 +218,7 @@ describe('StandardPageWithSelection', () => {
   });
 
   describe('Combined Selection and Expansion', () => {
-    const ExpandedContent = () => <div>Expanded details</div>;
+    const ExpandedContent = (): ReactElement => <div>Expanded details</div>;
 
     it('should support both selection and expansion simultaneously', () => {
       renderWithRouter(
@@ -247,7 +248,7 @@ describe('StandardPageWithSelection', () => {
   describe('Conditional Selection with canSelect', () => {
     it('should disable selection for items that fail canSelect', () => {
       const onSelect = jest.fn();
-      const canSelect = (item: { id: string }) => item.id !== '2';
+      const canSelect = (item: { id: string }): boolean => item.id !== '2';
 
       renderWithRouter(
         <StandardPageWithSelection
@@ -270,7 +271,7 @@ describe('StandardPageWithSelection', () => {
     it('should only select eligible items when Select All is used', async () => {
       const user = userEvent.setup();
       const onSelect = jest.fn();
-      const canSelect = (item: { id: string }) => item.id !== '2';
+      const canSelect = (item: { id: string }): boolean => item.id !== '2';
 
       renderWithRouter(
         <StandardPageWithSelection
@@ -293,7 +294,7 @@ describe('StandardPageWithSelection', () => {
     it('should not include non-selectable items when deselecting all', async () => {
       const user = userEvent.setup();
       const onSelect = jest.fn();
-      const canSelect = (item: { id: string }) => item.id !== '2';
+      const canSelect = (item: { id: string }): boolean => item.id !== '2';
 
       renderWithRouter(
         <StandardPageWithSelection

--- a/src/components/page/components/PageContent.tsx
+++ b/src/components/page/components/PageContent.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import type { OnPerPageSelect, OnSetPage } from '@patternfly/react-core';
 import { PageSection, Pagination } from '@patternfly/react-core';
@@ -25,7 +25,7 @@ export const PageContent = ({
   showPagination,
   toolbar,
   totalItems,
-}: PageContentProps) => (
+}: PageContentProps): ReactElement => (
   <PageSection hasBodyWrapper={false} padding={{ default: noPadding ? 'noPadding' : 'padding' }}>
     {toolbar}
     {children}

--- a/src/components/page/components/PageHeader.tsx
+++ b/src/components/page/components/PageHeader.tsx
@@ -25,7 +25,7 @@ export const PageHeader = ({
   shouldShowLearningExperienceButton = false,
   title,
   titleHelpContent,
-}: PageHeaderProps) => {
+}: PageHeaderProps): ReactElement | null => {
   if (!title) {
     return null;
   }

--- a/src/components/page/components/PageTable.tsx
+++ b/src/components/page/components/PageTable.tsx
@@ -49,7 +49,7 @@ export const PageTable = <T,>({
   title,
   toId,
   visibleColumns,
-}: PageTableProps<T>) => {
+}: PageTableProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
 
   const errorFetchingData = useMemo(() => error, [error]);

--- a/src/components/page/components/PageToolbar.tsx
+++ b/src/components/page/components/PageToolbar.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import { useMemo } from 'react';
+import { type ReactElement, type ReactNode, useMemo } from 'react';
 
 import { AttributeValueFilter } from '@components/common/FilterGroup/AttributeValueFilter';
 import { FilterGroup } from '@components/common/FilterGroup/FilterGroup';
@@ -71,7 +70,7 @@ export const PageToolbar = <T,>({
   sortedData,
   supportedFilters,
   totalItems,
-}: PageToolbarProps<T>) => {
+}: PageToolbarProps<T>): ReactElement => {
   const { t } = useForkliftTranslation();
 
   const primaryFilters = useMemo(

--- a/src/components/page/hooks/usePageFilters.ts
+++ b/src/components/page/hooks/usePageFilters.ts
@@ -5,7 +5,11 @@ import {
   defaultSupportedFilters,
   defaultValueMatchers,
 } from '@components/common/FilterGroup/matchers';
-import type { FilterRenderer, ValueMatcher } from '@components/common/FilterGroup/types';
+import type {
+  FilterRenderer,
+  GlobalFilters,
+  ValueMatcher,
+} from '@components/common/FilterGroup/types';
 import { useUrlFilters } from '@components/common/FilterGroup/useUrlFilters';
 import type { UserSettings } from '@components/common/Page/types';
 import type { ResourceField } from '@components/common/utils/types';
@@ -28,12 +32,22 @@ type UsePageFiltersProps = {
  * @param extraSupportedMatchers - Custom matching logic for filtering.
  *   Example: `[{ filterType: 'dateRange', matchValue: (value, filterValues) => ... }]`
  */
+type UsePageFiltersResult = {
+  clearAllFilters: () => void;
+  excludeFromClearFiltersIds: string[];
+  metaMatcher: ReturnType<typeof createMetaMatcher>;
+  selectedFilters: GlobalFilters;
+  setSelectedFilters: (filters: GlobalFilters) => void;
+  supportedFilters: Record<string, FilterRenderer>;
+  supportedMatchers: ValueMatcher<string>[];
+};
+
 export const usePageFilters = ({
   extraSupportedFilters,
   extraSupportedMatchers,
   fieldsMetadata,
   userSettings,
-}: UsePageFiltersProps) => {
+}: UsePageFiltersProps): UsePageFiltersResult => {
   const [selectedFilters, setSelectedFilters] = useUrlFilters({
     fields: fieldsMetadata,
     userSettings,

--- a/src/components/page/hooks/usePageSelection.ts
+++ b/src/components/page/hooks/usePageSelection.ts
@@ -45,7 +45,7 @@ export const usePageSelection = <T>({
   const isExpanded = useMemo(
     () =>
       onExpand || internalExpandedIds
-        ? (item: T) => internalExpandedIds?.includes(itemToId(item)) ?? false
+        ? (item: T): boolean => internalExpandedIds?.includes(itemToId(item)) ?? false
         : undefined,
     [onExpand, internalExpandedIds, itemToId],
   );

--- a/src/components/page/utils/createHeaderWithSelection.tsx
+++ b/src/components/page/utils/createHeaderWithSelection.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 
 import { Th } from '@patternfly/react-table';
 
@@ -13,8 +13,11 @@ export const createHeaderWithSelection = <T,>({
   canSelect?: boolean;
   header?: FC<TableViewHeaderProps<T>>;
   isExpanded?: (item: T) => boolean;
-}) => {
-  const HeaderWithSelection = ({ dataOnScreen, ...other }: TableViewHeaderProps<T>) => {
+}): FC<TableViewHeaderProps<T>> => {
+  const HeaderWithSelection = ({
+    dataOnScreen,
+    ...other
+  }: TableViewHeaderProps<T>): ReactElement => {
     return (
       <>
         {isExpanded && <Th />}

--- a/src/components/page/utils/createRowWithSelection.tsx
+++ b/src/components/page/utils/createRowWithSelection.tsx
@@ -1,4 +1,4 @@
-import { type FC, useRef } from 'react';
+import { type FC, type ReactElement, useRef } from 'react';
 
 import { Tooltip } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
@@ -24,8 +24,8 @@ export const createRowWithSelection = <T,>({
   toggleExpandFor: (items: T[]) => void;
   toggleSelectFor: (items: T[]) => void;
   toId?: (item: T) => string;
-}) => {
-  const RowWithSelection = (props: RowProps<T>) => {
+}): FC<RowProps<T>> => {
+  const RowWithSelection = (props: RowProps<T>): ReactElement => {
     const itemId = toId?.(props.resourceData) ?? '';
     const isExpanded = expandedIds?.includes(itemId) ?? false;
     const isSelected = selectedIds?.includes(itemId) ?? false;

--- a/src/components/table/utils/useStatusPhaseValues.tsx
+++ b/src/components/table/utils/useStatusPhaseValues.tsx
@@ -1,11 +1,11 @@
-import { type ReactNode, useMemo } from 'react';
+import { type ReactElement, type ReactNode, useMemo } from 'react';
 
 import { STATUS_ICONS } from '@components/status/statusIcons';
 import { Spinner } from '@patternfly/react-core';
 import { CATEGORY_TYPES } from '@utils/constants';
 import { useForkliftTranslation } from '@utils/i18n';
 
-const progressIcon = () => <Spinner size="sm" />;
+const progressIcon = (): ReactElement => <Spinner size="sm" />;
 
 export const useStatusPhaseValues = (
   phase?: string,

--- a/src/components/useTableSortContext.tsx
+++ b/src/components/useTableSortContext.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
 
-import { TableSortContext } from '@components/TableSortContext';
+import { TableSortContext, type TableSortContextProps } from '@components/TableSortContext';
 
-export const useTableSortContext = () => useContext(TableSortContext);
+export const useTableSortContext = (): TableSortContextProps => useContext(TableSortContext);

--- a/src/networkMaps/actions/NetworkMapActionsDropdown.tsx
+++ b/src/networkMaps/actions/NetworkMapActionsDropdown.tsx
@@ -26,11 +26,11 @@ const NetworkMapActionsDropdown: FC<NetworkMapActionsDropdownProps> = ({ data, i
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((value) => !value);
   };
 
-  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined): void => {
     setIsOpen(false);
   };
 

--- a/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
+++ b/src/networkMaps/actions/NetworkMapActionsDropdownItems.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { DeleteModal, type DeleteModalProps } from 'src/components/modals/DeleteModal/DeleteModal';
 import { useOwnerPlanActionGate } from 'src/plans/hooks/useOwnerPlanActionGate';
@@ -17,7 +18,7 @@ type NetworkMapActionsDropdownItemsProps = {
 export const NetworkMapActionsDropdownItems = ({
   data,
   isDetailsPage,
-}: NetworkMapActionsDropdownItemsProps) => {
+}: NetworkMapActionsDropdownItemsProps): ReactElement[] => {
   const { t } = useForkliftTranslation();
   const launchOverlay = useOverlay();
   const navigate = useNavigate();
@@ -31,7 +32,7 @@ export const NetworkMapActionsDropdownItems = ({
     reference: NetworkMapModelRef,
   });
 
-  const onDelete = () => {
+  const onDelete = (): void => {
     if (!networkMap) {
       return;
     }

--- a/src/networkMaps/create/utils/buildNetworkMappings.ts
+++ b/src/networkMaps/create/utils/buildNetworkMappings.ts
@@ -86,10 +86,14 @@ export const buildNetworkMappings = (
   }, []);
 };
 
-const openShiftNetworkAttachmentDefinitionToName = (net: OpenShiftNetworkAttachmentDefinition) =>
-  net?.namespace ? `${net?.namespace}/${net?.name}` : (net?.name ?? DEFAULT_NETWORK);
+const openShiftNetworkAttachmentDefinitionToName = (
+  net: OpenShiftNetworkAttachmentDefinition,
+): string => (net?.namespace ? `${net?.namespace}/${net?.name}` : (net?.name ?? DEFAULT_NETWORK));
 
-const getSourceNetName = (source: V1beta1NetworkMapSpecMapSource, isOpenShiftProvider: boolean) => {
+const getSourceNetName = (
+  source: V1beta1NetworkMapSpecMapSource,
+  isOpenShiftProvider: boolean,
+): string => {
   if (isOpenShiftProvider && source?.type === POD) {
     return DEFAULT_NETWORK;
   }
@@ -100,7 +104,7 @@ const getSourceNetName = (source: V1beta1NetworkMapSpecMapSource, isOpenShiftPro
 const getDestinationNetName = (
   networks: OpenShiftNetworkAttachmentDefinition[],
   destination: V1beta1NetworkMapSpecMapDestination,
-) => {
+): string => {
   const net = networks.find(
     (network) =>
       network?.name === destination?.name && network?.namespace === destination?.namespace,

--- a/src/networkMaps/create/utils/createNetworkMap.ts
+++ b/src/networkMaps/create/utils/createNetworkMap.ts
@@ -33,7 +33,7 @@ export const createNetworkMap = async ({
   sourceProvider,
   targetProvider,
   trackEvent,
-}: CreateNetworkMapParams) => {
+}: CreateNetworkMapParams): Promise<V1beta1NetworkMap> => {
   const sourceProviderName = sourceProvider?.metadata?.name;
 
   trackEvent?.('Network map create started', {

--- a/src/networkMaps/details/NetworkMapDetailsPage.tsx
+++ b/src/networkMaps/details/NetworkMapDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import { type FC, memo, type ReactElement } from 'react';
 import LearningExperienceDrawer from 'src/onlineHelp/learningExperienceDrawer/LearningExperienceDrawer';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -23,12 +23,12 @@ const NetworkMapDetailsPage: FC<NetworkMapDetailsPageProps> = memo(({ name, name
 
   const pages = [
     {
-      component: () => <NetworkMapDetailsTab name={name} namespace={namespace} />,
+      component: (): ReactElement => <NetworkMapDetailsTab name={name} namespace={namespace} />,
       href: '',
       name: t('Details'),
     },
     {
-      component: () => <NetworkMapYAMLTab name={name} namespace={namespace} />,
+      component: (): ReactElement => <NetworkMapYAMLTab name={name} namespace={namespace} />,
       href: 'yaml',
       name: t('YAML'),
     },

--- a/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
+++ b/src/networkMaps/details/components/MapsSection/NetworkMapEdit.tsx
@@ -67,7 +67,7 @@ const NetworkMapEdit: OverlayComponent<NetworkMapEditProps> = ({
     useTargetNetworks(destinationProvider);
   const loadError = sourceNetworksError ?? targetNetworksError;
 
-  const onSubmit = async (formData: NetworkEditFormValues) => {
+  const onSubmit = async (formData: NetworkEditFormValues): Promise<void> => {
     if (!isDirty) {
       closeOverlay();
       return;

--- a/src/networkMaps/list/NetworkMapRow.tsx
+++ b/src/networkMaps/list/NetworkMapRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { createStatusCell } from 'src/components/table/utils/createStatusCell';
 
@@ -32,10 +32,14 @@ type RenderTdProps = {
   resourceFields: ResourceField[];
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/onlineHelp/learningExperienceContent/topics/components/SourceMigrationSelection.tsx
+++ b/src/onlineHelp/learningExperienceContent/topics/components/SourceMigrationSelection.tsx
@@ -1,4 +1,4 @@
-import { type FC, type Ref, useContext, useState } from 'react';
+import { type FC, type MouseEvent, type Ref, useContext, useState } from 'react';
 import { LearningExperienceContext } from 'src/onlineHelp/learningExperienceDrawer/context/LearningExperienceContext';
 
 import {
@@ -17,7 +17,7 @@ const SourceMigrationSelection: FC = () => {
   const { data, setData } = useContext(LearningExperienceContext);
   const providerType = (data?.providerType as ProviderTypes) ?? PROVIDER_TYPES.vsphere;
 
-  const onSelect = (_event: React.MouseEvent | undefined, value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, value: string | number | undefined): void => {
     setIsOpen(false);
     setData('providerType', value);
   };

--- a/src/onlineHelp/learningExperienceContent/topics/components/utils.ts
+++ b/src/onlineHelp/learningExperienceContent/topics/components/utils.ts
@@ -1,4 +1,8 @@
-export const getNavigationTarget = (href?: string, isCreateForm?: boolean, url?: string) => {
+export const getNavigationTarget = (
+  href?: string,
+  isCreateForm?: boolean,
+  url?: string,
+): string | undefined => {
   if (href) {
     return href;
   }

--- a/src/onlineHelp/learningExperienceContent/topics/createProviderTopic/createProviderTopic.tsx
+++ b/src/onlineHelp/learningExperienceContent/topics/createProviderTopic/createProviderTopic.tsx
@@ -20,7 +20,7 @@ import { rhvCreateProviderSubTopics } from './subTopics/rhvCreateProviderSubTopi
 import { vmwareCreateProviderSubTopics } from './subTopics/vmwareCreateProviderSubTopics';
 
 const createProviderSubTopics = (providerType?: ProviderTypes): LearningExperienceSubTopic[] => {
-  const helpTopics = () => {
+  const helpTopics = (): ReturnType<typeof vmwareCreateProviderSubTopics> => {
     switch (providerType) {
       case PROVIDER_TYPES.vsphere:
         return vmwareCreateProviderSubTopics();

--- a/src/onlineHelp/learningExperienceContent/topics/migratingVMsTopic/migratingVMsTopic.tsx
+++ b/src/onlineHelp/learningExperienceContent/topics/migratingVMsTopic/migratingVMsTopic.tsx
@@ -16,7 +16,7 @@ import { LEARN_MORE_MIGRATING_VMS_DOCS_URL } from '../utils/constants';
 import { commonMigratingVMsSubTopics } from './subTopics/commonMigratingVMsSubTopics';
 
 const migratingVMsSubTopics = (providerType?: ProviderTypes): LearningExperienceSubTopic[] => {
-  const helpTopics = () => {
+  const helpTopics = (): ReturnType<typeof commonMigratingVMsSubTopics> => {
     switch (providerType) {
       case PROVIDER_TYPES.vsphere:
         return commonMigratingVMsSubTopics(t('Choose your VMware provider.'));

--- a/src/onlineHelp/learningExperienceDrawer/LearningExperienceDrawer.tsx
+++ b/src/onlineHelp/learningExperienceDrawer/LearningExperienceDrawer.tsx
@@ -19,7 +19,7 @@ const LearningExperienceDrawer: FC<{ children: ReactNode }> = ({ children }) => 
       const originalOverflow = listWrapper.style.overflowY;
       listWrapper.style.overflowY = 'hidden';
 
-      return () => {
+      return (): void => {
         listWrapper.style.overflowY = originalOverflow;
       };
     }

--- a/src/onlineHelp/learningExperienceDrawer/context/__tests__/utils.ts
+++ b/src/onlineHelp/learningExperienceDrawer/context/__tests__/utils.ts
@@ -35,7 +35,7 @@ export const createMockTopic = (id: string): LearningExperienceTopic => ({
 export const setupMocks = (
   persistedState: PersistedState = {},
   topicToReturn: LearningExperienceTopic | null = null,
-) => {
+): void => {
   mockParseOrClean.mockReturnValue(persistedState);
   mockFindTopicById.mockReturnValue(topicToReturn);
 };

--- a/src/onlineHelp/learningExperienceStructure/HelpTopicSection/HelpTopicSection.tsx
+++ b/src/onlineHelp/learningExperienceStructure/HelpTopicSection/HelpTopicSection.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useContext } from 'react';
+import { type FC, memo, type MouseEvent, useContext } from 'react';
 import { type LearningExperienceSubTopic, ListStyleType } from 'src/onlineHelp/utils/types';
 
 import { ExpandableSection } from '@patternfly/react-core';
@@ -23,7 +23,7 @@ const HelpTopicSection: FC<HelpTopicSectionProps> = ({ index, listStyleType, top
   const hasSubTopics = Boolean(topic.subTopics);
   const prefix = listStyleType === ListStyleType.DECIMAL ? `${index + 1}.` : undefined;
 
-  const handleToggle = (_ev: React.MouseEvent, expanded: boolean) => {
+  const handleToggle = (_ev: MouseEvent, expanded: boolean): void => {
     if (!hasSubTopics) {
       return;
     }

--- a/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/components/LearningExperienceSelect.tsx
+++ b/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/components/LearningExperienceSelect.tsx
@@ -1,4 +1,4 @@
-import { type FC, type Ref, useContext, useState } from 'react';
+import { type FC, type ReactElement, type Ref, useContext, useState } from 'react';
 import { learningExperienceTopics } from 'src/onlineHelp/learningExperienceContent/topics/utils/constants';
 import { LearningExperienceContext } from 'src/onlineHelp/learningExperienceDrawer/context/LearningExperienceContext';
 
@@ -24,7 +24,7 @@ const LearningExperienceSelect: FC = () => {
   const { trackEvent } = useForkliftAnalytics();
   const [isSelectOpen, setIsSelectOpen] = useState(false);
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => {
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => {
     return (
       <MenuToggle
         className="pf-v6-u-mt-md"

--- a/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/hooks/__tests__/utils.ts
+++ b/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/hooks/__tests__/utils.ts
@@ -45,7 +45,10 @@ export const fireScrollEvent = (element: MockScrollableElement, scrollTop: numbe
 
 export const createMockDebouncedFn = (
   mockCreateCancellableDebounce: jest.MockedFunction<typeof createCancellableDebounce>,
-) => {
+): {
+  getCancel: () => jest.Mock | undefined;
+  getCapturedFn: () => ((position: number) => void) | null;
+} => {
   let capturedFn: ((position: number) => void) | null = null;
 
   mockCreateCancellableDebounce.mockImplementation((fn) => {
@@ -58,8 +61,8 @@ export const createMockDebouncedFn = (
   });
 
   return {
-    getCapturedFn: () => capturedFn,
-    getCancel: () => {
+    getCapturedFn: (): ((position: number) => void) | null => capturedFn,
+    getCancel: (): jest.Mock | undefined => {
       const [lastCall] = mockCreateCancellableDebounce.mock.results;
       return lastCall?.value?.cancel as jest.Mock | undefined;
     },

--- a/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/hooks/useScrollPositionPersistence.ts
+++ b/src/onlineHelp/learningExperienceStructure/LearningExperiencePanel/hooks/useScrollPositionPersistence.ts
@@ -67,7 +67,7 @@ export const useScrollPositionPersistence = ({
   useEffect(() => {
     const debouncedSetPosition = debouncedSetPositionRef.current;
 
-    const handleScroll = (event: Event) => {
+    const handleScroll = (event: Event): void => {
       const target = event.currentTarget as HTMLDivElement;
       debouncedSetPositionRef.current(target?.scrollTop ?? 0);
     };
@@ -76,7 +76,7 @@ export const useScrollPositionPersistence = ({
       element.addEventListener('scroll', handleScroll);
     }
 
-    return () => {
+    return (): void => {
       if (element) {
         element.removeEventListener('scroll', handleScroll);
         debouncedSetPosition.cancel();

--- a/src/onlineHelp/learningExperienceStructure/ReferenceSection/ReferenceSection.tsx
+++ b/src/onlineHelp/learningExperienceStructure/ReferenceSection/ReferenceSection.tsx
@@ -32,7 +32,7 @@ const ReferenceSection: FC<ReferenceSectionProps> = ({ children, icon, id, title
     savedPosition: referenceScrollPositions[id] ?? 0,
   });
 
-  const handleToggle = () => {
+  const handleToggle = (): void => {
     if (isExpanded) {
       closeExpansionItem(id);
     } else {

--- a/src/overview/OverviewPage.tsx
+++ b/src/overview/OverviewPage.tsx
@@ -33,35 +33,35 @@ const OverviewPage: FC = () => {
   const tabs = [
     {
       name: OverviewTabName.Overview,
-      onClick: () => {
+      onClick: (): void => {
         trackEvent(TELEMETRY_EVENTS.OVERVIEW_TAB_CLICKED, { tabName: OverviewTabName.Overview });
       },
       to: getOverviewPath(),
     },
     {
       name: OverviewTabName.YAML,
-      onClick: () => {
+      onClick: (): void => {
         trackEvent(TELEMETRY_EVENTS.OVERVIEW_TAB_CLICKED, { tabName: OverviewTabName.YAML });
       },
       to: getOverviewPath(OverviewTabHref.YAML),
     },
     {
       name: OverviewTabName.Health,
-      onClick: () => {
+      onClick: (): void => {
         trackEvent(TELEMETRY_EVENTS.OVERVIEW_TAB_CLICKED, { tabName: OverviewTabName.Health });
       },
       to: getOverviewPath(OverviewTabHref.Health),
     },
     {
       name: OverviewTabName.History,
-      onClick: () => {
+      onClick: (): void => {
         trackEvent(TELEMETRY_EVENTS.OVERVIEW_TAB_CLICKED, { tabName: OverviewTabName.History });
       },
       to: getOverviewPath(OverviewTabHref.History),
     },
     {
       name: OverviewTabName.Settings,
-      onClick: () => {
+      onClick: (): void => {
         trackEvent(TELEMETRY_EVENTS.OVERVIEW_TAB_CLICKED, { tabName: OverviewTabName.Settings });
       },
       to: getOverviewPath(OverviewTabHref.Settings),

--- a/src/overview/components/TabTitle.tsx
+++ b/src/overview/components/TabTitle.tsx
@@ -1,7 +1,9 @@
+import type { ReactElement } from 'react';
+
 import { Button, ButtonVariant, Icon, Tooltip } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
-const TabTitle = ({ helpContent, title }: { helpContent: string; title: string }) => (
+const TabTitle = ({ helpContent, title }: { helpContent: string; title: string }): ReactElement => (
   <>
     {title}{' '}
     <Tooltip content={helpContent}>

--- a/src/overview/hooks/useOverviewContext.ts
+++ b/src/overview/hooks/useOverviewContext.ts
@@ -26,7 +26,7 @@ export const useOverviewContext = (): OverviewContextType => {
 
   const mounted = useRef(true);
   useEffect(
-    () => () => {
+    () => (): void => {
       mounted.current = false;
     },
     [],
@@ -41,7 +41,7 @@ export const useOverviewContext = (): OverviewContextType => {
   return useMemo(
     () => ({
       data,
-      setData: (newState: OverviewContextData) => {
+      setData: (newState: OverviewContextData): void => {
         // Save/clear the user settings stored in local storage
         if (newState.hideWelcomeCardByContext) {
           userSettings?.welcome?.save(true);

--- a/src/overview/hooks/useProvidersInventoryIsLive.ts
+++ b/src/overview/hooks/useProvidersInventoryIsLive.ts
@@ -36,7 +36,7 @@ export const useProvidersInventoryIsLive = ({
   const oldErrorRef = useRef<{ error?: string }>({ error: '' });
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       try {
         await consoleFetchJSON(getInventoryApiUrl(`providers`));
 
@@ -54,13 +54,13 @@ export const useProvidersInventoryIsLive = ({
       }
     };
 
-    (async () => {
+    (async (): Promise<void> => {
       await fetchData();
     })();
 
     // Polling interval set by the passed parameter
     const intervalId = setInterval(fetchData, interval);
-    return () => {
+    return (): void => {
       clearInterval(intervalId);
     };
   }, [interval]);

--- a/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
+++ b/src/overview/tabs/Health/cards/Controller/PodsTable.tsx
@@ -46,19 +46,22 @@ export const PodsTable: FC<PodsTableProps> = ({ limit, pods, showOwner }) => {
   const endIndex = startIndex + perPage;
   const paginatedPods = limitedPods.slice(startIndex, endIndex);
 
-  const onSetPage = (_event: MouseEvent | KeyboardEvent | globalThis.MouseEvent, page: number) => {
+  const onSetPage = (
+    _event: MouseEvent | KeyboardEvent | globalThis.MouseEvent,
+    page: number,
+  ): void => {
     setCurrentPage(page);
   };
 
   const onPerPageSelect = (
     _event: MouseEvent | KeyboardEvent | globalThis.MouseEvent,
     selectedPerPage: number,
-  ) => {
+  ): void => {
     setPerPage(selectedPerPage);
     setCurrentPage(1); // Reset to the first page
   };
 
-  const getPodLogsLink = (pod: IoK8sApiCoreV1Pod) =>
+  const getPodLogsLink = (pod: IoK8sApiCoreV1Pod): string =>
     getResourceUrl({
       name: pod.metadata?.name,
       namespace: pod.metadata?.namespace,

--- a/src/overview/tabs/History/cards/MigrationsListPage.tsx
+++ b/src/overview/tabs/History/cards/MigrationsListPage.tsx
@@ -98,7 +98,7 @@ const MigrationsListPage: FC = () => {
         type: FilterDefType.DateRange,
       },
       isVisible: false,
-      jsonPath: (resourceData: unknown) => {
+      jsonPath: (resourceData: unknown): { completed?: string; started?: string } => {
         const migration = resourceData as V1beta1Migration;
         return {
           completed: migration?.status?.completed,

--- a/src/overview/tabs/History/utils/matchers.ts
+++ b/src/overview/tabs/History/utils/matchers.ts
@@ -7,23 +7,25 @@ import type { V1beta1Migration } from '@forklift-ui/types';
 
 export const dateRangeObjectMatcher: ValueMatcher = {
   filterType: FilterDefType.DateRange,
-  matchValue: (value: unknown) => (filter: string) => {
-    if (!value || typeof value !== 'object') {
-      return false;
-    }
-    const obj = value as { completed?: string; started?: string };
-    const [from, to] = filter.split('/');
-    const fromDate = DateTime.fromISO(from);
-    const toDate = DateTime.fromISO(to);
-    const inRange = (dateStr?: string) => {
-      if (!dateStr) {
+  matchValue:
+    (value: unknown): ((filter: string) => boolean) =>
+    (filter: string) => {
+      if (!value || typeof value !== 'object') {
         return false;
       }
-      const date = DateTime.fromISO(dateStr);
-      return date >= fromDate && date <= toDate;
-    };
-    return inRange(obj.started);
-  },
+      const obj = value as { completed?: string; started?: string };
+      const [from, to] = filter.split('/');
+      const fromDate = DateTime.fromISO(from);
+      const toDate = DateTime.fromISO(to);
+      const inRange = (dateStr?: string): boolean => {
+        if (!dateStr) {
+          return false;
+        }
+        const date = DateTime.fromISO(dateStr);
+        return date >= fromDate && date <= toDate;
+      };
+      return inRange(obj.started);
+    },
 };
 
 export const filterMostRecentMigrations = (migrations: V1beta1Migration[]): V1beta1Migration[] => {

--- a/src/overview/tabs/Overview/cards/CardHeaderActions.tsx
+++ b/src/overview/tabs/Overview/cards/CardHeaderActions.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, type Ref, useState } from 'react';
+import { type MouseEvent, type ReactElement, type Ref, useState } from 'react';
 
 import { MenuToggle, type MenuToggleElement, Select, SelectOption } from '@patternfly/react-core';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -13,21 +13,21 @@ const HeaderActions = ({
   selectedTimeRange: TimeRangeOptions;
   setSelectedTimeRange: (range: TimeRangeOptions) => void;
   showAll?: boolean;
-}) => {
+}): ReactElement => {
   const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const valueToLabel = getValueToLabel();
 
-  const onSelect = (_event: MouseEvent | undefined, value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, value: string | number | undefined): void => {
     setSelectedTimeRange(value as TimeRangeOptions);
     setIsOpen(false);
   };
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen(!isOpen);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       className="forklift-overview__cards-select"
       isExpanded={isOpen}

--- a/src/overview/tabs/Overview/cards/MigrationPlansDonutCard.tsx
+++ b/src/overview/tabs/Overview/cards/MigrationPlansDonutCard.tsx
@@ -79,7 +79,7 @@ const MigrationPlansDonutCard: FC<MigrationPlansDonutCardProps> = () => {
             events={[
               {
                 eventHandlers: {
-                  onClick: (_, props: { index: number }) => {
+                  onClick: (_: unknown, props: { index: number }): null => {
                     // Get the phase from the clicked slice
                     const phase = data[props.index]?.phase;
                     // Build the URL with the phase param as a JSON array
@@ -89,7 +89,7 @@ const MigrationPlansDonutCard: FC<MigrationPlansDonutCardProps> = () => {
                     navigate(`${plansListURL}?${params.toString()}`)?.catch(() => undefined);
                     return null;
                   },
-                  onMouseOut: () => {
+                  onMouseOut: (): { mutation: () => { active: boolean }; target: string }[] => {
                     setHoveredIndex(null);
                     return [
                       {
@@ -98,7 +98,10 @@ const MigrationPlansDonutCard: FC<MigrationPlansDonutCardProps> = () => {
                       },
                     ];
                   },
-                  onMouseOver: (_, props: { index: number }) => {
+                  onMouseOver: (
+                    _: unknown,
+                    props: { index: number },
+                  ): { mutation: () => { active: boolean }; target: string }[] => {
                     setHoveredIndex(props.index);
                     return [
                       {

--- a/src/overview/tabs/Overview/cards/VmMigrationsDonutCard.tsx
+++ b/src/overview/tabs/Overview/cards/VmMigrationsDonutCard.tsx
@@ -26,7 +26,7 @@ const VmMigrationsDonutCard: FC<VmMigrationsDonutCardProps> = () => {
   const { t } = useForkliftTranslation();
   const { data, setData } = useContext(OverviewContext);
   const selectedRange = data?.vmMigrationsDonutSelectedRange ?? TimeRangeOptions.All;
-  const setSelectedRange = (range: TimeRangeOptions) => {
+  const setSelectedRange = (range: TimeRangeOptions): void => {
     setData({
       ...data,
       vmMigrationsDonutSelectedRange: range,
@@ -90,13 +90,13 @@ const VmMigrationsDonutCard: FC<VmMigrationsDonutCardProps> = () => {
               events={[
                 {
                   eventHandlers: {
-                    onClick: () => {
+                    onClick: (): void => {
                       if (total === 0) return;
                       const statusMap = ['Running', 'Failed', 'Succeeded', 'Canceled'];
                       const status = hoveredIndex === null ? undefined : statusMap[hoveredIndex];
                       navigateToHistoryTab({ navigate, selectedRange, status });
                     },
-                    onMouseOut: () => {
+                    onMouseOut: (): { mutation: () => { active: boolean }; target: string }[] => {
                       setHoveredIndex(null);
                       return [
                         {
@@ -105,7 +105,10 @@ const VmMigrationsDonutCard: FC<VmMigrationsDonutCardProps> = () => {
                         },
                       ];
                     },
-                    onMouseOver: (_, props: { index: number }) => {
+                    onMouseOver: (
+                      _: unknown,
+                      props: { index: number },
+                    ): { mutation: () => { active: boolean }; target: string }[] => {
                       setHoveredIndex(props.index);
                       return [
                         {

--- a/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryCard.tsx
+++ b/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryCard.tsx
@@ -22,7 +22,7 @@ const VmMigrationsHistoryCard: FC<MigrationsCardProps> = () => {
   const { t } = useForkliftTranslation();
   const { data, setData } = useContext(OverviewContext);
   const selectedRange = data?.vmMigrationsHistorySelectedRange ?? TimeRangeOptions.Last10Days;
-  const setSelectedRange = (range: TimeRangeOptions) => {
+  const setSelectedRange = (range: TimeRangeOptions): void => {
     setData({
       ...data,
       vmMigrationsHistorySelectedRange: range,

--- a/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryChart.tsx
+++ b/src/overview/tabs/Overview/cards/VmMigrationsHistory/VmMigrationsHistoryChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { type ReactElement, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import type { Interval } from 'luxon';
 import { TimeRangeOptions } from 'src/overview/tabs/Overview/utils/timeRangeOptions';
@@ -37,7 +37,7 @@ const VmMigrationsHistoryChart = ({
     running: MigrationDataPoint[];
     succeeded: MigrationDataPoint[];
   };
-}) => {
+}): ReactElement => {
   const { t } = useForkliftTranslation();
   const { trackEvent } = useForkliftAnalytics();
   const { count } = useMigrationCounts();
@@ -94,7 +94,7 @@ const VmMigrationsHistoryChart = ({
     events: [
       {
         eventHandlers: {
-          onClick: () => {
+          onClick: (): void => {
             if (!activeInterval) {
               return;
             }

--- a/src/overview/tabs/Overview/cards/VmMigrationsHistory/useResizeObserver.ts
+++ b/src/overview/tabs/Overview/cards/VmMigrationsHistory/useResizeObserver.ts
@@ -5,7 +5,7 @@ import { getResizeObserver } from '@patternfly/react-core';
 export const useResizeObserver = (
   ref: RefObject<HTMLElement>,
   initialDimensions = { height: 400, width: 800 },
-) => {
+): { height: number; width: number } => {
   const [dimensions, setDimensions] = useState(initialDimensions);
 
   const handleResize = useCallback(() => {
@@ -20,7 +20,7 @@ export const useResizeObserver = (
       const resizeObserver = getResizeObserver(ref.current, handleResize, true);
       handleResize();
 
-      return () => {
+      return (): void => {
         resizeObserver();
       };
     }

--- a/src/overview/tabs/Overview/cards/Welcome/__tests__/WelcomeCard.test.tsx
+++ b/src/overview/tabs/Overview/cards/Welcome/__tests__/WelcomeCard.test.tsx
@@ -17,24 +17,25 @@ const mockUseClusterIsAwsPlatform = jest.fn<() => { isAwsPlatform: boolean; load
 
 jest.mock('react-router', () => ({
   ...jest.requireActual<Record<string, unknown>>('react-router'),
-  useNavigate: () => mockNavigate,
+  useNavigate: (): typeof mockNavigate => mockNavigate,
 }));
 
 jest.mock('@utils/hooks/useClusterIsAwsPlatform', () => ({
-  useClusterIsAwsPlatform: () => mockUseClusterIsAwsPlatform(),
+  useClusterIsAwsPlatform: (): ReturnType<typeof mockUseClusterIsAwsPlatform> =>
+    mockUseClusterIsAwsPlatform(),
 }));
 
 jest.mock('@utils/hooks/useIsDarkTheme', () => ({
-  useIsDarkTheme: () => false,
+  useIsDarkTheme: (): boolean => false,
 }));
 
 jest.mock('@utils/analytics/hooks/useForkliftAnalytics', () => ({
-  useForkliftAnalytics: () => ({ trackEvent: jest.fn() }),
+  useForkliftAnalytics: (): { trackEvent: jest.Mock } => ({ trackEvent: jest.fn() }),
 }));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useActiveNamespace: () => ['test-ns'],
-  useFlag: () => true,
+  useActiveNamespace: (): string[] => ['test-ns'],
+  useFlag: (): boolean => true,
 }));
 
 const CORE_PROVIDER_TITLES = [

--- a/src/overview/tabs/Overview/components/MigrationAlertsCard/__tests__/MigrationAlertsCard.test.tsx
+++ b/src/overview/tabs/Overview/components/MigrationAlertsCard/__tests__/MigrationAlertsCard.test.tsx
@@ -9,21 +9,21 @@ const mockUseMigrationAlerts =
 
 jest.mock('@utils/hooks/useMigrationAlerts/useMigrationAlerts', () => ({
   __esModule: true,
-  default: () => mockUseMigrationAlerts(),
+  default: (): ReturnType<typeof mockUseMigrationAlerts> => mockUseMigrationAlerts(),
 }));
 
 const mockT = (key: string): string => key;
 
 jest.mock('src/utils/i18n', () => ({
-  ForkliftTrans: ({ children }: { children: unknown }) => children,
+  ForkliftTrans: ({ children }: { children: unknown }): unknown => children,
   t: mockT,
-  useForkliftTranslation: () => ({ t: mockT }),
+  useForkliftTranslation: (): { t: typeof mockT } => ({ t: mockT }),
 }));
 
 jest.mock('@utils/i18n', () => ({
-  ForkliftTrans: ({ children }: { children: unknown }) => children,
+  ForkliftTrans: ({ children }: { children: unknown }): unknown => children,
   t: mockT,
-  useForkliftTranslation: () => ({ t: mockT }),
+  useForkliftTranslation: (): { t: typeof mockT } => ({ t: mockT }),
 }));
 
 // Must import after mocks

--- a/src/overview/tabs/Overview/hooks/useVmMigrationsDataPoints.ts
+++ b/src/overview/tabs/Overview/hooks/useVmMigrationsDataPoints.ts
@@ -13,11 +13,15 @@ import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 import { TimeRangeOptions, TimeRangeOptionsDictionary } from '../utils/timeRangeOptions';
 import type { MigrationDataPoint } from '../utils/types';
 
-const toHourLabel = (date: DateTime | null) =>
+const toHourLabel = (date: DateTime | null): string =>
   date ? date.toLocal().toFormat('LLL dd HH:mm') : '';
-const toDayLabel = (date: DateTime | null) => (date ? date.toLocal().toFormat('LLL dd') : '');
+const toDayLabel = (date: DateTime | null): string =>
+  date ? date.toLocal().toFormat('LLL dd') : '';
 
-const createTimeBuckets = (selectedTimeRange: TimeRangeOptions, singleBucket = false) => {
+const createTimeBuckets = (
+  selectedTimeRange: TimeRangeOptions,
+  singleBucket = false,
+): Interval[] => {
   const { bucket, span, unit } = TimeRangeOptionsDictionary[selectedTimeRange];
   const now = DateTime.now().endOf(unit).toUTC();
   const start = now.minus(span).startOf(unit);
@@ -46,7 +50,10 @@ const createTimeBuckets = (selectedTimeRange: TimeRangeOptions, singleBucket = f
   return intervals;
 };
 
-const createBuckets = (intervals: Interval[], migrations: V1beta1Migration[]) => {
+const createBuckets = (
+  intervals: Interval[],
+  migrations: V1beta1Migration[],
+): { interval: Interval; migrations: V1beta1Migration[] }[] => {
   return intervals.map((interval) => {
     // Find migrations that fit the bucket interval
     const inBucket = migrations.filter((migration) => {
@@ -73,19 +80,38 @@ const createBuckets = (intervals: Interval[], migrations: V1beta1Migration[]) =>
   });
 };
 
-const isCanceled = (vm: V1beta1MigrationStatusVms) =>
-  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Canceled');
-const isFailed = (vm: V1beta1MigrationStatusVms) =>
-  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Failed');
-const isSucceeded = (vm: V1beta1MigrationStatusVms) =>
-  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Succeeded');
-const isRunning = (vm: V1beta1MigrationStatusVms) =>
+const isCanceled = (vm: V1beta1MigrationStatusVms): boolean =>
+  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Canceled') ??
+  false;
+const isFailed = (vm: V1beta1MigrationStatusVms): boolean =>
+  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Failed') ??
+  false;
+const isSucceeded = (vm: V1beta1MigrationStatusVms): boolean =>
+  vm?.conditions?.some((cond: V1beta1MigrationStatusVmsConditions) => cond?.type === 'Succeeded') ??
+  false;
+const isRunning = (vm: V1beta1MigrationStatusVms): boolean =>
   !isFailed(vm) && !isSucceeded(vm) && !isCanceled(vm) && vm?.phase !== 'Completed';
+
+type VmMigrationsDataPointsResult = {
+  canceled: MigrationDataPoint[];
+  failed: MigrationDataPoint[];
+  intervals?: Interval[];
+  loaded: boolean;
+  loadError: unknown;
+  obj?: V1beta1Migration[];
+  running: MigrationDataPoint[];
+  succeeded: MigrationDataPoint[];
+  total: number;
+  totalCanceledCount: number;
+  totalFailedCount: number;
+  totalRunningCount: number;
+  totalSucceededCount: number;
+};
 
 export const useVmMigrationsDataPoints = (
   selectedRange: TimeRangeOptions,
   singleBucket = false,
-) => {
+): VmMigrationsDataPointsResult => {
   const [migrations, loaded, loadError] = useK8sWatchResource<V1beta1Migration[]>({
     groupVersionKind: MigrationModelGroupVersionKind,
     isList: true,

--- a/src/overview/tabs/Overview/utils/getVmCounts.ts
+++ b/src/overview/tabs/Overview/utils/getVmCounts.ts
@@ -5,7 +5,7 @@ import type { V1beta1Migration, V1beta1MigrationStatusVms } from '@forklift-ui/t
 import { TimeRangeOptions, TimeRangeOptionsDictionary } from './timeRangeOptions';
 
 // Helper function to process 'True' vm conditions
-const processVmConditions = (vm: V1beta1MigrationStatusVms) => {
+const processVmConditions = (vm: V1beta1MigrationStatusVms): string[] => {
   if (!('conditions' in vm)) {
     return [];
   }
@@ -23,7 +23,7 @@ const incrementCounts = (
   conditions: string[],
   vm: V1beta1MigrationStatusVms,
   vmCounts: Record<string, number>,
-) => {
+): void => {
   vmCounts.Total += 1;
 
   const isRunning =

--- a/src/overview/tabs/Overview/utils/navigate.ts
+++ b/src/overview/tabs/Overview/utils/navigate.ts
@@ -19,7 +19,7 @@ export const navigateToHistoryTab = ({
   navigate: NavigateFunction;
   selectedRange?: TimeRangeOptions;
   status?: string;
-}) => {
+}): null => {
   const dateEnd = interval?.end ?? DateTime.now().toUTC();
   const dateStart =
     interval?.start ??

--- a/src/overview/tabs/Overview/utils/timeRangeOptions.ts
+++ b/src/overview/tabs/Overview/utils/timeRangeOptions.ts
@@ -2,9 +2,12 @@ import { DateTime } from 'luxon';
 
 import { t } from '@utils/i18n';
 
-const isLast24H = (date: DateTime) => DateTime.now().toUTC().diff(date, 'hours').hours <= 24;
-const isLast10Days = (date: DateTime) => DateTime.now().toUTC().diff(date, 'days').days <= 10;
-const isLast31Days = (date: DateTime) => DateTime.now().toUTC().diff(date, 'days').days <= 31;
+const isLast24H = (date: DateTime): boolean =>
+  DateTime.now().toUTC().diff(date, 'hours').hours <= 24;
+const isLast10Days = (date: DateTime): boolean =>
+  DateTime.now().toUTC().diff(date, 'days').days <= 10;
+const isLast31Days = (date: DateTime): boolean =>
+  DateTime.now().toUTC().diff(date, 'days').days <= 31;
 
 export enum TimeRangeOptions {
   Last10Days = 'Last10Days',

--- a/src/overview/tabs/Settings/components/SettingsEdit.tsx
+++ b/src/overview/tabs/Settings/components/SettingsEdit.tsx
@@ -52,7 +52,7 @@ const SettingsEdit: OverlayComponent<SettingsEditProps> = ({ closeOverlay, contr
     trigger(SettingsFields.AapUrl).catch(() => undefined);
   }, [trigger]);
 
-  const onSubmit = async (formData: ForkliftSettingsValues) => {
+  const onSubmit = async (formData: ForkliftSettingsValues): Promise<void> => {
     if (!isDirty) {
       closeOverlay();
       return;

--- a/src/overview/tabs/Settings/components/SettingsNumberInput.tsx
+++ b/src/overview/tabs/Settings/components/SettingsNumberInput.tsx
@@ -15,7 +15,7 @@ const SettingsNumberInput: FC<SettingsNumberInputProps> = ({
   testId,
   value,
 }) => {
-  const normalize = (val: number | string) => {
+  const normalize = (val: number | string): number => {
     const num = typeof val === 'number' ? val : parseInt(val, 10);
     if (isNaN(num) || num < 1) {
       return defaultValue;

--- a/src/overview/tabs/Settings/components/SettingsSelectInput.tsx
+++ b/src/overview/tabs/Settings/components/SettingsSelectInput.tsx
@@ -1,4 +1,12 @@
-import { type FC, type MouseEvent, type Ref, useCallback, useMemo, useState } from 'react';
+import {
+  type FC,
+  type MouseEvent,
+  type ReactElement,
+  type Ref,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 
 import {
   MenuToggle,
@@ -101,11 +109,11 @@ const SettingsSelectInput: FC<SettingsSelectInputProps> = ({
     return keyToName?.[value] ?? value;
   }, [blankOption, keyToName, showKeyAsSelected, value]);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((open) => !open);
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       className="forklift-overview__settings-select"
       data-testid={testId}
@@ -117,7 +125,7 @@ const SettingsSelectInput: FC<SettingsSelectInputProps> = ({
     </MenuToggle>
   );
 
-  const renderOptions = () => {
+  const renderOptions = (): ReactElement[] => {
     const optionElements = options?.map(({ description, key, name }) => (
       <SelectOption
         data-testid={testId ? `${testId}-option-${key}` : undefined}

--- a/src/overview/utils/helpers/OverviewUserSettings.ts
+++ b/src/overview/utils/helpers/OverviewUserSettings.ts
@@ -15,12 +15,12 @@ type WelcomeSettings = {
   save: (showWelcome: boolean) => void;
 };
 
-const getOverviewKey = () => `${process.env.PLUGIN_NAME}/Overview`;
+const getOverviewKey = (): string => `${process.env.PLUGIN_NAME}/Overview`;
 
 export const saveOverviewSelectedRanges = (ranges: {
   vmMigrationsDonutSelectedRange?: TimeRangeOptions;
   vmMigrationsHistorySelectedRange?: TimeRangeOptions;
-}) => {
+}): void => {
   const key = getOverviewKey();
   const current = parseOrClean<OverviewUserSettings>(key);
   saveToLocalStorage(
@@ -56,11 +56,11 @@ export const loadUserSettings = (userSettingsKeySuffix: string): OverviewUserSet
 
   return {
     welcome: {
-      clear: () => {
+      clear: (): void => {
         saveRestOrRemoveKey(key, { hideWelcome: { hideWelcome }, rest });
       },
       hideWelcome: typeof hideWelcome === 'boolean' ? hideWelcome : undefined,
-      save: (hide) => {
+      save: (hide): void => {
         saveToLocalStorage(key, JSON.stringify({ ...parseOrClean(key), hideWelcome: hide }));
       },
     },

--- a/src/overview/utils/utils.ts
+++ b/src/overview/utils/utils.ts
@@ -1,11 +1,11 @@
 import type { V1beta1Migration } from '@forklift-ui/types';
 
-export const getPlanKey = (migration: V1beta1Migration) => {
+export const getPlanKey = (migration: V1beta1Migration): string => {
   const plan = migration?.spec?.plan;
   return (
     plan?.uid ?? (plan?.namespace && plan?.name ? `${plan.namespace}/${plan.name}` : 'unknown-plan')
   );
 };
 
-export const getMigrationStarted = (migration: V1beta1Migration) =>
+export const getMigrationStarted = (migration: V1beta1Migration): string =>
   migration?.status?.started ?? migration?.metadata?.creationTimestamp ?? '1970-01-01T00:00:00Z';

--- a/src/plans/actions/PlanActionsDropdown.tsx
+++ b/src/plans/actions/PlanActionsDropdown.tsx
@@ -19,11 +19,11 @@ const PlanActionsDropdown: FC<PlanActionsDropdownProps> = ({ isDetailsPage, plan
 
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((open) => !open);
   };
 
-  const onSelect = () => {
+  const onSelect = (): void => {
     setIsOpen(false);
   };
 

--- a/src/plans/actions/PlanActionsDropdownItems.tsx
+++ b/src/plans/actions/PlanActionsDropdownItems.tsx
@@ -65,30 +65,30 @@ const PlanActionsDropdownItems: FC<PlanActionsDropdownItemsProps> = ({ isDetails
   const [activeMigration, migrationLoaded] = usePlanMigration(plan);
   const hasCutover = canScheduleCutover && Boolean(activeMigration?.spec?.cutover);
 
-  const onClickPlanStart = () => {
+  const onClickPlanStart = (): void => {
     launchOverlay<PlanStartMigrationModalProps>(PlanStartMigrationModal, {
       plan,
       title: buttonStartLabel,
     });
   };
 
-  const onClickResumeConversion = () => {
+  const onClickResumeConversion = (): void => {
     launchOverlay<PlanResumeConversionModalProps>(PlanResumeConversionModal, { plan });
   };
 
-  const onClickPlanCutover = () => {
+  const onClickPlanCutover = (): void => {
     launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
   };
 
-  const onClickDuplicate = () => {
+  const onClickDuplicate = (): void => {
     launchOverlay<PlanModalProps>(DuplicateModal, { plan });
   };
 
-  const onClickArchive = () => {
+  const onClickArchive = (): void => {
     launchOverlay<PlanModalProps>(ArchiveModal, { plan });
   };
 
-  const onClickPlanDelete = () => {
+  const onClickPlanDelete = (): void => {
     launchOverlay<PlanModalProps>(PlanDeleteModal, { plan });
   };
 

--- a/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
+++ b/src/plans/actions/__tests__/PlanEditCutoverButton.test.tsx
@@ -16,7 +16,7 @@ jest.mock('src/plans/hooks/usePlanMigration', () => ({
 
 const mockLauncher = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useOverlay: () => mockLauncher,
+  useOverlay: (): typeof mockLauncher => mockLauncher,
 }));
 
 const buildPlan = (

--- a/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
+++ b/src/plans/actions/components/CutoverModal/__tests__/PlanCutoverMigrationModal.test.tsx
@@ -5,35 +5,37 @@ import { userEvent } from '@testing-library/user-event';
 
 const mockPatchMigrationCutover = jest.fn().mockResolvedValue(undefined);
 jest.mock('../utils/utils', () => ({
-  formatDateTo12Hours: jest.fn(() => '12:00 PM'),
-  patchMigrationCutover: jest.fn((...args) => mockPatchMigrationCutover(...args)),
+  formatDateTo12Hours: jest.fn((): string => '12:00 PM'),
+  patchMigrationCutover: jest.fn((...args: unknown[]): unknown =>
+    mockPatchMigrationCutover(...args),
+  ),
 }));
 
 const mockUsePlanMigration = jest.fn();
 jest.mock('src/plans/hooks/usePlanMigration', () => ({
-  usePlanMigration: jest.fn((...args) => mockUsePlanMigration(...args)),
+  usePlanMigration: jest.fn((...args: unknown[]): unknown => mockUsePlanMigration(...args)),
 }));
 
 const mockT = (key: string): string => key;
 
 jest.mock('src/utils/i18n', () => ({
-  ForkliftTrans: ({ children }: { children: unknown }) => children,
+  ForkliftTrans: ({ children }: { children: unknown }): unknown => children,
   t: mockT,
-  useForkliftTranslation: () => ({ t: mockT }),
+  useForkliftTranslation: (): { t: typeof mockT } => ({ t: mockT }),
 }));
 
 jest.mock('@utils/i18n', () => ({
-  ForkliftTrans: ({ children }: { children: unknown }) => children,
+  ForkliftTrans: ({ children }: { children: unknown }): unknown => children,
   t: mockT,
-  useForkliftTranslation: () => ({ t: mockT }),
+  useForkliftTranslation: (): { t: typeof mockT } => ({ t: mockT }),
 }));
 
 jest.mock('@utils/analytics/hooks/useForkliftAnalytics', () => ({
-  useForkliftAnalytics: () => ({ trackEvent: jest.fn() }),
+  useForkliftAnalytics: (): { trackEvent: jest.Mock } => ({ trackEvent: jest.fn() }),
 }));
 
 jest.mock('@utils/crds/common/selectors', () => ({
-  getName: jest.fn(() => 'test-plan'),
+  getName: jest.fn((): string => 'test-plan'),
 }));
 
 // eslint-disable-next-line import/first

--- a/src/plans/actions/components/CutoverModal/utils/utils.ts
+++ b/src/plans/actions/components/CutoverModal/utils/utils.ts
@@ -14,7 +14,7 @@ export const patchMigrationCutover = async (
   migration: V1beta1Migration,
   cutover?: string,
   trackEvent?: (event: string, data: Record<string, unknown>) => void,
-) => {
+): Promise<V1beta1Migration> => {
   const op = migration?.spec?.cutover ? 'replace' : 'add';
 
   const result = await k8sPatch({

--- a/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
+++ b/src/plans/actions/components/DuplicateModal/utils/__tests__/utils.test.ts
@@ -19,7 +19,7 @@ jest.mock('src/plans/create/utils/addOwnerRefs', () => ({
 }));
 
 jest.mock('@utils/crds/common/utils', () => ({
-  getRandomChars: () => 'abcde',
+  getRandomChars: (): string => 'abcde',
 }));
 
 const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;

--- a/src/plans/actions/components/StartPlanModal/utils/utils.ts
+++ b/src/plans/actions/components/StartPlanModal/utils/utils.ts
@@ -11,7 +11,7 @@ export const startPlanMigration = async (
   plan: V1beta1Plan,
   trackEvent?: (event: string, data: Record<string, unknown>) => void,
   sourceProviderType?: string,
-) => {
+): Promise<void> => {
   const name = getName(plan);
   const namespace = getNamespace(plan);
   const uid = getUID(plan);

--- a/src/plans/create/CreatePlanWizard.tsx
+++ b/src/plans/create/CreatePlanWizard.tsx
@@ -61,7 +61,7 @@ const CreatePlanWizard: FC = () => {
   });
   const [targetStorages] = useTargetStorages(targetProvider, targetProject);
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     const formData = getValues();
 
     trackEvent(TELEMETRY_EVENTS.PLAN_CREATE_STARTED, {
@@ -72,7 +72,7 @@ const CreatePlanWizard: FC = () => {
       targetProviderType: formData.targetProvider?.spec?.type,
     });
 
-    const trackPlanWizardEvent = (eventType: string, properties = {}) => {
+    const trackPlanWizardEvent = (eventType: string, properties = {}): void => {
       trackEvent(eventType, { ...properties, creationMethod: CreationMethod.PlanWizard });
     };
 

--- a/src/plans/create/CreatePlanWizardInner.tsx
+++ b/src/plans/create/CreatePlanWizardInner.tsx
@@ -40,7 +40,7 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
 
   const hasCreatePlanError = Boolean(createPlanError?.message);
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (): Promise<void> => {
     setCreatePlanError(undefined);
     try {
       await onSubmit();
@@ -49,7 +49,9 @@ const CreatePlanWizardInner: FC<CreatePlanWizardInnerProps> = ({
     }
   };
 
-  const getStepProps = (id: PlanWizardStepId) => ({
+  const getStepProps = (
+    id: PlanWizardStepId,
+  ): { id: PlanWizardStepId; isDisabled: boolean; name: string } => ({
     id,
     isDisabled:
       isSubmitting ||

--- a/src/plans/create/hooks/useCreatePlanForm.ts
+++ b/src/plans/create/hooks/useCreatePlanForm.ts
@@ -1,4 +1,4 @@
-import { useForm, type UseFormProps } from 'react-hook-form';
+import { useForm, type UseFormProps, type UseFormReturn } from 'react-hook-form';
 
 import type { CreatePlanFormData } from '../types';
 
@@ -6,5 +6,6 @@ import type { CreatePlanFormData } from '../types';
  * Custom wrapper around react-hook-form's useForm hook
  * Provides typed form handling for the migration plan creation form
  */
-export const useCreatePlanForm = (props: UseFormProps<CreatePlanFormData>) =>
-  useForm<CreatePlanFormData>(props);
+export const useCreatePlanForm = (
+  props: UseFormProps<CreatePlanFormData>,
+): UseFormReturn<CreatePlanFormData> => useForm<CreatePlanFormData>(props);

--- a/src/plans/create/hooks/useCreatePlanFormContext.ts
+++ b/src/plans/create/hooks/useCreatePlanFormContext.ts
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, type UseFormReturn } from 'react-hook-form';
 
 import type { CreatePlanFormData } from '../types';
 
@@ -6,4 +6,5 @@ import type { CreatePlanFormData } from '../types';
  * Custom wrapper around react-hook-form's useFormContext hook
  * Provides typed access to form context for the migration plan creation form
  */
-export const useCreatePlanFormContext = () => useFormContext<CreatePlanFormData>();
+export const useCreatePlanFormContext = (): UseFormReturn<CreatePlanFormData> =>
+  useFormContext<CreatePlanFormData>();

--- a/src/plans/create/hooks/useOvirtDisksForVMs.ts
+++ b/src/plans/create/hooks/useOvirtDisksForVMs.ts
@@ -16,7 +16,11 @@ import { PROVIDER_TYPES } from '@utils/providers/constants';
 export const useOvirtDisksForVMs = (
   provider: V1beta1Provider | undefined,
   vms: ProviderVirtualMachine[],
-) => {
+): {
+  error: Error | null;
+  loading: boolean;
+  vmsWithDisks: ProviderVirtualMachine[];
+} => {
   const isOvirtProvider = provider?.spec?.type === PROVIDER_TYPES.ovirt;
 
   const {
@@ -29,7 +33,7 @@ export const useOvirtDisksForVMs = (
     subPath: 'disks?detail=10',
   });
 
-  const vmsWithDisks = useMemo(() => {
+  const vmsWithDisks = useMemo((): ProviderVirtualMachine[] => {
     if (!isOvirtProvider || disksLoading || isEmpty(vms) || isEmpty(disks)) {
       return vms;
     }
@@ -48,10 +52,10 @@ export const useOvirtDisksForVMs = (
             const disk = diskMap.get(attachment.disk);
             return disk ? { id: disk.id, storageDomain: disk.storageDomain } : null;
           })
-          .filter(Boolean) ?? [];
+          .filter((disk): disk is { id: string; storageDomain: string } => disk !== null) ?? [];
 
       return { ...vm, disks: vmDisks };
-    });
+    }) as ProviderVirtualMachine[];
   }, [isOvirtProvider, disksLoading, vms, disks]);
 
   return { error: disksError, loading: disksLoading, vmsWithDisks };

--- a/src/plans/create/hooks/useStepValidation.ts
+++ b/src/plans/create/hooks/useStepValidation.ts
@@ -7,7 +7,10 @@ import { useCreatePlanFormContext } from './useCreatePlanFormContext';
 /**
  * Validates wizard form steps and checks for step-specific errors.
  */
-export const useStepValidation = () => {
+export const useStepValidation = (): {
+  hasStepErrors: (stepId: PlanWizardStepId) => boolean;
+  validateStep: (stepId: PlanWizardStepId) => Promise<boolean>;
+} => {
   const {
     formState: { errors },
     trigger,

--- a/src/plans/create/steps/customization-scripts/ConfigMapSelect.tsx
+++ b/src/plans/create/steps/customization-scripts/ConfigMapSelect.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, type ForwardedRef, forwardRef, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  useMemo,
+} from 'react';
 
 import Select from '@components/common/Select';
 import type { IoK8sApiCoreV1ConfigMap } from '@forklift-ui/types';
@@ -23,7 +29,7 @@ type ConfigMapSelectProps = Pick<ComponentProps<typeof Select>, 'status'> & {
 const ConfigMapSelect = (
   { id, namespace, onSelect, status, testId, value }: ConfigMapSelectProps,
   ref: ForwardedRef<HTMLButtonElement>,
-) => {
+): ReactElement => {
   const { t } = useForkliftTranslation();
 
   const [allConfigMaps] = useK8sWatchResource<K8sResourceCommon[]>({

--- a/src/plans/create/steps/customization-scripts/ScriptContentField.tsx
+++ b/src/plans/create/steps/customization-scripts/ScriptContentField.tsx
@@ -29,7 +29,7 @@ const ScriptContentField: FC<ScriptContentFieldProps> = ({ guestType, onChange, 
     }
 
     const reader = new FileReader();
-    reader.onload = (ev) => {
+    reader.onload = (ev): void => {
       const content = ev.target?.result;
 
       if (typeof content === 'string') {

--- a/src/plans/create/steps/customization-scripts/__tests__/CustomScriptsStep.test.tsx
+++ b/src/plans/create/steps/customization-scripts/__tests__/CustomScriptsStep.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
@@ -9,17 +10,22 @@ import CustomScriptsStep from '../CustomScriptsStep';
 
 const mockUseCreatePlanFormContext = jest.fn();
 jest.mock('../../../hooks/useCreatePlanFormContext', () => ({
-  useCreatePlanFormContext: () => mockUseCreatePlanFormContext(),
+  useCreatePlanFormContext: (): ReturnType<typeof mockUseCreatePlanFormContext> =>
+    mockUseCreatePlanFormContext(),
 }));
 
-jest.mock('../ExistingConfigMapField', () => () => <div data-testid="existing-configmap-field" />);
-jest.mock('../NewScriptsFields', () => () => <div data-testid="new-scripts-fields" />);
+jest.mock('../ExistingConfigMapField', () => (): ReactElement => (
+  <div data-testid="existing-configmap-field" />
+));
+jest.mock('../NewScriptsFields', () => (): ReactElement => (
+  <div data-testid="new-scripts-fields" />
+));
 
 const TestWrapper = ({
   scriptsType = CustomScriptsType.Existing,
 }: {
   scriptsType?: CustomScriptsType;
-}) => {
+}): ReactElement => {
   const methods = useForm({
     defaultValues: {
       [CustomScriptsFieldId.ScriptsType]: scriptsType,

--- a/src/plans/create/steps/general-information/TargetProjectSelect.tsx
+++ b/src/plans/create/steps/general-information/TargetProjectSelect.tsx
@@ -61,7 +61,7 @@ const TargetProjectSelect: FC<TargetProjectSelectProps> = ({
       onChange={field.onChange}
       onNewValue={
         isLocalOpenshift
-          ? (newProjectName) => {
+          ? (newProjectName): void => {
               field.onChange(newProjectName);
             }
           : undefined

--- a/src/plans/create/steps/general-information/utils.ts
+++ b/src/plans/create/steps/general-information/utils.ts
@@ -10,7 +10,7 @@ import { t } from '@utils/i18n';
  * @param plans - Array of existing plans to check for uniqueness
  * @returns Error message string if invalid, undefined if valid
  */
-export const validatePlanName = (value: string, plans: V1beta1Plan[]) => {
+export const validatePlanName = (value: string, plans: V1beta1Plan[]): string | undefined => {
   if (!value) {
     return t('Plan name is required.');
   }

--- a/src/plans/create/steps/migration-hooks/components/AapConnectionSection.tsx
+++ b/src/plans/create/steps/migration-hooks/components/AapConnectionSection.tsx
@@ -44,7 +44,7 @@ const AapConnectionSection: FC<AapConnectionSectionProps> = ({ onConnected }) =>
         // errors are handled inside useAapConnection
       });
 
-    return () => {
+    return (): void => {
       cancelled = true;
     };
   }, [configLoaded, isConfigured, connect]);

--- a/src/plans/create/steps/network-map/NetworkMapSelect.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapSelect.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, type ForwardedRef, forwardRef, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  useMemo,
+} from 'react';
 
 import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
 import Select from '@components/common/Select';
@@ -40,7 +46,7 @@ const NetworkMapSelect = (
     value,
   }: NetworkMapSelectProps,
   ref: ForwardedRef<HTMLButtonElement>,
-) => {
+): ReactElement => {
   const { t } = useForkliftTranslation();
   const [allNetworkMaps] = useK8sWatchResource<V1beta1NetworkMap[]>({
     groupVersionKind: NetworkMapModelGroupVersionKind,

--- a/src/plans/create/steps/network-map/NetworkMapStep.tsx
+++ b/src/plans/create/steps/network-map/NetworkMapStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 
 import WizardStepContainer from '@components/common/WizardStepContainer';
@@ -15,7 +16,7 @@ import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
 import ExistingNetworkMapField from './ExistingNetworkMapField';
 import NewNetworkMapFields from './NewNetworkMapFields';
 
-const NetworkMapStep = () => {
+const NetworkMapStep = (): ReactElement => {
   const { t } = useForkliftTranslation();
   const { control, trigger, unregister } = useCreatePlanFormContext();
 
@@ -24,7 +25,7 @@ const NetworkMapStep = () => {
     name: [NetworkMapFieldId.ExistingNetworkMap, NetworkMapFieldId.NetworkMap],
   });
 
-  const handleNetworkMapTypeChange = (newType: NetworkMapType) => {
+  const handleNetworkMapTypeChange = (newType: NetworkMapType): void => {
     setTimeout(async () => {
       if (newType === NetworkMapType.Existing && !existingNetworkMap) {
         await trigger(NetworkMapFieldId.ExistingNetworkMap);

--- a/src/plans/create/steps/network-map/__tests__/vlanUtils.test.ts
+++ b/src/plans/create/steps/network-map/__tests__/vlanUtils.test.ts
@@ -12,7 +12,7 @@ import {
   validateNetworkMap,
 } from '../utils';
 
-const makeHypervVm = (name: string, nics: { networkId: string; vlanId?: number }[]) =>
+const makeHypervVm = (name: string, nics: { networkId: string; vlanId?: number }[]): never =>
   ({
     name,
     providerType: PROVIDER_TYPES.hyperv,

--- a/src/plans/create/steps/network-map/utils.ts
+++ b/src/plans/create/steps/network-map/utils.ts
@@ -280,7 +280,9 @@ export const getSourceNetworkValues = (
  * @param usedSourceNetworks - Networks that need to be mapped
  * @returns Error message if mapping is not valid, undefined otherwise
  */
-export const validateNetworkMap = (validateNetworkMapParams: ValidateNetworkMapParams) => {
+export const validateNetworkMap = (
+  validateNetworkMapParams: ValidateNetworkMapParams,
+): string | undefined => {
   const { oVirtNicProfiles, usedSourceNetworks, values, vms } = validateNetworkMapParams;
   const mappedNetworkNames = new Set(
     values.map((value) => value[NetworkMapFieldId.SourceNetwork].name),
@@ -313,7 +315,7 @@ export const validateNetworkMap = (validateNetworkMapParams: ValidateNetworkMapP
 export const filterTargetNetworksByProject = (
   availableTargetNetworks: OpenShiftNetworkAttachmentDefinition[],
   targetProject: string,
-) => {
+): Record<string, MappingValue> => {
   if (isEmpty(availableTargetNetworks) || !targetProject) {
     return { podNetwork: defaultNetMapping[NetworkMapFieldId.TargetNetwork] };
   }

--- a/src/plans/create/steps/other-settings/DiskPassPhraseFieldTable.tsx
+++ b/src/plans/create/steps/other-settings/DiskPassPhraseFieldTable.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { Controller, useFieldArray } from 'react-hook-form';
 
 import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
@@ -17,7 +18,7 @@ import {
 } from './constants';
 import { getDiskPassPhraseFieldId } from './utils';
 
-const DiskPassPhraseFieldTable = () => {
+const DiskPassPhraseFieldTable = (): ReactElement => {
   const { t } = useForkliftTranslation();
   const { control, setValue } = useCreatePlanFormContext();
 

--- a/src/plans/create/steps/other-settings/NBDEClevisField.tsx
+++ b/src/plans/create/steps/other-settings/NBDEClevisField.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { Controller } from 'react-hook-form';
 
 import { HelpIconPopover } from '@components/common/HelpIconPopover/HelpIconPopover';
@@ -8,7 +9,7 @@ import { useCreatePlanFormContext } from '../../hooks/useCreatePlanFormContext';
 
 import { otherFormFieldLabels, OtherSettingsFormFieldId } from './constants';
 
-const NBDEClevisField = () => {
+const NBDEClevisField = (): ReactElement => {
   const { t } = useForkliftTranslation();
   const { control } = useCreatePlanFormContext();
 

--- a/src/plans/create/steps/other-settings/__tests__/OtherSettingsStep.test.tsx
+++ b/src/plans/create/steps/other-settings/__tests__/OtherSettingsStep.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
@@ -11,18 +12,33 @@ import OtherSettingsStep from '../OtherSettingsStep';
 
 const mockUseCreatePlanFormContext = jest.fn();
 jest.mock('../../../hooks/useCreatePlanFormContext', () => ({
-  useCreatePlanFormContext: () => mockUseCreatePlanFormContext(),
+  useCreatePlanFormContext: (): ReturnType<typeof mockUseCreatePlanFormContext> =>
+    mockUseCreatePlanFormContext(),
 }));
 
-jest.mock('../InstanceTypeField', () => () => <div data-testid="instance-type-field" />);
-jest.mock('../NBDEClevisField', () => () => <div data-testid="nbde-field" />);
-jest.mock('../DiskPassPhraseFieldTable', () => () => <div data-testid="passphrase-field" />);
-jest.mock('../ExistingLUKSSecretField', () => () => <div data-testid="existing-luks-field" />);
-jest.mock('../TransferNetworkField', () => () => <div data-testid="transfer-field" />);
-jest.mock('../PreserveStaticIpsField', () => () => <div data-testid="static-ips-field" />);
-jest.mock('../RootDeviceField', () => () => <div data-testid="root-device-field" />);
-jest.mock('../SharedDisksField', () => () => <div data-testid="shared-disks-field" />);
-jest.mock('../TargetPowerStateField', () => () => <div data-testid="power-state-field" />);
+jest.mock('../InstanceTypeField', () => (): ReactElement => (
+  <div data-testid="instance-type-field" />
+));
+jest.mock('../NBDEClevisField', () => (): ReactElement => <div data-testid="nbde-field" />);
+jest.mock('../DiskPassPhraseFieldTable', () => (): ReactElement => (
+  <div data-testid="passphrase-field" />
+));
+jest.mock('../ExistingLUKSSecretField', () => (): ReactElement => (
+  <div data-testid="existing-luks-field" />
+));
+jest.mock('../TransferNetworkField', () => (): ReactElement => (
+  <div data-testid="transfer-field" />
+));
+jest.mock('../PreserveStaticIpsField', () => (): ReactElement => (
+  <div data-testid="static-ips-field" />
+));
+jest.mock('../RootDeviceField', () => (): ReactElement => <div data-testid="root-device-field" />);
+jest.mock('../SharedDisksField', () => (): ReactElement => (
+  <div data-testid="shared-disks-field" />
+));
+jest.mock('../TargetPowerStateField', () => (): ReactElement => (
+  <div data-testid="power-state-field" />
+));
 
 const TestWrapper = ({
   sourceProvider,
@@ -30,7 +46,7 @@ const TestWrapper = ({
 }: {
   nbdeClevis?: boolean;
   sourceProvider: any;
-}) => {
+}): ReactElement => {
   const methods = useForm({
     defaultValues: {
       [GeneralFormFieldId.SourceProvider]: sourceProvider,
@@ -80,7 +96,7 @@ describe('OtherSettingsStep', () => {
 
   it('reactively hides passphrase field when NBDE is toggled', async () => {
     const vsphereProvider = { spec: { type: PROVIDER_TYPES.vsphere } };
-    const DynamicWrapper = () => {
+    const DynamicWrapper = (): ReactElement => {
       const methods = useForm({
         defaultValues: {
           [GeneralFormFieldId.SourceProvider]: vsphereProvider,

--- a/src/plans/create/steps/review/StorageMapReviewTable.tsx
+++ b/src/plans/create/steps/review/StorageMapReviewTable.tsx
@@ -104,7 +104,7 @@ const StorageMapReviewTable: FC<StorageMapReviewTableProps> = ({ storageMap }) =
                       {...(hasOffloadData && {
                         expand: {
                           isExpanded,
-                          onToggle: () => {
+                          onToggle: (): void => {
                             handleToggleExpansion(rowKey);
                           },
                           rowIndex: index,

--- a/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
+++ b/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { beforeEach, describe, expect, it } from '@jest/globals';
@@ -10,13 +11,16 @@ import OtherSettingsReviewSection from '../OtherSettingsReviewSection';
 
 const mockUseCreatePlanFormContext = jest.fn();
 jest.mock('../../../hooks/useCreatePlanFormContext', () => ({
-  useCreatePlanFormContext: () => mockUseCreatePlanFormContext(),
+  useCreatePlanFormContext: (): ReturnType<typeof mockUseCreatePlanFormContext> =>
+    mockUseCreatePlanFormContext(),
 }));
 
 const mockGoToStepById = jest.fn();
 jest.mock('@patternfly/react-core', () => ({
   ...jest.requireActual('@patternfly/react-core'),
-  useWizardContext: () => ({ goToStepById: mockGoToStepById }),
+  useWizardContext: (): { goToStepById: typeof mockGoToStepById } => ({
+    goToStepById: mockGoToStepById,
+  }),
 }));
 
 const TestWrapper = ({
@@ -31,7 +35,7 @@ const TestWrapper = ({
   existingLUKSSecret?: any;
   nbdeClevis?: boolean;
   sourceProvider: any;
-}) => {
+}): ReactElement => {
   const methods = useForm({
     defaultValues: {
       [GeneralFormFieldId.SourceProvider]: sourceProvider,

--- a/src/plans/create/steps/storage-map/StorageMapSelect.tsx
+++ b/src/plans/create/steps/storage-map/StorageMapSelect.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, type ForwardedRef, forwardRef, useMemo } from 'react';
+import {
+  type ComponentProps,
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  useMemo,
+} from 'react';
 
 import { ExternalLink } from '@components/common/ExternalLink/ExternalLink';
 import Select from '@components/common/Select';
@@ -40,7 +46,7 @@ const StorageMapSelect = (
     value,
   }: StorageMapSelectProps,
   ref: ForwardedRef<HTMLButtonElement>,
-) => {
+): ReactElement => {
   const { t } = useForkliftTranslation();
   const [allStorageMaps] = useK8sWatchResource<V1beta1StorageMap[]>({
     groupVersionKind: StorageMapModelGroupVersionKind,

--- a/src/plans/create/steps/storage-map/StorageMapStep.tsx
+++ b/src/plans/create/steps/storage-map/StorageMapStep.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 
 import WizardStepContainer from '@components/common/WizardStepContainer';
@@ -11,7 +12,7 @@ import { CreatePlanStorageMapFieldId, StorageMapType, storageMapTypeLabels } fro
 import ExistingStorageMapField from './ExistingStorageMapField';
 import NewStorageMapFields from './NewStorageMapFields';
 
-const StorageMapStep = () => {
+const StorageMapStep = (): ReactElement => {
   const { t } = useForkliftTranslation();
   const { control, trigger, unregister } = useCreatePlanFormContext();
 
@@ -20,7 +21,7 @@ const StorageMapStep = () => {
     name: [CreatePlanStorageMapFieldId.ExistingStorageMap, CreatePlanStorageMapFieldId.StorageMap],
   });
 
-  const handleStorageMapTypeChange = (newType: StorageMapType) => {
+  const handleStorageMapTypeChange = (newType: StorageMapType): void => {
     setTimeout(async () => {
       if (newType === StorageMapType.Existing && !existingStorageMap) {
         await trigger(CreatePlanStorageMapFieldId.ExistingStorageMap);

--- a/src/plans/create/steps/virtual-machines/VirtualMachinesTable.tsx
+++ b/src/plans/create/steps/virtual-machines/VirtualMachinesTable.tsx
@@ -69,7 +69,7 @@ const VirtualMachinesTable: FC<VirtualMachinesTableProps> = ({
     () => ({
       ...(isSelectable && {
         initialSelectedIds: selectedIds,
-        onSelect: (selectedVmData: VmData[] | undefined) => {
+        onSelect: (selectedVmData: VmData[] | undefined): void => {
           const selectedVms = selectedVmData?.reduce(
             (acc: Record<string, ProviderVirtualMachine>, data) => ({
               ...acc,

--- a/src/plans/create/steps/virtual-machines/utils.ts
+++ b/src/plans/create/steps/virtual-machines/utils.ts
@@ -12,14 +12,16 @@ import { PROVIDER_TYPES } from '@utils/providers/constants';
 
 import type { ProviderVirtualMachine } from '../../types';
 
-export const hasCriticalConcern = (vm: ProviderVirtualMachine | KubeProviderVirtualMachine) =>
+export const hasCriticalConcern = (
+  vm: ProviderVirtualMachine | KubeProviderVirtualMachine,
+): boolean =>
   vm.providerType !== PROVIDER_TYPES.openshift &&
   vm.concerns?.some((concern) => concern.category === ConcernCategory.Critical);
 
 type VmConcernsFilterItems = { vm: { concerns: Concern[] } };
 
 export const criticalConcernFilter = (): FilterDef => ({
-  dynamicFilter: (unknownItems: unknown[]) => {
+  dynamicFilter: (unknownItems: unknown[]): Partial<FilterDef> => {
     const items = unknownItems as VmConcernsFilterItems[];
     const uniqueLabels = new Set<string>();
 
@@ -44,5 +46,7 @@ export const criticalConcernFilter = (): FilterDef => ({
   type: CustomFilterType.CriticalConcerns,
 });
 
-export const getVmsWithCriticalConcerns = (vms: Record<string, ProviderVirtualMachine>) =>
+export const getVmsWithCriticalConcerns = (
+  vms: Record<string, ProviderVirtualMachine>,
+): Record<string, ProviderVirtualMachine> =>
   Object.fromEntries(Object.entries(vms ?? {}).filter(([_, vm]) => hasCriticalConcern(vm)));

--- a/src/plans/create/utils/addOwnerRefs.ts
+++ b/src/plans/create/utils/addOwnerRefs.ts
@@ -10,7 +10,7 @@ export const addOwnerRefs = async (
   model: K8sModel,
   resource: K8sResourceCommon,
   newOwnerReferences: ObjectRef[],
-) => {
+): ReturnType<typeof k8sPatch> => {
   const existingOwnerReferences = resource.metadata?.ownerReferences;
   const ownerReferences =
     existingOwnerReferences && !isEmpty(existingOwnerReferences)

--- a/src/plans/create/utils/createNetworkMap.ts
+++ b/src/plans/create/utils/createNetworkMap.ts
@@ -23,7 +23,7 @@ type CreateNetworkMapParams = {
   trackEvent?: (eventType: string, properties?: Record<string, unknown>) => void;
 };
 
-const getNetworkType = (targetName: string) => {
+const getNetworkType = (targetName: string): string => {
   if (targetName === DefaultNetworkLabel.Source || targetName === '') {
     return POD;
   }
@@ -35,7 +35,10 @@ const getNetworkType = (targetName: string) => {
   return MULTUS;
 };
 
-const getSource = (sourceNetwork: MappingValue, sourceProvider?: V1beta1Provider) => {
+const getSource = (
+  sourceNetwork: MappingValue,
+  sourceProvider?: V1beta1Provider,
+): V1beta1NetworkMapSpecMap['source'] => {
   if (sourceNetwork.id === POD) {
     return { type: POD };
   }
@@ -81,7 +84,7 @@ export const createNetworkMap = async ({
   targetNamespace,
   targetProvider,
   trackEvent,
-}: CreateNetworkMapParams) => {
+}: CreateNetworkMapParams): Promise<V1beta1NetworkMap> => {
   const sourceProviderName = sourceProvider?.metadata?.name;
 
   trackEvent?.('Network map create started', {

--- a/src/plans/create/utils/createPlan.ts
+++ b/src/plans/create/utils/createPlan.ts
@@ -1,6 +1,6 @@
 import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
 import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
-import { getObjectRef } from '@utils/helpers/getObjectRef';
+import { getObjectRef, type ObjectRef } from '@utils/helpers/getObjectRef';
 
 import { MigrationTypeValue } from '../steps/migration-type/constants';
 import type { CreatePlanParams } from '../types';
@@ -33,7 +33,7 @@ export const createPlan = async ({
   targetProvider,
   transferNetwork,
   vms,
-}: CreatePlanParams) => {
+}: CreatePlanParams): Promise<ObjectRef> => {
   const plan: V1beta1Plan = {
     apiVersion: 'forklift.konveyor.io/v1beta1',
     kind: 'Plan',

--- a/src/plans/create/utils/getCreatedPlanPath.ts
+++ b/src/plans/create/utils/getCreatedPlanPath.ts
@@ -4,7 +4,10 @@ import { getResourceUrl } from '@utils/getResourceUrl';
 /**
  * Generates the resource URL path for a migration plan
  */
-export const getCreatedPlanPath = (planName: string, planProject: string) =>
+export const getCreatedPlanPath = (
+  planName: string,
+  planProject: string,
+): ReturnType<typeof getResourceUrl> =>
   getResourceUrl({
     name: planName,
     namespace: planProject,

--- a/src/plans/create/utils/getVMNetworksOrProfiles.ts
+++ b/src/plans/create/utils/getVMNetworksOrProfiles.ts
@@ -3,7 +3,7 @@ import { DefaultNetworkLabel } from '@utils/mappings/constants';
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 import { getEc2SubnetIds, isEc2Vm } from '@utils/types/ec2Inventory';
 
-const getNetworksForVM = (vm: ProviderVirtualMachine) => {
+const getNetworksForVM = (vm: ProviderVirtualMachine): string[] => {
   if (isEc2Vm(vm)) {
     return getEc2SubnetIds(vm);
   }
@@ -49,8 +49,8 @@ const getNetworksForVM = (vm: ProviderVirtualMachine) => {
 export const getVMNetworksOrProfiles = (
   vm: ProviderVirtualMachine,
   nicProfiles?: OVirtNicProfile[],
-) =>
-  getNetworksForVM(vm).map((network: unknown) =>
+): (string | undefined)[] =>
+  getNetworksForVM(vm).map((network) =>
     vm.providerType === PROVIDER_TYPES.ovirt && nicProfiles
       ? nicProfiles.find((nicProfile) => nicProfile?.id === network)?.network
       : network,

--- a/src/plans/create/utils/hasMultiplePodNetworkMappings.ts
+++ b/src/plans/create/utils/hasMultiplePodNetworkMappings.ts
@@ -8,7 +8,7 @@ export const hasMultiplePodNetworkMappings = (
   networkMap: NetworkMapping[],
   vms: Record<string, ProviderVirtualMachine>,
   oVirtNicProfiles: OVirtNicProfile[],
-) => {
+): boolean => {
   const netIdsMappedToPodNet = new Set(
     networkMap
       ?.filter(({ targetNetwork }) => targetNetwork?.name === DefaultNetworkLabel.Source)
@@ -28,6 +28,6 @@ export const hasMultiplePodNetworkMappings = (
   });
 };
 
-export const hasPodNetworkMappings = (networkMap: NetworkMapping[]) => {
+export const hasPodNetworkMappings = (networkMap: NetworkMapping[]): boolean => {
   return networkMap.some(({ targetNetwork }) => targetNetwork?.name === DefaultNetworkLabel.Source);
 };

--- a/src/plans/details/components/PlanConcernsPanel/utils/getPlanConcernsPanelFieldsData.tsx
+++ b/src/plans/details/components/PlanConcernsPanel/utils/getPlanConcernsPanelFieldsData.tsx
@@ -1,10 +1,14 @@
+import type { ReactElement } from 'react';
+
 import ResourceTableCell from '../ResourceTableCell';
 import SeverityTableCell from '../SeverityTableCell';
 import TypeTableCell from '../TypeTableCell';
 
 import { MigrationPlanConcernsTableResourceId, type PlanConcernsPanelData } from './types';
 
-export const getPlanConcernsPanelFieldsData = (fieldsData: PlanConcernsPanelData) => {
+export const getPlanConcernsPanelFieldsData = (
+  fieldsData: PlanConcernsPanelData,
+): Record<MigrationPlanConcernsTableResourceId, ReactElement> => {
   return {
     [MigrationPlanConcernsTableResourceId.Resource]: <ResourceTableCell fieldsData={fieldsData} />,
     [MigrationPlanConcernsTableResourceId.Severity]: <SeverityTableCell fieldsData={fieldsData} />,

--- a/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.ts
+++ b/src/plans/details/components/PlanPageHeader/hooks/usePlanAlerts.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import usePlanProviders from 'src/providers/hooks/usePlanSourceProvider';
-import { useSourceNetworks } from 'src/utils/hooks/useNetworks';
-import { useSourceStorages } from 'src/utils/hooks/useStorages';
+import { type InventoryNetwork, useSourceNetworks } from 'src/utils/hooks/useNetworks';
+import { type InventoryStorage, useSourceStorages } from 'src/utils/hooks/useStorages';
 
 import {
   NetworkMapModelGroupVersionKind,
@@ -17,9 +17,24 @@ import { isEmpty } from '@utils/helpers';
 import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 
 import { usePlanMappingData } from '../../../hooks/usePlanMappingData';
+import type { PlanStatuses } from '../../PlanStatus/utils/types';
 import { getPlanStatus } from '../../PlanStatus/utils/utils';
 
-const usePlanAlerts = (plan: V1beta1Plan) => {
+type UsePlanAlertsResult = {
+  criticalConditions: V1beta1PlanStatusConditions[] | undefined;
+  networkMaps: V1beta1NetworkMap[];
+  networkMapsError: Error | null;
+  networkMapsLoaded: boolean;
+  preserveIPWarningsConditions: V1beta1PlanStatusConditions[] | undefined;
+  showCriticalConditions: boolean;
+  showPreserveIPWarningsConditions: boolean;
+  sourceNetworks: InventoryNetwork[];
+  sourceStorages: InventoryStorage[];
+  status: PlanStatuses;
+  storageMaps: V1beta1StorageMap[];
+};
+
+const usePlanAlerts = (plan: V1beta1Plan): UsePlanAlertsResult => {
   const namespace = getNamespace(plan);
   const status = getPlanStatus(plan);
 

--- a/src/plans/details/components/PlanStatus/StatusPopover.tsx
+++ b/src/plans/details/components/PlanStatus/StatusPopover.tsx
@@ -42,11 +42,11 @@ const StatusPopover: FC<StatusPopoverProps> = ({ count, plan, status, vms }) => 
 
   const { actionLabel, body, header } = getPopoverMessageByStatus(status, count);
 
-  const openScheduleCutoverModal = () => {
+  const openScheduleCutoverModal = (): void => {
     launchOverlay<PlanModalProps>(PlanCutoverMigrationModal, { plan });
   };
 
-  const navigateToVMsTab = () => {
+  const navigateToVMsTab = (): void => {
     const url = `${getResourceUrl({ name: getName(plan), namespace: getNamespace(plan), reference: PlanModelRef })}/vms`;
     navigate(url)?.catch(() => undefined);
   };

--- a/src/plans/details/components/PlanStatus/utils/utils.ts
+++ b/src/plans/details/components/PlanStatus/utils/utils.ts
@@ -89,7 +89,9 @@ export const getMigrationVMStatus = (
   return null;
 };
 
-export const getCantStartVMStatusCount = (vms: V1beta1PlanSpecVms[]) => {
+export const getCantStartVMStatusCount = (
+  vms: V1beta1PlanSpecVms[],
+): MigrationVirtualMachinesStatusesCounts => {
   return {
     ...emptyCount,
     [MigrationVirtualMachineStatus.CantStart]: {
@@ -138,21 +140,23 @@ export const getMigrationVMsStatusCounts = (
 export const getVmTargetPowerState = (vm: V1beta1PlanSpecVms): TargetPowerStateValue =>
   vm?.targetPowerState;
 
-const getConditions = (plan: V1beta1Plan) =>
+const getConditions = (plan: V1beta1Plan): string[] =>
   (plan?.status?.conditions ?? [])
     ?.filter((condition) => condition.status === CONDITION_STATUS.TRUE)
     .map((condition) => condition.type);
 
-export const isPlanExecuting = (plan: V1beta1Plan) => {
+export const isPlanExecuting = (plan: V1beta1Plan): boolean => {
   const conditions = getConditions(plan);
 
   return conditions?.includes(PlanStatuses.Executing);
 };
 
-const isPlanWaitingForCutover = (plan: V1beta1Plan) =>
-  getPlanVirtualMachinesMigrationStatus(plan).some(isMigrationVirtualMachinePaused) &&
-  isPlanExecuting(plan) &&
-  getPlanIsWarm(plan);
+const isPlanWaitingForCutover = (plan: V1beta1Plan): boolean =>
+  Boolean(
+    getPlanVirtualMachinesMigrationStatus(plan).some(isMigrationVirtualMachinePaused) &&
+    isPlanExecuting(plan) &&
+    getPlanIsWarm(plan),
+  );
 
 const isPlanPendingExecution = (plan: V1beta1Plan): boolean => {
   if (!isPlanExecuting(plan)) {
@@ -164,7 +168,7 @@ const isPlanPendingExecution = (plan: V1beta1Plan): boolean => {
   return isEmpty(vms) || vms.every((vm) => !vm?.started);
 };
 
-export const isPlanArchived = (plan: V1beta1Plan) => {
+export const isPlanArchived = (plan: V1beta1Plan): boolean => {
   const conditions = getConditions(plan);
   return (
     (plan?.spec?.archived && !conditions.includes(PlanStatuses.Archived)) ?? // Archiving
@@ -236,7 +240,7 @@ export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {
   return PlanStatuses.Unknown;
 };
 
-export const canPlanStart = (plan: V1beta1Plan) => {
+export const canPlanStart = (plan: V1beta1Plan): boolean => {
   const conditions = getConditions(plan);
 
   return (
@@ -247,7 +251,7 @@ export const canPlanStart = (plan: V1beta1Plan) => {
   );
 };
 
-export const canPlanReStart = (plan: V1beta1Plan) => {
+export const canPlanReStart = (plan: V1beta1Plan): boolean => {
   const conditions = getConditions(plan);
 
   return (
@@ -265,13 +269,13 @@ export const canPlanResumeConversion = (plan: V1beta1Plan): boolean => {
   );
 };
 
-export const isPlanSucceeded = (plan: V1beta1Plan) => {
+export const isPlanSucceeded = (plan: V1beta1Plan): boolean => {
   const conditions = getConditions(plan);
 
   return conditions?.includes(CATEGORY_TYPES.SUCCEEDED);
 };
 
-export const isPlanEditable = (plan: V1beta1Plan) => {
+export const isPlanEditable = (plan: V1beta1Plan): boolean => {
   const status = getPlanStatus(plan);
   return (
     status === PlanStatuses.Ready ||

--- a/src/plans/details/hooks/usePlanMappingData.ts
+++ b/src/plans/details/hooks/usePlanMappingData.ts
@@ -21,6 +21,13 @@ type UsePlanMappingDataOptions = {
   storageMaps: V1beta1StorageMap[];
 };
 
+type UsePlanMappingDataResult = {
+  planNetworkMap: V1beta1NetworkMap | undefined;
+  planStorageMap: V1beta1StorageMap | undefined;
+  sourceNetworks: InventoryNetwork[];
+  sourceStorages: InventoryStorage[];
+};
+
 /**
  * Returns source storage/network data with fallback to map references
  * when provider inventory is unavailable.
@@ -32,7 +39,7 @@ export const usePlanMappingData = ({
   providerStorages,
   sourceProvider,
   storageMaps,
-}: UsePlanMappingDataOptions) => {
+}: UsePlanMappingDataOptions): UsePlanMappingDataResult => {
   const planNetworkMapName = getPlanNetworkMapName(plan);
   const planNetworkMap = useMemo(
     () =>

--- a/src/plans/details/hooks/usePlanPages.tsx
+++ b/src/plans/details/hooks/usePlanPages.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { type ReactElement, useMemo } from 'react';
 
 import type { NavPage } from '@openshift-console/dynamic-plugin-sdk';
 import { useForkliftTranslation } from '@utils/i18n';
@@ -10,43 +10,45 @@ import PlanMappingsPage from '../tabs/Mappings/PlanMappingsPage';
 import PlanResourcesPage from '../tabs/Resources/PlanResourcesPage';
 import PlanVirtualMachinesPage from '../tabs/VirtualMachines/PlanVirtualMachinesPage';
 import PlanYAMLPage from '../tabs/YAML/PlanYAMLPage';
-const usePlanPages = (name: string, namespace: string) => {
+const usePlanPages = (name: string, namespace: string): NavPage[] => {
   const { t } = useForkliftTranslation();
 
   const pages: NavPage[] = useMemo(
     () => [
       {
-        component: () => <PlanDetailsPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanDetailsPage name={name} namespace={namespace} />,
         href: '',
         name: t('Details'),
       },
       {
-        component: () => <PlanYAMLPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanYAMLPage name={name} namespace={namespace} />,
         href: 'yaml',
         name: t('YAML'),
       },
       {
-        component: () => <PlanVirtualMachinesPage name={name} namespace={namespace} />,
+        component: (): ReactElement => (
+          <PlanVirtualMachinesPage name={name} namespace={namespace} />
+        ),
         href: 'vms',
         name: t('Virtual machines'),
       },
       {
-        component: () => <PlanResourcesPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanResourcesPage name={name} namespace={namespace} />,
         href: 'resources',
         name: t('Utilization'),
       },
       {
-        component: () => <PlanMappingsPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanMappingsPage name={name} namespace={namespace} />,
         href: 'mappings',
         name: t('Mappings'),
       },
       {
-        component: () => <PlanAutomationPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanAutomationPage name={name} namespace={namespace} />,
         href: 'automation',
         name: t('Automation'),
       },
       {
-        component: () => <PlanHooksPage name={name} namespace={namespace} />,
+        component: (): ReactElement => <PlanHooksPage name={name} namespace={namespace} />,
         href: 'hooks',
         name: t('Hooks'),
       },

--- a/src/plans/details/tabs/Automation/__tests__/ScriptsSection.test.tsx
+++ b/src/plans/details/tabs/Automation/__tests__/ScriptsSection.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { GuestType, ScriptType } from 'src/plans/create/steps/customization-scripts/constants';
 import type { CustomScript } from 'src/plans/create/steps/customization-scripts/types';
 
@@ -16,7 +17,9 @@ jest.mock('src/plans/details/components/PlanStatus/utils/utils', () => ({
 const mockLaunchOverlay = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(() => ({ group: '', kind: 'ConfigMap', version: 'v1' })),
-  ResourceLink: ({ name }: { name: string }) => <span data-testid="resource-link">{name}</span>,
+  ResourceLink: ({ name }: { name: string }): ReactElement => (
+    <span data-testid="resource-link">{name}</span>
+  ),
   useOverlay: jest.fn(() => mockLaunchOverlay),
 }));
 

--- a/src/plans/details/tabs/Details/components/ConditionsSection/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/ConditionsSection/utils/utils.ts
@@ -1,6 +1,6 @@
 import { t } from '@utils/i18n';
 
-export const getStatusLabel = (status: string) => {
+export const getStatusLabel = (status: string): string => {
   const statusLabels: Record<string, string> = {
     False: t('False'),
     True: t('True'),

--- a/src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/MigrationsSection/components/utils/utils.ts
@@ -28,7 +28,9 @@ export const getMigrationStatusLabel = (
   return null;
 };
 
-export const getVMMigrationStatus = (statusVM: V1beta1PlanStatusMigrationVms | undefined) => {
+export const getVMMigrationStatus = (
+  statusVM: V1beta1PlanStatusMigrationVms | undefined,
+): string => {
   const isError = statusVM?.conditions?.find(
     (condition) =>
       condition.type === CATEGORY_TYPES.FAILED && condition.status === CONDITION_STATUS.TRUE,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveCpuModelSwitch.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/PreserveCpuModelSwitch.tsx
@@ -11,7 +11,7 @@ type PreserveCpuModelSwitchProps = {
 const PreserveCpuModelSwitch: FC<PreserveCpuModelSwitchProps> = ({ onChange, value }) => {
   const { t } = useForkliftTranslation();
 
-  const handleChange = (_event: FormEvent<HTMLInputElement>, checked: boolean) => {
+  const handleChange = (_event: FormEvent<HTMLInputElement>, checked: boolean): void => {
     onChange(checked);
   };
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/utils/utils.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/RootDisk/utils/utils.ts
@@ -54,7 +54,10 @@ export const getRootDiskLabelByKey = (diskKey: string | number | undefined): str
   return key;
 };
 
-export const onConfirmRootDisk = async (resource: V1beta1Plan, newValue: string) => {
+export const onConfirmRootDisk = async (
+  resource: V1beta1Plan,
+  newValue: string,
+): Promise<V1beta1Plan> => {
   const vms = getPlanVirtualMachines(resource);
   const op = vms ? REPLACE : ADD;
 

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/EditLUKSEncryptionPasswords.test.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/EditLUKSEncryptionPasswords.test.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { V1beta1Plan } from '@forklift-ui/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -31,14 +33,16 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 jest.mock(
   '../components/EditLUKSModalAlert',
   () =>
-    ({ shouldRender }: { shouldRender: any }) =>
+    ({ shouldRender }: { shouldRender: any }): ReactElement | null =>
       shouldRender ? <div data-testid="luks-modal-alert" /> : null,
 );
-jest.mock('../components/EditLUKSModalBody', () => () => <div data-testid="luks-modal-body" />);
+jest.mock('../components/EditLUKSModalBody', () => (): ReactElement => (
+  <div data-testid="luks-modal-body" />
+));
 jest.mock(
   '../LUKSPassphraseInputList',
   () =>
-    ({ value, onChange }: { onChange: any; value: any }) => (
+    ({ value, onChange }: { onChange: any; value: any }): ReactElement => (
       <div data-testid="luks-passphrase-input-list">
         <div>Passphrases: {value.join(', ')}</div>
         <button data-testid="add-passphrase" onClick={() => onChange([...value, 'new-passphrase'])}>

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/SetLUKSEncryptionPasswordsDetailsItem.test.tsx
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/SetLUKSEncryptionPasswords/__tests__/SetLUKSEncryptionPasswordsDetailsItem.test.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { V1beta1Plan } from '@forklift-ui/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
@@ -16,13 +18,19 @@ const mockShowModal = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   getGroupVersionKindForModel: jest.fn(),
-  ResourceLink: ({ name }: { name: string }) => <span data-testid="resource-link">{name}</span>,
-  useOverlay: jest.fn(() => mockShowModal),
+  ResourceLink: ({ name }: { name: string }): ReactElement => (
+    <span data-testid="resource-link">{name}</span>
+  ),
+  useOverlay: jest.fn((): typeof mockShowModal => mockShowModal),
 }));
 
-jest.mock('../EditLUKSEncryptionPasswords', () => ({ resource }: { resource: V1beta1Plan }) => (
-  <div data-testid="edit-luks-modal">Modal for {resource.metadata?.name}</div>
-));
+jest.mock(
+  '../EditLUKSEncryptionPasswords',
+  () =>
+    ({ resource }: { resource: V1beta1Plan }): ReactElement => (
+      <div data-testid="edit-luks-modal">Modal for {resource.metadata?.name}</div>
+    ),
+);
 
 const mockPlan = {
   metadata: { name: 'test-plan', namespace: 'test-namespace' },

--- a/src/plans/details/tabs/Hooks/components/HookEdit/AapHookEditFields.tsx
+++ b/src/plans/details/tabs/Hooks/components/HookEdit/AapHookEditFields.tsx
@@ -52,7 +52,7 @@ const AapHookEditFields: FC<AapHookEditFieldsProps> = ({ control }) => {
         // errors handled inside useAapConnection
       });
 
-    return () => {
+    return (): void => {
       cancelled = true;
     };
   }, [configLoaded, isConfigured, connect]);

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/PlanNetworkMapEdit.tsx
@@ -41,7 +41,7 @@ const PlanNetworkMapEdit: OverlayComponent<PlanNetworkMapEditProps> = ({
 
   const { error } = getFieldState(NetworkMapFieldId.NetworkMap);
 
-  const onSubmit = async (formData: PlanNetworkEditFormValues) => {
+  const onSubmit = async (formData: PlanNetworkEditFormValues): Promise<void> => {
     if (!isDirty) {
       closeOverlay();
       return;

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/utils.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/utils.ts
@@ -11,7 +11,7 @@ export const patchNetworkMappingValues = async (
   formData: PlanNetworkEditFormValues,
   networkMap: V1beta1NetworkMap,
   sourceProvider: V1beta1Provider,
-) => {
+): Promise<void> => {
   const op = isEmpty(networkMap?.spec?.map) ? ADD : REPLACE;
 
   await k8sPatch({

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/PlanStorageMapEdit.tsx
@@ -42,7 +42,7 @@ const PlanStorageMapEdit: OverlayComponent<PlanStorageMapEditProps> = ({
 
   const { error } = getFieldState(StorageMapFieldId.StorageMap);
 
-  const onSubmit = async (formValues: PlanStorageEditFormValues) => {
+  const onSubmit = async (formValues: PlanStorageEditFormValues): Promise<void> => {
     if (!isValid) {
       return;
     }

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/components/PlanStorageMapFieldsTable.tsx
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/components/PlanStorageMapFieldsTable.tsx
@@ -23,7 +23,9 @@ import type { PlanStorageEditFormValues } from '../utils/types';
 
 import TargetStorageInputField from './TargetStorageInputField';
 
-const getStorageMapHeaders = (isIscsi?: boolean) =>
+const getStorageMapHeaders = (
+  isIscsi?: boolean,
+): { label: string | undefined; width: 45 | 90 }[] =>
   isIscsi
     ? [
         {

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/utils.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/utils.ts
@@ -13,7 +13,7 @@ export const patchStorageMappingValues = async (
   formValues: PlanStorageEditFormValues,
   storageMap: V1beta1StorageMap,
   sourceProvider: V1beta1Provider,
-) => {
+): Promise<void> => {
   const filteredStorageMap = formValues.storageMap?.filter((mapping) => {
     const hasSource = Boolean(mapping[StorageMapFieldId.SourceStorage]?.name);
     const hasTarget = Boolean(mapping[StorageMapFieldId.TargetStorage]?.name);

--- a/src/plans/details/tabs/Mappings/hooks/usePlanProviders.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanProviders.ts
@@ -11,7 +11,14 @@ import {
 } from '@utils/crds/plans/selectors';
 import { useK8sWatchResource } from '@utils/hooks/useK8sWatchResource';
 
-export const usePlanProviders = (plan: V1beta1Plan) => {
+type UsePlanProvidersResult = {
+  error: Error | null;
+  loaded: boolean;
+  sourceProvider: V1beta1Provider;
+  targetProvider: V1beta1Provider;
+};
+
+export const usePlanProviders = (plan: V1beta1Plan): UsePlanProvidersResult => {
   const [sourceProvider, sourceProviderLoaded, sourceProviderError] =
     useK8sWatchResource<V1beta1Provider>({
       groupVersionKind: ProviderModelGroupVersionKind,

--- a/src/plans/details/tabs/Mappings/hooks/usePlanStorageMapResources.ts
+++ b/src/plans/details/tabs/Mappings/hooks/usePlanStorageMapResources.ts
@@ -77,7 +77,7 @@ export const usePlanStorageMapResources: UsePlanStorageMapResources = ({
   } = useOvirtDisksForVMs(sourceProvider, vmList);
 
   const vmsWithDisksResult: [ProviderVirtualMachine[], boolean, Error | null] = useMemo(
-    () => [vmsWithDisks as ProviderVirtualMachine[], vmsWithDisksLoading, vmsWithDisksError],
+    () => [vmsWithDisks, vmsWithDisksLoading, vmsWithDisksError],
     [vmsWithDisks, vmsWithDisksLoading, vmsWithDisksError],
   );
 

--- a/src/plans/details/tabs/Resources/utils/utils.ts
+++ b/src/plans/details/tabs/Resources/utils/utils.ts
@@ -134,7 +134,7 @@ const getOpenstackPlanResources = (planInventory: OpenstackVM[]): PlanResourcesT
   };
 };
 
-const getK8sCPU = (vm: V1VirtualMachine) =>
+const getK8sCPU = (vm: V1VirtualMachine): number | string =>
   vm?.spec?.template?.spec?.domain?.cpu?.cores ?? EMPTY_CPU;
 const getK8sVMMemory = (vm: V1VirtualMachine): string =>
   (vm?.spec?.template?.spec?.domain?.resources?.requests as unknown as Record<string, string>)

--- a/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesButton.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/CancelMigrationVirtualMachines/CancelMigrationVirtualMachinesButton.tsx
@@ -15,7 +15,7 @@ const CancelMigrationVirtualMachinesButton: FC<CancelMigrationVirtualMachinesPro
 }) => {
   const { t } = useForkliftTranslation();
   const launchOverlay = useOverlay();
-  const onClick = () => {
+  const onClick = (): void => {
     launchOverlay<CancelMigrationVirtualMachinesProps>(CancelMigrationVirtualMachinesModal, {
       migration,
       selectedIds,

--- a/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesButton.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/DeleteVirtualMachines/DeleteVirtualMachinesButton.tsx
@@ -14,7 +14,7 @@ const DeleteVirtualMachinesButton: FC<DeleteVirtualMachineProps> = ({ plan, sele
   const { t } = useForkliftTranslation();
   const launchOverlay = useOverlay();
 
-  const onClick = () => {
+  const onClick = (): void => {
     launchOverlay<DeleteVirtualMachineProps>(DeleteVirtualMachinesModal, { plan, selectedIds });
   };
 

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/MigrationStatusVirtualMachinesList.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/MigrationStatusVirtualMachinesList.tsx
@@ -22,9 +22,9 @@ type MigrationStatusVirtualMachinesListProps = {
 
 const selectedIds: string[] = [];
 
-const onSelect = () => undefined;
+const onSelect = (): void => undefined;
 
-const toId = (item: MigrationStatusVirtualMachinePageData) => item?.specVM?.id ?? '';
+const toId = (item: MigrationStatusVirtualMachinePageData): string => item?.specVM?.id ?? '';
 
 const MigrationStatusVirtualMachinesList: FC<MigrationStatusVirtualMachinesListProps> = ({
   plan,

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationPodsTable.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/MigrationStatusExpandedPage/components/MigrationPodsTable.tsx
@@ -17,7 +17,7 @@ type MigrationPodsTableProps = {
   pods: IoK8sApiCoreV1Pod[];
 };
 
-const getPodLogsLink = (pod: IoK8sApiCoreV1Pod) =>
+const getPodLogsLink = (pod: IoK8sApiCoreV1Pod): string =>
   getResourceUrl({
     name: getName(pod),
     namespace: getNamespace(pod),

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/icon.tsx
@@ -1,9 +1,13 @@
+import type { ReactElement } from 'react';
+
 import type { V1beta1PlanStatusMigrationVmsPipeline } from '@forklift-ui/types';
 import { Icon } from '@patternfly/react-core';
 import { CheckIcon, ResourcesEmptyIcon, TimesIcon } from '@patternfly/react-icons';
 import { PF_LABEL_STATUS, taskStatuses } from '@utils/constants';
 
-export const getPipelineProgressIcon = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
+export const getPipelineProgressIcon = (
+  pipeline: V1beta1PlanStatusMigrationVmsPipeline,
+): ReactElement => {
   if (pipeline?.error) {
     return (
       <Icon status={PF_LABEL_STATUS.DANGER}>

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/components/utils/utils.ts
@@ -14,21 +14,22 @@ import {
 
 import type { DiskTransferMap, TaskCounterMap } from './types';
 
-const hasPipelineNotFailed = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => !pipeline?.error;
+const hasPipelineNotFailed = (pipeline: V1beta1PlanStatusMigrationVmsPipeline): boolean =>
+  !pipeline?.error;
 
-const hasPipelineCompleted = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) =>
+const hasPipelineCompleted = (pipeline: V1beta1PlanStatusMigrationVmsPipeline): boolean =>
   hasPipelineNotFailed(pipeline) && pipeline?.phase === taskStatuses.completed;
 
 const hasPipelineOkAndTaskProgressCompleted = (
   taskProgress: V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
   pipeline: V1beta1PlanStatusMigrationVmsPipeline,
-) => hasPipelineNotFailed(pipeline) && taskProgress.completed === taskProgress.total;
+): boolean => hasPipelineNotFailed(pipeline) && taskProgress.completed === taskProgress.total;
 
 const hasTaskCompleted = (
   taskPhase: string | undefined,
   taskProgress: V1beta1PlanStatusMigrationVmsPipelineTasksProgress,
   pipeline: V1beta1PlanStatusMigrationVmsPipeline,
-) =>
+): boolean =>
   taskPhase === taskStatuses.completed ||
   (taskPhase === undefined && hasPipelineCompleted(pipeline)) ||
   (taskPhase === undefined && hasPipelineOkAndTaskProgressCompleted(taskProgress, pipeline));
@@ -77,7 +78,9 @@ export const getTaskProgress = (task: V1beta1PlanStatusMigrationVmsPipelineTasks
   return `${completeString} / ${totalString} ${task.annotations?.unit ?? EMPTY_MSG}`;
 };
 
-export const getPipelineTasks = (pipeline: V1beta1PlanStatusMigrationVmsPipeline) => {
+export const getPipelineTasks = (
+  pipeline: V1beta1PlanStatusMigrationVmsPipeline,
+): { completed: number; name: string | undefined; total: number } => {
   const tasks = pipeline?.tasks ?? [];
 
   // search for all completed tasks (either tasks that completed successfully or ones that aren't finished but their pipeline step is).
@@ -88,7 +91,7 @@ export const getPipelineTasks = (pipeline: V1beta1PlanStatusMigrationVmsPipeline
   return { completed: tasksCompleted.length, name: pipeline.name, total: tasks.length };
 };
 
-export const getJobPhase = (job: IoK8sApiBatchV1Job) => {
+export const getJobPhase = (job: IoK8sApiBatchV1Job): string => {
   const status = job?.status;
 
   if (Number(status?.failed) > 0) {

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationVirtualMachineActions.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/hooks/useMigrationVirtualMachineActions.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import {
   isPlanArchived,
   isPlanExecuting,
@@ -21,7 +21,7 @@ export const useMigrationVirtualMachineActions = (plan: V1beta1Plan): PageGlobal
   const isArchived = isPlanArchived(plan);
 
   return [
-    ({ selectedIds }) =>
+    ({ selectedIds }): ReactElement =>
       isExecuting && !isArchived && activeMigration ? (
         <CancelMigrationVirtualMachinesButton
           migration={activeMigration}

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/fields.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/fields.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { TableLinkCell } from 'src/components/TableCell/TableLinkCell';
 import MigrationStatusLabel from 'src/plans/details/tabs/Details/components/MigrationsSection/components/MigrationStatusLabel';
 
@@ -19,7 +20,7 @@ import {
 
 export const getMigrationStatusVirtualMachinesRowFields = (
   fieldsData: MigrationStatusVirtualMachinePageData,
-) => {
+): Record<MigrationStatusVirtualMachinesTableResourceId, ReactNode> => {
   const { specVM, statusVM, targetNamespace } = fieldsData;
   const vmCreated = isVirtualMachineCreationCompleted(statusVM);
   const diskTransferPipeline = getVMDiskTransferPipeline(statusVM);

--- a/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/MigrationStatusVirtualMachineList/utils/utils.ts
@@ -86,7 +86,7 @@ export const getVMMigrationStatus = (obj: unknown): string => {
 
 export const isVirtualMachineCreationCompleted = (
   statusVM: V1beta1PlanStatusMigrationVms | undefined,
-) => {
+): boolean => {
   const pipeline = statusVM?.pipeline ?? [];
   return pipeline.some(
     (pipe) =>
@@ -147,7 +147,7 @@ export const getVMDiskTransferPipeline = (
   return diskTransfer ?? diskAllocation;
 };
 
-export const getVMDiskProgress = (obj: unknown) => {
+export const getVMDiskProgress = (obj: unknown): number => {
   const vmMigrationStatusData = obj as MigrationStatusVirtualMachinePageData;
   const diskTransfer = getVMDiskTransferPipeline(vmMigrationStatusData.statusVM);
 
@@ -156,7 +156,7 @@ export const getVMDiskProgress = (obj: unknown) => {
     : 0;
 };
 
-export const groupByVmId = <T extends K8sResourceCommon>(items: T[]) =>
+export const groupByVmId = <T extends K8sResourceCommon>(items: T[]): Record<string, T[]> =>
   items.reduce<Record<string, T[]>>((acc, item) => {
     const vmID = item?.metadata?.labels?.vmID;
     if (vmID) {

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/PlanSpecVirtualMachinesList.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/PlanSpecVirtualMachinesList.tsx
@@ -29,7 +29,7 @@ type PlanVirtualMachinesListProps = {
 
 const selectedIds: string[] = [];
 const expandedIds: string[] = [];
-const onSelect = () => undefined;
+const onSelect = (): void => undefined;
 
 const PlanSpecVirtualMachinesList: FC<PlanVirtualMachinesListProps> = ({ plan }) => {
   const { t } = useForkliftTranslation();

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/SpecVirtualMachinesActionsDropdown.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/components/SpecVirtualMachinesActionsDropdown.tsx
@@ -19,11 +19,11 @@ const SpecVirtualMachinesActionsDropdown: FC<SpecVirtualMachinesActionsDropdownP
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((open) => !open);
   };
 
-  const onSelect = () => {
+  const onSelect = (): void => {
     setIsOpen(false);
   };
 

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesActions.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/hooks/useSpecVirtualMachinesActions.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import InspectVirtualMachinesButton from 'src/components/InspectVirtualMachines/InspectVirtualMachinesButton';
 import { useCanInspectPlan } from 'src/plans/details/hooks/useCanInspectPlan';
 
@@ -16,7 +16,7 @@ export const useSpecVirtualMachinesActions = (plan: V1beta1Plan): PageGlobalActi
 
   const inspectButton: PageGlobalActions = isVsphere
     ? [
-        () => (
+        (): ReactElement => (
           <InspectVirtualMachinesButton
             canInspect={canInspect}
             disabledReason={disabledReason}
@@ -29,8 +29,8 @@ export const useSpecVirtualMachinesActions = (plan: V1beta1Plan): PageGlobalActi
 
   return [
     ...inspectButton,
-    () => <AddVirtualMachinesButton plan={plan} />,
-    ({ selectedIds }) => (
+    (): ReactElement => <AddVirtualMachinesButton plan={plan} />,
+    ({ selectedIds }): ReactElement => (
       <DeleteVirtualMachinesButton plan={plan} selectedIds={selectedIds ?? []} />
     ),
   ];

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/concernSeverityOrTypeFilter.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/concernSeverityOrTypeFilter.ts
@@ -11,7 +11,7 @@ import { createInitialUniqueMaps, getUniqueMapByCategory } from './getUniqueMapB
 
 export const concernSeverityOrTypeFilter = (): FilterDef => {
   return {
-    dynamicFilter: (unknownItems: unknown[]) => {
+    dynamicFilter: (unknownItems: unknown[]): Partial<FilterDef> => {
       const items = unknownItems as SpecVirtualMachinePageData[];
 
       const result = items.reduce((acc, item) => {

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/fields.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/fields.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import VirtualMachineConcernsCell from '@components/Concerns/VirtualMachineConcernsCell';
 import { EMPTY_MSG } from '@utils/constants';
 import type { EnhancedPlanSpecVms } from '@utils/plans/types';
@@ -13,7 +15,9 @@ import SpecVirtualMachinesActions from '../components/SpecVirtualMachinesActions
 import { VMMigrateSharedDisksCellRenderer } from '../components/VMMigrateSharedDisksCellRenderer';
 import { VMTargetPowerStateCellRenderer } from '../components/VMTargetPowerStateCellRenderer';
 
-export const getSpecVirtualMachinesRowFields = (fieldsData: SpecVirtualMachinePageData) => {
+export const getSpecVirtualMachinesRowFields = (
+  fieldsData: SpecVirtualMachinePageData,
+): Record<PlanSpecVirtualMachinesTableResourceId, ReactNode> => {
   const {
     conditions,
     inspectionStatus,

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/getUniqueMapByCategory.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/getUniqueMapByCategory.ts
@@ -3,7 +3,11 @@ import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/cons
 import type { EnumValue } from '@components/common/utils/types';
 import { getCategoryLabel } from '@components/Concerns/utils/category';
 
-export const createInitialUniqueMaps = () => ({
+export const createInitialUniqueMaps = (): {
+  critical: Map<string, EnumValue>;
+  information: Map<string, EnumValue>;
+  warning: Map<string, EnumValue>;
+} => ({
   critical: new Map<string, EnumValue>(),
   information: new Map<string, EnumValue>(),
   warning: new Map<string, EnumValue>(),
@@ -11,7 +15,10 @@ export const createInitialUniqueMaps = () => ({
 
 type UniqueMaps = ReturnType<typeof createInitialUniqueMaps>;
 
-export const getUniqueMapByCategory = (acc: UniqueMaps, category: string) => {
+export const getUniqueMapByCategory = (
+  acc: UniqueMaps,
+  category: string,
+): Map<string, EnumValue> => {
   const label = getCategoryLabel(category);
   if (label === ConcernCategory.Critical) {
     return acc.critical;

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/utils.tsx
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/utils.tsx
@@ -185,7 +185,7 @@ export const getPlanConditionsDict = (
   return conditionsDict ?? {};
 };
 
-export const vmDataToId = (item: SpecVirtualMachinePageData) => item?.specVM?.id ?? '';
+export const vmDataToId = (item: SpecVirtualMachinePageData): string => item?.specVM?.id ?? '';
 
-export const canSelect = (item: SpecVirtualMachinePageData) =>
+export const canSelect = (item: SpecVirtualMachinePageData): boolean =>
   item?.statusVM?.started === undefined || item?.statusVM?.error !== undefined;

--- a/src/plans/details/tabs/VirtualMachines/components/utils/getPlanVirtualMachineIdByName.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/utils/getPlanVirtualMachineIdByName.ts
@@ -1,7 +1,10 @@
 import type { V1beta1Plan } from '@forklift-ui/types';
 import { getPlanVirtualMachinesMigrationStatus } from '@utils/crds/plans/selectors';
 
-export const getPlanVirtualMachineIdByName = (plan: V1beta1Plan, vmName: string | undefined) => {
+export const getPlanVirtualMachineIdByName = (
+  plan: V1beta1Plan,
+  vmName: string | undefined,
+): string | undefined => {
   const migrationVirtualMachines = getPlanVirtualMachinesMigrationStatus(plan);
 
   return migrationVirtualMachines.find((migrationVm) => migrationVm?.name === vmName)?.id;

--- a/src/plans/details/tabs/VirtualMachines/components/utils/utils.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/utils/utils.ts
@@ -1,7 +1,9 @@
 import type { V1beta1Plan, V1beta1PlanStatusMigrationVms } from '@forklift-ui/types';
 import { getPlanVirtualMachinesMigrationStatus } from '@utils/crds/plans/selectors';
 
-export const getPlanVirtualMachinesDict = (plan: V1beta1Plan) => {
+export const getPlanVirtualMachinesDict = (
+  plan: V1beta1Plan,
+): Record<string, V1beta1PlanStatusMigrationVms> => {
   const migrationVirtualMachines = getPlanVirtualMachinesMigrationStatus(plan);
 
   const vmDict = migrationVirtualMachines.reduce<Record<string, V1beta1PlanStatusMigrationVms>>(

--- a/src/plans/details/utils/utils.ts
+++ b/src/plans/details/utils/utils.ts
@@ -12,8 +12,9 @@ import type { SpecVirtualMachinePageData } from '@utils/types/specVirtualMachine
 
 import { planMigrationVirtualMachineStatuses } from '../components/PlanStatus/utils/types';
 
-export const isMigrationVirtualMachinePaused = (vm: V1beta1PlanStatusMigrationVms | undefined) =>
-  vm?.phase === planMigrationVirtualMachineStatuses.CopyingPaused;
+export const isMigrationVirtualMachinePaused = (
+  vm: V1beta1PlanStatusMigrationVms | undefined,
+): boolean => vm?.phase === planMigrationVirtualMachineStatuses.CopyingPaused;
 
 export const getPlanMigrationType = (plan: V1beta1Plan): MigrationTypeValue => {
   switch (plan?.spec?.type) {
@@ -33,7 +34,9 @@ export const getPlanMigrationType = (plan: V1beta1Plan): MigrationTypeValue => {
   }
 };
 
-export const getCriticalConcernsVmsMap = (vms: SpecVirtualMachinePageData[]) => {
+export const getCriticalConcernsVmsMap = (
+  vms: SpecVirtualMachinePageData[],
+): Map<string, number> => {
   const map = new Map<string, number>();
 
   for (const vmData of vms ?? []) {

--- a/src/plans/hooks/__tests__/useOwnerPlanActionGate.test.ts
+++ b/src/plans/hooks/__tests__/useOwnerPlanActionGate.test.ts
@@ -9,15 +9,18 @@ mockI18n();
 const mockUseK8sWatchResource = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useK8sWatchResource: (...args: unknown[]) => mockUseK8sWatchResource(...args),
+  useK8sWatchResource: (...args: unknown[]): ReturnType<typeof mockUseK8sWatchResource> =>
+    mockUseK8sWatchResource(...args),
 }));
 
 const mockIsPlanEditable = jest.fn();
 const mockGetPlanStatus = jest.fn();
 
 jest.mock('src/plans/details/components/PlanStatus/utils/utils', () => ({
-  getPlanStatus: (...args: unknown[]) => mockGetPlanStatus(...args),
-  isPlanEditable: (...args: unknown[]) => mockIsPlanEditable(...args),
+  getPlanStatus: (...args: unknown[]): ReturnType<typeof mockGetPlanStatus> =>
+    mockGetPlanStatus(...args),
+  isPlanEditable: (...args: unknown[]): ReturnType<typeof mockIsPlanEditable> =>
+    mockIsPlanEditable(...args),
 }));
 
 describe('useOwnerPlanActionGate', () => {

--- a/src/plans/list/PlansListPage.tsx
+++ b/src/plans/list/PlansListPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useMemo } from 'react';
+import { type FC, type ReactElement, useCallback, useMemo } from 'react';
 import { loadUserSettings } from 'src/components/common/Page/userSettings';
 import { StandardPageWithSelection } from 'src/components/page/StandardPageWithSelection';
 import LearningExperienceDrawer from 'src/onlineHelp/learningExperienceDrawer/LearningExperienceDrawer';
@@ -29,7 +29,7 @@ type PlansListPageProps = {
 
 const selectedIds: string[] = [];
 
-const onSelect = () => undefined;
+const onSelect = (): void => undefined;
 
 const PlansListPage: FC<PlansListPageProps> = ({ namespace }) => {
   const { t } = useForkliftTranslation();
@@ -46,7 +46,7 @@ const PlansListPage: FC<PlansListPageProps> = ({ namespace }) => {
   const { canCreate } = useGetDeleteAndEditAccessReview({ model: PlanModel, namespace });
 
   const GlobalActionToolbarItems = useMemo<FC<GlobalActionToolbarProps<V1beta1Plan>>[]>(
-    () => [(props) => <PlansBulkActionsDropdown {...props} namespace={namespace} />],
+    () => [(props): ReactElement => <PlansBulkActionsDropdown {...props} namespace={namespace} />],
     [namespace],
   );
 

--- a/src/plans/list/components/BulkPlanActions/PlansBulkActionsDropdown.tsx
+++ b/src/plans/list/components/BulkPlanActions/PlansBulkActionsDropdown.tsx
@@ -33,7 +33,7 @@ const PlansBulkActionsDropdown: FC<PlansBulkActionsDropdownProps> = ({
     namespace,
   });
 
-  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined): void => {
     setIsOpen(false);
   };
 

--- a/src/plans/list/components/PlanRow/hooks/usePlanListRowFields.tsx
+++ b/src/plans/list/components/PlanRow/hooks/usePlanListRowFields.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { TableCell } from 'src/components/TableCell/TableCell';
 import { TableEmptyCell } from 'src/components/TableCell/TableEmptyCell';
 import { TableLinkCell } from 'src/components/TableCell/TableLinkCell';
@@ -29,7 +30,7 @@ import PlanMigrationType from '../../PlanRowFields/PlanMigrationType/PlanMigrati
 import PlanStatus from '../../PlanRowFields/PlanStatus/PlanStatus';
 import PlanVirtualMachines from '../../PlanRowFields/PlanVirtualMachines/PlanVirtualMachines';
 
-export const usePlanListRowFields = (plan: V1beta1Plan) => {
+export const usePlanListRowFields = (plan: V1beta1Plan): Record<PlanTableResourceId, ReactNode> => {
   const { sourceProvider } = usePlanSourceProvider(plan);
   const sourceProviderType = sourceProvider?.spec?.type;
   const planNamespace = getNamespace(plan);

--- a/src/plans/list/components/PlanRowFields/PlanStatus/__tests__/PlanStatusResumeButton.test.tsx
+++ b/src/plans/list/components/PlanRowFields/PlanStatus/__tests__/PlanStatusResumeButton.test.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement } from 'react';
+
 import type { V1beta1Plan } from '@forklift-ui/types';
 import { mockI18n } from '@test-utils/mockI18n';
 
@@ -5,47 +7,50 @@ mockI18n();
 
 const mockLauncher = jest.fn();
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useOverlay: () => mockLauncher,
+  useOverlay: (): typeof mockLauncher => mockLauncher,
 }));
 
 const mockUsePlanMigration = jest.fn();
 jest.mock('src/plans/hooks/usePlanMigration', () => ({
-  usePlanMigration: (...args: unknown[]) => mockUsePlanMigration(...args),
+  usePlanMigration: (...args: unknown[]): ReturnType<typeof mockUsePlanMigration> =>
+    mockUsePlanMigration(...args),
 }));
 
 const mockCanPlanResumeConversion = jest.fn();
 const mockGetPlanStatus = jest.fn();
 jest.mock('src/plans/details/components/PlanStatus/utils/utils', () => ({
-  canPlanResumeConversion: (...args: unknown[]) => mockCanPlanResumeConversion(...args),
-  getCantStartVMStatusCount: jest.fn(() => ({})),
-  getMigrationVMsStatusCounts: jest.fn(() => ({})),
-  getPlanStatus: (...args: unknown[]) => mockGetPlanStatus(...args),
-  isPlanArchived: jest.fn(() => false),
-  isPlanExecuting: jest.fn(() => false),
+  canPlanResumeConversion: (...args: unknown[]): ReturnType<typeof mockCanPlanResumeConversion> =>
+    mockCanPlanResumeConversion(...args),
+  getCantStartVMStatusCount: jest.fn((): Record<string, never> => ({})),
+  getMigrationVMsStatusCounts: jest.fn((): Record<string, never> => ({})),
+  getPlanStatus: (...args: unknown[]): ReturnType<typeof mockGetPlanStatus> =>
+    mockGetPlanStatus(...args),
+  isPlanArchived: jest.fn((): boolean => false),
+  isPlanExecuting: jest.fn((): boolean => false),
 }));
 
 jest.mock('src/plans/details/components/PlanStatus/PlanStatusLabel', () => ({
   __esModule: true,
-  default: () => <span>StatusLabel</span>,
+  default: (): ReactElement => <span>StatusLabel</span>,
 }));
 
 jest.mock('src/plans/details/components/PlanStatus/VMStatusIconsRow', () => ({
   __esModule: true,
-  default: () => <span>VMIcons</span>,
+  default: (): ReactElement => <span>VMIcons</span>,
 }));
 
 jest.mock('../hooks/usePipelineTaskProgress', () => ({
   __esModule: true,
-  default: () => 0,
+  default: (): number => 0,
 }));
 
 jest.mock('@utils/crds/plans/selectors', () => ({
-  getPlanVirtualMachines: jest.fn(() => []),
-  getPlanVirtualMachinesMigrationStatus: jest.fn(() => []),
+  getPlanVirtualMachines: jest.fn((): unknown[] => []),
+  getPlanVirtualMachinesMigrationStatus: jest.fn((): unknown[] => []),
 }));
 
 jest.mock('@utils/helpers', () => ({
-  isEmpty: jest.fn((val: unknown) => !val),
+  isEmpty: jest.fn((val: unknown): boolean => !val),
 }));
 
 // eslint-disable-next-line import/first

--- a/src/plans/list/components/PlanRowFields/PlanStatus/hooks/usePipelineTaskProgress.ts
+++ b/src/plans/list/components/PlanRowFields/PlanStatus/hooks/usePipelineTaskProgress.ts
@@ -6,7 +6,7 @@ import { taskStatuses } from '@utils/constants';
 
 import type { VirtualMachinePipelineTask } from '../utils/types';
 
-const usePipelineTaskProgress = (plan: V1beta1Plan) => {
+const usePipelineTaskProgress = (plan: V1beta1Plan): number => {
   const [activeMigration] = usePlanMigration(plan);
 
   const vmPipelineTasks = useMemo(

--- a/src/plans/list/components/PlansAddButton.tsx
+++ b/src/plans/list/components/PlansAddButton.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, MouseEvent } from 'react';
 import { useNavigate } from 'react-router';
 import { useHasSufficientProviders } from 'src/utils/fetch';
 import { useForkliftTranslation } from 'src/utils/i18n';
@@ -21,7 +21,7 @@ const PlansAddButton: FC<PlansAddButtonProps> = ({ canCreate, namespace, testId 
   const { trackEvent } = useForkliftAnalytics();
   const hasSufficientProviders = useHasSufficientProviders(namespace);
 
-  const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const onClick = (event: MouseEvent<HTMLButtonElement>): void => {
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/providers/actions/ProviderActionsDropdown.tsx
+++ b/src/providers/actions/ProviderActionsDropdown.tsx
@@ -19,11 +19,11 @@ const ProviderActionsDropdown: FC<ProviderActionsDropdownProps> = ({ data, isDet
   const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((open) => !open);
   };
 
-  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined): void => {
     setIsOpen(false);
   };
 

--- a/src/providers/actions/ProviderActionsDropdownItems.tsx
+++ b/src/providers/actions/ProviderActionsDropdownItems.tsx
@@ -33,7 +33,7 @@ const ProviderActionsDropdownItems: FC<ProviderActionsDropdownItemsProps> = ({
 
   const providerURL = getProviderDetailsPageUrl(provider);
 
-  const onProviderDelete = () => {
+  const onProviderDelete = (): void => {
     launchOverlay<DeleteModalProps>(DeleteModal, { model: ProviderModel, resource: provider });
   };
 

--- a/src/providers/components/CertificateUpload/CertificateUpload.tsx
+++ b/src/providers/components/CertificateUpload/CertificateUpload.tsx
@@ -39,7 +39,7 @@ const CertificateUpload: FC<CertificateUploadProps> = ({
   const launchOverlay = useOverlay();
   const { t } = useForkliftTranslation();
   const isText = !type || type === 'text';
-  const onClick = () => {
+  const onClick = (): void => {
     const syntheticEvent = {
       target: { value },
     } as ChangeEvent<HTMLTextAreaElement>;

--- a/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
+++ b/src/providers/components/CertificateUpload/FetchCertificateModal.tsx
@@ -30,7 +30,7 @@ const FetchCertificateModal: OverlayComponent<FetchCertificateModalProps> = ({
   const hasThumbprintChanged =
     !isEmpty(existingCert) && success && thumbprint !== calculateThumbprint(existingCert);
 
-  const onConfirm = async () => {
+  const onConfirm = async (): Promise<undefined> => {
     handleSave(certificate);
     return Promise.resolve(undefined);
   };

--- a/src/providers/create/__tests__/setup-provider-form-mocks.tsx
+++ b/src/providers/create/__tests__/setup-provider-form-mocks.tsx
@@ -1,3 +1,5 @@
+import type { ReactElement, ReactNode } from 'react';
+
 import {
   mockCreateProvider,
   mockCreateProviderSecret,
@@ -8,38 +10,38 @@ import {
 
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
-  useNavigate: () => mockNavigate,
-  useSearchParams: () => [mockSearchParams, jest.fn()],
+  useNavigate: (): typeof mockNavigate => mockNavigate,
+  useSearchParams: (): [URLSearchParams, jest.Mock] => [mockSearchParams, jest.fn()],
 }));
 
 jest.mock('@utils/analytics/hooks/useForkliftAnalytics', () => ({
-  useForkliftAnalytics: () => ({
+  useForkliftAnalytics: (): { trackEvent: jest.Mock } => ({
     trackEvent: jest.fn(),
   }),
 }));
 
 jest.mock('src/providers/create/utils/createProvider', () => ({
-  createProvider: (...args: unknown[]) => mockCreateProvider(...args),
+  createProvider: (...args: unknown[]): unknown => mockCreateProvider(...args),
 }));
 
 jest.mock('src/providers/create/utils/createProviderSecret', () => ({
-  createProviderSecret: (...args: unknown[]) => mockCreateProviderSecret(...args),
+  createProviderSecret: (...args: unknown[]): unknown => mockCreateProviderSecret(...args),
 }));
 
 jest.mock('src/providers/create/utils/patchProviderSecretOwner', () => ({
-  patchProviderSecretOwner: (...args: unknown[]) => mockPatchProviderSecretOwner(...args),
+  patchProviderSecretOwner: (...args: unknown[]): unknown => mockPatchProviderSecretOwner(...args),
 }));
 
 jest.mock('@utils/hooks/useWatchProjectNames', () => ({
   __esModule: true,
-  default: () => [['test-namespace'], true],
+  default: (): [string[], boolean] => [['test-namespace'], true],
 }));
 
 jest.mock('../CreateProviderFormContextProvider', () => {
   const { CreateProviderFormContext } = jest.requireActual('../constants');
   return {
     __esModule: true,
-    default: ({ children }: { children: React.ReactNode }) => (
+    default: ({ children }: { children: ReactNode }): ReactElement => (
       <CreateProviderFormContext.Provider
         value={{
           providerNames: ['existing-provider'],
@@ -53,10 +55,14 @@ jest.mock('../CreateProviderFormContextProvider', () => {
 });
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useActiveNamespace: () => ['test-namespace', jest.fn()],
-  useK8sWatchResource: () => [[], true, null],
-  useOverlay: () => ({ isOpen: false, showModal: jest.fn(), hideModal: jest.fn() }),
-  useAccessReview: () => [true, false],
+  useActiveNamespace: (): [string, jest.Mock] => ['test-namespace', jest.fn()],
+  useK8sWatchResource: (): [unknown[], boolean, null] => [[], true, null],
+  useOverlay: (): { hideModal: jest.Mock; isOpen: boolean; showModal: jest.Mock } => ({
+    hideModal: jest.fn(),
+    isOpen: false,
+    showModal: jest.fn(),
+  }),
+  useAccessReview: (): [boolean, boolean] => [true, false],
   ProjectModel: {
     apiGroup: 'project.openshift.io',
     plural: 'projects',
@@ -64,5 +70,5 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
 }));
 
 jest.mock('@utils/hooks/useDefaultProject', () => ({
-  useDefaultProject: () => 'test-namespace',
+  useDefaultProject: (): string => 'test-namespace',
 }));

--- a/src/providers/create/__tests__/test-utils.tsx
+++ b/src/providers/create/__tests__/test-utils.tsx
@@ -23,7 +23,7 @@ export const mockCreateProviderTypeField = (
     '../hooks/useCreateProviderFormContext',
   );
 
-  const ProviderTypeField = () => {
+  const ProviderTypeField = (): ReactElement => {
     const { control } = useCreateProviderFormContext();
     const { field } = useController({ control, name: 'providerType' });
 

--- a/src/providers/create/fields/ProviderTypeField.tsx
+++ b/src/providers/create/fields/ProviderTypeField.tsx
@@ -36,7 +36,10 @@ const ProviderTypeField: FC = () => {
 
   const providerTypeOptions = getProviderTypeOptions(isDarkTheme, isAwsPlatform);
 
-  const onSelect = (_event: React.MouseEvent | undefined, itemId: string | number | undefined) => {
+  const onSelect = (
+    _event: React.MouseEvent | undefined,
+    itemId: string | number | undefined,
+  ): void => {
     if (typeof itemId === 'string') {
       onChange(itemId);
     }

--- a/src/providers/create/fields/hyperv/HypervTransferMethodField.tsx
+++ b/src/providers/create/fields/hyperv/HypervTransferMethodField.tsx
@@ -20,7 +20,7 @@ const HypervTransferMethodField: FC = () => {
 
   const setValueOptions = { shouldDirty: true, shouldValidate: true };
 
-  const handleChange = (method: HypervTransferMethod) => {
+  const handleChange = (method: HypervTransferMethod): void => {
     setValue(ProviderFormFieldId.TransferMethod, method, setValueOptions);
     if (method === HypervTransferMethod.ISCSI) {
       setValue(ProviderFormFieldId.SmbUrl, '', setValueOptions);

--- a/src/providers/create/fields/hyperv/SmbCredentialsFields.tsx
+++ b/src/providers/create/fields/hyperv/SmbCredentialsFields.tsx
@@ -18,7 +18,10 @@ const SmbCredentialsFields: FC = () => {
     name: ProviderFormFieldId.UseDifferentSmbCredentials,
   });
 
-  const handleCheckboxChange = (_event: React.FormEvent<HTMLInputElement>, checked: boolean) => {
+  const handleCheckboxChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    checked: boolean,
+  ): void => {
     setValue(ProviderFormFieldId.UseDifferentSmbCredentials, checked);
     if (!checked) {
       // Clear SMB credential fields when unchecking

--- a/src/providers/create/hooks/useCreateProviderDataContext.ts
+++ b/src/providers/create/hooks/useCreateProviderDataContext.ts
@@ -1,9 +1,11 @@
 import { useContext } from 'react';
 
 import { CreateProviderFormContext } from '../constants';
+import type { CreateProviderFormContextProps } from '../types';
 
 /**
  * Hook to access the Create Provider data context
  * @returns Context containing provider names for validation
  */
-export const useCreateProviderDataContext = () => useContext(CreateProviderFormContext);
+export const useCreateProviderDataContext = (): CreateProviderFormContextProps =>
+  useContext(CreateProviderFormContext);

--- a/src/providers/create/hooks/useCreateProviderFormContext.ts
+++ b/src/providers/create/hooks/useCreateProviderFormContext.ts
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, type UseFormReturn } from 'react-hook-form';
 
 import type { CreateProviderFormData } from '../types';
 
@@ -6,4 +6,5 @@ import type { CreateProviderFormData } from '../types';
  * Custom wrapper around react-hook-form's useFormContext hook
  * Provides typed access to form context for the provider creation form
  */
-export const useCreateProviderFormContext = () => useFormContext<CreateProviderFormData>();
+export const useCreateProviderFormContext = (): UseFormReturn<CreateProviderFormData> =>
+  useFormContext<CreateProviderFormData>();

--- a/src/providers/create/utils/createProvider.ts
+++ b/src/providers/create/utils/createProvider.ts
@@ -14,7 +14,7 @@ import {
 export const createProvider = async (
   provider: V1beta1Provider,
   secret: IoK8sApiCoreV1Secret | undefined,
-) => {
+): Promise<V1beta1Provider | undefined> => {
   if (!provider) {
     return undefined;
   }

--- a/src/providers/create/utils/createProviderSecret.ts
+++ b/src/providers/create/utils/createProviderSecret.ts
@@ -27,7 +27,7 @@ const cleanObject = (obj: Record<string, string> | undefined): Record<string, st
 export const createProviderSecret = async (
   provider: V1beta1Provider,
   secret: IoK8sApiCoreV1Secret,
-) => {
+): Promise<IoK8sApiCoreV1Secret | undefined> => {
   if (!secret || !provider) {
     return undefined;
   }

--- a/src/providers/create/utils/patchProviderSecretOwner.ts
+++ b/src/providers/create/utils/patchProviderSecretOwner.ts
@@ -8,7 +8,7 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 export const patchProviderSecretOwner = async (
   provider: V1beta1Provider | undefined,
   secret: IoK8sApiCoreV1Secret | undefined,
-) => {
+): Promise<void> => {
   if (!secret || !provider) {
     return;
   }

--- a/src/providers/details/components/__tests__/CreatePlanAction.test.tsx
+++ b/src/providers/details/components/__tests__/CreatePlanAction.test.tsx
@@ -10,24 +10,24 @@ const mockUseClusterIsAwsPlatform = jest.fn();
 
 jest.mock('react-router', () => ({
   ...jest.requireActual<Record<string, unknown>>('react-router'),
-  useNavigate: () => mockNavigate,
+  useNavigate: (): typeof mockNavigate => mockNavigate,
 }));
 
 jest.mock('@utils/hooks/useClusterIsAwsPlatform', () => ({
-  useClusterIsAwsPlatform: () => mockUseClusterIsAwsPlatform(),
+  useClusterIsAwsPlatform: (): unknown => mockUseClusterIsAwsPlatform(),
 }));
 
 jest.mock('@utils/analytics/hooks/useForkliftAnalytics', () => ({
-  useForkliftAnalytics: () => ({ trackEvent: jest.fn() }),
+  useForkliftAnalytics: (): { trackEvent: jest.Mock } => ({ trackEvent: jest.fn() }),
 }));
 
 jest.mock('src/utils/hooks/useGetDeleteAndEditAccessReview', () => ({
   __esModule: true,
-  default: () => ({ canCreate: true }),
+  default: (): { canCreate: boolean } => ({ canCreate: true }),
 }));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useAccessReview: () => [true, false],
+  useAccessReview: (): [boolean, boolean] => [true, false],
 }));
 
 const createProvider = (type: string): V1beta1Provider => ({

--- a/src/providers/details/tabs/Credentials/ProviderCredentialsTabPage.tsx
+++ b/src/providers/details/tabs/Credentials/ProviderCredentialsTabPage.tsx
@@ -61,7 +61,7 @@ const ProviderCredentialsTabPage: FC<ProviderDetailsPageProps> = ({ name, namesp
                 'data-testid': 'credentials-reveal-button',
                 icon: reveal ? <EyeSlashIcon /> : <EyeIcon />,
                 key: 'reveal-values-button',
-                onClick: () => {
+                onClick: (): void => {
                   setReveal((prev) => !prev);
                 },
               },

--- a/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
+++ b/src/providers/details/tabs/Credentials/components/EditProviderCredentials.tsx
@@ -40,7 +40,7 @@ const EditProviderCredentials: OverlayComponent<EditProviderCredentialsProps> = 
     reset,
   } = methods;
 
-  const onSubmit = async (formData: Partial<CreateProviderFormData>) => {
+  const onSubmit = async (formData: Partial<CreateProviderFormData>): Promise<void> => {
     const secretData = buildSecretData(formData, provider);
     const isOpenstack = providerType === PROVIDER_TYPES.openstack;
 

--- a/src/providers/details/tabs/Credentials/components/utils/patchSecretData.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/patchSecretData.ts
@@ -4,7 +4,7 @@ import { ADD, REPLACE } from '@components/ModalForm/utils/constants';
 import { type IoK8sApiCoreV1Secret, SecretModel } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-const cleanObject = (obj: Record<string, string> | undefined) => {
+const cleanObject = (obj: Record<string, string> | undefined): Record<string, string> => {
   const result: Record<string, string> = {};
   for (const key in obj) {
     if (obj[key] !== null && obj[key] !== '') {
@@ -43,7 +43,10 @@ const emptyOpenstackCredentials = {
  * @param {boolean} clean - Clean old values from the secret before patching.
  * @returns {Promise<void>} A promise that resolves when the patch operation is complete.
  */
-export const patchSecretData = async (secret: IoK8sApiCoreV1Secret, clean?: boolean) => {
+export const patchSecretData = async (
+  secret: IoK8sApiCoreV1Secret,
+  clean?: boolean,
+): Promise<void> => {
   const op = secret?.data ? REPLACE : ADD;
 
   // Sanitize secret data

--- a/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
+++ b/src/providers/details/tabs/Details/components/DetailsSection/EditProviderVDDKImage.tsx
@@ -38,7 +38,7 @@ const EditProviderVDDKImage: OverlayComponent<EditProviderVDDKImageProps> = ({
 
   const vddkInitImage = watch(ProviderFormFieldId.VsphereVddkInitImage);
 
-  const onSubmit = async (data: EditProviderVDDKImageFormData) => {
+  const onSubmit = async (data: EditProviderVDDKImageFormData): Promise<void> => {
     await onUpdateVddkImageSettings(provider, data);
     closeOverlay();
   };

--- a/src/providers/details/tabs/Details/components/DetailsSection/utils/utils.ts
+++ b/src/providers/details/tabs/Details/components/DetailsSection/utils/utils.ts
@@ -39,12 +39,12 @@ export const getDetailsSectionByType = (
   }
 };
 
-const getConditions = (provider: V1beta1Provider) =>
+const getConditions = (provider: V1beta1Provider): string[] =>
   (provider?.status?.conditions ?? [])
     ?.filter((condition) => condition.status === CONDITION_STATUS.TRUE)
     .map((condition) => condition.type);
 
-export const isApplianceManagementEnabled = (provider: V1beta1Provider) => {
+export const isApplianceManagementEnabled = (provider: V1beta1Provider): boolean => {
   const conditions = getConditions(provider);
 
   return conditions?.includes(ProviderStatus.ApplianceManagementEnabled);

--- a/src/providers/details/tabs/Hosts/components/HostsNetworksSelect.tsx
+++ b/src/providers/details/tabs/Hosts/components/HostsNetworksSelect.tsx
@@ -26,7 +26,10 @@ const HostsNetworksSelect: FC<HostsNetworksSelectProps> = ({
 }) => {
   const { t } = useForkliftTranslation();
 
-  const getNetworkAdapterByLabel = (networkAdapters: NetworkAdapters[], label: string) => {
+  const getNetworkAdapterByLabel = (
+    networkAdapters: NetworkAdapters[],
+    label: string,
+  ): NetworkAdapters | undefined => {
     const selectedAdapter = networkAdapters.find((adapter) => {
       const cidr = calculateCidrNotation(adapter?.ipAddress, adapter?.subnetMask);
       const adapterLabel = `${adapter.name} - ${cidr}`;
@@ -48,7 +51,7 @@ const HostsNetworksSelect: FC<HostsNetworksSelectProps> = ({
     };
   });
 
-  const onSelect = (selected: SelectValueType) => {
+  const onSelect = (selected: SelectValueType): void => {
     const selectedAdapter = getNetworkAdapterByLabel(
       firstInventoryHostPair?.inventory?.networkAdapters ?? [],
       selected.toString(),

--- a/src/providers/details/tabs/Hosts/components/HostsNetworksSetPassword.tsx
+++ b/src/providers/details/tabs/Hosts/components/HostsNetworksSetPassword.tsx
@@ -29,7 +29,7 @@ const HostsNetworksSetPassword: FC<HostsNetworksSetPasswordProps> = ({ password,
     setPassword(value);
   };
 
-  const togglePasswordHidden = () => {
+  const togglePasswordHidden = (): void => {
     setPasswordHidden((isHidden) => !isHidden);
   };
 

--- a/src/providers/details/tabs/Hosts/components/VSphereHostsList.tsx
+++ b/src/providers/details/tabs/Hosts/components/VSphereHostsList.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo, useState } from 'react';
+import { type FC, type ReactElement, useMemo, useState } from 'react';
 import { loadUserSettings } from 'src/components/common/Page/userSettings';
 import type { GlobalActionToolbarProps } from 'src/components/common/utils/types';
 import { StandardPageWithSelection } from 'src/components/page/StandardPageWithSelection';
@@ -53,7 +53,7 @@ const VSphereHostsList: FC<VSphereHostsListProps> = ({ data }) => {
   const hostsData = matchHostsToInventory(inventoryHosts, hosts, provider);
 
   const actions: FC<GlobalActionToolbarProps<InventoryHostNetworkTriple>>[] = [
-    () => (
+    (): ReactElement => (
       <SelectNetworkForHostButton
         hostsData={hostsData}
         provider={provider}
@@ -64,11 +64,12 @@ const VSphereHostsList: FC<VSphereHostsListProps> = ({ data }) => {
 
   const canPatchProps = permissions?.canPatch
     ? {
-        canSelect: (item: InventoryHostNetworkTriple) => !isEmpty(item?.inventory?.networkAdapters),
+        canSelect: (item: InventoryHostNetworkTriple): boolean =>
+          !isEmpty(item?.inventory?.networkAdapters),
         GlobalActionToolbarItems: actions,
         onSelect: setSelectedIds,
         selectedIds,
-        toId: (item: InventoryHostNetworkTriple) => item.inventory.id,
+        toId: (item: InventoryHostNetworkTriple): string => item.inventory.id,
       }
     : {};
 

--- a/src/providers/details/tabs/Hosts/components/utils/createHostSecret.ts
+++ b/src/providers/details/tabs/Hosts/components/utils/createHostSecret.ts
@@ -5,7 +5,7 @@ import { isEmpty } from '@utils/helpers';
 /**
  * Removes null or empty string values from an object.
  */
-const cleanObject = (obj: Record<string, string> | undefined) => {
+const cleanObject = (obj: Record<string, string> | undefined): Record<string, string> => {
   const result: Record<string, string> = {};
   for (const key in obj) {
     if (!isEmpty(obj[key])) {
@@ -22,7 +22,9 @@ const cleanObject = (obj: Record<string, string> | undefined) => {
  * @param {IoK8sApiCoreV1Secret} secret - The secret object containing the data to be created.
  * @returns {Promise<IoK8sApiCoreV1Secret>} A promise that resolves to the created secret.
  */
-export const createHostSecret = async (secret: IoK8sApiCoreV1Secret) => {
+export const createHostSecret = async (
+  secret: IoK8sApiCoreV1Secret,
+): Promise<IoK8sApiCoreV1Secret> => {
   const secretData = cleanObject(secret.data);
   const cleanedSecret = { ...secret, data: secretData };
 

--- a/src/providers/details/tabs/Hosts/components/utils/onSaveHost.ts
+++ b/src/providers/details/tabs/Hosts/components/utils/onSaveHost.ts
@@ -46,7 +46,7 @@ const processHostSecretPair = async (
   ipAddress: string,
   encodedUser?: string,
   encodedPassword?: string,
-) => {
+): Promise<V1beta1Host> => {
   const { host } = hostPair;
   const inventory: VSphereHostInventory = hostPair.inventory;
 
@@ -143,11 +143,11 @@ export const onSaveHost = async ({
   passwd,
   provider,
   user,
-}: OnSaveHostParams) => {
+}: OnSaveHostParams): Promise<V1beta1Host> => {
   const encodedUser = user && encode(user);
   const encodedPassword = passwd && encode(passwd);
 
-  const promises = hostPairs.map(async (hostPair) => {
+  const promises = hostPairs.map(async (hostPair): Promise<V1beta1Host> => {
     const inventory: VSphereHostInventory = hostPair.inventory;
 
     const hostNetwork = findNetworkAdapterByNameAndIp(inventory?.networkAdapters ?? [], network);

--- a/src/providers/details/tabs/Hosts/components/utils/patchHost.ts
+++ b/src/providers/details/tabs/Hosts/components/utils/patchHost.ts
@@ -1,7 +1,7 @@
 import { HostModel, type V1beta1Host } from '@forklift-ui/types';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
-export const patchHost = async (host: V1beta1Host, ipAddress: string) => {
+export const patchHost = async (host: V1beta1Host, ipAddress: string): Promise<void> => {
   await k8sPatch({
     data: [
       {

--- a/src/providers/details/tabs/Hosts/components/utils/patchHostSecretOwner.ts
+++ b/src/providers/details/tabs/Hosts/components/utils/patchHostSecretOwner.ts
@@ -11,7 +11,7 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 export const patchHostSecretOwner = async (
   secret: IoK8sApiCoreV1Secret,
   ownerRef: { name: string | undefined; uid: string | undefined },
-) => {
+): Promise<IoK8sApiCoreV1Secret> => {
   const patchedSecret = await k8sPatch({
     data: [
       {

--- a/src/providers/details/tabs/Hosts/components/utils/patchSecret.ts
+++ b/src/providers/details/tabs/Hosts/components/utils/patchSecret.ts
@@ -6,7 +6,7 @@ export const patchSecret = async (
   encodedIpAddress: string,
   encodedUser?: string,
   encodedPassword?: string,
-) => {
+): Promise<void> => {
   await k8sPatch({
     data: [
       {

--- a/src/providers/details/tabs/Hosts/components/utils/renderTd.tsx
+++ b/src/providers/details/tabs/Hosts/components/utils/renderTd.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import { NameCellRenderer } from 'src/providers/details/tabs/Hosts/components/NameCellRenderer';
 
 import type { ResourceField } from '@components/common/utils/types';
@@ -30,7 +30,11 @@ const cellRenderers: Record<string, FC<HostCellProps>> = {
  * If the cell is an inventory cell (NETWORK_COUNT, STORAGE_COUNT, VM_COUNT, or HOST_COUNT)
  * and there's no inventory data, it won't render the cell.
  */
-export const RenderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+export const RenderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   if (!resourceFieldId) {
     return <Td></Td>;
   }

--- a/src/providers/details/tabs/Networks/ProviderNetworksTabPage.tsx
+++ b/src/providers/details/tabs/Networks/ProviderNetworksTabPage.tsx
@@ -61,7 +61,7 @@ const ProviderNetworksTabPage: FC<ProviderDetailsPageProps> = ({ name, namespace
     [defaultNetworkName, error, loading, networks],
   );
 
-  const onClick = () => {
+  const onClick = (): void => {
     launchOverlay<EditProviderDefaultTransferNetworkProps>(EditProviderDefaultTransferNetwork, {
       defaultNetworkName,
       resource: provider,

--- a/src/providers/details/tabs/Networks/components/ProviderDefaultTransferNetworkDropdown.tsx
+++ b/src/providers/details/tabs/Networks/components/ProviderDefaultTransferNetworkDropdown.tsx
@@ -25,10 +25,10 @@ const ProviderDefaultTransferNetworkDropdown: FC<ProviderDefaultTransferNetworkD
   value,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((open) => !open);
   };
-  const onSelect = () => {
+  const onSelect = (): void => {
     setIsOpen(false);
   };
 

--- a/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/Ec2VirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 
 import type { ResourceField } from '@components/common/utils/types';
@@ -33,9 +33,13 @@ type RenderTdProps = {
   resourceFields: ResourceField[];
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
 
   return (
     <Td dataLabel={fieldId} key={fieldId}>

--- a/src/providers/details/tabs/VirtualMachines/HypervVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/HypervVirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { TableCell } from 'src/components/TableCell/TableCell';
 
@@ -21,10 +21,14 @@ const cellRenderers: Record<string, FC<VMCellProps>> = {
   status: PowerStateCellRenderer,
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/providers/details/tabs/VirtualMachines/OVirtVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OVirtVirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { TableCell } from 'src/components/TableCell/TableCell';
 
@@ -24,10 +24,14 @@ const cellRenderers: Record<string, FC<VMCellProps>> = {
   status: PowerStateCellRenderer,
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/providers/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OpenShiftVirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { TableCell } from 'src/components/TableCell/TableCell';
 
@@ -12,7 +12,7 @@ import { VmFeaturesCell } from './components/VmFeaturesCell';
 import { withResourceLink } from './components/VmResourceLinkRenderer';
 import { getVmTemplate } from './utils/helpers/vmProps';
 
-const toNamespace = ({ data }: VMCellProps) =>
+const toNamespace = ({ data }: VMCellProps): string =>
   data.vm.providerType === 'openshift' ? (data.vm.object?.metadata?.namespace ?? '') : '';
 
 const cellRenderers: Record<string, FC<VMCellProps>> = {
@@ -31,10 +31,14 @@ const cellRenderers: Record<string, FC<VMCellProps>> = {
   template: ({ data }) => <TableCell>{getVmTemplate(data?.vm)}</TableCell>,
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/providers/details/tabs/VirtualMachines/OpenStackVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OpenStackVirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { TableCell } from 'src/components/TableCell/TableCell';
 
@@ -22,10 +22,14 @@ const cellRenderers: Record<string, FC<VMCellProps>> = {
   tenantID: ({ data }) => <TableCell>{(data?.vm as OpenstackVM)?.tenantID}</TableCell>,
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesList.tsx
@@ -31,7 +31,7 @@ const ovaVmFieldsMetadataFactory = [
       type: 'freetext',
     },
     isVisible: true,
-    jsonPath: (data: unknown) => getVmGuestOS((data as VmData)?.vm),
+    jsonPath: (data: unknown): string => getVmGuestOS((data as VmData)?.vm),
     label: t('Guest OS'),
     resourceFieldId: 'guestOS',
     sortable: true,

--- a/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
+++ b/src/providers/details/tabs/VirtualMachines/OvaVirtualMachinesRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { TableCell } from 'src/components/TableCell/TableCell';
 
@@ -19,10 +19,14 @@ const cellRenderers: Record<string, FC<VMCellProps>> = {
   ovaPath: ({ data }) => <TableCell>{(data?.vm as OvaVM)?.ovfPath}</TableCell>,
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react';
+import { type FC, type ReactElement, useMemo } from 'react';
 import { loadUserSettings } from 'src/components/common/Page/userSettings';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { StandardPageWithSelection } from 'src/components/page/StandardPageWithSelection';
@@ -32,6 +32,21 @@ type ProviderVirtualMachinesListProps = {
   title?: string;
 };
 
+type StandardPageSelectionProps =
+  | {
+      expandedIds?: string[];
+      GlobalActionToolbarItems?: FC<GlobalActionToolbarProps<VmData>>[];
+      onSelect: (selectedIds: string[]) => void;
+      selectedIds: string[];
+      toId: (item: VmData) => string;
+    }
+  | {
+      expandedIds: string[];
+      onExpand: () => void;
+      toId: (item: VmData) => string;
+    }
+  | Record<string, never>;
+
 export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> = ({
   cellMapper,
   className,
@@ -51,7 +66,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   const userSettings = useMemo(() => loadUserSettings({ pageId }), [pageId]);
 
   const handleSelectedIds = onSelect
-    ? (selectedIds: string[]) => {
+    ? (selectedIds: string[]): void => {
         const selectedVms = vmData?.filter((data) => selectedIds.includes(getVmId(data)));
         onSelect(selectedVms);
       }
@@ -73,7 +88,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
     );
   }
 
-  const getStandardPageProps = () => {
+  const getStandardPageProps = (): StandardPageSelectionProps => {
     const ec2 = isProviderEc2(provider);
 
     if (handleSelectedIds) {
@@ -89,7 +104,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
     if (!isProviderOpenshift(provider) && !ec2) {
       return {
         expandedIds: [],
-        onExpand: () => undefined,
+        onExpand: (): void => undefined,
         toId: getVmId,
       };
     }
@@ -113,7 +128,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
       expanded={
         isProviderOpenshift(provider) || isProviderEc2(provider)
           ? undefined
-          : (props) => <ConcernsAndConditionsTable vmData={props.resourceData} />
+          : (props): ReactElement => <ConcernsAndConditionsTable vmData={props.resourceData} />
       }
     />
   );

--- a/src/providers/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
+++ b/src/providers/details/tabs/VirtualMachines/components/VmResourceLinkRenderer.tsx
@@ -13,7 +13,7 @@ export const withResourceLink = ({
   toGVK: (props: VMCellProps) => K8sGroupVersionKind;
   toName: (props: VMCellProps) => string;
   toNamespace: (props: VMCellProps) => string;
-}) => {
+}): FC<VMCellProps> => {
   const Enhanced: FC<VMCellProps> = (props: VMCellProps) => {
     const { isProviderLocalOpenshift } = props.data;
     return (

--- a/src/providers/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
+++ b/src/providers/details/tabs/VirtualMachines/utils/filters/OvirtHostFilter.ts
@@ -1,6 +1,6 @@
 import { CustomFilterType } from 'src/components/common/FilterGroup/constants';
 
-import type { EnumValue } from '@components/common/utils/types';
+import type { EnumValue, FilterDef } from '@components/common/utils/types';
 import { t } from '@utils/i18n';
 
 const labelToFilterItem = (label: string): EnumValue =>
@@ -10,9 +10,9 @@ const labelToFilterItem = (label: string): EnumValue =>
  * This component enables filtering the oVirt virtual machines
  * by the hostname that they are running on.
  */
-export const ovirtHostFilter = () => {
+export const ovirtHostFilter = (): FilterDef => {
   return {
-    dynamicFilter: (filterItems: unknown[]) => {
+    dynamicFilter: (filterItems: unknown[]): Partial<FilterDef> => {
       const items = filterItems as { vm: { host: string } }[];
       return {
         values: [

--- a/src/providers/details/tabs/VirtualMachines/utils/filters/concernFilter.ts
+++ b/src/providers/details/tabs/VirtualMachines/utils/filters/concernFilter.ts
@@ -7,7 +7,7 @@ import { t } from '@utils/i18n';
 type VmConcernsFilterItems = { vm: { concerns: { label: string }[] } };
 
 export const concernFilter = (): FilterDef => ({
-  dynamicFilter: (unknownItems: unknown[]) => {
+  dynamicFilter: (unknownItems: unknown[]): Partial<FilterDef> => {
     const items = unknownItems as VmConcernsFilterItems[];
     return {
       values: [

--- a/src/providers/hooks/useTlsCertificate.ts
+++ b/src/providers/hooks/useTlsCertificate.ts
@@ -8,7 +8,7 @@ import { getServicesApiUrl } from '@utils/api/getApiUrl';
  * @param value PEM encoded certificate
  * @returns parsed certificate or undefined if parsing failed
  */
-const parseToX509 = (value: string) => {
+const parseToX509 = (value: string): X509 | undefined => {
   if (!value) {
     return undefined;
   }
@@ -21,7 +21,7 @@ const parseToX509 = (value: string) => {
   }
 };
 
-export const toColonSeparatedHex = (hexString: string) =>
+export const toColonSeparatedHex = (hexString: string): string =>
   Array.from(hexString.toUpperCase())
     // [a,b,c,d] => [[c,d][a,b]]
     .reduce(
@@ -38,7 +38,7 @@ export const toColonSeparatedHex = (hexString: string) =>
  * @param pemEncodedCert valid PEM encoded certificate
  * @returns SHA1 thumbprint
  */
-export const calculateThumbprint = (pemEncodedCert: string) => {
+export const calculateThumbprint = (pemEncodedCert: string): string => {
   try {
     return toColonSeparatedHex(KJUR.crypto.Util.hashHex(pemtohex(pemEncodedCert), 'sha1'));
   } catch {
@@ -50,13 +50,23 @@ export const calculateThumbprint = (pemEncodedCert: string) => {
  * @param url URL param for the tls-certificate endpoint
  * @returns certificate and props calculated/parsed based on the certificate
  */
-export const useTlsCertificate = (url: string) => {
+export const useTlsCertificate = (
+  url: string,
+): {
+  certError: boolean;
+  certificate: string;
+  fetchError: Error | undefined;
+  issuer: string;
+  loading: boolean;
+  thumbprint: string;
+  validTo: Date | undefined;
+} => {
   const [certificate, setCertificate] = useState('');
   const [fetchError, setFetchError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    const fetchCertificate = async () => {
+    const fetchCertificate = async (): Promise<void> => {
       try {
         const response = await consoleFetch(getServicesApiUrl(`tls-certificate?URL=${url}`), {
           method: 'GET',
@@ -70,7 +80,7 @@ export const useTlsCertificate = (url: string) => {
       }
     };
 
-    (async () => {
+    (async (): Promise<void> => {
       await fetchCertificate();
     })();
   }, [url]);

--- a/src/providers/list/components/ProvidersAddButton.tsx
+++ b/src/providers/list/components/ProvidersAddButton.tsx
@@ -26,7 +26,7 @@ const ProvidersAddButton: FC<ProvidersAddButtonProps> = ({ canCreate, namespace,
     reference: ProviderModelRef,
   });
 
-  const onClick = () => {
+  const onClick = (): void => {
     trackEvent(TELEMETRY_EVENTS.PROVIDER_CREATE_CLICKED, {
       createSource: ProviderCreateSource.ProvidersPage,
       namespace,

--- a/src/providers/list/components/utils/constants.tsx
+++ b/src/providers/list/components/utils/constants.tsx
@@ -21,7 +21,7 @@ export enum ProvidersInventoryFields {
   ClusterCount = 'clusterCount',
 }
 
-const nullRenderer = () => null;
+const nullRenderer = (): null => null;
 
 export const ProviderDataCellRenderers: Record<ProvidersResourceFieldId, FC<CellProps>> = {
   actions: (props) => <ProviderActionsDropdown {...props} />,

--- a/src/providers/list/hooks/useProvidersInventoryList.ts
+++ b/src/providers/list/hooks/useProvidersInventoryList.ts
@@ -39,7 +39,7 @@ const useProvidersInventoryList = (
   };
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       try {
         const newInventory = (
           canList
@@ -61,7 +61,7 @@ const useProvidersInventoryList = (
     });
 
     const intervalId = setInterval(fetchData, interval);
-    return () => {
+    return (): void => {
       clearInterval(intervalId);
     };
   }, [canList, interval, namespace]);

--- a/src/providers/list/utils/getProviderStorageCount.ts
+++ b/src/providers/list/utils/getProviderStorageCount.ts
@@ -9,7 +9,7 @@ import type {
 import { PROVIDER_TYPES } from '@utils/providers/constants';
 import type { ProviderData } from '@utils/providers/types';
 
-export const getProviderStorageCount = (provider: ProviderData) => {
+export const getProviderStorageCount = (provider: ProviderData): number | undefined => {
   const { inventory } = provider;
 
   switch (inventory?.type) {

--- a/src/providers/list/utils/inventoryContentHasChanged.ts
+++ b/src/providers/list/utils/inventoryContentHasChanged.ts
@@ -9,7 +9,7 @@ export const inventoryContentHasChanged = (
   oldDataRef: MutableRefObject<ProvidersInventoryList | null>,
   fieldsToAvoidComparing: string[],
 ): boolean => {
-  const flatInventory = (inventoryList: ProvidersInventoryList | null) =>
+  const flatInventory = (inventoryList: ProvidersInventoryList | null): ProviderInventory[] =>
     Object.values(PROVIDER_TYPES).flatMap<ProviderInventory>(
       (type) => (inventoryList as Record<string, ProviderInventory[]> | null)?.[type] ?? [],
     );

--- a/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
+++ b/src/providers/modals/EditProviderURL/VSphereEditURLModal.tsx
@@ -20,7 +20,8 @@ export const VSphereEditURLModal: OverlayComponent<EditProviderURLModalProps> = 
   const validationHook =
     sdkEndpoint === 'esxi'
       ? validateEsxiURL
-      : (url: string) => validateVCenterURL(url, insecureSkipVerify);
+      : (url: string): ReturnType<typeof validateVCenterURL> =>
+          validateVCenterURL(url, insecureSkipVerify);
 
   const description = (
     <ForkliftTrans>

--- a/src/providers/utils/getProviderDetailsPageUrl.ts
+++ b/src/providers/utils/getProviderDetailsPageUrl.ts
@@ -3,7 +3,7 @@ import { getName, getNamespace } from '@utils/crds/common/selectors';
 import { getResourceUrl } from '@utils/getResourceUrl';
 
 // return a URL for providers derails page
-export const getProviderDetailsPageUrl = (provider: V1beta1Provider | undefined) => {
+export const getProviderDetailsPageUrl = (provider: V1beta1Provider | undefined): string => {
   return getResourceUrl({
     name: getName(provider),
     namespace: getNamespace(provider),

--- a/src/providers/utils/validators/provider/vsphere/validateVCenterURL.ts
+++ b/src/providers/utils/validators/provider/vsphere/validateVCenterURL.ts
@@ -4,7 +4,7 @@ import { validateIpv4, validateURL } from 'src/utils/validation/common';
 import { MTVConsole } from '@utils/console';
 import { type ValidationMsg, ValidationState } from '@utils/validation/Validation';
 
-const getUrlObject = (url: string) => {
+const getUrlObject = (url: string): URL | undefined => {
   try {
     return new URL(url);
   } catch {

--- a/src/storageMaps/actions/StorageMapActionsDropdown.tsx
+++ b/src/storageMaps/actions/StorageMapActionsDropdown.tsx
@@ -24,11 +24,11 @@ const StorageMapActionsKebabDropdown: FC<StorageMapActionsDropdownProps> = ({
   const { t } = useForkliftTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen((value) => !value);
   };
 
-  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined) => {
+  const onSelect = (_event: MouseEvent | undefined, _value: string | number | undefined): void => {
     setIsOpen(false);
   };
 

--- a/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
+++ b/src/storageMaps/actions/StorageMapActionsDropdownItems.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router';
 import { DeleteModal, type DeleteModalProps } from 'src/components/modals/DeleteModal/DeleteModal';
 import { useOwnerPlanActionGate } from 'src/plans/hooks/useOwnerPlanActionGate';
@@ -17,7 +18,7 @@ type StorageMapActionsDropdownItemsProps = {
 export const StorageMapActionsDropdownItems = ({
   data,
   isDetailsPage,
-}: StorageMapActionsDropdownItemsProps) => {
+}: StorageMapActionsDropdownItemsProps): ReactElement[] => {
   const { t } = useForkliftTranslation();
   const launchOverlay = useOverlay();
   const navigate = useNavigate();
@@ -31,7 +32,7 @@ export const StorageMapActionsDropdownItems = ({
     reference: StorageMapModelRef,
   });
 
-  const onDelete = () => {
+  const onDelete = (): void => {
     if (!storageMap) {
       return;
     }

--- a/src/storageMaps/components/TargetStorageField.tsx
+++ b/src/storageMaps/components/TargetStorageField.tsx
@@ -1,4 +1,4 @@
-import { type FC, useMemo } from 'react';
+import { type FC, type ReactElement, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import Select from '@components/common/Select';
@@ -32,7 +32,7 @@ type TargetStorageFieldProps = {
 const shouldShowDefaultLabel = (storage: TargetStorage): boolean =>
   storage.isDefaultVirt || storage.isDefault;
 
-const renderStorageOption = (storage: TargetStorage, t: (k: string) => string) => (
+const renderStorageOption = (storage: TargetStorage, t: (k: string) => string): ReactElement => (
   <Split hasGutter>
     <SplitItem isFilled>{storage.name}</SplitItem>
     {shouldShowDefaultLabel(storage) && (

--- a/src/storageMaps/create/CreateStorageMapForm.tsx
+++ b/src/storageMaps/create/CreateStorageMapForm.tsx
@@ -65,12 +65,12 @@ const CreateStorageMapForm: React.FC = () => {
     reference: StorageMapModelRef,
   });
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     setCreateError(undefined);
 
     const { mapName, sourceProvider, storageMap } = getValues();
 
-    const trackStorageMapEvent = (eventType: string, properties = {}) => {
+    const trackStorageMapEvent = (eventType: string, properties = {}): void => {
       trackEvent(eventType, { ...properties, creationMethod: CreationMethod.Form });
     };
 

--- a/src/storageMaps/create/fields/utils.ts
+++ b/src/storageMaps/create/fields/utils.ts
@@ -8,7 +8,7 @@ import { StorageMapFieldId, type StorageMapping } from '@utils/storage/types';
  * @param values - Array of storage mappings to validate
  * @returns Translation key string for validation error or true if valid
  */
-export const validateStorageMaps = (values: StorageMapping[]) => {
+export const validateStorageMaps = (values: StorageMapping[]): string | undefined => {
   if (!Array.isArray(values)) {
     return t('Invalid mappings');
   }

--- a/src/storageMaps/create/utils/createStorageMap.ts
+++ b/src/storageMaps/create/utils/createStorageMap.ts
@@ -42,7 +42,7 @@ export const createStorageMap = async ({
   targetProvider,
   targetStorages,
   trackEvent,
-}: CreateStorageMapParams) => {
+}: CreateStorageMapParams): Promise<V1beta1StorageMap> => {
   const sourceProviderName = sourceProvider?.metadata?.name;
 
   trackEvent?.(TELEMETRY_EVENTS.STORAGE_MAP_CREATE_STARTED, {

--- a/src/storageMaps/details/StorageMapDetailsPage.tsx
+++ b/src/storageMaps/details/StorageMapDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import { type FC, memo, type ReactElement } from 'react';
 import LearningExperienceDrawer from 'src/onlineHelp/learningExperienceDrawer/LearningExperienceDrawer';
 import { useForkliftTranslation } from 'src/utils/i18n';
 
@@ -23,12 +23,12 @@ const StorageMapDetailsPage: FC<StorageMapDetailsPageProps> = memo(({ name, name
 
   const pages = [
     {
-      component: () => <StorageMapDetailsTab name={name} namespace={namespace} />,
+      component: (): ReactElement => <StorageMapDetailsTab name={name} namespace={namespace} />,
       href: '',
       name: t('Details'),
     },
     {
-      component: () => <StorageMapYAMLTab name={name} namespace={namespace} />,
+      component: (): ReactElement => <StorageMapYAMLTab name={name} namespace={namespace} />,
       href: 'yaml',
       name: t('YAML'),
     },

--- a/src/storageMaps/details/components/StorageMapEdit.tsx
+++ b/src/storageMaps/details/components/StorageMapEdit.tsx
@@ -77,7 +77,7 @@ const StorageMapEdit: OverlayComponent<StorageMapEditProps> = ({
     reset(initialFormValues);
   }, [initialFormValues, reset]);
 
-  const onSubmit = async (formValues: UpdateMappingsFormData) => {
+  const onSubmit = async (formValues: UpdateMappingsFormData): Promise<void> => {
     const filteredStorageMap = formValues.storageMap?.filter((mapping) => {
       const hasSource = Boolean(mapping[StorageMapFieldId.SourceStorage]?.name);
       const hasTarget = Boolean(mapping[StorageMapFieldId.TargetStorage]?.name);

--- a/src/storageMaps/details/utils/utils.ts
+++ b/src/storageMaps/details/utils/utils.ts
@@ -118,7 +118,7 @@ export const transformStorageMapToFormValues = (
  * @param values - Array of storage mappings to validate
  * @returns Translation key string for validation error or undefined if valid
  */
-export const validateUpdatedStorageMaps = (values: StorageMapping[]) => {
+export const validateUpdatedStorageMaps = (values: StorageMapping[]): string | undefined => {
   if (!Array.isArray(values)) {
     return t('Invalid mappings');
   }

--- a/src/storageMaps/hooks/__tests__/useOffloadPlugins.test.ts
+++ b/src/storageMaps/hooks/__tests__/useOffloadPlugins.test.ts
@@ -9,7 +9,7 @@ jest.mock('../useStorageMapCrd');
 
 const mockUseStorageMapCrd = useStorageMapCrd as jest.MockedFunction<typeof useStorageMapCrd>;
 
-const makeCrd = (pluginNames: string[]) =>
+const makeCrd = (pluginNames: string[]): ReturnType<typeof useStorageMapCrd>['crd'] =>
   ({
     spec: {
       versions: [

--- a/src/storageMaps/hooks/__tests__/useStorageVendorProducts.test.ts
+++ b/src/storageMaps/hooks/__tests__/useStorageVendorProducts.test.ts
@@ -9,7 +9,9 @@ jest.mock('../useStorageMapCrd');
 
 const mockUseStorageMapCrd = useStorageMapCrd as jest.MockedFunction<typeof useStorageMapCrd>;
 
-const makeCrd = (pluginEnums: Record<string, string[]>) =>
+const makeCrd = (
+  pluginEnums: Record<string, string[]>,
+): ReturnType<typeof useStorageMapCrd>['crd'] =>
   ({
     spec: {
       versions: [

--- a/src/storageMaps/list/StorageMapRow.tsx
+++ b/src/storageMaps/list/StorageMapRow.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { FC, ReactElement } from 'react';
 import type { RowProps } from 'src/components/common/TableView/types';
 import { createStatusCell } from 'src/components/table/utils/createStatusCell';
 
@@ -32,10 +32,14 @@ type RenderTdProps = {
   resourceFields: ResourceField[];
 };
 
-const renderTd = ({ resourceData, resourceFieldId, resourceFields }: RenderTdProps) => {
+const renderTd = ({
+  resourceData,
+  resourceFieldId,
+  resourceFields,
+}: RenderTdProps): ReactElement => {
   const fieldId = resourceFieldId;
 
-  const CellRenderer = cellRenderers?.[fieldId] ?? (() => <></>);
+  const CellRenderer = cellRenderers?.[fieldId] ?? ((): ReactElement => <></>);
   return (
     <Td dataLabel={fieldId} key={fieldId}>
       <CellRenderer data={resourceData} fieldId={fieldId} fields={resourceFields} />

--- a/src/storageMaps/utils/__tests__/getSourceStorageValues.test.ts
+++ b/src/storageMaps/utils/__tests__/getSourceStorageValues.test.ts
@@ -23,7 +23,28 @@ const makeOvaStorage = (id: string, name: string): InventoryStorage => ({
  * while @forklift-ui/types defines them as camelCase (e.g. id).
  * This factory uses PascalCase to match real API responses.
  */
-const makeOvaVm = (diskUppercaseID: string) => ({
+type OvaVmApiFixture = {
+  cpuCount: number;
+  disks: {
+    Capacity: number;
+    CapacityAllocationUnits: string;
+    DiskId: string;
+    FilePath: string;
+    FileRef: string;
+    Format: string;
+    ID: string;
+    Name: string;
+    PopulatedSize: number;
+    Revision: number;
+    Variant: string;
+  }[];
+  memoryMB: number;
+  networks: unknown[];
+  powerState: string;
+  providerType: string;
+};
+
+const makeOvaVm = (diskUppercaseID: string): OvaVmApiFixture => ({
   cpuCount: 1,
   // Simulates actual API response: disk uses PascalCase `ID`, not camelCase `id`
   disks: [

--- a/src/test-utils/mockI18n.ts
+++ b/src/test-utils/mockI18n.ts
@@ -1,17 +1,19 @@
 import { jest } from '@jest/globals';
 
-const createMockT = () => (key: string, params?: Record<string, unknown>) => {
-  // Handle template strings with parameters
-  if (params && typeof key === 'string') {
-    return key.replace(/\{\{(?<paramName>\w+)\}\}/gu, (match, paramName: string) => {
-      const paramValue = params[paramName];
-      return paramValue?.toString() ?? match;
-    });
-  }
-  return key;
-};
+const createMockT =
+  (): ((key: string, params?: Record<string, unknown>) => string) =>
+  (key: string, params?: Record<string, unknown>): string => {
+    // Handle template strings with parameters
+    if (params && typeof key === 'string') {
+      return key.replace(/\{\{(?<paramName>\w+)\}\}/gu, (match, paramName: string) => {
+        const paramValue = params[paramName];
+        return paramValue?.toString() ?? match;
+      });
+    }
+    return key;
+  };
 
-export const mockI18n = () => {
+export const mockI18n = (): void => {
   const mockT = createMockT();
 
   const i18nMock = {

--- a/src/test-utils/renderWithForm.tsx
+++ b/src/test-utils/renderWithForm.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { render, type RenderOptions } from '@testing-library/react';
@@ -10,8 +10,8 @@ type RenderWithFormOptions = {
 export const renderWithForm = (
   ui: ReactElement,
   { defaultValues = {}, ...renderOptions }: RenderWithFormOptions = {},
-) => {
-  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+): ReturnType<typeof render> => {
+  const Wrapper = ({ children }: { children: ReactNode }): ReactElement => {
     const methods = useForm({ defaultValues });
     return <FormProvider {...methods}>{children}</FormProvider>;
   };

--- a/src/utils/analytics/hooks/useForkliftAnalytics.ts
+++ b/src/utils/analytics/hooks/useForkliftAnalytics.ts
@@ -5,10 +5,14 @@ import { sendAnalyticsEvent } from '../sendAnalyticsEvent';
 
 import { useAnalyticsConfig } from './useAnalyticsConfig';
 
+type UseForkliftAnalyticsResult = {
+  trackEvent: (eventType: string, properties?: Record<string, unknown>) => void;
+};
+
 /**
  * React hook for forklift telemetry with ConfigMap configuration
  */
-export const useForkliftAnalytics = () => {
+export const useForkliftAnalytics = (): UseForkliftAnalyticsResult => {
   const { clusterId, segmentKey } = useAnalyticsConfig();
   const initializationAttempted = useRef(false);
   const isTelemetryDisabled = window.SERVER_FLAGS?.telemetry?.TELEMETRY_DISABLED === 'true';
@@ -25,7 +29,7 @@ export const useForkliftAnalytics = () => {
     }
   }, [segmentKey, isTelemetryDisabled]);
 
-  const trackEvent = (eventType: string, properties: Record<string, unknown> = {}) => {
+  const trackEvent = (eventType: string, properties: Record<string, unknown> = {}): void => {
     if (!segmentKey || !clusterId || isTelemetryDisabled || !window.analytics?.track) {
       return;
     }

--- a/src/utils/analytics/initializeAnalytics.ts
+++ b/src/utils/analytics/initializeAnalytics.ts
@@ -4,7 +4,7 @@ import { SEGMENT_METHODS, SEGMENT_SNIPPET_VERSION } from './constants';
  * Initialize Segment analytics using official snippet v5.2.0
  * @param segmentKey
  */
-export const initializeAnalytics = (segmentKey: string) => {
+export const initializeAnalytics = (segmentKey: string): void => {
   if (window.analytics && typeof window.analytics.track === 'function') {
     return;
   }
@@ -26,8 +26,10 @@ export const initializeAnalytics = (segmentKey: string) => {
        *
        * @param method
        */
-      analytics.factory = function factory(method: string) {
-        return function analyticsMethodWrapper(...args: unknown[]) {
+      analytics.factory = function factory(
+        method: string,
+      ): (...args: unknown[]) => SegmentAnalytics {
+        return function analyticsMethodWrapper(...args: unknown[]): SegmentAnalytics {
           if (window.analytics?.initialized) {
             const analyticsMethod = window.analytics[method];
 
@@ -72,7 +74,7 @@ export const initializeAnalytics = (segmentKey: string) => {
        * @param key
        * @param options
        */
-      analytics.load = function load(key: string, options?: Record<string, unknown>) {
+      analytics.load = function load(key: string, options?: Record<string, unknown>): void {
         const script = document.createElement('script');
         script.type = 'text/javascript';
         script.async = true;

--- a/src/utils/analytics/sendAnalyticsEvent.ts
+++ b/src/utils/analytics/sendAnalyticsEvent.ts
@@ -11,7 +11,7 @@ export const sendAnalyticsEvent = (
   eventType: string,
   properties: Record<string, unknown>,
   config: AnalyticsConfig,
-) => {
+): void => {
   initializeAnalytics(config.segmentKey);
 
   const eventData = {

--- a/src/utils/crds/common/selectors.ts
+++ b/src/utils/crds/common/selectors.ts
@@ -1,22 +1,25 @@
-import type { V1beta1Provider } from '@forklift-ui/types';
+import type { V1beta1Provider, V1beta1ProviderSpecSecret } from '@forklift-ui/types';
 import type {
   K8sGroupVersionKind,
   K8sResourceCommon,
   OwnerReference,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-export const getName = (resource: K8sResourceCommon | undefined) => resource?.metadata?.name;
+export const getName = (resource: K8sResourceCommon | undefined): string | undefined =>
+  resource?.metadata?.name;
 
-export const getNamespace = (resource: K8sResourceCommon | undefined) =>
+export const getNamespace = (resource: K8sResourceCommon | undefined): string | undefined =>
   resource?.metadata?.namespace;
 
-export const getCreatedAt = (resource: K8sResourceCommon) => resource?.metadata?.creationTimestamp;
+export const getCreatedAt = (resource: K8sResourceCommon): string | undefined =>
+  resource?.metadata?.creationTimestamp;
 
-export const getUID = (resource: K8sResourceCommon) => resource?.metadata?.uid;
+export const getUID = (resource: K8sResourceCommon): string | undefined => resource?.metadata?.uid;
 
-export const getLabels = (resource: K8sResourceCommon) => resource?.metadata?.labels;
+export const getLabels = (resource: K8sResourceCommon): Record<string, string> | undefined =>
+  resource?.metadata?.labels;
 
-export const getOwnerReference = (resource: K8sResourceCommon) =>
+export const getOwnerReference = (resource: K8sResourceCommon): OwnerReference | undefined =>
   resource?.metadata?.ownerReferences?.[0];
 
 export const getGroupVersionKindFromOwnerReference = (
@@ -34,29 +37,36 @@ export const getGroupVersionKindFromOwnerReference = (
   };
 };
 
-const getSettings = (provider: V1beta1Provider) => provider?.spec?.settings;
+const getSettings = (provider: V1beta1Provider): Record<string, string> | undefined =>
+  provider?.spec?.settings;
 
-export const getVddkInitImage = (provider: V1beta1Provider) => getSettings(provider)?.vddkInitImage;
+export const getVddkInitImage = (provider: V1beta1Provider): string | undefined =>
+  getSettings(provider)?.vddkInitImage;
 
-export const getUseVddkAioOptimization = (provider: V1beta1Provider) =>
+export const getUseVddkAioOptimization = (provider: V1beta1Provider): string | undefined =>
   getSettings(provider)?.useVddkAioOptimization;
 
-export const getSdkEndpoint = (provider: V1beta1Provider) => getSettings(provider)?.sdkEndpoint;
+export const getSdkEndpoint = (provider: V1beta1Provider): string | undefined =>
+  getSettings(provider)?.sdkEndpoint;
 
-export const getApplianceManagement = (provider: V1beta1Provider) =>
+export const getApplianceManagement = (provider: V1beta1Provider): string | undefined =>
   getSettings(provider)?.applianceManagement;
 
-export const isApplianceManagementEnabled = (provider: V1beta1Provider) =>
+export const isApplianceManagementEnabled = (provider: V1beta1Provider): boolean =>
   getApplianceManagement(provider) === 'true';
 
 export const getAnnotation = (resource: K8sResourceCommon, key: string): string | undefined =>
   resource?.metadata?.annotations?.[key];
 
-export const getAnnotations = (resource: K8sResourceCommon | undefined) =>
-  resource?.metadata?.annotations;
+export const getAnnotations = (
+  resource: K8sResourceCommon | undefined,
+): Record<string, string> | undefined => resource?.metadata?.annotations;
 
-export const getUrl = (provider: V1beta1Provider) => provider?.spec?.url;
+export const getUrl = (provider: V1beta1Provider): string | undefined => provider?.spec?.url;
 
-export const getType = (provider: V1beta1Provider | undefined) => provider?.spec?.type;
+export const getType = (provider: V1beta1Provider | undefined): string | undefined =>
+  provider?.spec?.type;
 
-export const getProviderSecretRef = (provider: V1beta1Provider) => provider?.spec?.secret;
+export const getProviderSecretRef = (
+  provider: V1beta1Provider,
+): V1beta1ProviderSpecSecret | undefined => provider?.spec?.secret;

--- a/src/utils/crds/maps/selectors.ts
+++ b/src/utils/crds/maps/selectors.ts
@@ -1,13 +1,17 @@
 import type { V1beta1NetworkMap, V1beta1StorageMap } from '@forklift-ui/types';
 
-export const getMapSourceProviderName = (map: V1beta1NetworkMap | V1beta1StorageMap) =>
-  map?.spec?.provider?.source?.name;
+export const getMapSourceProviderName = (
+  map: V1beta1NetworkMap | V1beta1StorageMap,
+): string | undefined => map?.spec?.provider?.source?.name;
 
-export const getMapDestinationProviderName = (map: V1beta1NetworkMap | V1beta1StorageMap) =>
-  map?.spec?.provider?.destination?.name;
+export const getMapDestinationProviderName = (
+  map: V1beta1NetworkMap | V1beta1StorageMap,
+): string | undefined => map?.spec?.provider?.destination?.name;
 
-export const getMapSourceProviderNamespace = (map: V1beta1NetworkMap | V1beta1StorageMap) =>
-  map?.spec?.provider?.source?.namespace;
+export const getMapSourceProviderNamespace = (
+  map: V1beta1NetworkMap | V1beta1StorageMap,
+): string | undefined => map?.spec?.provider?.source?.namespace;
 
-export const getMapDestinationProviderNamespace = (map: V1beta1NetworkMap | V1beta1StorageMap) =>
-  map?.spec?.provider?.destination?.namespace;
+export const getMapDestinationProviderNamespace = (
+  map: V1beta1NetworkMap | V1beta1StorageMap,
+): string | undefined => map?.spec?.provider?.destination?.namespace;

--- a/src/utils/crds/maps/shared.ts
+++ b/src/utils/crds/maps/shared.ts
@@ -2,7 +2,7 @@ import { CATEGORY_TYPES, CONDITION_STATUS } from '@utils/constants';
 import type { NetworkMapData } from '@utils/crds/maps/types';
 import type { StorageMapData } from '@utils/storage/types';
 
-export const getMapPhase = (data: NetworkMapData | StorageMapData) => {
+export const getMapPhase = (data: NetworkMapData | StorageMapData): string => {
   const conditions = data?.obj?.status?.conditions;
 
   const isCritical = conditions?.find(

--- a/src/utils/crds/plans/selectors.ts
+++ b/src/utils/crds/plans/selectors.ts
@@ -1,64 +1,90 @@
-import type { V1beta1Plan } from '@forklift-ui/types';
+import type {
+  V1beta1Plan,
+  V1beta1PlanSpecMap,
+  V1beta1PlanSpecMapNetwork,
+  V1beta1PlanSpecMapStorage,
+  V1beta1PlanSpecProviderDestination,
+  V1beta1PlanSpecProviderSource,
+  V1beta1PlanSpecTransferNetwork,
+  V1beta1PlanSpecVms,
+  V1beta1PlanStatusMigrationVms,
+} from '@forklift-ui/types';
 import type { TargetPowerStateValue } from '@utils/plans/constants';
 import type { EnhancedPlanSpecVms } from '@utils/plans/types';
 
-export const getPlanDestinationProvider = (plan: V1beta1Plan) =>
+export const getPlanDestinationProvider = (plan: V1beta1Plan): V1beta1PlanSpecProviderDestination =>
   plan?.spec?.provider?.destination ?? {};
 
-export const getPlanDestinationProviderName = (plan: V1beta1Plan) =>
+export const getPlanDestinationProviderName = (plan: V1beta1Plan): string | undefined =>
   getPlanDestinationProvider(plan)?.name;
 
-export const getPlanDestinationProviderNamespace = (plan: V1beta1Plan) =>
+export const getPlanDestinationProviderNamespace = (plan: V1beta1Plan): string | undefined =>
   getPlanDestinationProvider(plan)?.namespace;
 
-export const getPlanSourceProvider = (plan: V1beta1Plan) => plan?.spec?.provider?.source ?? {};
+export const getPlanSourceProvider = (plan: V1beta1Plan): V1beta1PlanSpecProviderSource =>
+  plan?.spec?.provider?.source ?? {};
 
-export const getPlanSourceProviderName = (plan: V1beta1Plan) => getPlanSourceProvider(plan)?.name;
+export const getPlanSourceProviderName = (plan: V1beta1Plan): string | undefined =>
+  getPlanSourceProvider(plan)?.name;
 
-export const getPlanSourceProviderNamespace = (plan: V1beta1Plan) =>
+export const getPlanSourceProviderNamespace = (plan: V1beta1Plan): string | undefined =>
   getPlanSourceProvider(plan)?.namespace;
 
-export const getPlanMigrationStarted = (plan: V1beta1Plan) =>
+export const getPlanMigrationStarted = (plan: V1beta1Plan): string =>
   plan?.status?.migration?.started ?? '';
 
-export const getPlanIsWarm = (plan: V1beta1Plan) => plan?.spec?.warm;
+export const getPlanIsWarm = (plan: V1beta1Plan): boolean | undefined => plan?.spec?.warm;
 
-export const getPlanArchived = (plan: V1beta1Plan) => plan?.spec?.archived;
+export const getPlanArchived = (plan: V1beta1Plan): boolean | undefined => plan?.spec?.archived;
 
-export const getPlanVirtualMachinesMigrationStatus = (plan: V1beta1Plan) =>
-  plan?.status?.migration?.vms ?? [];
+export const getPlanVirtualMachinesMigrationStatus = (
+  plan: V1beta1Plan,
+): V1beta1PlanStatusMigrationVms[] => plan?.status?.migration?.vms ?? [];
 
-export const getPlanVirtualMachines = (plan: V1beta1Plan) => plan?.spec?.vms ?? [];
+export const getPlanVirtualMachines = (plan: V1beta1Plan): V1beta1PlanSpecVms[] =>
+  plan?.spec?.vms ?? [];
 
-export const getPlanPreserveIP = (plan: V1beta1Plan) => plan?.spec?.preserveStaticIPs;
+export const getPlanPreserveIP = (plan: V1beta1Plan): boolean | undefined =>
+  plan?.spec?.preserveStaticIPs;
 
-const getPlanMap = (plan: V1beta1Plan) => plan?.spec?.map;
+const getPlanMap = (plan: V1beta1Plan): V1beta1PlanSpecMap | undefined => plan?.spec?.map;
 
-const getPlanNetworkMap = (plan: V1beta1Plan) => getPlanMap(plan)?.network;
+const getPlanNetworkMap = (plan: V1beta1Plan): V1beta1PlanSpecMapNetwork | undefined =>
+  getPlanMap(plan)?.network;
 
-const getPlanStorageMap = (plan: V1beta1Plan) => getPlanMap(plan)?.storage;
+const getPlanStorageMap = (plan: V1beta1Plan): V1beta1PlanSpecMapStorage | undefined =>
+  getPlanMap(plan)?.storage;
 
-export const getPlanStorageMapName = (plan: V1beta1Plan) => getPlanStorageMap(plan)?.name;
+export const getPlanStorageMapName = (plan: V1beta1Plan): string | undefined =>
+  getPlanStorageMap(plan)?.name;
 
-export const getPlanStorageMapNamespace = (plan: V1beta1Plan) => getPlanStorageMap(plan)?.namespace;
+export const getPlanStorageMapNamespace = (plan: V1beta1Plan): string | undefined =>
+  getPlanStorageMap(plan)?.namespace;
 
-export const getPlanNetworkMapName = (plan: V1beta1Plan) => getPlanNetworkMap(plan)?.name;
+export const getPlanNetworkMapName = (plan: V1beta1Plan): string | undefined =>
+  getPlanNetworkMap(plan)?.name;
 
-export const getPlanNetworkMapNamespace = (plan: V1beta1Plan) => getPlanNetworkMap(plan)?.namespace;
+export const getPlanNetworkMapNamespace = (plan: V1beta1Plan): string | undefined =>
+  getPlanNetworkMap(plan)?.namespace;
 
-export const getPlanTransferNetwork = (plan: V1beta1Plan) => plan?.spec?.transferNetwork;
+export const getPlanTransferNetwork = (
+  plan: V1beta1Plan,
+): V1beta1PlanSpecTransferNetwork | undefined => plan?.spec?.transferNetwork;
 
-export const getPlanTargetNamespace = (plan: V1beta1Plan) => plan?.spec?.targetNamespace;
+export const getPlanTargetNamespace = (plan: V1beta1Plan): string | undefined =>
+  plan?.spec?.targetNamespace;
 
-export const getPlanPreserveClusterCpuModel = (plan: V1beta1Plan) =>
+export const getPlanPreserveClusterCpuModel = (plan: V1beta1Plan): boolean | undefined =>
   plan?.spec?.preserveClusterCpuModel;
 
-export const getLUKSSecretName = (plan: V1beta1Plan) => plan?.spec?.vms?.[0]?.luks?.name;
+export const getLUKSSecretName = (plan: V1beta1Plan): string | undefined =>
+  plan?.spec?.vms?.[0]?.luks?.name;
 
 export const getPlanHasNBDEClevis = (plan: V1beta1Plan): boolean =>
   plan?.spec?.vms?.some((vm: EnhancedPlanSpecVms) => vm.nbdeClevis === true) ?? false;
 
-export const getRootDisk = (plan: V1beta1Plan) => plan?.spec?.vms?.[0]?.rootDisk;
+export const getRootDisk = (plan: V1beta1Plan): string | undefined =>
+  plan?.spec?.vms?.[0]?.rootDisk;
 
 export const getPlanTargetPowerState = (plan: V1beta1Plan): TargetPowerStateValue =>
   plan?.spec?.targetPowerState;

--- a/src/utils/crds/plans/utils.ts
+++ b/src/utils/crds/plans/utils.ts
@@ -3,7 +3,7 @@ import { getResourceUrl } from '@utils/getResourceUrl';
 
 import { getName, getNamespace } from '../common/selectors';
 
-export const getPlanURL = (plan: V1beta1Plan) =>
+export const getPlanURL = (plan: V1beta1Plan): string =>
   getResourceUrl({
     name: getName(plan),
     namespace: getNamespace(plan),

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,10 +1,16 @@
+type CancellableDebouncedFn<T extends (...args: Parameters<T>) => ReturnType<T>> = ((
+  ...args: Parameters<T>
+) => void) & {
+  cancel: () => void;
+};
+
 export const createCancellableDebounce = <T extends (...args: Parameters<T>) => ReturnType<T>>(
   func: T,
   wait: number,
-) => {
+): CancellableDebouncedFn<T> => {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  const debouncedFn = (...args: Parameters<T>) => {
+  const debouncedFn = (...args: Parameters<T>): void => {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
@@ -13,7 +19,7 @@ export const createCancellableDebounce = <T extends (...args: Parameters<T>) => 
     }, wait);
   };
 
-  debouncedFn.cancel = () => {
+  debouncedFn.cancel = (): void => {
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = null;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,5 +4,5 @@ import { ServerBranding } from './constants';
  * Determines whether user is upstream based on SERVER_FLAGS branding
  * @returns boolean
  */
-export const isUpstream = () =>
+export const isUpstream = (): boolean =>
   (window.SERVER_FLAGS?.branding ?? '') === (ServerBranding.Okd as string);

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -24,7 +24,7 @@ const useHasSourceAndTargetProviders = (
   return [hasSourceProviders, hasTargetProviders, providersLoaded, providersError];
 };
 
-export const useHasSufficientProviders = (namespace?: string) => {
+export const useHasSufficientProviders = (namespace?: string): boolean => {
   const [hasSourceProviders, hasTargetProviders, providersLoaded, providersError] =
     useHasSourceAndTargetProviders(namespace);
   const hasSufficientProviders =

--- a/src/utils/form.ts
+++ b/src/utils/form.ts
@@ -2,5 +2,6 @@ import type { FieldError } from 'react-hook-form';
 
 import { ValidatedOptions } from '@patternfly/react-core';
 
-export const getInputValidated = (error: boolean | string | FieldError | undefined) =>
-  error ? ValidatedOptions.error : ValidatedOptions.default;
+export const getInputValidated = (
+  error: boolean | string | FieldError | undefined,
+): 'default' | 'error' => (error ? ValidatedOptions.error : ValidatedOptions.default);

--- a/src/utils/helpers/hasObjectChangedInGivenFields.ts
+++ b/src/utils/helpers/hasObjectChangedInGivenFields.ts
@@ -4,8 +4,8 @@ const isEqual = (obj1: unknown, obj2: unknown, fieldsToAvoidComparing: string[])
     return obj1 === obj2;
   }
 
-  const isFieldToCompare = (key: string) => !fieldsToAvoidComparing.includes(key);
-  const isFieldChanged = (key: string, keys2: string[], avoidedFields: string[]) =>
+  const isFieldToCompare = (key: string): boolean => !fieldsToAvoidComparing.includes(key);
+  const isFieldChanged = (key: string, keys2: string[], avoidedFields: string[]): boolean =>
     !keys2.includes(key) ||
     !isEqual(
       (obj1 as Record<string, unknown>)[key],

--- a/src/utils/helpers/safeBase64Decode.ts
+++ b/src/utils/helpers/safeBase64Decode.ts
@@ -1,6 +1,6 @@
 import { Base64 } from 'js-base64';
 
-export const safeBase64Decode = (value: string) => {
+export const safeBase64Decode = (value: string): string | undefined => {
   try {
     return Base64.decode(value);
   } catch {

--- a/src/utils/hooks/__tests__/useClusterIsAwsPlatform.test.ts
+++ b/src/utils/hooks/__tests__/useClusterIsAwsPlatform.test.ts
@@ -6,7 +6,7 @@ import { useClusterIsAwsPlatform } from '../useClusterIsAwsPlatform';
 const mockUseK8sWatchResource = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  useK8sWatchResource: (...args: unknown[]) => mockUseK8sWatchResource(...args),
+  useK8sWatchResource: (...args: unknown[]): unknown => mockUseK8sWatchResource(...args),
 }));
 
 describe('useClusterIsAwsPlatform', () => {

--- a/src/utils/hooks/useDefaultProject.ts
+++ b/src/utils/hooks/useDefaultProject.ts
@@ -11,7 +11,7 @@ import { getDefaultNamespace } from '@utils/namespaces';
  * - Returns an empty string if no matching namespace is available.
  * @param projectNames
  */
-export const useDefaultProject = (projectNames: string[]) => {
+export const useDefaultProject = (projectNames: string[]): string => {
   const [activeNamespace] = useActiveNamespace();
   const defaultNamespace = getDefaultNamespace();
 

--- a/src/utils/hooks/useIsDarkTheme.ts
+++ b/src/utils/hooks/useIsDarkTheme.ts
@@ -13,7 +13,7 @@ export const useIsDarkTheme = (): boolean => {
 
     observer.observe(document.documentElement, { attributeFilter: ['class'], attributes: true });
 
-    return () => {
+    return (): void => {
       observer.disconnect();
     };
   }, []);

--- a/src/utils/hooks/useLightspeed/__tests__/useLightspeed.test.ts
+++ b/src/utils/hooks/useLightspeed/__tests__/useLightspeed.test.ts
@@ -8,7 +8,7 @@ import { clickOLSSubmitButton } from '../utils';
 const mockDispatch = jest.fn();
 
 jest.mock('react-redux', () => ({
-  useDispatch: () => mockDispatch,
+  useDispatch: (): typeof mockDispatch => mockDispatch,
 }));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({

--- a/src/utils/hooks/useProviderInventory.ts
+++ b/src/utils/hooks/useProviderInventory.ts
@@ -116,7 +116,7 @@ const useProviderInventory = <T>({
   useEffect(() => {
     let active = true;
 
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       if (disabled) {
         return;
       }
@@ -165,12 +165,12 @@ const useProviderInventory = <T>({
       }
     };
 
-    (async () => {
+    (async (): Promise<void> => {
       await fetchData();
     })();
 
     const intervalId = setInterval(fetchData, interval);
-    return () => {
+    return (): void => {
       active = false;
       clearInterval(intervalId);
     };

--- a/src/utils/hooks/useToggle.ts
+++ b/src/utils/hooks/useToggle.ts
@@ -17,7 +17,7 @@ import { useState } from 'react';
 const useToggle = (initialValue = false): [boolean, () => void] => {
   const [value, setIsOpen] = useState(initialValue);
 
-  const toggle = () => {
+  const toggle = (): void => {
     setIsOpen((open) => !open);
   };
 

--- a/src/utils/i18n.tsx
+++ b/src/utils/i18n.tsx
@@ -3,7 +3,7 @@ import type { FC, ReactNode } from 'react';
 import { getI18n, Trans, useTranslation } from 'react-i18next';
 import type { TOptions } from 'i18next';
 
-export const useForkliftTranslation = () => {
+export const useForkliftTranslation = (): ReturnType<typeof useTranslation> => {
   return useTranslation('plugin__forklift-console-plugin');
 };
 
@@ -22,5 +22,5 @@ export const ForkliftTrans: FC<{ children?: ReactNode }> = ({ children }) => {
  * @param value string to translate
  * @param options (optional) options for translations
  */
-export const t = (value: string, options?: TOptions) =>
+export const t = (value: string, options?: TOptions): string =>
   getI18n().t(value, { ns: 'plugin__forklift-console-plugin', ...options });

--- a/src/utils/namespaces.ts
+++ b/src/utils/namespaces.ts
@@ -15,7 +15,7 @@ export const getDefaultNamespace = (): string => {
   return Namespace.OpenshiftMtv;
 };
 
-export const isSystemNamespace = (option: string) => {
+export const isSystemNamespace = (option: string): boolean => {
   const startsWithNamespace = SYSTEM_NAMESPACES_PREFIX.some((ns) => option.startsWith(ns));
   const isNamespace = SYSTEM_NAMESPACES.includes(option);
 

--- a/src/utils/selectToggle.tsx
+++ b/src/utils/selectToggle.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, Ref } from 'react';
+import type { ReactElement, ReactNode, Ref } from 'react';
 
 import { MenuToggle, type MenuToggleElement, type MenuToggleProps } from '@patternfly/react-core';
 
@@ -7,8 +7,12 @@ type SelectToggleProps = MenuToggleProps & {
   testId?: string;
 };
 
-const selectToggle = ({ selected, testId, ...menuProps }: SelectToggleProps) => {
-  return (toggleRef: Ref<MenuToggleElement>) => (
+const selectToggle = ({
+  selected,
+  testId,
+  ...menuProps
+}: SelectToggleProps): ((toggleRef: Ref<MenuToggleElement>) => ReactElement) => {
+  return (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle data-testid={testId} ref={toggleRef} {...menuProps}>
       {selected}
     </MenuToggle>

--- a/src/utils/userSettingsHelpers.ts
+++ b/src/utils/userSettingsHelpers.ts
@@ -21,7 +21,7 @@ export const parseOrClean = <T>(key: string): T => {
 export const saveRestOrRemoveKey = (
   key: string,
   { rest }: Record<string, Record<string, unknown>>,
-) => {
+): void => {
   if (isEmpty(Object.keys(rest))) {
     removeFromLocalStorage(key);
     return;

--- a/src/utils/validation/common.ts
+++ b/src/utils/validation/common.ts
@@ -61,39 +61,39 @@ const TMP_TOKEN_REGEX = /^sha256~[A-Za-z0-9+/=_-]{43}$/u;
 
 // helper methods
 
-export const validateContainerImage = (image: string) => {
+export const validateContainerImage = (image: string): boolean => {
   return IMAGE_REGEX.test(image);
 };
 
-export const validateURL = (url: string) => {
+export const validateURL = (url: string): boolean => {
   return URL_REGEX.test(url);
 };
 
-export const validateIpv4 = (value: string) => {
+export const validateIpv4 = (value: string): boolean => {
   return IPV4_REGEX.test(value);
 };
 
-export const validateNFSMount = (nfsPath: string) => {
+export const validateNFSMount = (nfsPath: string): boolean => {
   return NFS_REGEX.test(nfsPath);
 };
 
-export const validatePublicCert = (ca: string) => {
+export const validatePublicCert = (ca: string): boolean => {
   return CERTIFICATE_REGEX.test(ca);
 };
 
-export const validateFingerprint = (fingerprint: string) => {
+export const validateFingerprint = (fingerprint: string): boolean => {
   return FINGERPRINT_REGEX.test(fingerprint);
 };
 
-export const validateK8sName = (k8sName?: string) => {
+export const validateK8sName = (k8sName?: string): boolean | string | undefined => {
   return k8sName && DNS_SUBDOMAINS_NAME_REGEXP.test(k8sName);
 };
 
-export const validateK8sToken = (token: string) => {
+export const validateK8sToken = (token: string): boolean => {
   return JWT_TOKEN_REGEX.test(token) || K8S_TOKEN_REGEX.test(token) || TMP_TOKEN_REGEX.test(token);
 };
 
-export const validateNoSpaces = (value: string) => {
+export const validateNoSpaces = (value: string): boolean => {
   // any string without spaces
   return /^[^\s]+$/u.test(value);
 };

--- a/src/utils/vm/__tests__/getVmGuestOS.test.ts
+++ b/src/utils/vm/__tests__/getVmGuestOS.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from '@jest/globals';
 
 import { getVmGuestOS } from '../getVmGuestOS';
 
-const makeVm = (overrides: Partial<ProviderVirtualMachine>) => overrides as ProviderVirtualMachine;
+const makeVm = (overrides: Partial<ProviderVirtualMachine>): ProviderVirtualMachine =>
+  overrides as ProviderVirtualMachine;
 
 describe('getVmGuestOS', () => {
   it('returns empty string for undefined', () => {

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -16,6 +16,9 @@ declare module '*.png' {
   export default content;
 }
 
+declare module '*.scss';
+declare module '*.css';
+
 declare module '*.json' {
   const content: string;
   export default content;


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/explicit-function-return-type` as **error** for `src/**/*.{ts,tsx}` and annotate the frozen file list from MTV-6273 S5
- Turn off `@eslint-react/hooks-extra/prefer-use-state-lazy-initialization` (noise; not worth elevating)
- Declare `*.scss` / `*.css` modules in `types/globals.d.ts` to stop IDE cascades into `no-unsafe-assignment`
- Update `CONTRIBUTING.md` so `explicit-function-return-type` is no longer listed as deferred

## Test plan
- [x] `npx eslint` on `src/` shows no `explicit-function-return-type` errors
- [x] `npx tsc --noEmit` passes
- [x] Spot-check a few annotated call sites (filters, plans create, providers) still typecheck in the IDE
- [x] Confirm CI lint job is green

Resolves: MTV-6273

Made with [Cursor](https://cursor.com)