### PR TITLE
Resolves: MTV-6124 | isPlanArchived() false negative

### DIFF
--- a/src/plans/details/components/PlanStatus/utils/planStatusResolver.ts
+++ b/src/plans/details/components/PlanStatus/utils/planStatusResolver.ts
@@ -44,11 +44,11 @@ const isPlanPendingExecution = (plan: V1beta1Plan): boolean => {
 };
 
 export const isPlanArchived = (plan: V1beta1Plan): boolean => {
-  const conditions = getPlanConditions(plan);
-  return (
-    (plan?.spec?.archived && !conditions.includes(PlanStatuses.Archived)) ?? // Archiving
-    conditions.includes(PlanStatuses.Archived)
+  const conditions = plan.status?.conditions;
+  const hasArchivedCondition = (conditions ?? []).some(
+    (condition) => condition.type === (PlanStatuses.Archived as string),
   );
+  return Boolean(plan?.spec?.archived) || hasArchivedCondition;
 };
 
 export const getPlanStatus = (plan: V1beta1Plan): PlanStatuses => {


### PR DESCRIPTION
## Summary
Fixed an issue where isPlanArchived() in "src/plans/details/components/PlanStatus/utils/utils.ts" wrongfully returned false for a fully archived plan. A nullish check was short-circuiting to false, preventing the function from evaluating the second check "conditions.includes(PlanStatuses.Archived)", which evaluates to true for fully archived plans.

## 📝 Links\

https://redhat.atlassian.net/browse/MTV-6124

## 📝 Description
Simplified the condition with a simple 'or' check while treating the return values as booleans.


## 📝 CC://

- _Pre fix:_ Migration Status wrongfully appears for an archived plan and is stuck on zero
<img width="1251" height="557" alt="migration-status-before" src="https://github.com/user-attachments/assets/6f54b3a4-c70f-4e9c-9a02-cbdd30711165" />


- _Post fix:_ Migration Status rightfully appears as archived
<img width="1572" height="513" alt="migration-status-after" src="https://github.com/user-attachments/assets/5029c067-cba3-4757-83d0-f9e62f441b4e" />


- _Pre fix:_ The Schedule Cutover button wrongfully appears for an archived plan 
<img width="1565" height="122" alt="schedule-cutover-before" src="https://github.com/user-attachments/assets/b56a44e9-eacf-423a-9e56-3e5887529f8f" />


- _Post fix:_ The Schedule Cutover button is rightfully gone
<img width="1561" height="125" alt="schedule-cutover-after" src="https://github.com/user-attachments/assets/74691a37-222a-4b46-ad3a-2a355eda3622" />

<!---
> @tag as needed
-->

---

<details>
<summary>Merge automation commands</summary>

| Command | Description |
|---------|-------------|
| `/lgtm` or `/approve` | Add the `approved` label — PR will auto-merge when all checks pass |
| `/retest` | Re-trigger **Konflux** pipelines (handled by Pipelines as Code) |
| `/retest-gh` | Re-run **failed** GitHub Actions jobs |
| `/retest-gh-all` | Re-run **all** GitHub Actions workflows from scratch |
| `/retest-all` | Re-run failed GitHub Actions jobs **+** Konflux pipelines |
| `/hold` | Prevent auto-merge even if approved and checks pass |
| `/unhold` | Remove the hold and allow auto-merge again |

Submitting a **GitHub review approval** (Approve) also adds the `approved` label.

When checks fail on an approved PR, the bot automatically retries failed GitHub Actions up to **3 times**.
Konflux pipeline failures require a manual `/retest` to re-trigger.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archived plan detection by recognizing archived conditions regardless of their status.
  - Ensured plans marked as archived in their configuration are consistently identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->