### PR TITLE
Resolves: MTV-6463 | Enforce no-unstable-default-props on src

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -426,6 +426,8 @@ export const createEslintConfig = () =>
         ...eslintReact.configs['recommended-typescript'].rules,
         '@eslint-react/hooks-extra/no-direct-set-state-in-use-effect': 'error',
         '@eslint-react/hooks-extra/prefer-use-state-lazy-initialization': 'off',
+        // MTV-6463: stable module-level defaults instead of inline []/{}
+        '@eslint-react/no-unstable-default-props': 'error',
       },
     },
     // MTV-6273: enforce explicit return types on src/

--- a/src/__mocks__/console_components.tsx
+++ b/src/__mocks__/console_components.tsx
@@ -2,8 +2,10 @@ import type { ReactElement } from 'react';
 
 import type { ResourceLinkProps } from '@openshift-console/dynamic-plugin-sdk';
 
+const EMPTY_GROUP_VERSION_KIND = { kind: '', version: '' };
+
 export const ResourceLink = ({
-  groupVersionKind: { group = '', kind = '', version = '' } = { kind: '', version: '' },
+  groupVersionKind: { group = '', kind = '', version = '' } = EMPTY_GROUP_VERSION_KIND,
   name,
   namespace: ns,
 }: ResourceLinkProps): ReactElement => (

--- a/src/components/InspectVirtualMachines/InspectionVmTable.tsx
+++ b/src/components/InspectVirtualMachines/InspectionVmTable.tsx
@@ -12,6 +12,7 @@ import InspectionVmRow from './InspectionVmRow';
 import VmConfigForm from './VmConfigForm';
 
 const INSPECTION_VM_TABLE_ID = 'inspection-vm-table';
+const EMPTY_VM_OVERRIDES: Record<string, VmOverrides> = {};
 
 const getDiskEncryptionLabel = (overrides?: VmOverrides): string | undefined => {
   if (overrides?.nbdeClevis) {
@@ -43,7 +44,7 @@ const InspectionVmTable: FC<InspectionVmTableProps> = ({
   onSelect,
   onVmOverrideChange,
   selectedIds,
-  vmOverrides = {},
+  vmOverrides = EMPTY_VM_OVERRIDES,
   vmRows,
 }) => {
   const { t } = useForkliftTranslation();

--- a/src/components/SelectedToggle/SelectedToggleAction.tsx
+++ b/src/components/SelectedToggle/SelectedToggleAction.tsx
@@ -8,8 +8,10 @@ type SelectedToggleActionProps = GlobalActionToolbarProps<unknown> & {
   store: ShowAllStore;
 };
 
+const EMPTY_SELECTED_IDS: string[] = [];
+
 const SelectedToggleAction: FC<SelectedToggleActionProps> = ({
-  selectedIds: toolbarSelectedIds = [],
+  selectedIds: toolbarSelectedIds = EMPTY_SELECTED_IDS,
   store,
 }) => {
   const showAll = useSyncExternalStore(store.subscribe, store.getSnapshot);

--- a/src/components/common/Filter/DateFilter.tsx
+++ b/src/components/common/Filter/DateFilter.tsx
@@ -20,7 +20,7 @@ export const DateFilter = ({
   filterId,
   onFilterUpdate,
   placeholderLabel,
-  selectedFilters = [],
+  selectedFilters,
   showFilter = true,
   title,
 }: FilterTypeProps): ReactElement => {

--- a/src/components/common/Filter/EnumFilter.tsx
+++ b/src/components/common/Filter/EnumFilter.tsx
@@ -15,6 +15,9 @@ import { isEmpty } from '@utils/helpers';
 
 import type { FilterTypeProps } from './types';
 
+const EMPTY_ENUM_IDS: string[] = [];
+const EMPTY_ENUM_VALUES: NonNullable<FilterTypeProps['supportedValues']> = [];
+
 /**
  * This Filter type enables selecting one or many enum values from the list.
  *
@@ -37,9 +40,9 @@ export const EnumFilter = ({
   onFilterUpdate: onSelectedEnumIdsChange,
   placeholderLabel,
   resolvedLanguage,
-  selectedFilters: selectedEnumIds = [],
+  selectedFilters: selectedEnumIds = EMPTY_ENUM_IDS,
   showFilter = true,
-  supportedValues: supportedEnumValues = [],
+  supportedValues: supportedEnumValues = EMPTY_ENUM_VALUES,
   title = '',
 }: FilterTypeProps): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/common/Filter/GroupedEnumFilter.tsx
+++ b/src/components/common/Filter/GroupedEnumFilter.tsx
@@ -16,6 +16,9 @@ import { isEmpty } from '@utils/helpers';
 
 import type { FilterTypeProps } from './types';
 
+const EMPTY_ENUM_IDS: string[] = [];
+const EMPTY_ENUM_VALUES: NonNullable<FilterTypeProps['supportedValues']> = [];
+
 const renderOptions = (
   supportedGroups: EnumGroup[],
   supportedEnumValues: EnumValue[],
@@ -64,11 +67,11 @@ export const GroupedEnumFilter = ({
   hasMultipleResources,
   onFilterUpdate: onSelectedEnumIdsChange,
   placeholderLabel,
-  selectedFilters: selectedEnumIds = [],
+  selectedFilters: selectedEnumIds = EMPTY_ENUM_IDS,
   showFilter = true,
   showFilterIcon,
   supportedGroups,
-  supportedValues: supportedEnumValues = [],
+  supportedValues: supportedEnumValues = EMPTY_ENUM_VALUES,
 }: FilterTypeProps): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadSelect.tsx
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/MultiTypeaheadSelect.tsx
@@ -46,6 +46,8 @@ type MultiTypeaheadSelectProps = {
   values?: (string | number)[];
 } & Omit<SelectProps, 'toggle' | 'onSelect' | 'selected' | 'isOpen'>;
 
+const EMPTY_VALUES: (string | number)[] = [];
+
 const MultiTypeaheadSelect = (
   {
     allowClear = false,
@@ -67,7 +69,7 @@ const MultiTypeaheadSelect = (
     testId,
     toggleProps,
     toggleWidth,
-    values = [],
+    values = EMPTY_VALUES,
     ...selectProps
   }: MultiTypeaheadSelectProps,
   ref: ForwardedRef<HTMLInputElement>,

--- a/src/components/modals/AlertMessageForModals.tsx
+++ b/src/components/modals/AlertMessageForModals.tsx
@@ -10,11 +10,11 @@ export const AlertMessageForModals: FC<{
   message: ReactNode | string;
   title?: string;
   variant?: 'success' | 'danger' | 'warning' | 'info' | 'custom';
-}> = ({ className, message, title = t('Error'), variant = 'danger' }) => (
+}> = ({ className, message, title, variant = 'danger' }) => (
   <Alert
     className={className ?? 'co-alert forklift-alert--margin-top'}
     isInline
-    title={title}
+    title={title ?? t('Error')}
     variant={variant}
   >
     {message}

--- a/src/components/page/StandardPageInner.tsx
+++ b/src/components/page/StandardPageInner.tsx
@@ -24,6 +24,8 @@ type StandardPageInnerProps<T> = Omit<ComponentProps<typeof StandardPage<T>>, 'p
   TableSortContextProps &
   Required<Pick<ComponentProps<typeof StandardPage<T>>, 'pageRef'>>;
 
+const EMPTY_GLOBAL_ACTION_TOOLBAR_ITEMS: never[] = [];
+
 const StandardPageInner = <T,>({
   activeSort,
   addButton,
@@ -40,7 +42,7 @@ const StandardPageInner = <T,>({
   extraSupportedFilters,
   extraSupportedMatchers,
   fieldsMetadata,
-  GlobalActionToolbarItems = [],
+  GlobalActionToolbarItems = EMPTY_GLOBAL_ACTION_TOOLBAR_ITEMS,
   header = DefaultHeader<T>,
   namespace = '',
   noPadding,

--- a/src/components/page/StandardPageWithSelection.tsx
+++ b/src/components/page/StandardPageWithSelection.tsx
@@ -10,6 +10,8 @@ import { createHeaderWithSelection } from './utils/createHeaderWithSelection';
 import { createRowWithSelection } from './utils/createRowWithSelection';
 import StandardPage from './StandardPage';
 
+const defaultCanSelect = (_item: unknown): boolean => true;
+
 const wrapActionWithSelection = <T,>(
   Action: FC<GlobalActionToolbarProps<T>>,
   selectedIds: string[],
@@ -65,7 +67,7 @@ export const StandardPageWithSelection = <T,>(
   props: StandardPageWithSelectionProps<T>,
 ): ReactElement => {
   const {
-    canSelect = (): boolean => true,
+    canSelect: canSelectProp,
     cell,
     expanded,
     expandedIds,
@@ -78,6 +80,7 @@ export const StandardPageWithSelection = <T,>(
     toId,
     ...rest
   } = props;
+  const canSelect = canSelectProp ?? defaultCanSelect;
 
   const pageRef = useRef(rest.page ?? 1);
 

--- a/src/plans/create/steps/migration-type/MigrationTypeRadio.tsx
+++ b/src/plans/create/steps/migration-type/MigrationTypeRadio.tsx
@@ -14,6 +14,8 @@ import { useForkliftTranslation } from '@utils/i18n';
 
 import { migrationTypeLabels, MigrationTypeValue } from './constants';
 
+const EMPTY_CBT_DISABLED_VMS: ProviderVirtualMachine[] = [];
+
 type MigrationTypeRadioProps = {
   cbtDisabledVms?: ProviderVirtualMachine[];
   migrationType: MigrationTypeValue;
@@ -23,7 +25,7 @@ type MigrationTypeRadioProps = {
 };
 
 const MigrationTypeRadio: FC<MigrationTypeRadioProps> = ({
-  cbtDisabledVms = [],
+  cbtDisabledVms = EMPTY_CBT_DISABLED_VMS,
   migrationType,
   onChange,
   sourceProvider,

--- a/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
+++ b/src/plans/create/steps/review/__tests__/OtherSettingsReviewSection.test.tsx
@@ -23,10 +23,12 @@ jest.mock('@patternfly/react-core', () => ({
   }),
 }));
 
+const EMPTY_DISK_PASS_PHRASES: unknown[] = [];
+
 const TestWrapper = ({
   sourceProvider,
   nbdeClevis = false,
-  diskPassPhrases = [],
+  diskPassPhrases = EMPTY_DISK_PASS_PHRASES,
   diskDecryptionType = DiskDecryptionType.New,
   existingLUKSSecret,
 }: {

--- a/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
+++ b/src/providers/details/tabs/VirtualMachines/components/ProviderVirtualMachinesList.tsx
@@ -16,6 +16,8 @@ import { getVmId } from '../utils/helpers/vmProps';
 import { extraSupportedFilters, extraSupportedMatchers } from './constants';
 import type { VmData } from './VMCellProps';
 
+const EMPTY_SELECTED_IDS: string[] = [];
+
 type ProviderVirtualMachinesListProps = {
   cellMapper: FC<RowProps<VmData>>;
   className?: string;
@@ -52,7 +54,7 @@ export const ProviderVirtualMachinesList: FC<ProviderVirtualMachinesListProps> =
   className,
   fieldsMetadata,
   GlobalActionToolbarItems,
-  initialSelectedIds = [],
+  initialSelectedIds = EMPTY_SELECTED_IDS,
   obj,
   onSelect,
   pageId,


### PR DESCRIPTION
## Summary
- Enable `@eslint-react/no-unstable-default-props` as `error` for `src/**/*.{ts,tsx}`
- Replace inline `[]` / `{}` / function default props with stable module-level constants (or remove unstable defaults) across shared filters, page wrappers, selects, and related call sites
- Keeps default prop identities stable across renders to avoid unnecessary re-renders / effect loops

## Test plan
- [x] `npx eslint 'src/**/*.{ts,tsx}' --quiet` — no `no-unstable-default-props` errors
- [x] Spot-check filter/select pages (EnumFilter, DateFilter, MultiTypeaheadSelect) still work with empty defaults
- [x] Spot-check StandardPage / selection tables still select and expand correctly
- [x] CI green (lint, unit tests)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal error messaging by consistently displaying a translated “Error” title when no title is provided.
  * Preserved expected filtering and selection behavior when optional values are omitted.

* **Performance and Stability**
  * Reduced unnecessary repeated allocations across filters, selections, migration steps, virtual machine views, and page actions for smoother rendering.

* **Developer Experience**
  * Added safeguards to detect unstable default properties during development and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->