### PR TITLE
Resolves: MTV-6134 | Blank cell in provider's credentials tab

### DIFF
--- a/src/providers/details/tabs/Credentials/components/CredentialFieldContent.tsx
+++ b/src/providers/details/tabs/Credentials/components/CredentialFieldContent.tsx
@@ -21,7 +21,8 @@ const CredentialContentField: FC<CredentialContentFieldProps> = ({ fieldKey, rev
   }
 
   if (fieldKey && fieldKey === SecretFieldsId.InsecureSkipVerify) {
-    return <>{value}</>;
+    if (value) return <>{value}</>;
+    return <>{EMPTY_MSG}</>;
   }
 
   if (value) {


### PR DESCRIPTION
## 📝 Links
https://redhat.atlassian.net/browse/MTV-6134
## 📝 Description
Added a check in the CredentialContentField component inside the "Skip certificate validation" block to verify truthy values. If the value exists, it is returned; otherwise, it gracefully falls back to the shared placeholder `EMPTY_MSG`.
## 🎥 Demo
_Pre fix:_
<img width="435" height="258" alt="providers-credentials" src="https://github.com/user-attachments/assets/ae641122-d096-4548-a781-ea67ea9dca29" />
_Post fix:_
<img width="443" height="287" alt="providers-credentials-after" src="https://github.com/user-attachments/assets/1a71b095-cfb4-454e-9a40-f5469e84ac69" />

<details>
<summary>Merge automation commands</summary>

| Command | Description |
|---------|-------------|
| `/lgtm` or `/approve` | Add the `approved` label — PR will auto-merge when all checks pass |
| `/retest` | Re-trigger **Konflux** pipelines (handled by Pipelines as Code) |
| `/retest-gh` | Re-run **failed** GitHub Actions jobs |
| `/retest-gh-all` | Re-run **all** GitHub Actions workflows from scratch |
| `/retest-all` | Re-run failed GitHub Actions jobs **+** Konflux pipelines |
| `/hold` | Prevent auto-merge even if approved and checks pass |
| `/unhold` | Remove the hold and allow auto-merge again |

Submitting a **GitHub review approval** (Approve) also adds the `approved` label.

When checks fail on an approved PR, the bot automatically retries failed GitHub Actions up to **3 times**.
Konflux pipeline failures require a manual `/retest` to re-trigger.
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty values for “Insecure Skip Verify” credentials now display a clear placeholder instead of appearing blank.
  * Existing non-empty credential values continue to display unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->