### PR TITLE
Resolves: MTV-6497 MTV-6498 | Tips drawer scope + offload create empty-row E2E

### DIFF
--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -159,6 +159,9 @@ test.describe(
       });
 
       await test.step('Select source/target storage and submit form', async () => {
+        // MTV-6324: create form rejects empty extra rows; remove the row added only for
+        // independent offload-state checks before submitting a single complete mapping.
+        await createPage.removeMapping(1);
         await createPage.selectFirstAvailableSourceAtIndex(0);
         await createPage.selectFirstAvailableTargetAtIndex(0);
         await createPage.submit();

--- a/testing/playwright/page-objects/LearningExperienceDrawer.ts
+++ b/testing/playwright/page-objects/LearningExperienceDrawer.ts
@@ -28,6 +28,13 @@ export class LearningExperienceDrawer {
     this.navigation = new NavigationHelper(page);
   }
 
+  /** Scopes locators away from Overview Welcome tiles with the same provider aria-labels. */
+  private get drawerPanel(): Locator {
+    return this.page.locator('.pf-v6-c-drawer__panel').filter({
+      has: this.page.getByRole('heading', { name: 'Tips and tricks', level: 2 }),
+    });
+  }
+
   private async verifyQuickReferenceItems(items: readonly string[]): Promise<void> {
     for (const item of items) {
       await expect(this.getQuickReferenceItemHeading(item)).toBeVisible();
@@ -56,19 +63,19 @@ export class LearningExperienceDrawer {
   }
 
   getExternalLinksHeading(): Locator {
-    return this.page.getByRole('heading', { name: 'External links', level: 3 });
+    return this.drawerPanel.getByRole('heading', { name: 'External links', level: 3 });
   }
 
   getKeyConsiderationsButton(): Locator {
-    return this.page.getByRole('button', { name: 'Key considerations' });
+    return this.drawerPanel.getByRole('button', { name: 'Key considerations' });
   }
 
   getKeyTerminologyButton(): Locator {
-    return this.page.getByRole('button', { name: 'Key terminology' });
+    return this.drawerPanel.getByRole('button', { name: 'Key terminology' });
   }
 
   getProviderTypeDropdown(providerName: string): Locator {
-    return this.page.getByRole('button', { name: providerName });
+    return this.drawerPanel.getByRole('button', { name: providerName });
   }
 
   getProviderTypeMenuItem(providerName: string): Locator {

--- a/testing/playwright/page-objects/LearningExperienceDrawer.ts
+++ b/testing/playwright/page-objects/LearningExperienceDrawer.ts
@@ -28,11 +28,13 @@ export class LearningExperienceDrawer {
     this.navigation = new NavigationHelper(page);
   }
 
-  /** Scopes locators away from Overview Welcome tiles with the same provider aria-labels. */
+  /**
+   * Tips panel root. Uses the long-lived project class (not PatternFly drawer classes
+   * and not a new data-testid) so the same locator works on V2_11+ zstream and main.
+   * Scopes provider MenuToggle away from Overview Welcome tiles with the same aria-labels.
+   */
   private get drawerPanel(): Locator {
-    return this.page.locator('.pf-v6-c-drawer__panel').filter({
-      has: this.page.getByRole('heading', { name: 'Tips and tricks', level: 2 }),
-    });
+    return this.page.locator('.forklift--learning');
   }
 
   private async verifyQuickReferenceItems(items: readonly string[]): Promise<void> {

--- a/testing/playwright/page-objects/StorageMapCreatePage.ts
+++ b/testing/playwright/page-objects/StorageMapCreatePage.ts
@@ -76,6 +76,13 @@ export class StorageMapCreatePage {
     await input.fill(name);
   }
 
+  async removeMapping(index: number): Promise<void> {
+    const removeButton = this.page.getByTestId(`remove-row-${index}`);
+    await expect(removeButton).toBeVisible();
+    await expect(removeButton).toBeEnabled();
+    await removeButton.click();
+  }
+
   async selectFirstAvailableSourceAtIndex(index: number): Promise<string> {
     return this.selectFirstAvailableOptionFromDropdown(this.sourceStorageTestId(index));
   }


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6497](https://redhat.atlassian.net/browse/MTV-6497)
- Resolves: [MTV-6498](https://redhat.atlassian.net/browse/MTV-6498)
- Related: [MTV-6220](https://redhat.atlassian.net/browse/MTV-6220) (Welcome card aria-label that exposed Tips collision)
- Related: [MTV-6324](https://redhat.atlassian.net/browse/MTV-6324) (create rejects empty extra storage map rows)

## 📝 Description

- **MTV-6497:** Scope Tips provider MenuToggle (and related Quick Reference controls) to `.forklift--learning` so Overview Welcome cards with the same aria-label do not cause Playwright strict-mode failures. No new `data-testid` (zstream-safe).
- **MTV-6498:** After MTV-6324, create StorageMap form rejects empty extra rows. Offload E2E added a second mapping for UI isolation then submitted with only row 0 filled — remove the spare row before Create.

## 🎥 Demo

N/A — test-only locator/flow changes, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6497]: https://redhat.atlassian.net/browse/MTV-6497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6498]: https://redhat.atlassian.net/browse/MTV-6498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6220]: https://redhat.atlassian.net/browse/MTV-6220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6324]: https://redhat.atlassian.net/browse/MTV-6324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for storage map creation by removing incomplete mapping rows before submission.
  * Strengthened drawer validation by scoping checks to the Tips and tricks panel.
  * Added support for removing specific mapping rows during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->