### PR TITLE
Resolves: MTV-6522 | Restore Playwright locators broken by #2792

### DIFF
--- a/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
+++ b/testing/playwright/e2e/downstream/storage-maps/create-storage-map-offload.spec.ts
@@ -164,9 +164,6 @@ test.describe(
         await createPage.removeMapping(1);
         await createPage.selectFirstAvailableSourceAtIndex(0);
         await createPage.selectFirstAvailableTargetAtIndex(0);
-        // Second row was only for independent offload-state checks — remove it so Create
-        // is not blocked by an incomplete mapping.
-        await createPage.removeMapping(1);
         await createPage.submit();
         resourceManager.addStorageMap(storageMapName, MTV_NAMESPACE);
       });

--- a/testing/playwright/e2e/downstream/vm-folder-list.spec.ts
+++ b/testing/playwright/e2e/downstream/vm-folder-list.spec.ts
@@ -124,7 +124,7 @@ providerTest.describe('VM folder list - Provider Details Page', { tag: '@downstr
         expect(columnsAfterAdd).toContain('Path');
       });
 
-      await test.step('6. Test column management - reorder columns via drag and drop', async () => {
+      await test.step('6. Test column management - reorder columns', async () => {
         const initialColumns = await vmTab.getColumns();
         const initialPowerIndex = initialColumns.indexOf('Power');
         const initialConcernsIndex = initialColumns.indexOf('Concerns');

--- a/testing/playwright/e2e/downstream/vm-folder-list.spec.ts
+++ b/testing/playwright/e2e/downstream/vm-folder-list.spec.ts
@@ -124,7 +124,7 @@ providerTest.describe('VM folder list - Provider Details Page', { tag: '@downstr
         expect(columnsAfterAdd).toContain('Path');
       });
 
-      await test.step('6. Test column management - reorder columns', async () => {
+      await test.step('6. Test column management - reorder columns via drag and drop', async () => {
         const initialColumns = await vmTab.getColumns();
         const initialPowerIndex = initialColumns.indexOf('Power');
         const initialConcernsIndex = initialColumns.indexOf('Concerns');

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -2,14 +2,22 @@ import type { Locator, Page } from '@playwright/test';
 
 import type { ScriptConfig } from '../../../types/test-data';
 import { fillScriptFields } from '../../../utils/script-form-helpers';
+import { V5_0_0 } from '../../../utils/version/constants';
+import { isVersionAtLeast } from '../../../utils/version/version';
 import { BaseModal } from '../../common/BaseModal';
 
-// Details edit modal testIds differ from the plan-create wizard
-// (script-name-input-* vs script-name-*).
-const MODAL_FIELD_TEST_IDS = {
+/** 2.12 details modal uses distinct *-input / *-select test ids. */
+const V2_12_SCRIPT_FIELD_TEST_IDS = {
   guestTypeSelect: (i: number): string => `script-guest-type-select-${i}`,
   nameInput: (i: number): string => `script-name-input-${i}`,
   scriptTypeSelect: (i: number): string => `script-type-select-${i}`,
+};
+
+/** 5.0+ details edit shares getScriptFieldInputs with the plan-create wizard. */
+const V5_SCRIPT_FIELD_TEST_IDS = {
+  guestTypeSelect: (i: number): string => `script-guest-type-${i}`,
+  nameInput: (i: number): string => `script-name-${i}`,
+  scriptTypeSelect: (i: number): string => `script-type-${i}`,
 };
 
 export class ScriptEditModal extends BaseModal {
@@ -25,7 +33,12 @@ export class ScriptEditModal extends BaseModal {
   }
 
   async configureScript(index: number, config: ScriptConfig): Promise<void> {
-    await fillScriptFields(this.page, index, config, MODAL_FIELD_TEST_IDS);
+    await fillScriptFields(
+      this.page,
+      index,
+      config,
+      isVersionAtLeast(V5_0_0) ? V5_SCRIPT_FIELD_TEST_IDS : V2_12_SCRIPT_FIELD_TEST_IDS,
+    );
   }
 
   getScriptCount(): Promise<number> {

--- a/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/modals/ScriptEditModal.ts
@@ -4,11 +4,12 @@ import type { ScriptConfig } from '../../../types/test-data';
 import { fillScriptFields } from '../../../utils/script-form-helpers';
 import { BaseModal } from '../../common/BaseModal';
 
-// Aligned with shared getScriptFieldInputs testIds (plan create + details edit).
+// Details edit modal testIds differ from the plan-create wizard
+// (script-name-input-* vs script-name-*).
 const MODAL_FIELD_TEST_IDS = {
-  guestTypeSelect: (i: number): string => `script-guest-type-${i}`,
-  nameInput: (i: number): string => `script-name-${i}`,
-  scriptTypeSelect: (i: number): string => `script-type-${i}`,
+  guestTypeSelect: (i: number): string => `script-guest-type-select-${i}`,
+  nameInput: (i: number): string => `script-name-input-${i}`,
+  scriptTypeSelect: (i: number): string => `script-type-select-${i}`,
 };
 
 export class ScriptEditModal extends BaseModal {

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -221,9 +221,9 @@ export class VirtualMachinesTable {
   }
 
   /**
-   * Reorders columns using move up/down controls in the Manage columns modal.
+   * Reorders columns using drag and drop in the Manage columns modal.
    * @param sourceColumn - Column to move
-   * @param targetColumn - Column to move before
+   * @param targetColumn - Column to move before/after
    */
   async reorderColumn(sourceColumn: string, targetColumn: string): Promise<void> {
     const manageColumnsBtn = this.page.getByTestId('manage-columns-button');
@@ -233,25 +233,37 @@ export class VirtualMachinesTable {
     await expect(modalBody).toBeVisible();
 
     const columnList = modalBody.getByTestId('manage-columns-list');
-    const sourceId = sourceColumn.toLowerCase();
-    const targetId = targetColumn.toLowerCase();
-    const sourceItem = columnList.locator(`#${sourceId}`);
-    const targetItem = columnList.locator(`#${targetId}`);
+    const sourceItem = columnList.locator(`#${sourceColumn.toLowerCase()}`);
+    const targetItem = columnList.locator(`#${targetColumn.toLowerCase()}`);
 
     await expect(sourceItem).toBeVisible();
     await expect(targetItem).toBeVisible();
 
-    const moveUpButton = columnList.getByTestId(`manage-columns-move-up-${sourceId}`);
+    const sourceDragHandle = sourceItem.getByRole('button').first();
+    const targetDragHandle = targetItem.getByRole('button').first();
 
-    // Move source up until it appears before the target column.
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      const sourceBox = await sourceItem.boundingBox();
-      const targetBox = await targetItem.boundingBox();
-      if (sourceBox && targetBox && sourceBox.y < targetBox.y) {
-        break;
-      }
-      await expect(moveUpButton).toBeEnabled();
-      await moveUpButton.click();
+    const sourceBox = await sourceDragHandle.boundingBox();
+    const targetBox = await targetDragHandle.boundingBox();
+
+    if (sourceBox && targetBox) {
+      await this.page.mouse.move(
+        sourceBox.x + sourceBox.width / 2,
+        sourceBox.y + sourceBox.height / 2,
+      );
+      await this.page.mouse.down();
+      await this.page.waitForTimeout(100);
+
+      await this.page.mouse.move(
+        targetBox.x + targetBox.width / 2,
+        targetBox.y + targetBox.height / 2,
+        {
+          steps: 10,
+        },
+      );
+      await this.page.waitForTimeout(100);
+
+      await this.page.mouse.up();
+      await this.page.waitForTimeout(500);
     }
 
     const saveBtn = this.page.getByTestId('manage-columns-save-button');

--- a/testing/playwright/page-objects/common/VirtualMachinesTable.ts
+++ b/testing/playwright/page-objects/common/VirtualMachinesTable.ts
@@ -1,6 +1,14 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 
+import { V5_0_0 } from '../../utils/version/constants';
+import { isVersionAtLeast } from '../../utils/version/version';
+
 import { Table } from './Table';
+
+const DRAG_DROP_SETTLE_MS = 500;
+const DRAG_HOLD_MS = 100;
+const DRAG_MOVE_STEPS = 10;
+const MANAGE_COLUMNS_REORDER_MAX_ATTEMPTS = 20;
 
 /**
  * Shared component for VM tables that appear in:
@@ -17,6 +25,65 @@ export class VirtualMachinesTable {
     this.page = page;
     this.rootLocator = rootLocator;
     this.table = new Table(page, rootLocator);
+  }
+
+  private async reorderColumnWithDrag(
+    sourceColumn: string,
+    targetColumn: string,
+    sourceItem: Locator,
+    targetItem: Locator,
+  ): Promise<void> {
+    const sourceDragHandle = sourceItem.getByRole('button').first();
+    const targetDragHandle = targetItem.getByRole('button').first();
+    const sourceBox = await sourceDragHandle.boundingBox();
+    const targetBox = await targetDragHandle.boundingBox();
+
+    if (!sourceBox || !targetBox) {
+      throw new Error(
+        `Cannot drag column "${sourceColumn}" onto "${targetColumn}": missing bounding box for a drag handle`,
+      );
+    }
+
+    // DragDropSort needs a short hold after mousedown before it treats the pointer as a drag.
+    await this.page.mouse.move(
+      sourceBox.x + sourceBox.width / 2,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await this.page.mouse.down();
+    await this.page.waitForTimeout(DRAG_HOLD_MS);
+
+    await this.page.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height / 2,
+      { steps: DRAG_MOVE_STEPS },
+    );
+    await this.page.waitForTimeout(DRAG_HOLD_MS);
+
+    await this.page.mouse.up();
+    await this.page.waitForTimeout(DRAG_DROP_SETTLE_MS);
+  }
+
+  private async reorderColumnWithMoveButtons(
+    columnList: Locator,
+    sourceId: string,
+    sourceItem: Locator,
+    targetItem: Locator,
+  ): Promise<void> {
+    const moveUpButton = columnList.getByTestId(`manage-columns-move-up-${sourceId}`);
+
+    for (let attempt = 0; attempt < MANAGE_COLUMNS_REORDER_MAX_ATTEMPTS; attempt += 1) {
+      const sourceBox = await sourceItem.boundingBox();
+      const targetBox = await targetItem.boundingBox();
+      if (sourceBox && targetBox && sourceBox.y < targetBox.y) {
+        return;
+      }
+      await expect(moveUpButton).toBeEnabled();
+      await moveUpButton.click();
+    }
+
+    throw new Error(
+      `Failed to move column "${sourceId}" above the target after ${MANAGE_COLUMNS_REORDER_MAX_ATTEMPTS} move-up clicks`,
+    );
   }
 
   /**
@@ -221,9 +288,8 @@ export class VirtualMachinesTable {
   }
 
   /**
-   * Reorders columns using drag and drop in the Manage columns modal.
-   * @param sourceColumn - Column to move
-   * @param targetColumn - Column to move before/after
+   * Reorders columns in the Manage columns modal.
+   * 5.0+ uses move-up buttons; 2.12 uses DragDropSort handles.
    */
   async reorderColumn(sourceColumn: string, targetColumn: string): Promise<void> {
     const manageColumnsBtn = this.page.getByTestId('manage-columns-button');
@@ -233,37 +299,18 @@ export class VirtualMachinesTable {
     await expect(modalBody).toBeVisible();
 
     const columnList = modalBody.getByTestId('manage-columns-list');
-    const sourceItem = columnList.locator(`#${sourceColumn.toLowerCase()}`);
-    const targetItem = columnList.locator(`#${targetColumn.toLowerCase()}`);
+    const sourceId = sourceColumn.toLowerCase();
+    const targetId = targetColumn.toLowerCase();
+    const sourceItem = columnList.locator(`#${sourceId}`);
+    const targetItem = columnList.locator(`#${targetId}`);
 
     await expect(sourceItem).toBeVisible();
     await expect(targetItem).toBeVisible();
 
-    const sourceDragHandle = sourceItem.getByRole('button').first();
-    const targetDragHandle = targetItem.getByRole('button').first();
-
-    const sourceBox = await sourceDragHandle.boundingBox();
-    const targetBox = await targetDragHandle.boundingBox();
-
-    if (sourceBox && targetBox) {
-      await this.page.mouse.move(
-        sourceBox.x + sourceBox.width / 2,
-        sourceBox.y + sourceBox.height / 2,
-      );
-      await this.page.mouse.down();
-      await this.page.waitForTimeout(100);
-
-      await this.page.mouse.move(
-        targetBox.x + targetBox.width / 2,
-        targetBox.y + targetBox.height / 2,
-        {
-          steps: 10,
-        },
-      );
-      await this.page.waitForTimeout(100);
-
-      await this.page.mouse.up();
-      await this.page.waitForTimeout(500);
+    if (isVersionAtLeast(V5_0_0)) {
+      await this.reorderColumnWithMoveButtons(columnList, sourceId, sourceItem, targetItem);
+    } else {
+      await this.reorderColumnWithDrag(sourceColumn, targetColumn, sourceItem, targetItem);
     }
 
     const saveBtn = this.page.getByTestId('manage-columns-save-button');


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-6522](https://redhat.atlassian.net/browse/MTV-6522)
- Related: [MTV-6498](https://redhat.atlassian.net/browse/MTV-6498) (#2774 added the first `removeMapping(1)`; #2792 duplicated it)

## 📝 Description

#2792 (MTV-6276 max-lines split) changed 5.0 product locators while 2.12 zstream UI stayed on the old widgets. Three `@downstream` tests that were green on 2026-08-19 failed on qemtv-09 / MTV 2.12.7.

Page objects now branch with `isVersionAtLeast(V5_0_0)`:

- `ScriptEditModal`: 5.0 uses shared wizard ids (`script-name-*`); 2.12 uses details-modal ids (`script-name-input-*`)
- `reorderColumn`: 5.0 clicks `manage-columns-move-up-*`; 2.12 uses DragDropSort. Missing drag bounding boxes throw instead of saving
- `create-storage-map-offload`: keep a single `removeMapping(1)` on both streams

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-6522]: https://redhat.atlassian.net/browse/MTV-6522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-6498]: https://redhat.atlassian.net/browse/MTV-6498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved automated test coverage and reliability for storage map creation workflows.
  - Updated script editing tests to support the latest product version while maintaining compatibility with earlier versions.
  - Enhanced virtual machine table reordering tests across supported product versions, including clearer validation of move and drag-and-drop behavior.
  - Refined test scenarios and error handling to provide more consistent results across different interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->