### PR TITLE
Resolves: MTV-2836 | Cover LUKS NBDE mutual exclusion and empty-passphrase edit

### DIFF
--- a/testing/playwright/e2e/downstream/plans/plan-existing-luks-secret.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-existing-luks-secret.spec.ts
@@ -131,8 +131,8 @@ test.describe('Plan existing LUKS secret', { tag: '@downstream' }, () => {
 
   test('should show empty passphrases in edit modal when plan has no LUKS secret', async ({
     page,
-    testProvider,
     resourceManager,
+    testProvider,
   }) => {
     test.setTimeout(LUKS_TEST_TIMEOUT_MS);
     const testData: PlanTestData = createPlanTestData({

--- a/testing/playwright/e2e/downstream/plans/plan-existing-luks-secret.spec.ts
+++ b/testing/playwright/e2e/downstream/plans/plan-existing-luks-secret.spec.ts
@@ -50,10 +50,14 @@ test.describe('Plan existing LUKS secret', { tag: '@downstream' }, () => {
 
     const { additionalSettings } = wizard;
 
-    await test.step('Verify radio toggle is visible and select existing secret', async () => {
+    await test.step('Verify radio toggle is visible and NBDE hides it', async () => {
       await additionalSettings.verifyStepVisible();
       await expect(additionalSettings.existingSecretRadio).toBeVisible();
       await expect(additionalSettings.newPassphrasesRadio).toBeVisible();
+      await additionalSettings.verifyNbdeHidesLuksRadios();
+    });
+
+    await test.step('Select existing secret', async () => {
       await additionalSettings.selectExistingLUKSSecret(LUKS_TEST_SECRET_NAME);
     });
 
@@ -93,6 +97,14 @@ test.describe('Plan existing LUKS secret', { tag: '@downstream' }, () => {
       await expect(detailsTab.saveDiskDecryptionButton).toBeEnabled();
     });
 
+    await test.step('Verify NBDE/Clevis hides LUKS radios in the edit modal', async () => {
+      const { detailsTab } = new PlanDetailsPage(page);
+      await detailsTab.verifyNbdeHidesLuksRadios();
+      await expect(page.getByTestId('edit-luks-secret-select').getByRole('combobox')).toHaveValue(
+        LUKS_TEST_SECRET_NAME,
+      );
+    });
+
     await test.step('Toggle between modes and verify state preservation', async () => {
       await page.getByTestId('edit-use-existing-secret-radio').click();
       await expect(page.getByTestId('edit-luks-secret-select')).toBeVisible();
@@ -114,6 +126,48 @@ test.describe('Plan existing LUKS secret', { tag: '@downstream' }, () => {
       await expect(detailsTab.editDiskDecryptionModal).toBeVisible();
       await expect(page.getByTestId('edit-use-passphrases-radio')).toBeChecked();
       await expect(page.getByTestId('edit-luks-secret-select')).not.toBeVisible();
+    });
+  });
+
+  test('should show empty passphrases in edit modal when plan has no LUKS secret', async ({
+    page,
+    testProvider,
+    resourceManager,
+  }) => {
+    test.setTimeout(LUKS_TEST_TIMEOUT_MS);
+    const testData: PlanTestData = createPlanTestData({
+      sourceProvider: testProvider?.metadata?.name ?? '',
+    });
+    resourceManager.addPlan(testData.planName, testData.planProject);
+
+    await test.step('Create a plan with no disk decryption configured', async () => {
+      const wizard = new CreatePlanWizardPage(page, resourceManager);
+      await wizard.navigate();
+      await wizard.waitForWizardLoad();
+      await wizard.fillAndSubmit(testData);
+    });
+
+    const { detailsTab } = new PlanDetailsPage(page);
+
+    await test.step('Open edit modal from a plan with no decryption defined', async () => {
+      await detailsTab.navigateToDetailsTab();
+      await expect(detailsTab.diskDecryptionDetailItem()).toContainText('No decryption defined');
+      await detailsTab.clickEditDiskDecryption();
+      await expect(detailsTab.editDiskDecryptionModal).toBeVisible();
+      await expect(page.getByTestId('edit-luks-secret-loading')).toHaveCount(0);
+    });
+
+    await test.step('Verify passphrases default with a single empty field and no leaked values', async () => {
+      await expect(page.getByTestId('edit-use-passphrases-radio')).toBeChecked();
+      await expect(page.getByTestId('edit-use-existing-secret-radio')).toBeVisible();
+      await expect(page.getByTestId('edit-luks-secret-select')).toHaveCount(0);
+
+      const passphraseInputs = detailsTab.editDiskDecryptionModal.getByRole('textbox');
+      await expect(passphraseInputs).toHaveCount(1);
+      await expect(passphraseInputs).toHaveValue('');
+      await expect(
+        detailsTab.editDiskDecryptionModal.getByRole('button', { name: 'Remove' }),
+      ).toBeDisabled();
     });
   });
 });

--- a/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
+++ b/testing/playwright/page-objects/CreatePlanWizard/steps/AdditionalSettingsSteps.ts
@@ -118,6 +118,15 @@ export class AdditionalSettingsStep {
     await expect(this.page.locator('[data-testid^="instance-type-select-"]')).toHaveCount(expected);
   }
 
+  async verifyNbdeHidesLuksRadios(): Promise<void> {
+    await this.useNbdeClevisCheckbox.check();
+    await expect(this.existingSecretRadio).toBeHidden();
+    await expect(this.newPassphrasesRadio).toBeHidden();
+    await this.useNbdeClevisCheckbox.uncheck();
+    await expect(this.existingSecretRadio).toBeVisible();
+    await expect(this.newPassphrasesRadio).toBeVisible();
+  }
+
   async verifyStepVisible(): Promise<void> {
     await expect(this.page.getByRole('heading', { name: 'Other settings' })).toBeVisible();
   }

--- a/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
+++ b/testing/playwright/page-objects/PlanDetailsPage/tabs/DetailsTab.ts
@@ -293,6 +293,18 @@ export class DetailsTab {
     await expect(this.page.locator('[data-test-id="horizontal-link-Details"]')).toBeVisible();
   }
 
+  async verifyNbdeHidesLuksRadios(): Promise<void> {
+    const existingSecretRadio = this.page.getByTestId('edit-use-existing-secret-radio');
+    const passphrasesRadio = this.page.getByTestId('edit-use-passphrases-radio');
+
+    await this.useNbdeClevisCheckbox.check();
+    await expect(existingSecretRadio).toBeHidden();
+    await expect(passphrasesRadio).toBeHidden();
+    await this.useNbdeClevisCheckbox.uncheck();
+    await expect(existingSecretRadio).toBeVisible();
+    await expect(passphrasesRadio).toBeVisible();
+  }
+
   async verifyPlanDetails(planData: PlanTestData): Promise<void> {
     await expect(this.page.getByTestId('name-detail-item')).toContainText(planData.planName ?? '');
     await expect(this.page.getByTestId('project-detail-item')).toContainText(


### PR DESCRIPTION
## 📝 Links

- Resolves: [MTV-2836](https://redhat.atlassian.net/browse/MTV-2836)
- Related: [MTV-2833](https://redhat.atlassian.net/browse/MTV-2833) (DEV PR #2495)

## 📝 Description

Closes the remaining downstream E2E gaps for specifying an existing LUKS secret:

- Assert NBDE/Clevis hides the LUKS radio toggle in the plan wizard Other settings step and the plan-details edit modal (and that the selected secret is restored after unchecking NBDE).
- Add a case for a plan with no disk decryption: the edit modal defaults to Enter passphrases with a single empty field and no leaked secret values.

Verified locally against qemtv-09: `plan-existing-luks-secret.spec.ts` — 2 passed.

## 🎥 Demo

N/A — test-only change, no product UI changes.

## 📝 CC://

<!---
> @tag as needed
-->

[MTV-2836]: https://redhat.atlassian.net/browse/MTV-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MTV-2833]: https://redhat.atlassian.net/browse/MTV-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk decryption settings so enabling NBDE/Clevis hides incompatible LUKS secret options while preserving the selected secret.
  * Restored LUKS options when NBDE/Clevis is disabled.
  * Ensured plans without disk decryption start with a single empty passphrase field and do not expose stored secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->