### PR TITLE
[MTV-6264] T1-2: Unit tests for VsphereFolders hooks/utils

### DIFF
--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
@@ -1,0 +1,61 @@
+import type { ProviderVmData } from 'src/utils/types';
+
+import { ConcernCategoryOptions } from '@components/Concerns/utils/constants';
+import { COLUMN_IDS, ROW_TYPE, type VmRow } from '@components/VsphereFoldersTable/utils/types';
+
+type ConcernStub = { category?: string; label?: string };
+
+type MakeVmRowOverrides = Partial<VmRow> & {
+  concerns?: ConcernStub[];
+  guestName?: string;
+  host?: string;
+  name?: string;
+  path?: string;
+  powerState?: string;
+};
+
+export const makeVmRow = (overrides: MakeVmRowOverrides = {}): VmRow => {
+  const {
+    name = 'vm-a',
+    host = 'esxi-1',
+    path = '/dc/vm/folder/vm-a',
+    powerState = 'poweredOn',
+    guestName,
+    concerns = [],
+    ...rowOverrides
+  } = overrides;
+
+  const vmData: ProviderVmData = {
+    folderName: 'folder',
+    hostName: host,
+    name,
+    namespace: 'ns',
+    vm: {
+      concerns,
+      guestName,
+      id: name,
+      name,
+      path,
+      powerState,
+      providerType: 'vsphere',
+    } as never,
+  };
+
+  return {
+    isHidden: false,
+    isSelected: false,
+    key: `vm-${name}`,
+    parentFolderKey: 'folder-folder',
+    treeRow: { props: {}, rowIndex: 0 },
+    type: ROW_TYPE.Vm,
+    vmData,
+    ...rowOverrides,
+  };
+};
+
+export const criticalConcern = { category: ConcernCategoryOptions.Critical, label: 'CPU' };
+export const warningConcern = { category: ConcernCategoryOptions.Warning, label: 'Disk' };
+export const infoConcern = { category: ConcernCategoryOptions.Information, label: 'NIC' };
+
+export const nameSortAsc = { column: COLUMN_IDS.Name, direction: 'asc' as const };
+export const nameSortDesc = { column: COLUMN_IDS.Name, direction: 'desc' as const };

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
@@ -46,7 +46,7 @@ export const makeVmRow = (overrides: MakeVmRowOverrides = {}): VmRow => {
     isSelected: false,
     key: `vm-${name}`,
     parentFolderKey: 'folder-folder',
-    treeRow: { props: {}, rowIndex: 0 },
+    treeRow: { onCollapse: jest.fn(), props: {}, rowIndex: 0 },
     type: ROW_TYPE.Vm,
     vmData,
     ...rowOverrides,

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/fixtures.ts
@@ -1,7 +1,7 @@
 import type { ProviderVmData } from 'src/utils/types';
 
 import { ConcernCategoryOptions } from '@components/Concerns/utils/constants';
-import { COLUMN_IDS, ROW_TYPE, type VmRow } from '@components/VsphereFoldersTable/utils/types';
+import { ROW_TYPE, type VmRow } from '@components/VsphereFoldersTable/utils/types';
 
 type ConcernStub = { category?: string; label?: string };
 
@@ -56,6 +56,3 @@ export const makeVmRow = (overrides: MakeVmRowOverrides = {}): VmRow => {
 export const criticalConcern = { category: ConcernCategoryOptions.Critical, label: 'CPU' };
 export const warningConcern = { category: ConcernCategoryOptions.Warning, label: 'Disk' };
 export const infoConcern = { category: ConcernCategoryOptions.Information, label: 'NIC' };
-
-export const nameSortAsc = { column: COLUMN_IDS.Name, direction: 'asc' as const };
-export const nameSortDesc = { column: COLUMN_IDS.Name, direction: 'desc' as const };

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
@@ -1,0 +1,145 @@
+import { ROW_TYPE } from '@components/VsphereFoldersTable/utils/types';
+
+import { NO_FOLDER } from '../constants';
+import { makeFolderRow, makeVmAndConcernsRows, partitionFolderEntries } from '../treeRowBuilders';
+
+const baseVmArgs = {
+  canSelect: false as const,
+  checkboxId: undefined,
+  isVmExpanded: true,
+  level1SetSize: 1,
+  onToggle: jest.fn(),
+  parentSize: 1,
+  rowIndex: 1,
+  vmChecked: false,
+  vmData: { name: 'vm1', namespace: 'ns', vm: { id: '1' } as never },
+  vmIdx: 0,
+  vmKey: '1',
+};
+
+describe('treeRowBuilders - rows', () => {
+  it('builds a selectable expanded folder row', () => {
+    const onCheckChange = jest.fn();
+    const { folderKey, row } = makeFolderRow({
+      canSelect: true,
+      checkboxId: 'cb-folder',
+      folderChecked: true,
+      folderIdx: 0,
+      folderName: 'Prod',
+      isExpanded: true,
+      level1SetSize: 2,
+      onCheckChange,
+      onToggle: jest.fn(),
+      rowIndex: 0,
+    });
+
+    expect(folderKey).toBe('folder-Prod');
+    expect(row.type).toBe(ROW_TYPE.Folder);
+    expect(row.isSelected).toBe(true);
+    expect(row.treeRow?.props?.isExpanded).toBe(true);
+    expect(row.treeRow?.props?.isChecked).toBe(true);
+    expect(row.treeRow?.props?.['aria-posinset']).toBe(1);
+    expect(row.treeRow?.onCheckChange).toBe(onCheckChange);
+  });
+
+  it('omits checkbox props when selection is disabled', () => {
+    const { row } = makeFolderRow({
+      canSelect: false,
+      checkboxId: undefined,
+      folderChecked: false,
+      folderIdx: 1,
+      folderName: 'Dev',
+      isExpanded: false,
+      level1SetSize: 1,
+      onToggle: jest.fn(),
+      rowIndex: 3,
+    });
+
+    expect(row.treeRow?.props?.checkboxId).toBeUndefined();
+    expect(row.treeRow?.onCheckChange).toBeUndefined();
+    expect(row.isSelected).toBe(false);
+  });
+
+  it('treats indeterminate folderChecked as selected', () => {
+    const { row } = makeFolderRow({
+      canSelect: true,
+      checkboxId: 'cb',
+      folderChecked: null,
+      folderIdx: 0,
+      folderName: 'Mixed',
+      isExpanded: false,
+      level1SetSize: 1,
+      onCheckChange: jest.fn(),
+      onToggle: jest.fn(),
+      rowIndex: 0,
+    });
+
+    expect(row.isSelected).toBe(true);
+    expect(row.treeRow?.props?.isChecked).toBeNull();
+  });
+
+  it('builds vm and concerns rows under an expanded folder', () => {
+    const { concernsRow, vmRow } = makeVmAndConcernsRows({
+      ...baseVmArgs,
+      canSelect: true,
+      checkboxId: 'cb-vm',
+      onCheckChange: jest.fn(),
+      parentExpanded: true,
+      parentFolderKey: 'folder-Prod',
+      vmChecked: true,
+    });
+
+    expect(vmRow.type).toBe(ROW_TYPE.Vm);
+    expect(vmRow.key).toBe('vm-1');
+    expect(vmRow.isHidden).toBe(false);
+    expect(vmRow.treeRow?.props?.['aria-level']).toBe(2);
+    expect(concernsRow.key).toBe('concerns-1');
+    expect(concernsRow.isHidden).toBe(false);
+  });
+
+  it('hides nested vm and concerns when parent folder is collapsed', () => {
+    const { concernsRow, vmRow } = makeVmAndConcernsRows({
+      ...baseVmArgs,
+      parentExpanded: false,
+      parentFolderKey: 'folder-Prod',
+    });
+
+    expect(vmRow.isHidden).toBe(true);
+    expect(concernsRow.isHidden).toBe(true);
+  });
+
+  it('treats no-folder parent as top-level vm', () => {
+    const { concernsRow, vmRow } = makeVmAndConcernsRows({
+      ...baseVmArgs,
+      isVmExpanded: false,
+      level1SetSize: 3,
+      parentExpanded: false,
+      parentFolderKey: NO_FOLDER,
+      rowIndex: 0,
+    });
+
+    expect(vmRow.treeRow?.props?.['aria-level']).toBe(1);
+    expect(vmRow.treeRow?.props?.['aria-setsize']).toBe(3);
+    expect(vmRow.isHidden).toBe(false);
+    expect(concernsRow.isHidden).toBe(true);
+  });
+
+  it('partitions real folders and root vms', () => {
+    const map = new Map<string, string[]>([
+      ['Prod', ['1']],
+      [NO_FOLDER, ['2', '3']],
+      ['Dev', ['4']],
+    ]);
+    const result = partitionFolderEntries(map);
+    expect(result.realFolderEntries.map(([n]) => n).sort()).toEqual(['Dev', 'Prod']);
+    expect(result.rootVmKeys).toEqual(['2', '3']);
+    expect(result.level1SetSize).toBe(4);
+  });
+
+  it('handles empty folder map', () => {
+    const result = partitionFolderEntries(new Map());
+    expect(result.realFolderEntries).toEqual([]);
+    expect(result.rootVmKeys).toEqual([]);
+    expect(result.level1SetSize).toBe(0);
+  });
+});

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
@@ -131,7 +131,11 @@ describe('treeRowBuilders - rows', () => {
       ['Dev', ['4']],
     ]);
     const result = partitionFolderEntries(map);
-    expect(result.realFolderEntries.map(([n]) => n).sort()).toEqual(['Dev', 'Prod']);
+    expect(
+      result.realFolderEntries
+        .map(([folderName]) => folderName)
+        .toSorted((left, right) => left.localeCompare(right)),
+    ).toEqual(['Dev', 'Prod']);
     expect(result.rootVmKeys).toEqual(['2', '3']);
     expect(result.level1SetSize).toBe(4);
   });

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/treeRowBuilders.rows.test.tsx
@@ -79,11 +79,12 @@ describe('treeRowBuilders - rows', () => {
   });
 
   it('builds vm and concerns rows under an expanded folder', () => {
+    const onCheckChange = jest.fn();
     const { concernsRow, vmRow } = makeVmAndConcernsRows({
       ...baseVmArgs,
       canSelect: true,
       checkboxId: 'cb-vm',
-      onCheckChange: jest.fn(),
+      onCheckChange,
       parentExpanded: true,
       parentFolderKey: 'folder-Prod',
       vmChecked: true,
@@ -92,7 +93,15 @@ describe('treeRowBuilders - rows', () => {
     expect(vmRow.type).toBe(ROW_TYPE.Vm);
     expect(vmRow.key).toBe('vm-1');
     expect(vmRow.isHidden).toBe(false);
-    expect(vmRow.treeRow?.props?.['aria-level']).toBe(2);
+    expect(vmRow.isSelected).toBe(true);
+    expect(vmRow.treeRow?.props).toMatchObject({
+      'aria-level': 2,
+      'aria-posinset': 1,
+      'aria-setsize': 1,
+      checkboxId: 'cb-vm',
+      isChecked: true,
+    });
+    expect(vmRow.treeRow?.onCheckChange).toBe(onCheckChange);
     expect(concernsRow.key).toBe('concerns-1');
     expect(concernsRow.isHidden).toBe(false);
   });

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/utils.buildIndexes.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/utils.buildIndexes.test.ts
@@ -28,7 +28,7 @@ describe('utils - buildIndexes', () => {
     'folder-1': { id: 'folder-1', name: 'Prod', path: '/Prod' },
   } as never;
   const hostsDict = {
-    'host-1': { id: 'host-1', name: 'esxi-1' },
+    'host-1': { id: 'host-1', name: 'ESXi-1' },
   } as never;
 
   it('returns empty indexes for undefined or empty vm arrays', () => {
@@ -38,8 +38,8 @@ describe('utils - buildIndexes', () => {
 
   it('indexes vms by folder and host and sorts by name', () => {
     const vms = [
-      makeVmData('2', 'bravo', 'folder-1', 'host-1'),
-      makeVmData('1', 'alpha', 'folder-1', 'host-1'),
+      makeVmData('2', 'Bravo', 'folder-1', 'host-1'),
+      makeVmData('1', 'Alpha', 'folder-1', 'host-1'),
       makeVmData('3', 'root-vm', 'missing', 'missing-host'),
     ];
 
@@ -47,14 +47,15 @@ describe('utils - buildIndexes', () => {
 
     expect(folderToVmKeys.get('Prod')).toEqual(['1', '2']);
     expect(folderToVmKeys.get(NO_FOLDER)).toEqual(['3']);
-    expect(vmByKey.get('1')?.hostName).toBe('esxi-1');
+    expect(vmByKey.get('1')?.hostName).toBe('ESXi-1');
     expect(vmByKey.get('1')?.folderName).toBe('Prod');
     expect(vmByKey.get('3')?.folderName).toBe(NO_FOLDER);
     expect(vmByKey.get('3')?.hostName).toBe('');
-    expect(tokensByVmKey.get('1')).toMatchObject({
+    expect(tokensByVmKey.get('1')).toEqual({
+      concerns: [{ category: 'Warning', label: 'warn' }],
       host: 'esxi-1',
       name: 'alpha',
-      path: '/dc/alpha',
+      path: '/dc/Alpha',
       power: 'on',
     });
   });

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/utils.buildIndexes.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/utils.buildIndexes.test.ts
@@ -1,0 +1,75 @@
+import type { ProviderVmData } from 'src/utils/types';
+
+import { FOLDER_PREFIX, NO_FOLDER } from '../constants';
+import { buildIndexes, getFolderNameFromKey, isFolderChecked } from '../utils';
+
+const makeVmData = (
+  id: string,
+  name: string,
+  parentId: string,
+  hostId: string,
+): ProviderVmData => ({
+  name,
+  namespace: 'ns',
+  vm: {
+    concerns: [{ category: 'Warning', label: 'warn' }],
+    host: hostId,
+    id,
+    name,
+    parent: { id: parentId, kind: 'Folder' },
+    path: `/dc/${name}`,
+    powerState: 'poweredOn',
+    providerType: 'vsphere',
+  } as never,
+});
+
+describe('utils - buildIndexes', () => {
+  const foldersDict = {
+    'folder-1': { id: 'folder-1', name: 'Prod', path: '/Prod' },
+  } as never;
+  const hostsDict = {
+    'host-1': { id: 'host-1', name: 'esxi-1' },
+  } as never;
+
+  it('returns empty indexes for undefined or empty vm arrays', () => {
+    expect(buildIndexes(undefined, foldersDict, hostsDict).vmByKey.size).toBe(0);
+    expect(buildIndexes([], foldersDict, hostsDict).folderToVmKeys.size).toBe(0);
+  });
+
+  it('indexes vms by folder and host and sorts by name', () => {
+    const vms = [
+      makeVmData('2', 'bravo', 'folder-1', 'host-1'),
+      makeVmData('1', 'alpha', 'folder-1', 'host-1'),
+      makeVmData('3', 'root-vm', 'missing', 'missing-host'),
+    ];
+
+    const { folderToVmKeys, tokensByVmKey, vmByKey } = buildIndexes(vms, foldersDict, hostsDict);
+
+    expect(folderToVmKeys.get('Prod')).toEqual(['1', '2']);
+    expect(folderToVmKeys.get(NO_FOLDER)).toEqual(['3']);
+    expect(vmByKey.get('1')?.hostName).toBe('esxi-1');
+    expect(vmByKey.get('1')?.folderName).toBe('Prod');
+    expect(vmByKey.get('3')?.folderName).toBe(NO_FOLDER);
+    expect(vmByKey.get('3')?.hostName).toBe('');
+    expect(tokensByVmKey.get('1')).toMatchObject({
+      host: 'esxi-1',
+      name: 'alpha',
+      path: '/dc/alpha',
+      power: 'on',
+    });
+  });
+
+  it('isFolderChecked returns false, true, or indeterminate', () => {
+    const selected = new Set(['a', 'b']);
+    expect(isFolderChecked([], selected)).toBe(false);
+    expect(isFolderChecked(['a', 'b'], selected)).toBe(true);
+    expect(isFolderChecked(['a', 'c'], selected)).toBeNull();
+    expect(isFolderChecked(['c'], selected)).toBe(false);
+  });
+
+  it('getFolderNameFromKey strips folder prefix', () => {
+    expect(getFolderNameFromKey(`${FOLDER_PREFIX}Prod`)).toBe('Prod');
+    expect(getFolderNameFromKey('Prod')).toBe('Prod');
+    expect(getFolderNameFromKey(FOLDER_PREFIX)).toBe('');
+  });
+});

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmComparator.sort.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmComparator.sort.test.ts
@@ -1,0 +1,111 @@
+import { COLUMN_IDS } from '@components/VsphereFoldersTable/utils/types';
+import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
+import type { VmInspectionStatus } from '@utils/hooks/useVmInspectionStatus';
+
+import { buildVmComparator } from '../vmComparator';
+
+import {
+  criticalConcern,
+  infoConcern,
+  makeVmRow,
+  nameSortAsc,
+  nameSortDesc,
+  warningConcern,
+} from './fixtures';
+
+describe('buildVmComparator', () => {
+  const a = makeVmRow({
+    guestName: 'Linux',
+    host: 'h1',
+    name: 'alpha',
+    path: '/a',
+    powerState: 'poweredOn',
+  });
+  const b = makeVmRow({
+    guestName: 'Windows',
+    host: 'h2',
+    name: 'bravo',
+    path: '/b',
+    powerState: 'poweredOff',
+  });
+
+  it.each([
+    [COLUMN_IDS.Name, 'asc', -1],
+    [COLUMN_IDS.Name, 'desc', 1],
+    [COLUMN_IDS.GuestOS, 'asc', -1],
+    [COLUMN_IDS.Host, 'asc', -1],
+    [COLUMN_IDS.Path, 'asc', -1],
+    [COLUMN_IDS.Power, 'asc', 1],
+  ] as const)('sorts by %s %s', (column, direction, expectedSign) => {
+    const cmp = buildVmComparator({ column, direction });
+    expect(Math.sign(cmp(a, b))).toBe(expectedSign);
+  });
+
+  it('sorts concerns by Critical then Warning then Information quantity', () => {
+    const criticalHeavy = makeVmRow({
+      concerns: [criticalConcern, criticalConcern, warningConcern],
+      name: 'c',
+    });
+    const warningHeavy = makeVmRow({
+      concerns: [warningConcern, warningConcern, infoConcern],
+      name: 'w',
+    });
+    const cmpAsc = buildVmComparator({ column: COLUMN_IDS.Concerns, direction: 'asc' });
+    expect(cmpAsc(criticalHeavy, warningHeavy)).toBeLessThan(0);
+
+    const cmpDesc = buildVmComparator({ column: COLUMN_IDS.Concerns, direction: 'desc' });
+    expect(cmpDesc(criticalHeavy, warningHeavy)).toBeGreaterThan(0);
+  });
+
+  it('uses name as tiebreaker for equal concern counts', () => {
+    const first = makeVmRow({ concerns: [warningConcern], name: 'a' });
+    const second = makeVmRow({ concerns: [warningConcern], name: 'b' });
+    const cmp = buildVmComparator({ column: COLUMN_IDS.Concerns, direction: 'asc' });
+    expect(cmp(first, second)).toBeLessThan(0);
+  });
+
+  it('sorts inspection status by severity rank with name tiebreaker', () => {
+    const issues = makeVmRow({ name: 'z-issues' });
+    const passed = makeVmRow({ name: 'a-passed' });
+    const getStatus = (vmId: string): VmInspectionStatus | undefined => {
+      if (vmId === 'z-issues') {
+        return { status: INSPECTION_STATUS.ISSUES_FOUND } as VmInspectionStatus;
+      }
+      if (vmId === 'a-passed') {
+        return { status: INSPECTION_STATUS.INSPECTION_PASSED } as VmInspectionStatus;
+      }
+      return undefined;
+    };
+
+    const cmpAsc = buildVmComparator(
+      { column: COLUMN_IDS.InspectionStatus, direction: 'asc' },
+      getStatus,
+    );
+    expect(cmpAsc(issues, passed)).toBeLessThan(0);
+    expect(cmpAsc(makeVmRow({ name: 'a' }), makeVmRow({ name: 'b' }))).toBeLessThan(0);
+  });
+
+  it('defaults missing inspection status to Not inspected', () => {
+    const inspected = makeVmRow({ name: 'inspected' });
+    const missing = makeVmRow({ name: 'missing' });
+    const getStatus = (vmId: string): VmInspectionStatus | undefined =>
+      vmId === 'inspected'
+        ? ({ status: INSPECTION_STATUS.FAILED } as VmInspectionStatus)
+        : undefined;
+    const cmp = buildVmComparator(
+      { column: COLUMN_IDS.InspectionStatus, direction: 'asc' },
+      getStatus,
+    );
+    expect(cmp(inspected, missing)).toBeLessThan(0);
+  });
+
+  it('returns zero comparator for unknown columns', () => {
+    const cmp = buildVmComparator({ column: 'unknown' as never, direction: 'asc' });
+    expect(cmp(a, b)).toBe(0);
+  });
+
+  it('respects name sort fixtures', () => {
+    expect(buildVmComparator(nameSortAsc)(a, b)).toBeLessThan(0);
+    expect(buildVmComparator(nameSortDesc)(a, b)).toBeGreaterThan(0);
+  });
+});

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmComparator.sort.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmComparator.sort.test.ts
@@ -4,14 +4,7 @@ import type { VmInspectionStatus } from '@utils/hooks/useVmInspectionStatus';
 
 import { buildVmComparator } from '../vmComparator';
 
-import {
-  criticalConcern,
-  infoConcern,
-  makeVmRow,
-  nameSortAsc,
-  nameSortDesc,
-  warningConcern,
-} from './fixtures';
+import { criticalConcern, infoConcern, makeVmRow, warningConcern } from './fixtures';
 
 describe('buildVmComparator', () => {
   const a = makeVmRow({
@@ -86,17 +79,26 @@ describe('buildVmComparator', () => {
   });
 
   it('defaults missing inspection status to Not inspected', () => {
-    const inspected = makeVmRow({ name: 'inspected' });
-    const missing = makeVmRow({ name: 'missing' });
-    const getStatus = (vmId: string): VmInspectionStatus | undefined =>
-      vmId === 'inspected'
-        ? ({ status: INSPECTION_STATUS.FAILED } as VmInspectionStatus)
-        : undefined;
+    const withExplicit = makeVmRow({ name: 'tie' });
+    const withMissing = makeVmRow({ name: 'tie' });
+    (withExplicit.vmData.vm as { id: string }).id = 'explicit';
+    (withMissing.vmData.vm as { id: string }).id = 'missing';
+    const passed = makeVmRow({ name: 'passed' });
+    const getStatus = (vmId: string): VmInspectionStatus | undefined => {
+      if (vmId === 'explicit') {
+        return { status: INSPECTION_STATUS.NOT_INSPECTED } as VmInspectionStatus;
+      }
+      if (vmId === 'passed') {
+        return { status: INSPECTION_STATUS.INSPECTION_PASSED } as VmInspectionStatus;
+      }
+      return undefined;
+    };
     const cmp = buildVmComparator(
       { column: COLUMN_IDS.InspectionStatus, direction: 'asc' },
       getStatus,
     );
-    expect(cmp(inspected, missing)).toBeLessThan(0);
+    expect(cmp(withExplicit, withMissing)).toBe(0);
+    expect(cmp(withMissing, passed)).toBeLessThan(0);
   });
 
   it('returns zero comparator for unknown columns', () => {
@@ -104,8 +106,10 @@ describe('buildVmComparator', () => {
     expect(cmp(a, b)).toBe(0);
   });
 
-  it('respects name sort fixtures', () => {
-    expect(buildVmComparator(nameSortAsc)(a, b)).toBeLessThan(0);
-    expect(buildVmComparator(nameSortDesc)(a, b)).toBeGreaterThan(0);
+  it('sorts names case-insensitively', () => {
+    const upper = makeVmRow({ name: 'Alpha' });
+    const lower = makeVmRow({ name: 'alpha' });
+    const cmp = buildVmComparator({ column: COLUMN_IDS.Name, direction: 'asc' });
+    expect(cmp(upper, lower)).toBe(0);
   });
 });

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
@@ -38,7 +38,10 @@ describe('vmRowAccessors - concernLabels', () => {
   it('builds concern filter options sorted by severity', () => {
     const rows = [
       makeVmRow({ concerns: [infoConcern, criticalConcern], name: 'vm1' }),
-      makeVmRow({ concerns: [warningConcern, criticalConcern], name: 'vm2' }),
+      makeVmRow({
+        concerns: [warningConcern, criticalConcern, { category: 'Warning', label: 'cpu' }],
+        name: 'vm2',
+      }),
       {
         folderName: 'f',
         isHidden: false as const,
@@ -48,6 +51,7 @@ describe('vmRowAccessors - concernLabels', () => {
       },
     ];
 
+    // CPU vs cpu collapse case-insensitively; first-seen label/category win (Critical)
     expect(getConcernLabelFilterOptions(rows).map((option) => option.label)).toEqual([
       'CPU',
       'Disk',

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
@@ -15,7 +15,7 @@ describe('vmRowAccessors - concernLabels', () => {
     });
     const { categoryMapper, labelIconMapper, labels } = getVmConcernLabels(row);
 
-    expect(labels.sort()).toEqual(['CPU', 'Disk']);
+    expect(labels.toSorted((left, right) => left.localeCompare(right))).toEqual(['CPU', 'Disk']);
     expect(categoryMapper.CPU).toBe('Critical');
     expect(labelIconMapper.CPU).toBeDefined();
   });
@@ -43,12 +43,16 @@ describe('vmRowAccessors - concernLabels', () => {
         folderName: 'f',
         isHidden: false as const,
         key: 'folder-f',
-        treeRow: { props: {}, rowIndex: 0 },
+        treeRow: { onCollapse: jest.fn(), props: {}, rowIndex: 0 },
         type: ROW_TYPE.Folder,
       },
     ];
 
-    expect(getConcernLabelFilterOptions(rows).map((o) => o.label)).toEqual(['CPU', 'Disk', 'NIC']);
+    expect(getConcernLabelFilterOptions(rows).map((option) => option.label)).toEqual([
+      'CPU',
+      'Disk',
+      'NIC',
+    ]);
   });
 
   it('builds unique hostname filter options sorted case-insensitively', () => {
@@ -58,7 +62,10 @@ describe('vmRowAccessors - concernLabels', () => {
       makeVmRow({ host: 'ESXI-A', name: 'vm3' }),
     ];
 
-    expect(getHostnameFilterOptions(rows).map((o) => o.label)).toEqual(['esxi-a', 'esxi-b']);
+    expect(getHostnameFilterOptions(rows).map((option) => option.label)).toEqual([
+      'esxi-a',
+      'esxi-b',
+    ]);
   });
 
   it('returns empty filter options for empty rows', () => {

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.concernLabels.test.ts
@@ -1,0 +1,68 @@
+import { ROW_TYPE } from '@components/VsphereFoldersTable/utils/types';
+
+import {
+  getConcernLabelFilterOptions,
+  getHostnameFilterOptions,
+  getVmConcernLabels,
+} from '../vmRowAccessors';
+
+import { criticalConcern, infoConcern, makeVmRow, warningConcern } from './fixtures';
+
+describe('vmRowAccessors - concernLabels', () => {
+  it('builds unique labels with icons and categories', () => {
+    const row = makeVmRow({
+      concerns: [criticalConcern, warningConcern, { category: 'Critical', label: '  ' }],
+    });
+    const { categoryMapper, labelIconMapper, labels } = getVmConcernLabels(row);
+
+    expect(labels.sort()).toEqual(['CPU', 'Disk']);
+    expect(categoryMapper.CPU).toBe('Critical');
+    expect(labelIconMapper.CPU).toBeDefined();
+  });
+
+  it('returns empty maps when concerns are missing or not an array', () => {
+    expect(getVmConcernLabels(makeVmRow({ concerns: undefined as never }))).toEqual({
+      categoryMapper: {},
+      labelIconMapper: {},
+      labels: [],
+    });
+    const row = makeVmRow();
+    (row.vmData.vm as { concerns?: unknown }).concerns = { bad: true };
+    expect(getVmConcernLabels(row)).toEqual({
+      categoryMapper: {},
+      labelIconMapper: {},
+      labels: [],
+    });
+  });
+
+  it('builds concern filter options sorted by severity', () => {
+    const rows = [
+      makeVmRow({ concerns: [infoConcern, criticalConcern], name: 'vm1' }),
+      makeVmRow({ concerns: [warningConcern, criticalConcern], name: 'vm2' }),
+      {
+        folderName: 'f',
+        isHidden: false as const,
+        key: 'folder-f',
+        treeRow: { props: {}, rowIndex: 0 },
+        type: ROW_TYPE.Folder,
+      },
+    ];
+
+    expect(getConcernLabelFilterOptions(rows).map((o) => o.label)).toEqual(['CPU', 'Disk', 'NIC']);
+  });
+
+  it('builds unique hostname filter options sorted case-insensitively', () => {
+    const rows = [
+      makeVmRow({ host: 'esxi-b', name: 'vm1' }),
+      makeVmRow({ host: 'esxi-a', name: 'vm2' }),
+      makeVmRow({ host: 'ESXI-A', name: 'vm3' }),
+    ];
+
+    expect(getHostnameFilterOptions(rows).map((o) => o.label)).toEqual(['esxi-a', 'esxi-b']);
+  });
+
+  it('returns empty filter options for empty rows', () => {
+    expect(getConcernLabelFilterOptions([])).toEqual([]);
+    expect(getHostnameFilterOptions([])).toEqual([]);
+  });
+});

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.fields.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.fields.test.ts
@@ -1,0 +1,92 @@
+import { ROW_TYPE } from '@components/VsphereFoldersTable/utils/types';
+
+import {
+  cmpStr,
+  getFolderNameFromFolderRow,
+  getVmConcernCategories,
+  getVmGuestOSValue,
+  getVmHost,
+  getVmName,
+  getVmPath,
+  getVmPower,
+  getVmRowsId,
+} from '../vmRowAccessors';
+
+import { criticalConcern, infoConcern, makeVmRow, warningConcern } from './fixtures';
+
+describe('vmRowAccessors - fields', () => {
+  it('reads vm name, guest OS, host, path and power', () => {
+    const row = makeVmRow({
+      guestName: 'RHEL 9',
+      host: 'host-a',
+      name: 'web',
+      path: '/dc/web',
+      powerState: 'poweredOff',
+    });
+
+    expect(getVmName(row)).toBe('web');
+    expect(getVmGuestOSValue(row)).toBe('RHEL 9');
+    expect(getVmHost(row)).toBe('host-a');
+    expect(getVmPath(row)).toBe('/dc/web');
+    expect(getVmPower(row)).toBe('off');
+  });
+
+  it('returns empty strings for missing optional fields', () => {
+    const row = makeVmRow({ host: '', name: 'x', path: undefined as never });
+    row.vmData.name = undefined as never;
+    row.vmData.hostName = undefined;
+    (row.vmData.vm as { path?: string }).path = undefined;
+
+    expect(getVmName(row)).toBe('');
+    expect(getVmHost(row)).toBe('');
+    expect(getVmPath(row)).toBe('');
+    expect(getVmGuestOSValue(row)).toBe('');
+  });
+
+  it('collects vm ids from mixed rows', () => {
+    const vm = makeVmRow({ name: 'vm-1' });
+    const folder = {
+      folderName: 'f1',
+      isHidden: false as const,
+      key: 'folder-f1',
+      treeRow: { props: {}, rowIndex: 0 },
+      type: ROW_TYPE.Folder,
+    };
+
+    expect(getVmRowsId([folder, vm])).toEqual(['vm-1']);
+    expect(getVmRowsId([])).toEqual([]);
+  });
+
+  it('extracts valid concern categories and ignores unknowns', () => {
+    const row = makeVmRow({
+      concerns: [criticalConcern, warningConcern, infoConcern, { category: 'Bogus', label: 'x' }],
+    });
+
+    expect(getVmConcernCategories(row).sort()).toEqual(['Critical', 'Information', 'Warning']);
+  });
+
+  it('returns empty categories when concerns missing or not an array', () => {
+    expect(getVmConcernCategories(makeVmRow({ concerns: undefined as never }))).toEqual([]);
+    const row = makeVmRow();
+    (row.vmData.vm as { concerns?: unknown }).concerns = { bad: true };
+    expect(getVmConcernCategories(row)).toEqual([]);
+  });
+
+  it('compares strings case-insensitively', () => {
+    expect(cmpStr('a', 'B')).toBeLessThan(0);
+    expect(cmpStr('B', 'a')).toBeGreaterThan(0);
+    expect(cmpStr('Same', 'same')).toBe(0);
+  });
+
+  it('reads folder name only for folder rows', () => {
+    const folder = {
+      folderName: 'Prod',
+      isHidden: false as const,
+      key: 'folder-Prod',
+      treeRow: { props: {}, rowIndex: 0 },
+      type: ROW_TYPE.Folder,
+    };
+    expect(getFolderNameFromFolderRow(folder)).toBe('Prod');
+    expect(getFolderNameFromFolderRow(makeVmRow())).toBe('');
+  });
+});

--- a/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.fields.test.ts
+++ b/src/components/VsphereFoldersTable/hooks/utils/__tests__/vmRowAccessors.fields.test.ts
@@ -49,7 +49,7 @@ describe('vmRowAccessors - fields', () => {
       folderName: 'f1',
       isHidden: false as const,
       key: 'folder-f1',
-      treeRow: { props: {}, rowIndex: 0 },
+      treeRow: { onCollapse: jest.fn(), props: {}, rowIndex: 0 },
       type: ROW_TYPE.Folder,
     };
 
@@ -62,7 +62,9 @@ describe('vmRowAccessors - fields', () => {
       concerns: [criticalConcern, warningConcern, infoConcern, { category: 'Bogus', label: 'x' }],
     });
 
-    expect(getVmConcernCategories(row).sort()).toEqual(['Critical', 'Information', 'Warning']);
+    expect(
+      getVmConcernCategories(row).toSorted((left, right) => left.localeCompare(right)),
+    ).toEqual(['Critical', 'Information', 'Warning']);
   });
 
   it('returns empty categories when concerns missing or not an array', () => {
@@ -83,7 +85,7 @@ describe('vmRowAccessors - fields', () => {
       folderName: 'Prod',
       isHidden: false as const,
       key: 'folder-Prod',
-      treeRow: { props: {}, rowIndex: 0 },
+      treeRow: { onCollapse: jest.fn(), props: {}, rowIndex: 0 },
       type: ROW_TYPE.Folder,
     };
     expect(getFolderNameFromFolderRow(folder)).toBe('Prod');


### PR DESCRIPTION
## Summary
- Adds Jest unit coverage for VsphereFolders `hooks/utils` modules split in MTV-6264 Tier 1: `vmComparator`, `vmRowAccessors`, `treeRowBuilders`, and `utils` (indexes / folder selection helpers).
- Covers happy paths, null/empty inputs, sorting boundaries (including inspection-status severity), and filter-option aggregation.
- Skips `buildTreeRows` (already covered by existing `__tests__/buildTreeRows.test.ts`).

## Test plan
- [x] `npm test -- --testPathPattern='VsphereFoldersTable/hooks/utils/__tests__' --watchAll=false` (6 suites / 39 tests passing)
- [ ] Confirm CI Jest job is green on this PR

Resolves: MTV-6264

Made with [Cursor](https://cursor.com)