### PR TITLE
test: MTV-6265 T2-6 InspectVM labels and MultiTypeahead leftovers

### DIFF
--- a/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
@@ -15,8 +15,10 @@ describe('ConversionPhaseLabel', () => {
     [CONVERSION_PHASE.RUNNING, 'Running'],
     [CONVERSION_PHASE.PENDING, 'Pending'],
     [undefined, 'Pending'],
+    ['unknown-phase' as never, 'Pending'],
   ] as const)('renders %s as %s', (phase, label) => {
-    render(<ConversionPhaseLabel phase={phase} />);
+    const { unmount } = render(<ConversionPhaseLabel phase={phase} />);
     expect(screen.getByText(label)).toBeInTheDocument();
+    unmount();
   });
 });

--- a/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
@@ -3,7 +3,6 @@ import { mockI18n } from '@test-utils/mockI18n';
 mockI18n();
 
 import { render, screen } from '@testing-library/react';
-
 import { CONVERSION_PHASE } from '@utils/crds/conversion/constants';
 
 import ConversionPhaseLabel from '../ConversionPhaseLabel';

--- a/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
@@ -1,0 +1,23 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
+import { render, screen } from '@testing-library/react';
+
+import { CONVERSION_PHASE } from '@utils/crds/conversion/constants';
+
+import ConversionPhaseLabel from '../ConversionPhaseLabel';
+
+describe('ConversionPhaseLabel', () => {
+  it.each([
+    [CONVERSION_PHASE.SUCCEEDED, 'Succeeded'],
+    [CONVERSION_PHASE.FAILED, 'Failed'],
+    [CONVERSION_PHASE.CANCELED, 'Canceled'],
+    [CONVERSION_PHASE.RUNNING, 'Running'],
+    [CONVERSION_PHASE.PENDING, 'Pending'],
+    [undefined, 'Pending'],
+  ] as const)('renders %s as %s', (phase, label) => {
+    render(<ConversionPhaseLabel phase={phase} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});

--- a/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/ConversionPhaseLabel.test.tsx
@@ -15,7 +15,6 @@ describe('ConversionPhaseLabel', () => {
     [CONVERSION_PHASE.RUNNING, 'Running'],
     [CONVERSION_PHASE.PENDING, 'Pending'],
     [undefined, 'Pending'],
-    ['unknown-phase' as never, 'Pending'],
   ] as const)('renders %s as %s', (phase, label) => {
     const { unmount } = render(<ConversionPhaseLabel phase={phase} />);
     expect(screen.getByText(label)).toBeInTheDocument();

--- a/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
@@ -9,8 +9,8 @@ import InspectionConcernBadges from '../InspectionConcernBadges';
 
 describe('InspectionConcernBadges', () => {
   it('renders nothing for empty concerns', () => {
-    const { container } = render(<InspectionConcernBadges concerns={[]} />);
-    expect(container.querySelectorAll('button')).toHaveLength(0);
+    render(<InspectionConcernBadges concerns={[]} />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
   });
 
   it('renders category badges and popover content', async () => {
@@ -19,9 +19,9 @@ describe('InspectionConcernBadges', () => {
     render(
       <InspectionConcernBadges
         concerns={[
-          { category: 'Warning', id: '1', label: 'Shared disk' },
-          { category: 'Critical', id: '2', label: 'UEFI' },
-          { category: 'Warning', id: '3', label: 'CPU' },
+          { category: 'Warning', id: '1', label: 'Shared disk', message: 'Shared disk msg' },
+          { category: 'Critical', id: '2', label: 'UEFI', message: 'UEFI msg' },
+          { category: 'Warning', id: '3', label: 'CPU', message: 'CPU msg' },
         ]}
       />,
     );

--- a/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
@@ -1,0 +1,36 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import InspectionConcernBadges from '../InspectionConcernBadges';
+
+describe('InspectionConcernBadges', () => {
+  it('renders nothing for empty concerns', () => {
+    const { container } = render(<InspectionConcernBadges concerns={[]} />);
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
+
+  it('renders category badges and popover content', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <InspectionConcernBadges
+        concerns={[
+          { category: 'Warning', id: '1', label: 'Shared disk' },
+          { category: 'Critical', id: '2', label: 'UEFI' },
+          { category: 'Warning', id: '3', label: 'CPU' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /2/ }));
+    expect(screen.getByText('Shared disk')).toBeInTheDocument();
+    expect(screen.getByText('CPU')).toBeInTheDocument();
+  });
+});

--- a/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionConcernBadges.test.tsx
@@ -26,11 +26,22 @@ describe('InspectionConcernBadges', () => {
       />,
     );
 
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
+    const warningBadge = screen.getByRole('button', { name: '2' });
+    const criticalBadge = screen.getByRole('button', { name: '1' });
+    expect(warningBadge).toBeInTheDocument();
+    expect(criticalBadge).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /2/ }));
+    await user.click(warningBadge);
+    expect(screen.getByLabelText('Warning inspection concerns')).toBeInTheDocument();
+    expect(screen.getByText('Warning inspection concerns')).toBeInTheDocument();
+    expect(screen.getByText('Total: 2')).toBeInTheDocument();
     expect(screen.getByText('Shared disk')).toBeInTheDocument();
     expect(screen.getByText('CPU')).toBeInTheDocument();
+
+    await user.click(criticalBadge);
+    expect(screen.getByLabelText('Critical inspection concerns')).toBeInTheDocument();
+    expect(screen.getByText('Critical inspection concerns')).toBeInTheDocument();
+    expect(screen.getByText('Total: 1')).toBeInTheDocument();
+    expect(screen.getByText('UEFI')).toBeInTheDocument();
   });
 });

--- a/src/components/InspectVirtualMachines/__tests__/InspectionPassedLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionPassedLabel.test.tsx
@@ -1,0 +1,19 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
+import { render, screen } from '@testing-library/react';
+
+import InspectionPassedLabel from '../InspectionPassedLabel';
+
+describe('InspectionPassedLabel', () => {
+  it('renders passed label', () => {
+    render(<InspectionPassedLabel passed />);
+    expect(screen.getByText('Inspection passed')).toBeInTheDocument();
+  });
+
+  it('renders issues found label', () => {
+    render(<InspectionPassedLabel passed={false} />);
+    expect(screen.getByText('Issues found')).toBeInTheDocument();
+  });
+});

--- a/src/components/InspectVirtualMachines/__tests__/InspectionStatusLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionStatusLabel.test.tsx
@@ -3,7 +3,6 @@ import { mockI18n } from '@test-utils/mockI18n';
 mockI18n();
 
 import { render, screen } from '@testing-library/react';
-
 import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
 
 import InspectionStatusLabel from '../InspectionStatusLabel';

--- a/src/components/InspectVirtualMachines/__tests__/InspectionStatusLabel.test.tsx
+++ b/src/components/InspectVirtualMachines/__tests__/InspectionStatusLabel.test.tsx
@@ -1,0 +1,24 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
+import { render, screen } from '@testing-library/react';
+
+import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
+
+import InspectionStatusLabel from '../InspectionStatusLabel';
+
+describe('InspectionStatusLabel', () => {
+  it.each([
+    [INSPECTION_STATUS.INSPECTION_PASSED, 'Inspection passed'],
+    [INSPECTION_STATUS.ISSUES_FOUND, 'Issues found'],
+    [INSPECTION_STATUS.FAILED, 'Inspection error'],
+    [INSPECTION_STATUS.RUNNING, 'Running'],
+    [INSPECTION_STATUS.PENDING, 'Pending'],
+    [INSPECTION_STATUS.CANCELED, 'Canceled'],
+    [INSPECTION_STATUS.NOT_INSPECTED, 'Not inspected'],
+  ] as const)('renders %s', (status, label) => {
+    render(<InspectionStatusLabel status={status} testId="status" />);
+    expect(screen.getByTestId('status')).toHaveTextContent(label);
+  });
+});

--- a/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
+++ b/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
@@ -2,6 +2,7 @@ import { mockI18n } from '@test-utils/mockI18n';
 
 mockI18n();
 
+import { PF_LABEL_STATUS } from '@utils/constants';
 import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
 import { t } from '@utils/i18n';
 
@@ -10,25 +11,44 @@ import { getInspectionStatusConfig } from '../getInspectionStatusConfig';
 const translate = t as Parameters<typeof getInspectionStatusConfig>[1];
 
 describe('getInspectionStatusConfig', () => {
-  it('returns icon and label for each status', () => {
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.INSPECTION_PASSED, translate).label).toBe(
-      'Inspection passed',
-    );
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.ISSUES_FOUND, translate).label).toBe(
-      'Issues found',
-    );
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.FAILED, translate).label).toBe(
-      'Inspection error',
-    );
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.RUNNING, translate).label).toBe('Running');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.PENDING, translate).label).toBe('Pending');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.CANCELED, translate).label).toBe('Canceled');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.NOT_INSPECTED, translate).label).toBe(
-      'Not inspected',
-    );
+  it('returns icon, label, and labelStatus for each status', () => {
+    const passed = getInspectionStatusConfig(INSPECTION_STATUS.INSPECTION_PASSED, translate);
+    expect(passed.label).toBe('Inspection passed');
+    expect(passed.labelStatus).toBe(PF_LABEL_STATUS.SUCCESS);
+    expect(passed.icon).toBeTruthy();
+
+    const issues = getInspectionStatusConfig(INSPECTION_STATUS.ISSUES_FOUND, translate);
+    expect(issues.label).toBe('Issues found');
+    expect(issues.labelStatus).toBe(PF_LABEL_STATUS.WARNING);
+    expect(issues.icon).toBeTruthy();
+
+    const failed = getInspectionStatusConfig(INSPECTION_STATUS.FAILED, translate);
+    expect(failed.label).toBe('Inspection error');
+    expect(failed.labelStatus).toBe(PF_LABEL_STATUS.WARNING);
+    expect(failed.icon).toBeTruthy();
+
+    const running = getInspectionStatusConfig(INSPECTION_STATUS.RUNNING, translate);
+    expect(running.label).toBe('Running');
+    expect(running.labelStatus).toBe(PF_LABEL_STATUS.INFO);
+    expect(running.icon).toBeTruthy();
+
+    const pending = getInspectionStatusConfig(INSPECTION_STATUS.PENDING, translate);
+    expect(pending.label).toBe('Pending');
+    expect(pending.labelStatus).toBeUndefined();
+    expect(pending.icon).toBeTruthy();
+
+    const canceled = getInspectionStatusConfig(INSPECTION_STATUS.CANCELED, translate);
+    expect(canceled.label).toBe('Canceled');
+    expect(canceled.icon).toBeTruthy();
+
+    const notInspected = getInspectionStatusConfig(INSPECTION_STATUS.NOT_INSPECTED, translate);
+    expect(notInspected.label).toBe('Not inspected');
+    expect(notInspected.icon).toBeUndefined();
   });
 
   it('defaults unknown status to not inspected', () => {
-    expect(getInspectionStatusConfig('unknown' as never, translate).label).toBe('Not inspected');
+    const unknown = getInspectionStatusConfig('unknown' as never, translate);
+    expect(unknown.label).toBe('Not inspected');
+    expect(unknown.icon).toBeUndefined();
   });
 });

--- a/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
+++ b/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
@@ -7,22 +7,28 @@ import { t } from '@utils/i18n';
 
 import { getInspectionStatusConfig } from '../getInspectionStatusConfig';
 
+const translate = t as Parameters<typeof getInspectionStatusConfig>[1];
+
 describe('getInspectionStatusConfig', () => {
   it('returns icon and label for each status', () => {
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.INSPECTION_PASSED, t).label).toBe(
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.INSPECTION_PASSED, translate).label).toBe(
       'Inspection passed',
     );
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.ISSUES_FOUND, t).label).toBe('Issues found');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.FAILED, t).label).toBe('Inspection error');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.RUNNING, t).label).toBe('Running');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.PENDING, t).label).toBe('Pending');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.CANCELED, t).label).toBe('Canceled');
-    expect(getInspectionStatusConfig(INSPECTION_STATUS.NOT_INSPECTED, t).label).toBe(
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.ISSUES_FOUND, translate).label).toBe(
+      'Issues found',
+    );
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.FAILED, translate).label).toBe(
+      'Inspection error',
+    );
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.RUNNING, translate).label).toBe('Running');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.PENDING, translate).label).toBe('Pending');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.CANCELED, translate).label).toBe('Canceled');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.NOT_INSPECTED, translate).label).toBe(
       'Not inspected',
     );
   });
 
   it('defaults unknown status to not inspected', () => {
-    expect(getInspectionStatusConfig('unknown' as never, t).label).toBe('Not inspected');
+    expect(getInspectionStatusConfig('unknown' as never, translate).label).toBe('Not inspected');
   });
 });

--- a/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
+++ b/src/components/InspectVirtualMachines/utils/__tests__/getInspectionStatusConfig.test.tsx
@@ -1,0 +1,28 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
+import { INSPECTION_STATUS } from '@utils/crds/conversion/constants';
+import { t } from '@utils/i18n';
+
+import { getInspectionStatusConfig } from '../getInspectionStatusConfig';
+
+describe('getInspectionStatusConfig', () => {
+  it('returns icon and label for each status', () => {
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.INSPECTION_PASSED, t).label).toBe(
+      'Inspection passed',
+    );
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.ISSUES_FOUND, t).label).toBe('Issues found');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.FAILED, t).label).toBe('Inspection error');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.RUNNING, t).label).toBe('Running');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.PENDING, t).label).toBe('Pending');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.CANCELED, t).label).toBe('Canceled');
+    expect(getInspectionStatusConfig(INSPECTION_STATUS.NOT_INSPECTED, t).label).toBe(
+      'Not inspected',
+    );
+  });
+
+  it('defaults unknown status to not inspected', () => {
+    expect(getInspectionStatusConfig('unknown' as never, t).label).toBe('Not inspected');
+  });
+});

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+
+import { PLACEHOLDER_VALUES } from '../../../utils/constants';
+import { useMultiTypeaheadFiltering } from '../useMultiTypeaheadFiltering';
+
+const options = [
+  { content: 'Alpha', value: 'a' },
+  { content: 'Beta', value: 'b' },
+  { content: 'Gamma', value: 'c' },
+];
+
+describe('useMultiTypeaheadFiltering', () => {
+  it('maps selected values to options and synthesizes missing ones', () => {
+    const { result } = renderHook(() =>
+      useMultiTypeaheadFiltering({
+        inputValue: '',
+        isFiltering: false,
+        options,
+        values: ['a', 'missing'],
+      }),
+    );
+
+    expect(result.current.selectedOptions).toEqual([
+      { content: 'Alpha', value: 'a' },
+      { content: 'missing', value: 'missing' },
+    ]);
+  });
+
+  it('shows no-options placeholder when options are empty and not filtering', () => {
+    const { result } = renderHook(() =>
+      useMultiTypeaheadFiltering({
+        inputValue: '',
+        isFiltering: false,
+        options: [],
+        values: [],
+      }),
+    );
+
+    expect(result.current.displayOptions).toEqual([
+      expect.objectContaining({
+        optionProps: { isDisabled: true },
+        value: PLACEHOLDER_VALUES.NO_OPTIONS,
+      }),
+    ]);
+  });
+
+  it('filters options when filtering', () => {
+    const { result } = renderHook(() =>
+      useMultiTypeaheadFiltering({
+        inputValue: 'be',
+        isFiltering: true,
+        options,
+        values: [],
+      }),
+    );
+
+    expect(result.current.displayOptions.map((o) => o.value)).toEqual(['b']);
+  });
+});

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
@@ -54,6 +54,6 @@ describe('useMultiTypeaheadFiltering', () => {
       }),
     );
 
-    expect(result.current.displayOptions.map((o) => o.value)).toEqual(['b']);
+    expect(result.current.displayOptions.map((option) => option.value)).toEqual(['b']);
   });
 });

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadFiltering.test.ts
@@ -56,4 +56,43 @@ describe('useMultiTypeaheadFiltering', () => {
 
     expect(result.current.displayOptions.map((option) => option.value)).toEqual(['b']);
   });
+
+  it('shows no-results placeholder when filtering yields no matches', () => {
+    const { result } = renderHook(() =>
+      useMultiTypeaheadFiltering({
+        inputValue: 'zzz',
+        isFiltering: true,
+        options,
+        values: [],
+      }),
+    );
+
+    expect(result.current.displayOptions).toEqual([
+      expect.objectContaining({
+        optionProps: { isDisabled: true },
+        value: PLACEHOLDER_VALUES.NO_RESULTS,
+      }),
+    ]);
+  });
+
+  it('surfaces a create option when creatable and filter has no exact match', () => {
+    const { result } = renderHook(() =>
+      useMultiTypeaheadFiltering({
+        inputValue: 'Delta',
+        isCreatable: true,
+        isFiltering: true,
+        options,
+        values: [],
+      }),
+    );
+
+    expect(result.current.displayOptions[0]).toEqual(
+      expect.objectContaining({
+        optionProps: expect.objectContaining({
+          testId: 'multi-typeahead-select-create-option',
+        }),
+        value: 'Delta',
+      }),
+    );
+  });
 });

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
+import { PLACEHOLDER_VALUES } from '../../../utils/constants';
 import { useMultiTypeaheadSelect } from '../useMultiTypeaheadSelect';
 
 const options = [
@@ -32,5 +33,30 @@ describe('useMultiTypeaheadSelect', () => {
       result.current.handleSelect('2');
     });
     expect(onChange).toHaveBeenCalledWith(['2']);
+  });
+
+  it('deselects an already selected value through handleSelect', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(() =>
+      useMultiTypeaheadSelect({ onChange, options, values: ['2'] }),
+    );
+
+    act(() => {
+      result.current.handleSelect('2');
+    });
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('ignores placeholder values in handleSelect', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(() => useMultiTypeaheadSelect({ onChange, options, values: [] }));
+
+    act(() => {
+      result.current.handleSelect(PLACEHOLDER_VALUES.NO_RESULTS);
+    });
+    act(() => {
+      result.current.handleSelect(PLACEHOLDER_VALUES.NO_OPTIONS);
+    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
@@ -21,9 +21,7 @@ describe('useMultiTypeaheadSelect', () => {
 
   it('opens on toggle and selects values through handleSelect', () => {
     const onChange = jest.fn();
-    const { result } = renderHook(() =>
-      useMultiTypeaheadSelect({ onChange, options, values: [] }),
-    );
+    const { result } = renderHook(() => useMultiTypeaheadSelect({ onChange, options, values: [] }));
 
     act(() => {
       result.current.onToggleClick();

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/hooks/__tests__/useMultiTypeaheadSelect.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useMultiTypeaheadSelect } from '../useMultiTypeaheadSelect';
+
+const options = [
+  { content: 'One', value: '1' },
+  { content: 'Two', value: '2' },
+];
+
+describe('useMultiTypeaheadSelect', () => {
+  it('exposes filtering and open state with default listbox id', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(() =>
+      useMultiTypeaheadSelect({ onChange, options, values: ['1'] }),
+    );
+
+    expect(result.current.listboxId).toBe('select-multi-typeahead-listbox');
+    expect(result.current.selectedOptions).toEqual([options[0]]);
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('opens on toggle and selects values through handleSelect', () => {
+    const onChange = jest.fn();
+    const { result } = renderHook(() =>
+      useMultiTypeaheadSelect({ onChange, options, values: [] }),
+    );
+
+    act(() => {
+      result.current.onToggleClick();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.handleSelect('2');
+    });
+    expect(onChange).toHaveBeenCalledWith(['2']);
+  });
+});

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
@@ -41,4 +41,9 @@ describe('MultiTypeaheadSelect utils - navigation', () => {
     expect(getNextEnabledIndex(options, 1)).toBe(1);
     expect(getPrevEnabledIndex(options, 1)).toBe(1);
   });
+
+  it('returns startIndex when options are empty', () => {
+    expect(getNextEnabledIndex([], 3)).toBe(3);
+    expect(getPrevEnabledIndex([], -1)).toBe(-1);
+  });
 });

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
@@ -1,9 +1,5 @@
 import type { TypeaheadSelectOption } from '../../../utils/types';
-import {
-  createItemElementId,
-  getNextEnabledIndex,
-  getPrevEnabledIndex,
-} from '../utils';
+import { createItemElementId, getNextEnabledIndex, getPrevEnabledIndex } from '../utils';
 
 const opts = (flags: boolean[]): TypeaheadSelectOption[] =>
   flags.map((disabled, index) => ({

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
@@ -21,6 +21,20 @@ describe('MultiTypeaheadSelect utils - navigation', () => {
     expect(getPrevEnabledIndex(options, 0)).toBe(3);
   });
 
+  it('skips disabled options when startIndex is mid-list (ArrowUp/Down path)', () => {
+    const options = opts([false, true, false]);
+
+    expect(getNextEnabledIndex(options, 1)).toBe(2);
+    expect(getPrevEnabledIndex(options, 1)).toBe(0);
+  });
+
+  it('wraps past the end to the first enabled option', () => {
+    const options = opts([false, true, false]);
+
+    expect(getNextEnabledIndex(options, 3)).toBe(0);
+    expect(getPrevEnabledIndex(options, -1)).toBe(2);
+  });
+
   it('returns startIndex when every option is disabled', () => {
     const options = opts([true, true, true]);
 

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/__tests__/utils.navigation.test.ts
@@ -1,0 +1,34 @@
+import type { TypeaheadSelectOption } from '../../../utils/types';
+import {
+  createItemElementId,
+  getNextEnabledIndex,
+  getPrevEnabledIndex,
+} from '../utils';
+
+const opts = (flags: boolean[]): TypeaheadSelectOption[] =>
+  flags.map((disabled, index) => ({
+    content: `opt-${index}`,
+    optionProps: { isDisabled: disabled },
+    value: index,
+  }));
+
+describe('MultiTypeaheadSelect utils - navigation', () => {
+  it('creates stable element ids from values', () => {
+    expect(createItemElementId('hello world')).toBe('select-multi-typeahead-hello-world');
+    expect(createItemElementId(12)).toBe('select-multi-typeahead-12');
+  });
+
+  it('advances from a disabled start index to the next enabled option', () => {
+    const options = opts([true, false, true, false]);
+
+    expect(getNextEnabledIndex(options, 0)).toBe(1);
+    expect(getPrevEnabledIndex(options, 0)).toBe(3);
+  });
+
+  it('returns startIndex when every option is disabled', () => {
+    const options = opts([true, true, true]);
+
+    expect(getNextEnabledIndex(options, 1)).toBe(1);
+    expect(getPrevEnabledIndex(options, 1)).toBe(1);
+  });
+});

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from '@utils/helpers';
+
 import type { TypeaheadSelectOption } from '../../utils/types';
 
 export const createItemElementId = (value: string | number): string =>
@@ -7,13 +9,17 @@ export const getPrevEnabledIndex = (
   options: TypeaheadSelectOption[],
   startIndex: number,
 ): number => {
+  if (isEmpty(options)) {
+    return startIndex;
+  }
+
   let index = startIndex;
   if (index < 0) {
     index = options.length - 1;
   }
 
-  for (const option of options) {
-    if (!option?.optionProps?.isDisabled) {
+  for (let step = 0; step < options.length; step += 1) {
+    if (!options[index]?.optionProps?.isDisabled) {
       return index;
     }
     index -= 1;
@@ -28,13 +34,17 @@ export const getNextEnabledIndex = (
   options: TypeaheadSelectOption[],
   startIndex: number,
 ): number => {
+  if (isEmpty(options)) {
+    return startIndex;
+  }
+
   let index = startIndex;
   if (index >= options.length) {
     index = 0;
   }
 
-  for (const option of options) {
-    if (!option?.optionProps?.isDisabled) {
+  for (let step = 0; step < options.length; step += 1) {
+    if (!options[index]?.optionProps?.isDisabled) {
       return index;
     }
     index += 1;

--- a/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
+++ b/src/components/common/TypeaheadSelect/MultiTypeaheadSelect/utils/utils.ts
@@ -18,7 +18,7 @@ export const getPrevEnabledIndex = (
     index = options.length - 1;
   }
 
-  for (let step = 0; step < options.length; step += 1) {
+  for (const _ of options) {
     if (!options[index]?.optionProps?.isDisabled) {
       return index;
     }
@@ -43,7 +43,7 @@ export const getNextEnabledIndex = (
     index = 0;
   }
 
-  for (let step = 0; step < options.length; step += 1) {
+  for (const _ of options) {
     if (!options[index]?.optionProps?.isDisabled) {
       return index;
     }


### PR DESCRIPTION
## Summary
- Unit tests for InspectVM status/phase labels, concern badges, `getInspectionStatusConfig`
- MultiTypeahead leftovers: filtering hook, select hook, navigation utils (skips T1-covered interactions/open hooks)

## Test plan
- [x] `npm test -- --testPathPattern='(InspectVirtualMachines/__tests__|InspectVirtualMachines/utils/__tests__|MultiTypeaheadSelect/.*/__tests__)'`

Resolves: MTV-6265

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-select navigation handling when no options are available, while preserving wraparound and disabled-option behavior.

- **Tests**
  - Expanded coverage for virtual machine inspection labels, statuses, concerns, icons, and fallback states.
  - Added coverage for multi-select filtering, selection changes, placeholders, creatable options, and keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->