### PR TITLE
test(MTV-6266): Tier 3-1 plans/create utils coverage

### DIFF
--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -38,6 +38,24 @@ describe('addOwnerRefs - ownerRefs', () => {
     );
   });
 
+  it('treats empty ownerReferences as none exist', async () => {
+    const resource = { metadata: { name: 'sec', ownerReferences: [] } } as never;
+
+    await addOwnerRefs(model, resource, [planRef]);
+
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          {
+            op: 'add',
+            path: '/metadata/ownerReferences',
+            value: [{ ...planRef, namespace: undefined }],
+          },
+        ],
+      }),
+    );
+  });
+
   it('appends to existing owner references', async () => {
     const existing = { apiVersion: 'v1', kind: 'Plan', name: 'old', uid: 'old-uid' };
     const resource = { metadata: { ownerReferences: [existing] } } as never;

--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { addOwnerRefs } from '../addOwnerRefs';
+
+const model = { kind: 'Secret', apiVersion: 'v1' } as never;
+const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan-1', uid: 'uid-1' };
+
+describe('addOwnerRefs - ownerRefs', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('adds owner refs when none exist and strips namespace', async () => {
+    const resource = { metadata: { name: 'sec' } } as never;
+
+    await addOwnerRefs(model, resource, [planRef]);
+
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          {
+            op: 'add',
+            path: '/metadata/ownerReferences',
+            value: [{ ...planRef, namespace: undefined }],
+          },
+        ],
+        model,
+        resource,
+      }),
+    );
+  });
+
+  it('appends to existing owner references', async () => {
+    const existing = { apiVersion: 'v1', kind: 'Plan', name: 'old', uid: 'old-uid' };
+    const resource = { metadata: { ownerReferences: [existing] } } as never;
+
+    await addOwnerRefs(model, resource, [planRef]);
+
+    const value = mockK8sPatch.mock.calls[0][0].data[0].value;
+    expect(value).toHaveLength(2);
+    expect(value[0]).toEqual({ ...existing, namespace: undefined });
+    expect(value[1]).toEqual({ ...planRef, namespace: undefined });
+  });
+});

--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -8,14 +8,14 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { addOwnerRefs } from '../addOwnerRefs';
 
-const mockK8sPatch = k8sPatch as jest.MockedFunction<typeof k8sPatch>;
+const mockK8sPatch = k8sPatch as unknown as jest.Mock;
 const model = { kind: 'Secret', apiVersion: 'v1' } as never;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan-1', uid: 'uid-1' };
 
 describe('addOwnerRefs - ownerRefs', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({} as never);
   });
 
   it('adds owner refs when none exist and strips namespace', async () => {

--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
-
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: jest.fn(),
 }));
+
+import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { addOwnerRefs } from '../addOwnerRefs';
 
+const mockK8sPatch = k8sPatch as jest.Mock;
 const model = { kind: 'Secret', apiVersion: 'v1' } as never;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan-1', uid: 'uid-1' };
 
@@ -43,7 +44,9 @@ describe('addOwnerRefs - ownerRefs', () => {
 
     await addOwnerRefs(model, resource, [planRef]);
 
-    const { value } = mockK8sPatch.mock.calls[0][0].data[0];
+    const [firstCall] = mockK8sPatch.mock.calls;
+    const [patchArg] = firstCall as [{ data: { value: unknown[] }[] }];
+    const [{ value }] = patchArg.data;
     expect(value).toHaveLength(2);
     expect(value[0]).toEqual({ ...existing, namespace: undefined });
     expect(value[1]).toEqual({ ...planRef, namespace: undefined });

--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -43,7 +43,7 @@ describe('addOwnerRefs - ownerRefs', () => {
 
     await addOwnerRefs(model, resource, [planRef]);
 
-    const value = mockK8sPatch.mock.calls[0][0].data[0].value;
+    const { value } = mockK8sPatch.mock.calls[0][0].data[0];
     expect(value).toHaveLength(2);
     expect(value[0]).toEqual({ ...existing, namespace: undefined });
     expect(value[1]).toEqual({ ...planRef, namespace: undefined });

--- a/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addOwnerRefs.ownerRefs.test.ts
@@ -8,14 +8,14 @@ import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
 
 import { addOwnerRefs } from '../addOwnerRefs';
 
-const mockK8sPatch = k8sPatch as jest.Mock;
+const mockK8sPatch = k8sPatch as jest.MockedFunction<typeof k8sPatch>;
 const model = { kind: 'Secret', apiVersion: 'v1' } as never;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan-1', uid: 'uid-1' };
 
 describe('addOwnerRefs - ownerRefs', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('adds owner refs when none exist and strips namespace', async () => {

--- a/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
@@ -10,13 +10,13 @@ import { ConfigMapModel } from '@utils/constants';
 import { addOwnerRefs } from '../addOwnerRefs';
 import { addPlanResourceOwnerRefs } from '../addPlanResourceOwnerRefs';
 
-const mockAddOwnerRefs = addOwnerRefs as jest.Mock;
+const mockAddOwnerRefs = addOwnerRefs as jest.MockedFunction<typeof addOwnerRefs>;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan', uid: 'u1' };
 
 describe('addPlanResourceOwnerRefs - ownerRefs', () => {
   beforeEach(() => {
     mockAddOwnerRefs.mockReset();
-    mockAddOwnerRefs.mockResolvedValue({});
+    mockAddOwnerRefs.mockResolvedValue(undefined as never);
   });
 
   it('always owns storage and network maps', async () => {

--- a/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
@@ -10,13 +10,13 @@ import { ConfigMapModel } from '@utils/constants';
 import { addOwnerRefs } from '../addOwnerRefs';
 import { addPlanResourceOwnerRefs } from '../addPlanResourceOwnerRefs';
 
-const mockAddOwnerRefs = addOwnerRefs as jest.MockedFunction<typeof addOwnerRefs>;
+const mockAddOwnerRefs = addOwnerRefs as unknown as jest.Mock;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan', uid: 'u1' };
 
 describe('addPlanResourceOwnerRefs - ownerRefs', () => {
   beforeEach(() => {
     mockAddOwnerRefs.mockReset();
-    mockAddOwnerRefs.mockResolvedValue(undefined as never);
+    mockAddOwnerRefs.mockResolvedValue({} as never);
   });
 
   it('always owns storage and network maps', async () => {

--- a/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
@@ -48,10 +48,8 @@ describe('addPlanResourceOwnerRefs - ownerRefs', () => {
     expect(mockAddOwnerRefs).toHaveBeenCalledWith(SecretModel, resources.secret, [planRef]);
     expect(mockAddOwnerRefs).toHaveBeenCalledWith(HookModel, resources.hooks.preHook, [planRef]);
     expect(mockAddOwnerRefs).toHaveBeenCalledWith(HookModel, resources.hooks.postHook, [planRef]);
-    expect(mockAddOwnerRefs).toHaveBeenCalledWith(
-      ConfigMapModel,
-      resources.scriptsConfigMap,
-      [planRef],
-    );
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(ConfigMapModel, resources.scriptsConfigMap, [
+      planRef,
+    ]);
   });
 });

--- a/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockAddOwnerRefs = jest.fn();
+
+jest.mock('../addOwnerRefs', () => ({
+  addOwnerRefs: (...args: unknown[]) => mockAddOwnerRefs(...args),
+}));
+
+import { HookModel, NetworkMapModel, SecretModel, StorageMapModel } from '@forklift-ui/types';
+import { ConfigMapModel } from '@utils/constants';
+
+import { addPlanResourceOwnerRefs } from '../addPlanResourceOwnerRefs';
+
+const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan', uid: 'u1' };
+
+describe('addPlanResourceOwnerRefs - ownerRefs', () => {
+  beforeEach(() => {
+    mockAddOwnerRefs.mockReset();
+    mockAddOwnerRefs.mockResolvedValue({});
+  });
+
+  it('always owns storage and network maps', async () => {
+    const networkMap = { metadata: { name: 'nm' } } as never;
+    const storageMap = { metadata: { name: 'sm' } } as never;
+
+    await addPlanResourceOwnerRefs({ hooks: {}, networkMap, storageMap }, planRef);
+
+    expect(mockAddOwnerRefs).toHaveBeenCalledTimes(2);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(StorageMapModel, storageMap, [planRef]);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(NetworkMapModel, networkMap, [planRef]);
+  });
+
+  it('owns optional secret, hooks, and scripts config map when present', async () => {
+    const resources = {
+      hooks: {
+        postHook: { metadata: { name: 'post' } } as never,
+        preHook: { metadata: { name: 'pre' } } as never,
+      },
+      networkMap: { metadata: { name: 'nm' } } as never,
+      scriptsConfigMap: { metadata: { name: 'cm' } } as never,
+      secret: { metadata: { name: 'sec' } } as never,
+      storageMap: { metadata: { name: 'sm' } } as never,
+    };
+
+    await addPlanResourceOwnerRefs(resources, planRef);
+
+    expect(mockAddOwnerRefs).toHaveBeenCalledTimes(6);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(SecretModel, resources.secret, [planRef]);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(HookModel, resources.hooks.preHook, [planRef]);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(HookModel, resources.hooks.postHook, [planRef]);
+    expect(mockAddOwnerRefs).toHaveBeenCalledWith(
+      ConfigMapModel,
+      resources.scriptsConfigMap,
+      [planRef],
+    );
+  });
+});

--- a/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
+++ b/src/plans/create/utils/__tests__/addPlanResourceOwnerRefs.ownerRefs.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockAddOwnerRefs = jest.fn();
-
 jest.mock('../addOwnerRefs', () => ({
-  addOwnerRefs: (...args: unknown[]) => mockAddOwnerRefs(...args),
+  addOwnerRefs: jest.fn(),
 }));
 
 import { HookModel, NetworkMapModel, SecretModel, StorageMapModel } from '@forklift-ui/types';
 import { ConfigMapModel } from '@utils/constants';
 
+import { addOwnerRefs } from '../addOwnerRefs';
 import { addPlanResourceOwnerRefs } from '../addPlanResourceOwnerRefs';
 
+const mockAddOwnerRefs = addOwnerRefs as jest.Mock;
 const planRef = { apiVersion: 'v1', kind: 'Plan', name: 'plan', uid: 'u1' };
 
 describe('addPlanResourceOwnerRefs - ownerRefs', () => {

--- a/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
@@ -24,7 +24,7 @@ describe('copyNetworkMap - copy', () => {
     const existing = {
       apiVersion: 'forklift.konveyor.io/v1beta1',
       kind: 'NetworkMap',
-      metadata: { labels: { x: 'y' }, name: 'nm' },
+      metadata: { annotations: { a: '1' }, labels: { x: 'y' }, name: 'nm' },
       spec: { map: [{ destination: {}, source: {} }] },
     } as never;
 
@@ -33,12 +33,32 @@ describe('copyNetworkMap - copy', () => {
     expect(mockK8sCreate).toHaveBeenCalledWith({
       data: expect.objectContaining({
         metadata: expect.objectContaining({
+          annotations: { a: '1' },
           labels: { x: 'y' },
           name: 'plan-a-nm',
           namespace: 'ns-1',
         }),
+        spec: { map: [{ destination: {}, source: {} }] },
       }),
       model: NetworkMapModel,
     });
+  });
+
+  it('omits labels and annotations when absent', async () => {
+    const existing = {
+      metadata: { name: 'nm' },
+      spec: {},
+    } as never;
+
+    await copyNetworkMap(existing, 'p', 'ns');
+
+    const [firstCall] = mockK8sCreate.mock.calls;
+    const [createArg] = firstCall as [
+      { data: { metadata: { annotations?: unknown; labels?: unknown }; spec: unknown } },
+    ];
+    const { data } = createArg;
+    expect(data.metadata.labels).toBeUndefined();
+    expect(data.metadata.annotations).toBeUndefined();
+    expect(data.spec).toEqual({});
   });
 });

--- a/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sCreate = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+}));
+
+import { NetworkMapModel } from '@forklift-ui/types';
+
+import { copyNetworkMap } from '../copyNetworkMap';
+
+describe('copyNetworkMap - copy', () => {
+  beforeEach(() => {
+    mockK8sCreate.mockReset();
+    mockK8sCreate.mockImplementation(async ({ data }) => data);
+  });
+
+  it('creates a plan-prefixed network map copy', async () => {
+    const existing = {
+      apiVersion: 'forklift.konveyor.io/v1beta1',
+      kind: 'NetworkMap',
+      metadata: { labels: { x: 'y' }, name: 'nm' },
+      spec: { map: [{ destination: {}, source: {} }] },
+    } as never;
+
+    await copyNetworkMap(existing, 'plan-a', 'ns-1');
+
+    expect(mockK8sCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        metadata: expect.objectContaining({
+          labels: { x: 'y' },
+          name: 'plan-a-nm',
+          namespace: 'ns-1',
+        }),
+      }),
+      model: NetworkMapModel,
+    });
+  });
+});

--- a/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sCreate = jest.fn();
-
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+  k8sCreate: jest.fn(),
 }));
 
 import { NetworkMapModel } from '@forklift-ui/types';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyNetworkMap } from '../copyNetworkMap';
+
+const mockK8sCreate = k8sCreate as jest.Mock;
 
 describe('copyNetworkMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(async ({ data }) => data);
+    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
   });
 
   it('creates a plan-prefixed network map copy', async () => {

--- a/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
@@ -9,12 +9,12 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyNetworkMap } from '../copyNetworkMap';
 
-const mockK8sCreate = k8sCreate as jest.Mock;
+const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
 
 describe('copyNetworkMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
   });
 
   it('creates a plan-prefixed network map copy', async () => {

--- a/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyNetworkMap.copy.test.ts
@@ -9,12 +9,15 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyNetworkMap } from '../copyNetworkMap';
 
-const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
+const mockK8sCreate = k8sCreate as unknown as jest.Mock;
 
 describe('copyNetworkMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation((...args: unknown[]) => {
+      const [{ data }] = args as [{ data: Record<string, unknown> }];
+      return Promise.resolve(data);
+    });
   });
 
   it('creates a plan-prefixed network map copy', async () => {

--- a/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sCreate = jest.fn();
-
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+  k8sCreate: jest.fn(),
 }));
 
 import { StorageMapModel } from '@forklift-ui/types';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyStorageMap } from '../copyStorageMap';
+
+const mockK8sCreate = k8sCreate as jest.Mock;
 
 describe('copyStorageMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(async ({ data }) => data);
+    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
   });
 
   it('creates a plan-prefixed copy preserving labels and annotations', async () => {
@@ -22,7 +23,7 @@ describe('copyStorageMap - copy', () => {
       kind: 'StorageMap',
       metadata: {
         annotations: { a: '1' },
-        labels: { l: '2' },
+        labels: { label: '2' },
         name: 'existing-sm',
         namespace: 'old-ns',
       },
@@ -35,7 +36,7 @@ describe('copyStorageMap - copy', () => {
       data: expect.objectContaining({
         metadata: {
           annotations: { a: '1' },
-          labels: { l: '2' },
+          labels: { label: '2' },
           name: 'my-plan-existing-sm',
           namespace: 'plan-ns',
         },
@@ -54,7 +55,11 @@ describe('copyStorageMap - copy', () => {
 
     await copyStorageMap(existing, 'p', 'ns');
 
-    const { data } = mockK8sCreate.mock.calls[0][0];
+    const [firstCall] = mockK8sCreate.mock.calls;
+    const [createArg] = firstCall as [
+      { data: { metadata: { annotations?: unknown; labels?: unknown } } },
+    ];
+    const { data } = createArg;
     expect(data.metadata.labels).toBeUndefined();
     expect(data.metadata.annotations).toBeUndefined();
   });

--- a/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
@@ -54,7 +54,7 @@ describe('copyStorageMap - copy', () => {
 
     await copyStorageMap(existing, 'p', 'ns');
 
-    const data = mockK8sCreate.mock.calls[0][0].data;
+    const { data } = mockK8sCreate.mock.calls[0][0];
     expect(data.metadata.labels).toBeUndefined();
     expect(data.metadata.annotations).toBeUndefined();
   });

--- a/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
@@ -9,12 +9,15 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyStorageMap } from '../copyStorageMap';
 
-const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
+const mockK8sCreate = k8sCreate as unknown as jest.Mock;
 
 describe('copyStorageMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation((...args: unknown[]) => {
+      const [{ data }] = args as [{ data: Record<string, unknown> }];
+      return Promise.resolve(data);
+    });
   });
 
   it('creates a plan-prefixed copy preserving labels and annotations', async () => {

--- a/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
@@ -9,12 +9,12 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { copyStorageMap } from '../copyStorageMap';
 
-const mockK8sCreate = k8sCreate as jest.Mock;
+const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
 
 describe('copyStorageMap - copy', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
   });
 
   it('creates a plan-prefixed copy preserving labels and annotations', async () => {

--- a/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
+++ b/src/plans/create/utils/__tests__/copyStorageMap.copy.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sCreate = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+}));
+
+import { StorageMapModel } from '@forklift-ui/types';
+
+import { copyStorageMap } from '../copyStorageMap';
+
+describe('copyStorageMap - copy', () => {
+  beforeEach(() => {
+    mockK8sCreate.mockReset();
+    mockK8sCreate.mockImplementation(async ({ data }) => data);
+  });
+
+  it('creates a plan-prefixed copy preserving labels and annotations', async () => {
+    const existing = {
+      apiVersion: 'forklift.konveyor.io/v1beta1',
+      kind: 'StorageMap',
+      metadata: {
+        annotations: { a: '1' },
+        labels: { l: '2' },
+        name: 'existing-sm',
+        namespace: 'old-ns',
+      },
+      spec: { map: [] },
+    } as never;
+
+    const result = await copyStorageMap(existing, 'my-plan', 'plan-ns');
+
+    expect(mockK8sCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        metadata: {
+          annotations: { a: '1' },
+          labels: { l: '2' },
+          name: 'my-plan-existing-sm',
+          namespace: 'plan-ns',
+        },
+        spec: { map: [] },
+      }),
+      model: StorageMapModel,
+    });
+    expect(result.metadata?.name).toBe('my-plan-existing-sm');
+  });
+
+  it('omits labels and annotations when absent', async () => {
+    const existing = {
+      metadata: { name: 'sm' },
+      spec: {},
+    } as never;
+
+    await copyStorageMap(existing, 'p', 'ns');
+
+    const data = mockK8sCreate.mock.calls[0][0].data;
+    expect(data.metadata.labels).toBeUndefined();
+    expect(data.metadata.annotations).toBeUndefined();
+  });
+});

--- a/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
+++ b/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sCreate = jest.fn();
-
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+  k8sCreate: jest.fn(),
 }));
 
 import { SecretModel } from '@forklift-ui/types';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { createDecryptionSecret } from '../createDecryptionSecret';
+
+const mockK8sCreate = k8sCreate as jest.Mock;
 
 describe('createDecryptionSecret - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(async ({ data }) => data);
+    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
   });
 
   it('base64-encodes passphrases keyed by index', async () => {
@@ -35,6 +36,8 @@ describe('createDecryptionSecret - create', () => {
   it('creates an empty data object when no passphrases are provided', async () => {
     await createDecryptionSecret([], 'plan', 'ns');
 
-    expect(mockK8sCreate.mock.calls[0][0].data.data).toEqual({});
+    const [firstCall] = mockK8sCreate.mock.calls;
+    const [createArg] = firstCall as [{ data: { data: Record<string, string> } }];
+    expect(createArg.data.data).toEqual({});
   });
 });

--- a/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
+++ b/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
@@ -9,12 +9,15 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { createDecryptionSecret } from '../createDecryptionSecret';
 
-const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
+const mockK8sCreate = k8sCreate as unknown as jest.Mock;
 
 describe('createDecryptionSecret - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation((...args: unknown[]) => {
+      const [{ data }] = args as [{ data: Record<string, unknown> }];
+      return Promise.resolve(data);
+    });
   });
 
   it('base64-encodes passphrases keyed by index', async () => {

--- a/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
+++ b/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sCreate = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+}));
+
+import { SecretModel } from '@forklift-ui/types';
+
+import { createDecryptionSecret } from '../createDecryptionSecret';
+
+describe('createDecryptionSecret - create', () => {
+  beforeEach(() => {
+    mockK8sCreate.mockReset();
+    mockK8sCreate.mockImplementation(async ({ data }) => data);
+  });
+
+  it('base64-encodes passphrases keyed by index', async () => {
+    await createDecryptionSecret([{ value: 'one' }, { value: 'two' }], 'plan', 'ns');
+
+    expect(mockK8sCreate).toHaveBeenCalledWith({
+      data: {
+        data: {
+          '0': btoa('one'),
+          '1': btoa('two'),
+        },
+        metadata: { generateName: 'plan-', namespace: 'ns' },
+        type: 'Opaque',
+      },
+      model: SecretModel,
+    });
+  });
+
+  it('creates an empty data object when no passphrases are provided', async () => {
+    await createDecryptionSecret([], 'plan', 'ns');
+
+    expect(mockK8sCreate.mock.calls[0][0].data.data).toEqual({});
+  });
+});

--- a/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
+++ b/src/plans/create/utils/__tests__/createDecryptionSecret.create.test.ts
@@ -9,12 +9,12 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { createDecryptionSecret } from '../createDecryptionSecret';
 
-const mockK8sCreate = k8sCreate as jest.Mock;
+const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
 
 describe('createDecryptionSecret - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
   });
 
   it('base64-encodes passphrases keyed by index', async () => {

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -1,15 +1,16 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sCreate = jest.fn();
-
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+  k8sCreate: jest.fn(),
 }));
 
 import { PlanModel } from '@forklift-ui/types';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 import { MigrationTypeValue } from '../../steps/migration-type/constants';
 import { createPlan } from '../createPlan';
+
+const mockK8sCreate = k8sCreate as jest.Mock;
 
 const provider = {
   apiVersion: 'forklift.konveyor.io/v1beta1',
@@ -26,7 +27,7 @@ const mapRef = {
 describe('createPlan - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(async ({ data }) => data);
+    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
   });
 
   it('creates a cold plan and returns an object ref', async () => {
@@ -39,7 +40,7 @@ describe('createPlan - create', () => {
       preserveStaticIps: true,
       sourceProvider: provider,
       storageMap: {
-        ...mapRef,
+        apiVersion: 'forklift.konveyor.io/v1beta1',
         kind: 'StorageMap',
         metadata: { name: 'sm', namespace: 'ns', uid: 's1' },
       },
@@ -82,7 +83,9 @@ describe('createPlan - create', () => {
       vms: [],
     });
 
-    const { spec } = mockK8sCreate.mock.calls[0][0].data;
+    const [firstCall] = mockK8sCreate.mock.calls;
+    const [createArg] = firstCall as [{ data: { spec: { description?: string; warm?: boolean } } }];
+    const { spec } = createArg.data;
     expect(spec.warm).toBe(true);
     expect(spec.description).toBe('desc');
   });

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -10,7 +10,7 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { MigrationTypeValue } from '../../steps/migration-type/constants';
 import { createPlan } from '../createPlan';
 
-const mockK8sCreate = k8sCreate as jest.Mock;
+const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
 
 const provider = {
   apiVersion: 'forklift.konveyor.io/v1beta1',
@@ -27,7 +27,7 @@ const mapRef = {
 describe('createPlan - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }: { data: unknown }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
   });
 
   it('creates a cold plan and returns an object ref', async () => {

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -10,7 +10,7 @@ import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
 import { MigrationTypeValue } from '../../steps/migration-type/constants';
 import { createPlan } from '../createPlan';
 
-const mockK8sCreate = k8sCreate as jest.MockedFunction<typeof k8sCreate>;
+const mockK8sCreate = k8sCreate as unknown as jest.Mock;
 
 const provider = {
   apiVersion: 'forklift.konveyor.io/v1beta1',
@@ -27,7 +27,10 @@ const mapRef = {
 describe('createPlan - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
-    mockK8sCreate.mockImplementation(({ data }) => Promise.resolve(data));
+    mockK8sCreate.mockImplementation((...args: unknown[]) => {
+      const [{ data }] = args as [{ data: Record<string, unknown> }];
+      return Promise.resolve(data);
+    });
   });
 
   it('creates a cold plan and returns an object ref', async () => {

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -24,6 +24,12 @@ const mapRef = {
   metadata: { name: 'nm', namespace: 'ns', uid: 'm1' },
 } as never;
 
+const storageMapRef = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'StorageMap',
+  metadata: { name: 'sm', namespace: 'ns', uid: 's1' },
+} as never;
+
 describe('createPlan - create', () => {
   beforeEach(() => {
     mockK8sCreate.mockReset();
@@ -42,11 +48,7 @@ describe('createPlan - create', () => {
       planProject: 'ns',
       preserveStaticIps: true,
       sourceProvider: provider,
-      storageMap: {
-        apiVersion: 'forklift.konveyor.io/v1beta1',
-        kind: 'StorageMap',
-        metadata: { name: 'sm', namespace: 'ns', uid: 's1' },
-      },
+      storageMap: storageMapRef,
       targetPowerState: 'on',
       targetProject: 'target-ns',
       targetProvider: provider,
@@ -58,8 +60,19 @@ describe('createPlan - create', () => {
         data: expect.objectContaining({
           metadata: { name: 'plan-1', namespace: 'ns' },
           spec: expect.objectContaining({
+            map: {
+              network: expect.objectContaining({ name: 'nm', namespace: 'ns' }),
+              storage: expect.objectContaining({ name: 'sm', namespace: 'ns' }),
+            },
+            migrateSharedDisks: true,
+            preserveStaticIPs: true,
+            provider: {
+              destination: expect.objectContaining({ name: 'src', namespace: 'ns' }),
+              source: expect.objectContaining({ name: 'src', namespace: 'ns' }),
+            },
             targetNamespace: 'target-ns',
             type: MigrationTypeValue.Cold,
+            vms: [expect.objectContaining({ id: 'vm-1', name: 'vm-1' })],
             warm: false,
           }),
         }),
@@ -79,7 +92,7 @@ describe('createPlan - create', () => {
       planProject: 'ns',
       preserveStaticIps: false,
       sourceProvider: provider,
-      storageMap: mapRef,
+      storageMap: storageMapRef,
       targetPowerState: 'off',
       targetProject: 'target-ns',
       targetProvider: provider,
@@ -87,9 +100,12 @@ describe('createPlan - create', () => {
     });
 
     const [firstCall] = mockK8sCreate.mock.calls;
-    const [createArg] = firstCall as [{ data: { spec: { description?: string; warm?: boolean } } }];
+    const [createArg] = firstCall as [
+      { data: { spec: { description?: string; type?: string; warm?: boolean } } },
+    ];
     const { spec } = createArg.data;
     expect(spec.warm).toBe(true);
+    expect(spec.type).toBe(MigrationTypeValue.Warm);
     expect(spec.description).toBe('desc');
   });
 });

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -38,7 +38,11 @@ describe('createPlan - create', () => {
       planProject: 'ns',
       preserveStaticIps: true,
       sourceProvider: provider,
-      storageMap: { ...mapRef, kind: 'StorageMap', metadata: { name: 'sm', namespace: 'ns', uid: 's1' } },
+      storageMap: {
+        ...mapRef,
+        kind: 'StorageMap',
+        metadata: { name: 'sm', namespace: 'ns', uid: 's1' },
+      },
       targetPowerState: 'on',
       targetProject: 'target-ns',
       targetProvider: provider,
@@ -78,7 +82,7 @@ describe('createPlan - create', () => {
       vms: [],
     });
 
-    const spec = mockK8sCreate.mock.calls[0][0].data.spec;
+    const { spec } = mockK8sCreate.mock.calls[0][0].data;
     expect(spec.warm).toBe(true);
     expect(spec.description).toBe('desc');
   });

--- a/src/plans/create/utils/__tests__/createPlan.create.test.ts
+++ b/src/plans/create/utils/__tests__/createPlan.create.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sCreate = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sCreate: (...args: unknown[]) => mockK8sCreate(...args),
+}));
+
+import { PlanModel } from '@forklift-ui/types';
+
+import { MigrationTypeValue } from '../../steps/migration-type/constants';
+import { createPlan } from '../createPlan';
+
+const provider = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'Provider',
+  metadata: { name: 'src', namespace: 'ns', uid: 'p1' },
+} as never;
+
+const mapRef = {
+  apiVersion: 'forklift.konveyor.io/v1beta1',
+  kind: 'NetworkMap',
+  metadata: { name: 'nm', namespace: 'ns', uid: 'm1' },
+} as never;
+
+describe('createPlan - create', () => {
+  beforeEach(() => {
+    mockK8sCreate.mockReset();
+    mockK8sCreate.mockImplementation(async ({ data }) => data);
+  });
+
+  it('creates a cold plan and returns an object ref', async () => {
+    const ref = await createPlan({
+      migrateSharedDisks: true,
+      migrationType: MigrationTypeValue.Cold,
+      networkMap: mapRef,
+      planName: 'plan-1',
+      planProject: 'ns',
+      preserveStaticIps: true,
+      sourceProvider: provider,
+      storageMap: { ...mapRef, kind: 'StorageMap', metadata: { name: 'sm', namespace: 'ns', uid: 's1' } },
+      targetPowerState: 'on',
+      targetProject: 'target-ns',
+      targetProvider: provider,
+      vms: [{ id: 'vm-1', name: 'vm-1', providerType: 'vsphere' } as never],
+    });
+
+    expect(mockK8sCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: { name: 'plan-1', namespace: 'ns' },
+          spec: expect.objectContaining({
+            targetNamespace: 'target-ns',
+            type: MigrationTypeValue.Cold,
+            warm: false,
+          }),
+        }),
+        model: PlanModel,
+      }),
+    );
+    expect(ref.name).toBe('plan-1');
+  });
+
+  it('sets warm true for warm migration type and includes description', async () => {
+    await createPlan({
+      migrateSharedDisks: false,
+      migrationType: MigrationTypeValue.Warm,
+      networkMap: mapRef,
+      planDescription: 'desc',
+      planName: 'warm-plan',
+      planProject: 'ns',
+      preserveStaticIps: false,
+      sourceProvider: provider,
+      storageMap: mapRef,
+      targetPowerState: 'off',
+      targetProject: 'target-ns',
+      targetProvider: provider,
+      vms: [],
+    });
+
+    const spec = mockK8sCreate.mock.calls[0][0].data.spec;
+    expect(spec.warm).toBe(true);
+    expect(spec.description).toBe('desc');
+  });
+});

--- a/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
+++ b/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { fillUnmappedSources } from '../fillUnmappedSources';
+
+const fieldIds = { sourceField: 'source', targetField: 'target' } as const;
+
+describe('fillUnmappedSources - mappings', () => {
+  it('fills empty rows then appends remaining sources', () => {
+    const existing = [
+      { source: { id: '', name: '  ' }, target: { id: 't1', name: 't1' } },
+      { source: { id: 's0', name: 'kept' }, target: { id: 't0', name: 't0' } },
+    ];
+    const unmapped = [
+      { id: 'u1', name: 'u1' },
+      { id: 'u2', name: 'u2' },
+      { id: 'u3', name: 'u3' },
+    ];
+
+    const result = fillUnmappedSources({
+      existingMappings: existing,
+      fieldIds,
+      targetValue: { id: 'default', name: 'default' },
+      unmappedSources: unmapped,
+    });
+
+    expect(result).toEqual([
+      { source: { id: 'u1', name: 'u1' }, target: { id: 't1', name: 't1' } },
+      { source: { id: 's0', name: 'kept' }, target: { id: 't0', name: 't0' } },
+      { source: { id: 'u2', name: 'u2' }, target: { id: 'default', name: 'default' } },
+      { source: { id: 'u3', name: 'u3' }, target: { id: 'default', name: 'default' } },
+    ]);
+  });
+
+  it('returns existing mappings unchanged when there are no unmapped sources', () => {
+    const existing = [{ source: { id: 's', name: 's' }, target: { id: 't', name: 't' } }];
+
+    expect(
+      fillUnmappedSources({
+        existingMappings: existing,
+        fieldIds,
+        targetValue: { id: 'd', name: 'd' },
+        unmappedSources: [],
+      }),
+    ).toEqual(existing);
+  });
+});

--- a/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
+++ b/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import { fillUnmappedSources } from '../fillUnmappedSources';
 
-const fieldIds = { sourceField: 'source', targetField: 'target' } as const;
+const fieldIds = { mapField: 'mappings', sourceField: 'source', targetField: 'target' } as const;
 
 describe('fillUnmappedSources - mappings', () => {
   it('fills empty rows then appends remaining sources', () => {

--- a/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
+++ b/src/plans/create/utils/__tests__/fillUnmappedSources.mappings.test.ts
@@ -43,4 +43,40 @@ describe('fillUnmappedSources - mappings', () => {
       }),
     ).toEqual(existing);
   });
+
+  it('leaves leftover empty rows empty when unmapped sources are exhausted', () => {
+    const existing = [
+      { source: { id: '', name: '' }, target: { id: 't1', name: 't1' } },
+      { source: { id: '', name: '' }, target: { id: 't2', name: 't2' } },
+    ];
+
+    expect(
+      fillUnmappedSources({
+        existingMappings: existing,
+        fieldIds,
+        targetValue: { id: 'default', name: 'default' },
+        unmappedSources: [{ id: 'u1', name: 'u1' }],
+      }),
+    ).toEqual([
+      { source: { id: 'u1', name: 'u1' }, target: { id: 't1', name: 't1' } },
+      { source: { id: '', name: '' }, target: { id: 't2', name: 't2' } },
+    ]);
+  });
+
+  it('appends all sources with targetValue when existing mappings are empty', () => {
+    expect(
+      fillUnmappedSources({
+        existingMappings: [],
+        fieldIds,
+        targetValue: { id: 'default', name: 'default' },
+        unmappedSources: [
+          { id: 'u1', name: 'u1' },
+          { id: 'u2', name: 'u2' },
+        ],
+      }),
+    ).toEqual([
+      { source: { id: 'u1', name: 'u1' }, target: { id: 'default', name: 'default' } },
+      { source: { id: 'u2', name: 'u2' }, target: { id: 'default', name: 'default' } },
+    ]);
+  });
 });

--- a/src/plans/create/utils/__tests__/getDefaultFormValues.defaults.test.ts
+++ b/src/plans/create/utils/__tests__/getDefaultFormValues.defaults.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { GeneralFormFieldId } from '../../steps/general-information/constants';
+import { HooksFormFieldId, MigrationHookFieldId } from '../../steps/migration-hooks/constants';
+import { getDefaultFormValues } from '../getDefaultFormValues';
+
+describe('getDefaultFormValues - defaults', () => {
+  it('returns existing map types and disabled hooks by default', () => {
+    const values = getDefaultFormValues();
+
+    expect(values[GeneralFormFieldId.ShowDefaultProjects]).toBe(false);
+    expect(values[HooksFormFieldId.PreMigration]?.[MigrationHookFieldId.EnableHook]).toBe(false);
+    expect(values[HooksFormFieldId.PostMigration]?.[MigrationHookFieldId.EnableHook]).toBe(false);
+    expect(values[GeneralFormFieldId.PlanProject]).toBeUndefined();
+    expect(values[GeneralFormFieldId.SourceProvider]).toBeUndefined();
+  });
+
+  it('applies optional planProject and sourceProvider overrides', () => {
+    const sourceProvider = { metadata: { name: 'vsphere' } } as never;
+    const values = getDefaultFormValues({ planProject: 'ns-a', sourceProvider });
+
+    expect(values[GeneralFormFieldId.PlanProject]).toBe('ns-a');
+    expect(values[GeneralFormFieldId.SourceProvider]).toBe(sourceProvider);
+  });
+});

--- a/src/plans/create/utils/__tests__/getDefaultFormValues.defaults.test.ts
+++ b/src/plans/create/utils/__tests__/getDefaultFormValues.defaults.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
+import { NetworkMapFieldId, NetworkMapType } from '@utils/mappings/networkMap';
+import { StorageMapFieldId } from '@utils/storage/types';
 
 import { GeneralFormFieldId } from '../../steps/general-information/constants';
 import { HooksFormFieldId, MigrationHookFieldId } from '../../steps/migration-hooks/constants';
+import { CreatePlanStorageMapFieldId, StorageMapType } from '../../steps/storage-map/constants';
 import { getDefaultFormValues } from '../getDefaultFormValues';
 
 describe('getDefaultFormValues - defaults', () => {
@@ -13,6 +16,10 @@ describe('getDefaultFormValues - defaults', () => {
     expect(values[HooksFormFieldId.PostMigration]?.[MigrationHookFieldId.EnableHook]).toBe(false);
     expect(values[GeneralFormFieldId.PlanProject]).toBeUndefined();
     expect(values[GeneralFormFieldId.SourceProvider]).toBeUndefined();
+    expect(values[NetworkMapFieldId.NetworkMapType]).toBe(NetworkMapType.Existing);
+    expect(values[CreatePlanStorageMapFieldId.StorageMapType]).toBe(StorageMapType.Existing);
+    expect(values[NetworkMapFieldId.NetworkMap]).toHaveLength(1);
+    expect(values[StorageMapFieldId.StorageMap]).toHaveLength(1);
   });
 
   it('applies optional planProject and sourceProvider overrides', () => {

--- a/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
+++ b/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
@@ -55,9 +55,7 @@ describe('hasMultiplePodNetworkMappings - edgeCases', () => {
   it('hasPodNetworkMappings detects pod network targets', () => {
     expect(hasPodNetworkMappings([])).toBe(false);
     expect(
-      hasPodNetworkMappings([
-        { targetNetwork: { name: DefaultNetworkLabel.Source } },
-      ] as never),
+      hasPodNetworkMappings([{ targetNetwork: { name: DefaultNetworkLabel.Source } }] as never),
     ).toBe(true);
   });
 });

--- a/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
+++ b/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from '@jest/globals';
+import { DefaultNetworkLabel } from '@utils/mappings/constants';
+
+import {
+  hasMultiplePodNetworkMappings,
+  hasPodNetworkMappings,
+} from '../hasMultiplePodNetworkMappings';
+
+describe('hasMultiplePodNetworkMappings - edgeCases', () => {
+  it('returns true when a VM has two networks mapped to pod network', () => {
+    const networkMap = [
+      {
+        sourceNetwork: { id: 'n1', name: 'n1' },
+        targetNetwork: { name: DefaultNetworkLabel.Source },
+      },
+      {
+        sourceNetwork: { id: 'n2', name: 'n2' },
+        targetNetwork: { name: DefaultNetworkLabel.Source },
+      },
+    ] as never;
+
+    const vms = {
+      vm1: {
+        id: 'vm1',
+        name: 'vm1',
+        networks: [{ id: 'n1' }, { id: 'n2' }],
+        providerType: 'vsphere',
+      },
+    } as never;
+
+    expect(hasMultiplePodNetworkMappings(networkMap, vms, [])).toBe(true);
+  });
+
+  it('returns false when networks are missing or only one maps to pod network', () => {
+    const networkMap = [
+      {
+        sourceNetwork: { id: 'n1', name: 'n1' },
+        targetNetwork: { name: DefaultNetworkLabel.Source },
+      },
+    ] as never;
+
+    expect(
+      hasMultiplePodNetworkMappings(
+        networkMap,
+        { vm1: { id: 'vm1', networks: [{ id: 'n1' }], providerType: 'vsphere' } } as never,
+        [],
+      ),
+    ).toBe(false);
+
+    expect(hasMultiplePodNetworkMappings(networkMap, { vm1: { id: 'vm1' } } as never, [])).toBe(
+      false,
+    );
+  });
+
+  it('hasPodNetworkMappings detects pod network targets', () => {
+    expect(hasPodNetworkMappings([])).toBe(false);
+    expect(
+      hasPodNetworkMappings([
+        { targetNetwork: { name: DefaultNetworkLabel.Source } },
+      ] as never),
+    ).toBe(true);
+  });
+});

--- a/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
+++ b/src/plans/create/utils/__tests__/hasMultiplePodNetworkMappings.edgeCases.test.ts
@@ -50,6 +50,18 @@ describe('hasMultiplePodNetworkMappings - edgeCases', () => {
     expect(hasMultiplePodNetworkMappings(networkMap, { vm1: { id: 'vm1' } } as never, [])).toBe(
       false,
     );
+
+    // two VMs each with a single pod-network mapping must not trip the per-VM invariant
+    expect(
+      hasMultiplePodNetworkMappings(
+        networkMap,
+        {
+          vm1: { id: 'vm1', networks: [{ id: 'n1' }], providerType: 'vsphere' },
+          vm2: { id: 'vm2', networks: [{ id: 'n1' }], providerType: 'vsphere' },
+        } as never,
+        [],
+      ),
+    ).toBe(false);
   });
 
   it('hasPodNetworkMappings detects pod network targets', () => {


### PR DESCRIPTION
## Summary
- Add unit tests for plans/create utils: defaults, owner refs, copy maps, decryption secret, createPlan, fillUnmappedSources, and pod-network mapping edge cases
- Skips Tier 1 HIGH-VALUE sources (`createNetworkMap`, `submitMigrationPlan`, `createMigrationHooks`, etc.)

## Test plan
- [x] `npm test -- <new test paths>`
- [ ] CI green

Resolves: MTV-6266

Made with [Cursor](https://cursor.com)