### PR TITLE
test(MTV-6266): Tier 3-3 plans/details mapping/status utils

### DIFF
--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it } from '@jest/globals';
 import { ConcernCategoryOptions } from '@components/Concerns/utils/constants';
+import { describe, expect, it } from '@jest/globals';
 
-import { CONCERN_SOURCE } from '../types';
 import { convertToPlanConcernsConditionsPanelData } from '../convertToPlanConcernsConditionsPanelData';
+import { CONCERN_SOURCE } from '../types';
 
 describe('convertToPlanConcernsConditionsPanelData - convert', () => {
   it('maps conditions and merged concerns with source preference', () => {
     const result = convertToPlanConcernsConditionsPanelData(
       [{ category: 'Critical', items: ['a', 'b'], message: 'm', type: 'Ready' }] as never,
-      new Map([['Shared disk', 3], ['Inspected', 1]]),
+      new Map([
+        ['Shared disk', 3],
+        ['Inspected', 1],
+      ]),
       '/plan/url',
       new Set(['Inspected']),
     );

--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConcernCategoryOptions } from '@components/Concerns/utils/constants';
+
+import { CONCERN_SOURCE } from '../types';
+import { convertToPlanConcernsConditionsPanelData } from '../convertToPlanConcernsConditionsPanelData';
+
+describe('convertToPlanConcernsConditionsPanelData - convert', () => {
+  it('maps conditions and merged concerns with source preference', () => {
+    const result = convertToPlanConcernsConditionsPanelData(
+      [{ category: 'Critical', items: ['a', 'b'], message: 'm', type: 'Ready' }] as never,
+      new Map([['Shared disk', 3], ['Inspected', 1]]),
+      '/plan/url',
+      new Set(['Inspected']),
+    );
+
+    expect(result[0].criticalConditionOrConcern).toEqual(
+      expect.objectContaining({
+        source: CONCERN_SOURCE.CONDITION,
+        type: 'Ready',
+        vmsNum: 2,
+      }),
+    );
+    expect(result[1].criticalConditionOrConcern).toEqual(
+      expect.objectContaining({
+        severity: ConcernCategoryOptions.Critical,
+        source: CONCERN_SOURCE.INVENTORY,
+        type: 'Shared disk',
+        vmsNum: 3,
+      }),
+    );
+    expect(result[2].criticalConditionOrConcern.source).toBe(CONCERN_SOURCE.INSPECTION);
+  });
+
+  it('handles undefined conditions', () => {
+    expect(convertToPlanConcernsConditionsPanelData(undefined, new Map(), '/p')).toEqual([]);
+  });
+});

--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/convertToPlanConcernsConditionsPanelData.convert.test.ts
@@ -16,22 +16,36 @@ describe('convertToPlanConcernsConditionsPanelData - convert', () => {
       new Set(['Inspected']),
     );
 
-    expect(result[0].criticalConditionOrConcern).toEqual(
-      expect.objectContaining({
+    expect(result[0]).toEqual({
+      criticalConditionOrConcern: {
+        message: 'm',
+        severity: 'Critical',
         source: CONCERN_SOURCE.CONDITION,
         type: 'Ready',
         vmsNum: 2,
-      }),
-    );
-    expect(result[1].criticalConditionOrConcern).toEqual(
-      expect.objectContaining({
+      },
+      planUrl: '/plan/url',
+    });
+    expect(result[1]).toEqual({
+      criticalConditionOrConcern: {
+        message: 'Shared disk',
         severity: ConcernCategoryOptions.Critical,
         source: CONCERN_SOURCE.INVENTORY,
         type: 'Shared disk',
         vmsNum: 3,
-      }),
-    );
-    expect(result[2].criticalConditionOrConcern.source).toBe(CONCERN_SOURCE.INSPECTION);
+      },
+      planUrl: '/plan/url',
+    });
+    expect(result[2]).toEqual({
+      criticalConditionOrConcern: {
+        message: 'Inspected',
+        severity: ConcernCategoryOptions.Critical,
+        source: CONCERN_SOURCE.INSPECTION,
+        type: 'Inspected',
+        vmsNum: 1,
+      },
+      planUrl: '/plan/url',
+    });
   });
 
   it('handles undefined conditions', () => {

--- a/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
+++ b/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
@@ -8,24 +8,32 @@ describe('PlanMigrationTypeLabel utils - labels', () => {
   it('maps live to label/color', () => {
     expect(typeLabel(MigrationTypeValue.Live)).toBe('Live');
     expect(getLabelColor(MigrationTypeValue.Live)).toBe('teal');
-    expect(bodyContent(MigrationTypeValue.Live).length).toBeGreaterThan(0);
+    expect(bodyContent(MigrationTypeValue.Live)).toBe(
+      'With a live migration, we will move an active virtual machine without downtime.',
+    );
   });
 
   it('maps warm to label/color', () => {
     expect(typeLabel(MigrationTypeValue.Warm)).toBe('Warm');
     expect(getLabelColor(MigrationTypeValue.Warm)).toBe('orange');
-    expect(bodyContent(MigrationTypeValue.Warm).length).toBeGreaterThan(0);
+    expect(bodyContent(MigrationTypeValue.Warm)).toBe(
+      'With a warm migration, we will move an active virtual machine between hosts with minimal downtime. This is not a live migration.',
+    );
   });
 
   it('maps conversion to label/color', () => {
     expect(typeLabel(MigrationTypeValue.Conversion)).toBe('Conversion');
     expect(getLabelColor(MigrationTypeValue.Conversion)).toBe('purple');
-    expect(bodyContent(MigrationTypeValue.Conversion).length).toBeGreaterThan(0);
+    expect(bodyContent(MigrationTypeValue.Conversion)).toBe(
+      'With a conversion migration, we will convert a virtual machine to a different architecture.',
+    );
   });
 
   it('maps cold to label/color', () => {
     expect(typeLabel(MigrationTypeValue.Cold)).toBe('Cold');
     expect(getLabelColor(MigrationTypeValue.Cold)).toBe('blue');
-    expect(bodyContent(MigrationTypeValue.Cold).length).toBeGreaterThan(0);
+    expect(bodyContent(MigrationTypeValue.Cold)).toBe(
+      'With a cold migration, we will move the shut down VM between hosts.',
+    );
   });
 });

--- a/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
+++ b/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
@@ -5,14 +5,27 @@ import { describe, expect, it } from '@jest/globals';
 import { bodyContent, getLabelColor, typeLabel } from '../utils';
 
 describe('PlanMigrationTypeLabel utils - labels', () => {
-  it.each([
-    [MigrationTypeValue.Live, 'Live', 'teal'],
-    [MigrationTypeValue.Warm, 'Warm', 'orange'],
-    [MigrationTypeValue.Conversion, 'Conversion', 'purple'],
-    [MigrationTypeValue.Cold, 'Cold', 'blue'],
-  ] as const)('maps %s to label/color', (type, label, color) => {
-    expect(typeLabel(type)).toBe(label);
-    expect(getLabelColor(type)).toBe(color);
-    expect(bodyContent(type).length).toBeGreaterThan(0);
+  it('maps live to label/color', () => {
+    expect(typeLabel(MigrationTypeValue.Live)).toBe('Live');
+    expect(getLabelColor(MigrationTypeValue.Live)).toBe('teal');
+    expect(bodyContent(MigrationTypeValue.Live).length).toBeGreaterThan(0);
+  });
+
+  it('maps warm to label/color', () => {
+    expect(typeLabel(MigrationTypeValue.Warm)).toBe('Warm');
+    expect(getLabelColor(MigrationTypeValue.Warm)).toBe('orange');
+    expect(bodyContent(MigrationTypeValue.Warm).length).toBeGreaterThan(0);
+  });
+
+  it('maps conversion to label/color', () => {
+    expect(typeLabel(MigrationTypeValue.Conversion)).toBe('Conversion');
+    expect(getLabelColor(MigrationTypeValue.Conversion)).toBe('purple');
+    expect(bodyContent(MigrationTypeValue.Conversion).length).toBeGreaterThan(0);
+  });
+
+  it('maps cold to label/color', () => {
+    expect(typeLabel(MigrationTypeValue.Cold)).toBe('Cold');
+    expect(getLabelColor(MigrationTypeValue.Cold)).toBe('blue');
+    expect(bodyContent(MigrationTypeValue.Cold).length).toBeGreaterThan(0);
   });
 });

--- a/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
+++ b/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
+
+import { bodyContent, getLabelColor, typeLabel } from '../utils';
+
+describe('PlanMigrationTypeLabel utils - labels', () => {
+  it.each([
+    [MigrationTypeValue.Live, 'Live', 'teal'],
+    [MigrationTypeValue.Warm, 'Warm', 'orange'],
+    [MigrationTypeValue.Conversion, 'Conversion', 'purple'],
+    [MigrationTypeValue.Cold, 'Cold', 'blue'],
+  ] as const)('maps %s to label/color', (type, label, color) => {
+    expect(typeLabel(type)).toBe(label);
+    expect(getLabelColor(type)).toBe(color);
+    expect(bodyContent(type).length).toBeGreaterThan(0);
+  });
+});

--- a/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
+++ b/src/plans/details/components/PlanMigrationTypeLabel/utils/__tests__/typeLabel.labels.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
 import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
+
+import { describe, expect, it } from '@jest/globals';
 
 import { bodyContent, getLabelColor, typeLabel } from '../utils';
 

--- a/src/plans/details/tabs/Details/components/ConditionsSection/utils/__tests__/getStatusLabel.labels.test.ts
+++ b/src/plans/details/tabs/Details/components/ConditionsSection/utils/__tests__/getStatusLabel.labels.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from '@jest/globals';
 import { getStatusLabel } from '../utils';
 
 describe('getStatusLabel - labels', () => {
-  it('maps True/False and passes through unknown statuses', () => {
-    expect(getStatusLabel('True')).toBe('True');
-    expect(getStatusLabel('False')).toBe('False');
+  // True/False map to t('True')/t('False'); under the Jest i18n mock that returns the key,
+  // those cases do not exercise meaningful app logic. Assert the fallback path instead.
+  it('passes through statuses absent from the label map', () => {
     expect(getStatusLabel('Unknown')).toBe('Unknown');
+    expect(getStatusLabel('CustomStatus')).toBe('CustomStatus');
   });
 });

--- a/src/plans/details/tabs/Details/components/ConditionsSection/utils/__tests__/getStatusLabel.labels.test.ts
+++ b/src/plans/details/tabs/Details/components/ConditionsSection/utils/__tests__/getStatusLabel.labels.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getStatusLabel } from '../utils';
+
+describe('getStatusLabel - labels', () => {
+  it('maps True/False and passes through unknown statuses', () => {
+    expect(getStatusLabel('True')).toBe('True');
+    expect(getStatusLabel('False')).toBe('False');
+    expect(getStatusLabel('Unknown')).toBe('Unknown');
+  });
+});

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -18,7 +18,7 @@ import { patchNetworkMappingValues } from '../utils';
 describe('patchNetworkMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
     mockBuildNetworkMappings.mockClear();
   });
 

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -13,12 +13,14 @@ jest.mock('src/networkMaps/create/utils/buildNetworkMappings', (): unknown => ({
     (mockBuildNetworkMappings as (...a: unknown[]) => unknown)(...args),
 }));
 
-import { NetworkMapModel } from '@forklift-ui/types';
+import { NetworkMapModel, type V1beta1NetworkMap, type V1beta1Provider } from '@forklift-ui/types';
 
 import { patchNetworkMappingValues } from '../utils';
 
-const provider = { metadata: { name: 'src' } } as never;
-const formData = { networkMap: [{ source: { name: 'net' } }] } as never;
+import type { PlanNetworkEditFormValues } from '../types';
+
+const provider = { metadata: { name: 'src' } } as unknown as V1beta1Provider;
+const formData = { networkMap: [{ source: { name: 'net' } }] } as unknown as PlanNetworkEditFormValues;
 
 describe('patchNetworkMappingValues - patch', () => {
   beforeEach(() => {
@@ -28,7 +30,7 @@ describe('patchNetworkMappingValues - patch', () => {
   });
 
   it('ADDs map when empty', async () => {
-    const emptyMap = { metadata: { name: 'nm' }, spec: { map: [] } } as never;
+    const emptyMap = { metadata: { name: 'nm' }, spec: { map: [] } } as unknown as V1beta1NetworkMap;
 
     await patchNetworkMappingValues(formData, emptyMap, provider);
 
@@ -43,7 +45,10 @@ describe('patchNetworkMappingValues - patch', () => {
   });
 
   it('REPLACEs map when present', async () => {
-    const existing = { metadata: { name: 'nm' }, spec: { map: [{ source: {} }] } } as never;
+    const existing = {
+      metadata: { name: 'nm' },
+      spec: { map: [{ source: {} }] },
+    } as unknown as V1beta1NetworkMap;
 
     await patchNetworkMappingValues(formData, existing, provider);
 

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+const mockBuildNetworkMappings = jest.fn(() => [{ source: { id: '1' } }]);
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+jest.mock('src/networkMaps/create/utils/buildNetworkMappings', () => ({
+  buildNetworkMappings: (...args: unknown[]) => mockBuildNetworkMappings(...args),
+}));
+
+import { NetworkMapModel } from '@forklift-ui/types';
+
+import { patchNetworkMappingValues } from '../utils';
+
+describe('patchNetworkMappingValues - patch', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+    mockBuildNetworkMappings.mockClear();
+  });
+
+  it('ADDs map when empty and REPLACEs when present', async () => {
+    const emptyMap = { metadata: { name: 'nm' }, spec: { map: [] } } as never;
+    const provider = { metadata: { name: 'src' } } as never;
+    const formData = { networkMap: [] } as never;
+
+    await patchNetworkMappingValues(formData, emptyMap, provider);
+
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ op: 'add', path: '/spec/map', value: [{ source: { id: '1' } }] }],
+        model: NetworkMapModel,
+        resource: emptyMap,
+      }),
+    );
+
+    const existing = { metadata: { name: 'nm' }, spec: { map: [{ source: {} }] } } as never;
+    await patchNetworkMappingValues(formData, existing, provider);
+    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+  });
+});

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -17,6 +17,9 @@ import { NetworkMapModel } from '@forklift-ui/types';
 
 import { patchNetworkMappingValues } from '../utils';
 
+const provider = { metadata: { name: 'src' } } as never;
+const formData = { networkMap: [{ source: { name: 'net' } }] } as never;
+
 describe('patchNetworkMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
@@ -24,13 +27,12 @@ describe('patchNetworkMappingValues - patch', () => {
     mockBuildNetworkMappings.mockClear();
   });
 
-  it('ADDs map when empty and REPLACEs when present', async () => {
+  it('ADDs map when empty', async () => {
     const emptyMap = { metadata: { name: 'nm' }, spec: { map: [] } } as never;
-    const provider = { metadata: { name: 'src' } } as never;
-    const formData = { networkMap: [] } as never;
 
     await patchNetworkMappingValues(formData, emptyMap, provider);
 
+    expect(mockBuildNetworkMappings).toHaveBeenCalledWith(formData.networkMap, provider);
     expect(mockK8sPatch).toHaveBeenCalledWith(
       expect.objectContaining({
         data: [{ op: 'add', path: '/spec/map', value: [{ source: { id: '1' } }] }],
@@ -38,11 +40,20 @@ describe('patchNetworkMappingValues - patch', () => {
         resource: emptyMap,
       }),
     );
+  });
 
+  it('REPLACEs map when present', async () => {
     const existing = { metadata: { name: 'nm' }, spec: { map: [{ source: {} }] } } as never;
+
     await patchNetworkMappingValues(formData, existing, provider);
-    expect(
-      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('replace');
+
+    expect(mockBuildNetworkMappings).toHaveBeenCalledWith(formData.networkMap, provider);
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ op: 'replace', path: '/spec/map', value: [{ source: { id: '1' } }] }],
+        model: NetworkMapModel,
+        resource: existing,
+      }),
+    );
   });
 });

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 const mockBuildNetworkMappings = jest.fn(() => [{ source: { id: '1' } }]);
 
-jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+jest.mock('@openshift-console/dynamic-plugin-sdk', (): unknown => ({
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
-jest.mock('src/networkMaps/create/utils/buildNetworkMappings', () => ({
-  buildNetworkMappings: (...args: unknown[]): unknown => mockBuildNetworkMappings(...args),
+jest.mock('src/networkMaps/create/utils/buildNetworkMappings', (): unknown => ({
+  buildNetworkMappings: (...args: unknown[]): unknown =>
+    (mockBuildNetworkMappings as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { NetworkMapModel } from '@forklift-ui/types';
@@ -18,7 +20,7 @@ import { patchNetworkMappingValues } from '../utils';
 describe('patchNetworkMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
     mockBuildNetworkMappings.mockClear();
   });
 
@@ -39,6 +41,8 @@ describe('patchNetworkMappingValues - patch', () => {
 
     const existing = { metadata: { name: 'nm' }, spec: { map: [{ source: {} }] } } as never;
     await patchNetworkMappingValues(formData, existing, provider);
-    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+    expect(
+      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('replace');
   });
 });

--- a/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanNetworkMapEdit/utils/__tests__/patchNetworkMappingValues.patch.test.ts
@@ -4,11 +4,11 @@ const mockK8sPatch = jest.fn();
 const mockBuildNetworkMappings = jest.fn(() => [{ source: { id: '1' } }]);
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 jest.mock('src/networkMaps/create/utils/buildNetworkMappings', () => ({
-  buildNetworkMappings: (...args: unknown[]) => mockBuildNetworkMappings(...args),
+  buildNetworkMappings: (...args: unknown[]): unknown => mockBuildNetworkMappings(...args),
 }));
 
 import { NetworkMapModel } from '@forklift-ui/types';

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 const mockTransform = jest.fn(() => ({ spec: { map: [{ source: { id: 's' } }] } }));
 
-jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+jest.mock('@openshift-console/dynamic-plugin-sdk', (): unknown => ({
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
-jest.mock('src/storageMaps/details/utils/utils', () => ({
-  transformFormValuesToK8sSpec: (...args: unknown[]): unknown => mockTransform(...args),
+jest.mock('src/storageMaps/details/utils/utils', (): unknown => ({
+  transformFormValuesToK8sSpec: (...args: unknown[]): unknown =>
+    (mockTransform as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { StorageMapModel } from '@forklift-ui/types';
@@ -19,7 +21,7 @@ import { patchStorageMappingValues } from '../utils';
 describe('patchStorageMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
     mockTransform.mockClear();
   });
 
@@ -53,7 +55,7 @@ describe('patchStorageMappingValues - patch', () => {
   });
 
   it('skips patch when transform returns undefined', async () => {
-    mockTransform.mockReturnValueOnce(undefined);
+    mockTransform.mockReturnValueOnce(undefined as never);
     await patchStorageMappingValues({ storageMap: [] }, {} as never, {} as never);
     expect(mockK8sPatch).not.toHaveBeenCalled();
   });

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -54,7 +54,7 @@ describe('patchStorageMappingValues - patch', () => {
 
   it('skips patch when transform returns undefined', async () => {
     mockTransform.mockReturnValueOnce(undefined);
-    await patchStorageMappingValues({ storageMap: [] } as never, {} as never, {} as never);
+    await patchStorageMappingValues({ storageMap: [] }, {} as never, {} as never);
     expect(mockK8sPatch).not.toHaveBeenCalled();
   });
 });

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+const mockTransform = jest.fn(() => ({ spec: { map: [{ source: { id: 's' } }] } }));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+jest.mock('src/storageMaps/details/utils/utils', () => ({
+  transformFormValuesToK8sSpec: (...args: unknown[]) => mockTransform(...args),
+}));
+
+import { StorageMapModel } from '@forklift-ui/types';
+import { StorageMapFieldId } from '@utils/storage/types';
+
+import { patchStorageMappingValues } from '../utils';
+
+describe('patchStorageMappingValues - patch', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+    mockTransform.mockClear();
+  });
+
+  it('filters empty rows and patches storage map', async () => {
+    const storageMap = { metadata: { name: 'sm' }, spec: { map: [] } } as never;
+    const formValues = {
+      storageMap: [
+        {
+          [StorageMapFieldId.SourceStorage]: { id: 's', name: 's' },
+          [StorageMapFieldId.TargetStorage]: { id: 't', name: 't' },
+        },
+        {
+          [StorageMapFieldId.SourceStorage]: { id: '', name: '' },
+          [StorageMapFieldId.TargetStorage]: { id: '', name: '' },
+        },
+      ],
+    } as never;
+
+    await patchStorageMappingValues(formValues, storageMap, {
+      spec: { type: 'vsphere' },
+    } as never);
+
+    expect(mockTransform).toHaveBeenCalled();
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ op: 'add', path: '/spec/map', value: [{ source: { id: 's' } }] }],
+        model: StorageMapModel,
+        resource: storageMap,
+      }),
+    );
+  });
+
+  it('skips patch when transform returns undefined', async () => {
+    mockTransform.mockReturnValueOnce(undefined);
+    await patchStorageMappingValues({ storageMap: [] } as never, {} as never, {} as never);
+    expect(mockK8sPatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -19,7 +19,7 @@ import { patchStorageMappingValues } from '../utils';
 describe('patchStorageMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
     mockTransform.mockClear();
   });
 

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -41,11 +41,7 @@ describe('patchStorageMappingValues - patch', () => {
 
     await patchStorageMappingValues(formValues, storageMap, vsphereProvider);
 
-    expect(mockTransform).toHaveBeenCalledWith(
-      { storageMap: [nonEmptyRow] },
-      storageMap,
-      false,
-    );
+    expect(mockTransform).toHaveBeenCalledWith({ storageMap: [nonEmptyRow] }, storageMap, false);
     expect(mockK8sPatch).toHaveBeenCalledWith(
       expect.objectContaining({
         data: [{ op: 'add', path: '/spec/map', value: [{ source: { id: 's' } }] }],

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -4,11 +4,11 @@ const mockK8sPatch = jest.fn();
 const mockTransform = jest.fn(() => ({ spec: { map: [{ source: { id: 's' } }] } }));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 jest.mock('src/storageMaps/details/utils/utils', () => ({
-  transformFormValuesToK8sSpec: (...args: unknown[]) => mockTransform(...args),
+  transformFormValuesToK8sSpec: (...args: unknown[]): unknown => mockTransform(...args),
 }));
 
 import { StorageMapModel } from '@forklift-ui/types';

--- a/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
+++ b/src/plans/details/tabs/Mappings/components/PlanStorageMapEdit/utils/__tests__/patchStorageMappingValues.patch.test.ts
@@ -18,6 +18,17 @@ import { StorageMapFieldId } from '@utils/storage/types';
 
 import { patchStorageMappingValues } from '../utils';
 
+const nonEmptyRow = {
+  [StorageMapFieldId.SourceStorage]: { id: 's', name: 's' },
+  [StorageMapFieldId.TargetStorage]: { id: 't', name: 't' },
+};
+const emptyRow = {
+  [StorageMapFieldId.SourceStorage]: { id: '', name: '' },
+  [StorageMapFieldId.TargetStorage]: { id: '', name: '' },
+};
+const formValues = { storageMap: [nonEmptyRow, emptyRow] } as never;
+const vsphereProvider = { spec: { type: 'vsphere' } } as never;
+
 describe('patchStorageMappingValues - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
@@ -25,29 +36,36 @@ describe('patchStorageMappingValues - patch', () => {
     mockTransform.mockClear();
   });
 
-  it('filters empty rows and patches storage map', async () => {
+  it('filters empty rows and ADDs when map is empty', async () => {
     const storageMap = { metadata: { name: 'sm' }, spec: { map: [] } } as never;
-    const formValues = {
-      storageMap: [
-        {
-          [StorageMapFieldId.SourceStorage]: { id: 's', name: 's' },
-          [StorageMapFieldId.TargetStorage]: { id: 't', name: 't' },
-        },
-        {
-          [StorageMapFieldId.SourceStorage]: { id: '', name: '' },
-          [StorageMapFieldId.TargetStorage]: { id: '', name: '' },
-        },
-      ],
-    } as never;
 
-    await patchStorageMappingValues(formValues, storageMap, {
-      spec: { type: 'vsphere' },
-    } as never);
+    await patchStorageMappingValues(formValues, storageMap, vsphereProvider);
 
-    expect(mockTransform).toHaveBeenCalled();
+    expect(mockTransform).toHaveBeenCalledWith(
+      { storageMap: [nonEmptyRow] },
+      storageMap,
+      false,
+    );
     expect(mockK8sPatch).toHaveBeenCalledWith(
       expect.objectContaining({
         data: [{ op: 'add', path: '/spec/map', value: [{ source: { id: 's' } }] }],
+        model: StorageMapModel,
+        resource: storageMap,
+      }),
+    );
+  });
+
+  it('REPLACEs when spec.map is non-empty', async () => {
+    const storageMap = {
+      metadata: { name: 'sm' },
+      spec: { map: [{ source: { id: 'old' } }] },
+    } as never;
+
+    await patchStorageMappingValues(formValues, storageMap, vsphereProvider);
+
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [{ op: 'replace', path: '/spec/map', value: [{ source: { id: 's' } }] }],
         model: StorageMapModel,
         resource: storageMap,
       }),

--- a/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
+++ b/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
@@ -1,3 +1,7 @@
+import { mockI18n } from '@test-utils/mockI18n';
+
+mockI18n();
+
 import { describe, expect, it } from '@jest/globals';
 
 import { getMappingPageMessage } from '../utils';
@@ -20,12 +24,8 @@ describe('getMappingPageMessage - states', () => {
       resourcesError: new Error('boom'),
       storageMapsEmpty: false,
     });
-    expect(message).toMatch(/not available/i);
-    // i18n test mock may leave the placeholder literal; ensure error message is passed through when interpolated
-    expect(
-      message === 'The mapping data from the inventory is not available, {{resourcesError}}.' ||
-        (message ?? '').includes('boom'),
-    ).toBe(true);
+    expect(message).toBe('The mapping data from the inventory is not available, boom.');
+    expect(message).toContain('boom');
   });
 
   it('returns null when ready', () => {

--- a/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
+++ b/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
@@ -22,7 +22,10 @@ describe('getMappingPageMessage - states', () => {
     });
     expect(message).toMatch(/not available/i);
     // i18n test mock may leave the placeholder literal; ensure error message is passed through when interpolated
-    expect(message === 'The mapping data from the inventory is not available, {{resourcesError}}.' || /boom/.test(message ?? '')).toBe(true);
+    expect(
+      message === 'The mapping data from the inventory is not available, {{resourcesError}}.' ||
+        (message ?? '').includes('boom'),
+    ).toBe(true);
   });
 
   it('returns null when ready', () => {

--- a/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
+++ b/src/plans/details/tabs/Mappings/utils/__tests__/getMappingPageMessage.states.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getMappingPageMessage } from '../utils';
+
+describe('getMappingPageMessage - states', () => {
+  it('returns loading message first', () => {
+    expect(
+      getMappingPageMessage({
+        loadingResources: true,
+        networkMapsEmpty: true,
+        storageMapsEmpty: true,
+      }),
+    ).toMatch(/loading/i);
+  });
+
+  it('returns inventory unavailable message when maps empty', () => {
+    const message = getMappingPageMessage({
+      loadingResources: false,
+      networkMapsEmpty: true,
+      resourcesError: new Error('boom'),
+      storageMapsEmpty: false,
+    });
+    expect(message).toMatch(/not available/i);
+    // i18n test mock may leave the placeholder literal; ensure error message is passed through when interpolated
+    expect(message === 'The mapping data from the inventory is not available, {{resourcesError}}.' || /boom/.test(message ?? '')).toBe(true);
+  });
+
+  it('returns null when ready', () => {
+    expect(
+      getMappingPageMessage({
+        loadingResources: false,
+        networkMapsEmpty: false,
+        storageMapsEmpty: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -2,7 +2,31 @@ import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/cons
 
 import { describe, expect, it } from '@jest/globals';
 
-import { getCriticalConcernsVmsMap, mergeConcernsMaps } from '../utils';
+import { CATEGORY_TYPES } from '@utils/constants';
+import { CONVERSION_LABELS, CONVERSION_PHASE } from '@utils/crds/conversion/constants';
+
+import {
+  getCriticalConcernsVmsMap,
+  getCriticalInspectionConcernsVmsMap,
+  mergeConcernsMaps,
+} from '../utils';
+
+const conversion = (
+  vmId: string,
+  phase: string,
+  createdAt: string,
+  concerns?: { category: string; label: string }[],
+): never =>
+  ({
+    metadata: {
+      creationTimestamp: createdAt,
+      labels: { [CONVERSION_LABELS.VM_ID]: vmId },
+    },
+    status: {
+      inspectionResult: concerns ? { concerns } : undefined,
+      phase,
+    },
+  }) as never;
 
 describe('plan details utils - concerns maps', () => {
   it('counts critical inventory concerns by label', () => {
@@ -41,5 +65,31 @@ describe('plan details utils - concerns maps', () => {
     );
 
     expect(Object.fromEntries(merged)).toEqual({ alpha: 3, beta: 5, keyC: 2 });
+  });
+
+  it('aggregates CRITICAL/ERROR from latest succeeded conversion per VM', () => {
+    const map = getCriticalInspectionConcernsVmsMap([
+      conversion('vm-1', CONVERSION_PHASE.SUCCEEDED, '2024-01-01T00:00:00Z', [
+        { category: CATEGORY_TYPES.CRITICAL, label: 'Old concern' },
+        { category: CATEGORY_TYPES.WARNING, label: 'warn' },
+      ]),
+      conversion('vm-1', CONVERSION_PHASE.SUCCEEDED, '2024-02-01T00:00:00Z', [
+        { category: CATEGORY_TYPES.CRITICAL, label: 'Shared disk' },
+        { category: CATEGORY_TYPES.ERROR, label: 'Bad driver' },
+        { category: CATEGORY_TYPES.CRITICAL, label: 'Shared disk' },
+      ]),
+      conversion('vm-2', CONVERSION_PHASE.SUCCEEDED, '2024-02-01T00:00:00Z', [
+        { category: CATEGORY_TYPES.CRITICAL, label: 'Shared disk' },
+      ]),
+      conversion('vm-3', CONVERSION_PHASE.FAILED, '2024-03-01T00:00:00Z', [
+        { category: CATEGORY_TYPES.CRITICAL, label: 'Ignored' },
+      ]),
+      conversion('vm-4', CONVERSION_PHASE.SUCCEEDED, '2024-03-01T00:00:00Z'),
+    ]);
+
+    expect(Object.fromEntries(map)).toEqual({ 'Bad driver': 1, 'Shared disk': 2 });
+    expect(map.has('Old concern')).toBe(false);
+    expect(map.has('warn')).toBe(false);
+    expect(map.has('Ignored')).toBe(false);
   });
 });

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
+
+import {
+  getCriticalConcernsVmsMap,
+  mergeConcernsMaps,
+} from '../utils';
+
+describe('plan details utils - concerns maps', () => {
+  it('counts critical inventory concerns by label', () => {
+    const map = getCriticalConcernsVmsMap([
+      {
+        inventoryVmData: {
+          vm: {
+            concerns: [
+              { category: ConcernCategory.Critical, label: 'Shared disk' },
+              { category: ConcernCategory.Warning, label: 'warn' },
+            ],
+          },
+        },
+      },
+      {
+        inventoryVmData: {
+          vm: { concerns: [{ category: ConcernCategory.Critical, label: 'Shared disk' }] },
+        },
+      },
+    ] as never);
+
+    expect(map.get('Shared disk')).toBe(2);
+    expect(map.has('warn')).toBe(false);
+  });
+
+  it('merges maps preferring the larger count', () => {
+    const merged = mergeConcernsMaps(
+      new Map([['a', 1], ['b', 5]]),
+      new Map([['a', 3], ['c', 2]]),
+    );
+
+    expect(Object.fromEntries(merged)).toEqual({ a: 3, b: 5, c: 2 });
+  });
+});

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -31,15 +31,15 @@ describe('plan details utils - concerns maps', () => {
   it('merges maps preferring the larger count', () => {
     const merged = mergeConcernsMaps(
       new Map([
-        ['a', 1],
-        ['b', 5],
+        ['alpha', 1],
+        ['beta', 5],
       ]),
       new Map([
-        ['a', 3],
-        ['c', 2],
+        ['alpha', 3],
+        ['keyC', 2],
       ]),
     );
 
-    expect(Object.fromEntries(merged)).toEqual({ a: 3, b: 5, c: 2 });
+    expect(Object.fromEntries(merged)).toEqual({ a: 3, b: 5, keyC: 2 });
   });
 });

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -40,6 +40,6 @@ describe('plan details utils - concerns maps', () => {
       ]),
     );
 
-    expect(Object.fromEntries(merged)).toEqual({ a: 3, b: 5, keyC: 2 });
+    expect(Object.fromEntries(merged)).toEqual({ alpha: 3, beta: 5, keyC: 2 });
   });
 });

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -1,10 +1,8 @@
-import { describe, expect, it } from '@jest/globals';
 import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
 
-import {
-  getCriticalConcernsVmsMap,
-  mergeConcernsMaps,
-} from '../utils';
+import { describe, expect, it } from '@jest/globals';
+
+import { getCriticalConcernsVmsMap, mergeConcernsMaps } from '../utils';
 
 describe('plan details utils - concerns maps', () => {
   it('counts critical inventory concerns by label', () => {
@@ -32,8 +30,14 @@ describe('plan details utils - concerns maps', () => {
 
   it('merges maps preferring the larger count', () => {
     const merged = mergeConcernsMaps(
-      new Map([['a', 1], ['b', 5]]),
-      new Map([['a', 3], ['c', 2]]),
+      new Map([
+        ['a', 1],
+        ['b', 5],
+      ]),
+      new Map([
+        ['a', 3],
+        ['c', 2],
+      ]),
     );
 
     expect(Object.fromEntries(merged)).toEqual({ a: 3, b: 5, c: 2 });

--- a/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
+++ b/src/plans/details/utils/__tests__/concernsMaps.merge.test.ts
@@ -1,7 +1,6 @@
 import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
 
 import { describe, expect, it } from '@jest/globals';
-
 import { CATEGORY_TYPES } from '@utils/constants';
 import { CONVERSION_LABELS, CONVERSION_PHASE } from '@utils/crds/conversion/constants';
 

--- a/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
+++ b/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
@@ -6,13 +6,22 @@ import { planMigrationVirtualMachineStatuses } from '../../components/PlanStatus
 import { getPlanMigrationType, isMigrationVirtualMachinePaused } from '../utils';
 
 describe('plan details utils - migration type', () => {
-  it.each([
-    ['warm', MigrationTypeValue.Warm],
-    ['live', MigrationTypeValue.Live],
-    ['conversion', MigrationTypeValue.Conversion],
-    ['cold', MigrationTypeValue.Cold],
-  ] as const)('maps spec.type %s', (type, expected) => {
-    expect(getPlanMigrationType({ spec: { type } } as never)).toBe(expected);
+  it('maps warm type', () => {
+    expect(getPlanMigrationType({ spec: { type: 'warm' } } as never)).toBe(MigrationTypeValue.Warm);
+  });
+
+  it('maps live type', () => {
+    expect(getPlanMigrationType({ spec: { type: 'live' } } as never)).toBe(MigrationTypeValue.Live);
+  });
+
+  it('maps conversion type', () => {
+    expect(getPlanMigrationType({ spec: { type: 'conversion' } } as never)).toBe(
+      MigrationTypeValue.Conversion,
+    );
+  });
+
+  it('maps cold type', () => {
+    expect(getPlanMigrationType({ spec: { type: 'cold' } } as never)).toBe(MigrationTypeValue.Cold);
   });
 
   it('falls back to warm flag when type is missing', () => {

--- a/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
+++ b/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@jest/globals';
+import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
+
+import { getPlanMigrationType, isMigrationVirtualMachinePaused } from '../utils';
+import { planMigrationVirtualMachineStatuses } from '../../components/PlanStatus/utils/types';
+
+describe('plan details utils - migration type', () => {
+  it.each([
+    ['warm', MigrationTypeValue.Warm],
+    ['live', MigrationTypeValue.Live],
+    ['conversion', MigrationTypeValue.Conversion],
+    ['cold', MigrationTypeValue.Cold],
+  ] as const)('maps spec.type %s', (type, expected) => {
+    expect(getPlanMigrationType({ spec: { type } } as never)).toBe(expected);
+  });
+
+  it('falls back to warm flag when type is missing', () => {
+    expect(getPlanMigrationType({ spec: { warm: true } } as never)).toBe(MigrationTypeValue.Warm);
+    expect(getPlanMigrationType({ spec: {} } as never)).toBe(MigrationTypeValue.Cold);
+  });
+
+  it('detects paused migration VMs', () => {
+    expect(
+      isMigrationVirtualMachinePaused({
+        phase: planMigrationVirtualMachineStatuses.CopyingPaused,
+      } as never),
+    ).toBe(true);
+    expect(isMigrationVirtualMachinePaused(undefined)).toBe(false);
+  });
+});

--- a/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
+++ b/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
@@ -24,6 +24,12 @@ describe('plan details utils - migration type', () => {
     expect(getPlanMigrationType({ spec: { type: 'cold' } } as never)).toBe(MigrationTypeValue.Cold);
   });
 
+  it('returns Warm when type is cold but warm flag is true', () => {
+    expect(getPlanMigrationType({ spec: { type: 'cold', warm: true } } as never)).toBe(
+      MigrationTypeValue.Warm,
+    );
+  });
+
   it('falls back to warm flag when type is missing', () => {
     expect(getPlanMigrationType({ spec: { warm: true } } as never)).toBe(MigrationTypeValue.Warm);
     expect(getPlanMigrationType({ spec: {} } as never)).toBe(MigrationTypeValue.Cold);
@@ -35,6 +41,7 @@ describe('plan details utils - migration type', () => {
         phase: planMigrationVirtualMachineStatuses.CopyingPaused,
       } as never),
     ).toBe(true);
+    expect(isMigrationVirtualMachinePaused({ phase: 'Running' } as never)).toBe(false);
     expect(isMigrationVirtualMachinePaused(undefined)).toBe(false);
   });
 });

--- a/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
+++ b/src/plans/details/utils/__tests__/getPlanMigrationType.types.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from '@jest/globals';
 import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
 
-import { getPlanMigrationType, isMigrationVirtualMachinePaused } from '../utils';
+import { describe, expect, it } from '@jest/globals';
+
 import { planMigrationVirtualMachineStatuses } from '../../components/PlanStatus/utils/types';
+import { getPlanMigrationType, isMigrationVirtualMachinePaused } from '../utils';
 
 describe('plan details utils - migration type', () => {
   it.each([


### PR DESCRIPTION
## Summary
- Add unit tests for plan details mapping/status helpers: migration type labels, mapping page messages, concerns maps, network/storage map patches, and conditions labels

## Test plan
- [x] `npm test -- <new test paths>`
- [ ] CI green

Resolves: MTV-6266

Made with [Cursor](https://cursor.com)