### PR TITLE
test(MTV-6266): Tier 3-4 plans/details settings utils batch A

### DIFF
--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { onConfirmDescription } from '../utils';
 
 describe('Description utils - confirm', () => {
@@ -15,16 +17,39 @@ describe('Description utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('patches plan description', async () => {
+  it('REPLACEs description when present', async () => {
     const resource = { metadata: { name: 'p' }, spec: { description: 'old' } } as never;
+
     await onConfirmDescription({ newValue: 'new', resource });
-    expect(mockK8sPatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.arrayContaining([
-          expect.objectContaining({ path: '/spec/description', value: 'new' }),
-        ]),
-        resource,
-      }),
-    );
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/description', value: 'new' }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('trims description input before patching', async () => {
+    const resource = { metadata: { name: 'p' }, spec: {} } as never;
+
+    await onConfirmDescription({ newValue: '  new  ', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/description', value: 'new' }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('stores empty string for whitespace-only input', async () => {
+    const resource = { metadata: { name: 'p' }, spec: { description: 'old' } } as never;
+
+    await onConfirmDescription({ newValue: '   ', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/description', value: '' }],
+      model: PlanModel,
+      resource,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmDescription } from '../utils';

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmDescription } from '../utils';
 describe('Description utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('patches plan description', async () => {

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmDescription } from '../utils';
+
+describe('Description utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('patches plan description', async () => {
+    const resource = { metadata: { name: 'p' }, spec: { description: 'old' } } as never;
+    await onConfirmDescription({ newValue: 'new', resource });
+    expect(mockK8sPatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ path: '/spec/description', value: 'new' }),
+        ]),
+        resource,
+      }),
+    );
+  });
+});

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/Description/utils/__tests__/onConfirmDescription.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmDescription } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmDescription } from '../utils';
 describe('Description utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('patches plan description', async () => {

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmTargetNamespace } from '../utils';
 describe('PlanTargetNamespace utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('patches targetNamespace', async () => {

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmTargetNamespace } from '../utils';

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmTargetNamespace } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmTargetNamespace } from '../utils';
 describe('PlanTargetNamespace utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('patches targetNamespace', async () => {
@@ -19,7 +20,7 @@ describe('PlanTargetNamespace utils - confirm', () => {
       newValue: 'ns-2',
       resource: { metadata: { name: 'p' }, spec: { targetNamespace: 'ns-1' } } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual(
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual(
       expect.objectContaining({ path: '/spec/targetNamespace', value: 'ns-2' }),
     );
   });

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmTargetNamespace } from '../utils';
+
+describe('PlanTargetNamespace utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('patches targetNamespace', async () => {
+    await onConfirmTargetNamespace({
+      newValue: 'ns-2',
+      resource: { metadata: { name: 'p' }, spec: { targetNamespace: 'ns-1' } } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual(
+      expect.objectContaining({ path: '/spec/targetNamespace', value: 'ns-2' }),
+    );
+  });
+});

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/PlanTargetNamespace/utils/__tests__/onConfirmTargetNamespace.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { onConfirmTargetNamespace } from '../utils';
 
 describe('PlanTargetNamespace utils - confirm', () => {
@@ -15,13 +17,39 @@ describe('PlanTargetNamespace utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('patches targetNamespace', async () => {
-    await onConfirmTargetNamespace({
-      newValue: 'ns-2',
-      resource: { metadata: { name: 'p' }, spec: { targetNamespace: 'ns-1' } } as never,
+  it('ADDs targetNamespace when unset', async () => {
+    const resource = { metadata: { name: 'p' }, spec: {} } as never;
+
+    await onConfirmTargetNamespace({ newValue: 'ns-2', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/targetNamespace', value: 'ns-2' }],
+      model: PlanModel,
+      resource,
     });
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual(
-      expect.objectContaining({ path: '/spec/targetNamespace', value: 'ns-2' }),
-    );
+  });
+
+  it('REPLACEs targetNamespace when present', async () => {
+    const resource = { metadata: { name: 'p' }, spec: { targetNamespace: 'ns-1' } } as never;
+
+    await onConfirmTargetNamespace({ newValue: 'ns-2', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/targetNamespace', value: 'ns-2' }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('clears targetNamespace to undefined for empty string', async () => {
+    const resource = { metadata: { name: 'p' }, spec: { targetNamespace: 'ns-1' } } as never;
+
+    await onConfirmTargetNamespace({ newValue: '', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/targetNamespace', value: undefined }],
+      model: PlanModel,
+      resource,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -25,8 +25,18 @@ describe('EditNameTemplate utils - options', () => {
     expect(getSelectedOption('custom', true)).toBe(NameTemplateOptions.CustomNameTemplate);
     expect(getSelectedOption(undefined, true)).toBe(NameTemplateOptions.InheritPlanWideSetting);
     expect(getSelectedOption(undefined, false)).toBe(NameTemplateOptions.DefaultNameTemplate);
-    expect(getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false)).toMatch(
-      /Custom name template/i,
-    );
+
+    expect(
+      getNameTemplateStateLabel(NameTemplateOptions.InheritPlanWideSetting, true),
+    ).toMatch(/Inherit plan wide setting/i);
+    expect(
+      getNameTemplateStateLabel(NameTemplateOptions.DefaultNameTemplate, false),
+    ).toMatch(/Default name template/i);
+    expect(
+      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, true),
+    ).toMatch(/Custom name template/i);
+    expect(
+      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false),
+    ).toMatch(/Custom name template/i);
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -6,7 +6,7 @@ import { getNameTemplateOptions, getNameTemplateStateLabel, getSelectedOption } 
 describe('EditNameTemplate utils - options', () => {
   it('includes inherit option when allowed', () => {
     const options = getNameTemplateOptions(true);
-    expect(options.map((option) => o.value)).toEqual([
+    expect(options.map((option) => option.value)).toEqual([
       NameTemplateOptions.InheritPlanWideSetting,
       NameTemplateOptions.CustomNameTemplate,
     ]);
@@ -15,7 +15,7 @@ describe('EditNameTemplate utils - options', () => {
   });
 
   it('includes default option when inherit is not allowed', () => {
-    expect(getNameTemplateOptions(false).map((option) => o.value)).toEqual([
+    expect(getNameTemplateOptions(false).map((option) => option.value)).toEqual([
       NameTemplateOptions.DefaultNameTemplate,
       NameTemplateOptions.CustomNameTemplate,
     ]);

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -6,7 +6,7 @@ import { getNameTemplateOptions, getNameTemplateStateLabel, getSelectedOption } 
 describe('EditNameTemplate utils - options', () => {
   it('includes inherit option when allowed', () => {
     const options = getNameTemplateOptions(true);
-    expect(options.map((o) => o.value)).toEqual([
+    expect(options.map((option) => o.value)).toEqual([
       NameTemplateOptions.InheritPlanWideSetting,
       NameTemplateOptions.CustomNameTemplate,
     ]);
@@ -15,7 +15,7 @@ describe('EditNameTemplate utils - options', () => {
   });
 
   it('includes default option when inherit is not allowed', () => {
-    expect(getNameTemplateOptions(false).map((o) => o.value)).toEqual([
+    expect(getNameTemplateOptions(false).map((option) => o.value)).toEqual([
       NameTemplateOptions.DefaultNameTemplate,
       NameTemplateOptions.CustomNameTemplate,
     ]);

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -26,17 +26,17 @@ describe('EditNameTemplate utils - options', () => {
     expect(getSelectedOption(undefined, true)).toBe(NameTemplateOptions.InheritPlanWideSetting);
     expect(getSelectedOption(undefined, false)).toBe(NameTemplateOptions.DefaultNameTemplate);
 
-    expect(
-      getNameTemplateStateLabel(NameTemplateOptions.InheritPlanWideSetting, true),
-    ).toMatch(/Inherit plan wide setting/i);
-    expect(
-      getNameTemplateStateLabel(NameTemplateOptions.DefaultNameTemplate, false),
-    ).toMatch(/Default name template/i);
-    expect(
-      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, true),
-    ).toMatch(/Custom name template/i);
-    expect(
-      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false),
-    ).toMatch(/Custom name template/i);
+    expect(getNameTemplateStateLabel(NameTemplateOptions.InheritPlanWideSetting, true)).toMatch(
+      /Inherit plan wide setting/i,
+    );
+    expect(getNameTemplateStateLabel(NameTemplateOptions.DefaultNameTemplate, false)).toMatch(
+      /Default name template/i,
+    );
+    expect(getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, true)).toMatch(
+      /Custom name template/i,
+    );
+    expect(getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false)).toMatch(
+      /Custom name template/i,
+    );
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { NameTemplateOptions } from '../types';
+import {
+  getNameTemplateOptions,
+  getNameTemplateStateLabel,
+  getSelectedOption,
+} from '../utils';
+
+describe('EditNameTemplate utils - options', () => {
+  it('includes inherit option when allowed', () => {
+    const options = getNameTemplateOptions(true);
+    expect(options.map((o) => o.value)).toEqual([
+      NameTemplateOptions.InheritPlanWideSetting,
+      NameTemplateOptions.CustomNameTemplate,
+    ]);
+    expect(options[0].getInheritToDescription?.('')).toMatch(/default/i);
+    expect(options[0].getInheritToDescription?.('tpl')).toMatch(/tpl/);
+  });
+
+  it('includes default option when inherit is not allowed', () => {
+    expect(getNameTemplateOptions(false).map((o) => o.value)).toEqual([
+      NameTemplateOptions.DefaultNameTemplate,
+      NameTemplateOptions.CustomNameTemplate,
+    ]);
+  });
+
+  it('resolves selected option and labels', () => {
+    expect(getSelectedOption('custom', true)).toBe(NameTemplateOptions.CustomNameTemplate);
+    expect(getSelectedOption(undefined, true)).toBe(NameTemplateOptions.InheritPlanWideSetting);
+    expect(getSelectedOption(undefined, false)).toBe(NameTemplateOptions.DefaultNameTemplate);
+    expect(
+      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false),
+    ).toMatch(/Custom name template/i);
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/EditNameTemplate/utils/__tests__/nameTemplate.options.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { NameTemplateOptions } from '../types';
-import {
-  getNameTemplateOptions,
-  getNameTemplateStateLabel,
-  getSelectedOption,
-} from '../utils';
+import { getNameTemplateOptions, getNameTemplateStateLabel, getSelectedOption } from '../utils';
 
 describe('EditNameTemplate utils - options', () => {
   it('includes inherit option when allowed', () => {
@@ -29,8 +25,8 @@ describe('EditNameTemplate utils - options', () => {
     expect(getSelectedOption('custom', true)).toBe(NameTemplateOptions.CustomNameTemplate);
     expect(getSelectedOption(undefined, true)).toBe(NameTemplateOptions.InheritPlanWideSetting);
     expect(getSelectedOption(undefined, false)).toBe(NameTemplateOptions.DefaultNameTemplate);
-    expect(
-      getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false),
-    ).toMatch(/Custom name template/i);
+    expect(getNameTemplateStateLabel(NameTemplateOptions.CustomNameTemplate, false)).toMatch(
+      /Custom name template/i,
+    );
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
@@ -36,6 +36,40 @@ describe('patchGuestConversion - patch', () => {
     });
   });
 
+  it('only patches skipGuestConversion when compatibility is omitted', async () => {
+    const resource = { metadata: { name: 'plan' }, spec: {} } as never;
+
+    await patchGuestConversion({ newValue: true, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/skipGuestConversion', value: true }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('REPLACEs skip and compatibility when already set', async () => {
+    const resource = {
+      metadata: { name: 'plan' },
+      spec: { skipGuestConversion: false, useCompatibilityMode: false },
+    } as never;
+
+    await patchGuestConversion({
+      newValue: true,
+      resource,
+      useCompatibilityMode: true,
+    });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [
+        { op: 'replace', path: '/spec/skipGuestConversion', value: true },
+        { op: 'replace', path: '/spec/useCompatibilityMode', value: true },
+      ],
+      model: PlanModel,
+      resource,
+    });
+  });
+
   it('removes compatibility mode when no longer skipping', async () => {
     const resource = {
       metadata: { name: 'plan' },
@@ -44,9 +78,13 @@ describe('patchGuestConversion - patch', () => {
 
     await patchGuestConversion({ newValue: false, resource });
 
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown }])[0].data).toEqual([
-      { op: 'replace', path: '/spec/skipGuestConversion', value: false },
-      { op: 'remove', path: '/spec/useCompatibilityMode' },
-    ]);
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [
+        { op: 'replace', path: '/spec/skipGuestConversion', value: false },
+        { op: 'remove', path: '/spec/useCompatibilityMode' },
+      ],
+      model: PlanModel,
+      resource,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { PlanModel } from '@forklift-ui/types';
+
+import { patchGuestConversion } from '../patchGuestConversion';
+
+describe('patchGuestConversion - patch', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('adds skipGuestConversion and compatibility mode when skipping', async () => {
+    const resource = { metadata: { name: 'plan' }, spec: {} } as never;
+
+    await patchGuestConversion({
+      newValue: true,
+      resource,
+      useCompatibilityMode: true,
+    });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [
+        { op: 'add', path: '/spec/skipGuestConversion', value: true },
+        { op: 'add', path: '/spec/useCompatibilityMode', value: true },
+      ],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('removes compatibility mode when no longer skipping', async () => {
+    const resource = {
+      metadata: { name: 'plan' },
+      spec: { skipGuestConversion: true, useCompatibilityMode: false },
+    } as never;
+
+    await patchGuestConversion({ newValue: false, resource });
+
+    expect(mockK8sPatch.mock.calls[0][0].data).toEqual([
+      { op: 'replace', path: '/spec/skipGuestConversion', value: false },
+      { op: 'remove', path: '/spec/useCompatibilityMode' },
+    ]);
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { PlanModel } from '@forklift-ui/types';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
@@ -13,7 +13,7 @@ import { patchGuestConversion } from '../patchGuestConversion';
 describe('patchGuestConversion - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('adds skipGuestConversion and compatibility mode when skipping', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/patchGuestConversion.patch.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { PlanModel } from '@forklift-ui/types';
@@ -13,7 +14,7 @@ import { patchGuestConversion } from '../patchGuestConversion';
 describe('patchGuestConversion - patch', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('adds skipGuestConversion and compatibility mode when skipping', async () => {
@@ -43,7 +44,7 @@ describe('patchGuestConversion - patch', () => {
 
     await patchGuestConversion({ newValue: false, resource });
 
-    expect(mockK8sPatch.mock.calls[0][0].data).toEqual([
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown }])[0].data).toEqual([
       { op: 'replace', path: '/spec/skipGuestConversion', value: false },
       { op: 'remove', path: '/spec/useCompatibilityMode' },
     ]);

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { PROVIDER_DEFAULTS } from '../constants';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -17,13 +17,13 @@ describe('PlanTransferNetwork utils - confirm', () => {
 
   it('formats network names and defaults', () => {
     expect(getNetworkName(null)).toBe(PROVIDER_DEFAULTS);
-    expect(getNetworkName({ name: 'net', namespace: 'ns' } as never)).toBe('ns/net');
+    expect(getNetworkName({ name: 'net', namespace: 'ns' })).toBe('ns/net');
   });
 
   it('patches transfer network with ADD/REPLACE', async () => {
     const empty = { metadata: { name: 'plan' }, spec: {} } as never;
     await onConfirmTransferNetwork({
-      newValue: { name: 'net', namespace: 'ns' } as never,
+      newValue: { name: 'net', namespace: 'ns' },
       resource: empty,
     });
     expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { PROVIDER_DEFAULTS } from '../constants';
@@ -12,7 +13,7 @@ import { getNetworkName, onConfirmTransferNetwork } from '../utils';
 describe('PlanTransferNetwork utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('formats network names and defaults', () => {
@@ -26,14 +27,16 @@ describe('PlanTransferNetwork utils - confirm', () => {
       newValue: { name: 'net', namespace: 'ns' },
       resource: empty,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+    expect(
+      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('add');
 
     const existing = {
       metadata: { name: 'plan' },
       spec: { transferNetwork: { name: 'old', namespace: 'ns' } },
     } as never;
     await onConfirmTransferNetwork({ newValue: null, resource: existing });
-    expect(mockK8sPatch.mock.calls[1][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[1] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'replace',
       path: '/spec/transferNetwork',
       value: undefined,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { PROVIDER_DEFAULTS } from '../constants';
+import { getNetworkName, onConfirmTransferNetwork } from '../utils';
+
+describe('PlanTransferNetwork utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('formats network names and defaults', () => {
+    expect(getNetworkName(null)).toBe(PROVIDER_DEFAULTS);
+    expect(getNetworkName({ name: 'net', namespace: 'ns' } as never)).toBe('ns/net');
+  });
+
+  it('patches transfer network with ADD/REPLACE', async () => {
+    const empty = { metadata: { name: 'plan' }, spec: {} } as never;
+    await onConfirmTransferNetwork({
+      newValue: { name: 'net', namespace: 'ns' } as never,
+      resource: empty,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+
+    const existing = {
+      metadata: { name: 'plan' },
+      spec: { transferNetwork: { name: 'old', namespace: 'ns' } },
+    } as never;
+    await onConfirmTransferNetwork({ newValue: null, resource: existing });
+    expect(mockK8sPatch.mock.calls[1][0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/transferNetwork',
+      value: undefined,
+    });
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { PROVIDER_DEFAULTS } from '../constants';
 import { getNetworkName, onConfirmTransferNetwork } from '../utils';
 
@@ -21,25 +23,39 @@ describe('PlanTransferNetwork utils - confirm', () => {
     expect(getNetworkName({ name: 'net', namespace: 'ns' })).toBe('ns/net');
   });
 
-  it('patches transfer network with ADD/REPLACE', async () => {
-    const empty = { metadata: { name: 'plan' }, spec: {} } as never;
+  it('ADDs transfer network with name and namespace', async () => {
+    const resource = { metadata: { name: 'plan' }, spec: {} } as never;
+
     await onConfirmTransferNetwork({
       newValue: { name: 'net', namespace: 'ns' },
-      resource: empty,
+      resource,
     });
-    expect(
-      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('add');
 
-    const existing = {
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [
+        {
+          op: 'add',
+          path: '/spec/transferNetwork',
+          value: { name: 'net', namespace: 'ns' },
+        },
+      ],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('REPLACEs transfer network with undefined when clearing', async () => {
+    const resource = {
       metadata: { name: 'plan' },
       spec: { transferNetwork: { name: 'old', namespace: 'ns' } },
     } as never;
-    await onConfirmTransferNetwork({ newValue: null, resource: existing });
-    expect((mockK8sPatch.mock.calls[1] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
-      op: 'replace',
-      path: '/spec/transferNetwork',
-      value: undefined,
+
+    await onConfirmTransferNetwork({ newValue: null, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/transferNetwork', value: undefined }],
+      model: PlanModel,
+      resource,
     });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PlanTransferNetwork/utils/__tests__/transferNetwork.confirm.test.ts
@@ -12,7 +12,7 @@ import { getNetworkName, onConfirmTransferNetwork } from '../utils';
 describe('PlanTransferNetwork utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('formats network names and defaults', () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmPreserveCpuModel } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { onConfirmPreserveCpuModel } from '../utils';
 
 describe('PreserveClusterCpuModel utils - confirm', () => {
@@ -16,24 +18,29 @@ describe('PreserveClusterCpuModel utils - confirm', () => {
   });
 
   it('patches preserveClusterCpuModel with ADD when unset', async () => {
-    await onConfirmPreserveCpuModel({
-      newValue: true,
-      resource: { metadata: { name: 'p' }, spec: {} } as never,
-    });
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
-      op: 'add',
-      path: '/spec/preserveClusterCpuModel',
-      value: true,
+    const resource = { metadata: { name: 'p' }, spec: {} } as never;
+
+    await onConfirmPreserveCpuModel({ newValue: true, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/preserveClusterCpuModel', value: true }],
+      model: PlanModel,
+      resource,
     });
   });
 
   it('stores undefined when disabling', async () => {
-    await onConfirmPreserveCpuModel({
-      newValue: false,
-      resource: { metadata: { name: 'p' }, spec: { preserveClusterCpuModel: true } } as never,
+    const resource = {
+      metadata: { name: 'p' },
+      spec: { preserveClusterCpuModel: true },
+    } as never;
+
+    await onConfirmPreserveCpuModel({ newValue: false, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/preserveClusterCpuModel', value: undefined }],
+      model: PlanModel,
+      resource,
     });
-    expect(
-      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { value: unknown }[] }])[0].data[0].value,
-    ).toBeUndefined();
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmPreserveCpuModel } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmPreserveCpuModel } from '../utils';
 describe('PreserveClusterCpuModel utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('patches preserveClusterCpuModel with ADD when unset', async () => {
@@ -19,7 +20,7 @@ describe('PreserveClusterCpuModel utils - confirm', () => {
       newValue: true,
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'add',
       path: '/spec/preserveClusterCpuModel',
       value: true,
@@ -31,6 +32,8 @@ describe('PreserveClusterCpuModel utils - confirm', () => {
       newValue: false,
       resource: { metadata: { name: 'p' }, spec: { preserveClusterCpuModel: true } } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].value).toBeUndefined();
+    expect(
+      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { value: unknown }[] }])[0].data[0].value,
+    ).toBeUndefined();
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmPreserveCpuModel } from '../utils';
 describe('PreserveClusterCpuModel utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('patches preserveClusterCpuModel with ADD when unset', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveClusterCpuModel/utils/__tests__/preserveCpuModel.confirm.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmPreserveCpuModel } from '../utils';
+
+describe('PreserveClusterCpuModel utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('patches preserveClusterCpuModel with ADD when unset', async () => {
+    await onConfirmPreserveCpuModel({
+      newValue: true,
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/preserveClusterCpuModel',
+      value: true,
+    });
+  });
+
+  it('stores undefined when disabling', async () => {
+    await onConfirmPreserveCpuModel({
+      newValue: false,
+      resource: { metadata: { name: 'p' }, spec: { preserveClusterCpuModel: true } } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].value).toBeUndefined();
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmPreserveStaticIPs } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmPreserveStaticIPs } from '../utils';
 describe('PreserveStaticIPs utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('ADDs then REPLACEs preserveStaticIPs', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmPreserveStaticIPs } from '../utils';
+
+describe('PreserveStaticIPs utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('ADDs then REPLACEs preserveStaticIPs', async () => {
+    await onConfirmPreserveStaticIPs({
+      newValue: true,
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+
+    await onConfirmPreserveStaticIPs({
+      newValue: false,
+      resource: { metadata: { name: 'p' }, spec: { preserveStaticIPs: true } } as never,
+    });
+    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { onConfirmPreserveStaticIPs } from '../utils';
 
 describe('PreserveStaticIPs utils - confirm', () => {
@@ -15,21 +17,27 @@ describe('PreserveStaticIPs utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('ADDs then REPLACEs preserveStaticIPs', async () => {
-    await onConfirmPreserveStaticIPs({
-      newValue: true,
-      resource: { metadata: { name: 'p' }, spec: {} } as never,
-    });
-    expect(
-      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('add');
+  it('ADDs preserveStaticIPs with true', async () => {
+    const resource = { metadata: { name: 'p' }, spec: {} } as never;
 
-    await onConfirmPreserveStaticIPs({
-      newValue: false,
-      resource: { metadata: { name: 'p' }, spec: { preserveStaticIPs: true } } as never,
+    await onConfirmPreserveStaticIPs({ newValue: true, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/preserveStaticIPs', value: true }],
+      model: PlanModel,
+      resource,
     });
-    expect(
-      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('replace');
+  });
+
+  it('REPLACEs preserveStaticIPs keeping false', async () => {
+    const resource = { metadata: { name: 'p' }, spec: { preserveStaticIPs: true } } as never;
+
+    await onConfirmPreserveStaticIPs({ newValue: false, resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/preserveStaticIPs', value: false }],
+      model: PlanModel,
+      resource,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PreserveStaticIPs/utils/__tests__/preserveStaticIPs.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmPreserveStaticIPs } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmPreserveStaticIPs } from '../utils';
 describe('PreserveStaticIPs utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('ADDs then REPLACEs preserveStaticIPs', async () => {
@@ -19,12 +20,16 @@ describe('PreserveStaticIPs utils - confirm', () => {
       newValue: true,
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+    expect(
+      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('add');
 
     await onConfirmPreserveStaticIPs({
       newValue: false,
       resource: { metadata: { name: 'p' }, spec: { preserveStaticIPs: true } } as never,
     });
-    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+    expect(
+      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('replace');
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
@@ -7,6 +7,8 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
     (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
+import { PlanModel } from '@forklift-ui/types';
+
 import { onConfirmTargetPowerState, onConfirmVmTargetPowerState } from '../utils';
 
 describe('TargetPowerState utils - confirm', () => {
@@ -17,11 +19,40 @@ describe('TargetPowerState utils - confirm', () => {
 
   it('ADDs plan target power state when missing', async () => {
     const resource = { metadata: { name: 'plan' }, spec: {} } as never;
+
     await onConfirmTargetPowerState({ newValue: 'on', resource });
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
-      op: 'add',
-      path: '/spec/targetPowerState',
-      value: 'on',
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/targetPowerState', value: 'on' }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('REPLACEs plan target power state when already set', async () => {
+    const resource = { metadata: { name: 'plan' }, spec: { targetPowerState: 'off' } } as never;
+
+    await onConfirmTargetPowerState({ newValue: 'on', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/targetPowerState', value: 'on' }],
+      model: PlanModel,
+      resource,
+    });
+  });
+
+  it('ADDs VM target power state when missing', async () => {
+    const resource = {
+      metadata: { name: 'plan' },
+      spec: { vms: [{ name: 'vm' }] },
+    } as never;
+
+    await onConfirmVmTargetPowerState(0)({ newValue: 'on', resource });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/vms/0/targetPowerState', value: 'on' }],
+      model: PlanModel,
+      resource,
     });
   });
 
@@ -33,10 +64,10 @@ describe('TargetPowerState utils - confirm', () => {
 
     await onConfirmVmTargetPowerState(0)({ newValue: 'on', resource });
 
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
-      op: 'replace',
-      path: '/spec/vms/0/targetPowerState',
-      value: 'on',
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/vms/0/targetPowerState', value: 'on' }],
+      model: PlanModel,
+      resource,
     });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmTargetPowerState, onConfirmVmTargetPowerState } from '../utils';
+
+describe('TargetPowerState utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({ metadata: { name: 'plan' } });
+  });
+
+  it('ADDs plan target power state when missing', async () => {
+    const resource = { metadata: { name: 'plan' }, spec: {} } as never;
+    await onConfirmTargetPowerState({ newValue: 'on' as never, resource });
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/targetPowerState',
+      value: 'on',
+    });
+  });
+
+  it('REPLACEs VM target power state by index', async () => {
+    const resource = {
+      metadata: { name: 'plan' },
+      spec: { targetPowerState: 'off', vms: [{ name: 'vm', targetPowerState: 'off' }] },
+    } as never;
+
+    await onConfirmVmTargetPowerState(0)({ newValue: 'on' as never, resource });
+
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/vms/0/targetPowerState',
+      value: 'on',
+    });
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmTargetPowerState, onConfirmVmTargetPowerState } from '../utils';
@@ -17,7 +18,7 @@ describe('TargetPowerState utils - confirm', () => {
   it('ADDs plan target power state when missing', async () => {
     const resource = { metadata: { name: 'plan' }, spec: {} } as never;
     await onConfirmTargetPowerState({ newValue: 'on', resource });
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'add',
       path: '/spec/targetPowerState',
       value: 'on',
@@ -32,7 +33,7 @@ describe('TargetPowerState utils - confirm', () => {
 
     await onConfirmVmTargetPowerState(0)({ newValue: 'on', resource });
 
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'replace',
       path: '/spec/vms/0/targetPowerState',
       value: 'on',

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmTargetPowerState, onConfirmVmTargetPowerState } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/TargetPowerState/utils/__tests__/targetPowerState.confirm.test.ts
@@ -16,7 +16,7 @@ describe('TargetPowerState utils - confirm', () => {
 
   it('ADDs plan target power state when missing', async () => {
     const resource = { metadata: { name: 'plan' }, spec: {} } as never;
-    await onConfirmTargetPowerState({ newValue: 'on' as never, resource });
+    await onConfirmTargetPowerState({ newValue: 'on', resource });
     expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
       op: 'add',
       path: '/spec/targetPowerState',
@@ -30,7 +30,7 @@ describe('TargetPowerState utils - confirm', () => {
       spec: { targetPowerState: 'off', vms: [{ name: 'vm', targetPowerState: 'off' }] },
     } as never;
 
-    await onConfirmVmTargetPowerState(0)({ newValue: 'on' as never, resource });
+    await onConfirmVmTargetPowerState(0)({ newValue: 'on', resource });
 
     expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
       op: 'replace',

--- a/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { PlanModel } from '@forklift-ui/types';
@@ -30,6 +31,8 @@ describe('patchPlanSpec - patch', () => {
   it('uses REPLACE when current value is defined', async () => {
     const plan = { metadata: { name: 'plan' } } as never;
     await patchPlanSpec({ currentValue: false, newValue: true, path: '/spec/flag', plan });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('replace');
+    expect(
+      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('replace');
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
@@ -31,8 +31,11 @@ describe('patchPlanSpec - patch', () => {
   it('uses REPLACE when current value is defined', async () => {
     const plan = { metadata: { name: 'plan' } } as never;
     await patchPlanSpec({ currentValue: false, newValue: true, path: '/spec/flag', plan });
-    expect(
-      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('replace');
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'replace', path: '/spec/flag', value: true }],
+      model: PlanModel,
+      resource: plan,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { PlanModel } from '@forklift-ui/types';
+
+import { patchPlanSpec } from '../patchPlanSpec';
+
+describe('patchPlanSpec - patch', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({ metadata: { name: 'plan' } });
+  });
+
+  it('uses ADD when current value is undefined', async () => {
+    const plan = { metadata: { name: 'plan' } } as never;
+    await patchPlanSpec({ currentValue: undefined, newValue: true, path: '/spec/flag', plan });
+
+    expect(mockK8sPatch).toHaveBeenCalledWith({
+      data: [{ op: 'add', path: '/spec/flag', value: true }],
+      model: PlanModel,
+      resource: plan,
+    });
+  });
+
+  it('uses REPLACE when current value is defined', async () => {
+    const plan = { metadata: { name: 'plan' } } as never;
+    await patchPlanSpec({ currentValue: false, newValue: true, path: '/spec/flag', plan });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('replace');
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/utils/__tests__/patchPlanSpec.patch.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { PlanModel } from '@forklift-ui/types';


### PR DESCRIPTION
## Summary
- Add unit tests for plan settings patch helpers: `patchPlanSpec`, guest conversion, target power state, transfer network, preserve static IPs/CPU model, name templates, description, and target namespace

## Test plan
- [x] `npm test -- <new test paths>`
- [ ] CI green

Resolves: MTV-6266

Made with [Cursor](https://cursor.com)