### PR TITLE
test(MTV-6266): Tier 3-5 plans/details settings + concerns filters

### DIFF
--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { planConcernsPanelFields } from '../planConcernsPanelFields';
+
+describe('planConcernsPanelFields - fields', () => {
+  it('exposes field definitions for the concerns panel', () => {
+    expect(planConcernsPanelFields.length).toBe(3);
+    expect(planConcernsPanelFields.map((f) => f.resourceFieldId)).toEqual([
+      'severity',
+      'type',
+      'resource',
+    ]);
+  });
+});

--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
@@ -5,7 +5,7 @@ import { planConcernsPanelFields } from '../planConcernsPanelFields';
 describe('planConcernsPanelFields - fields', () => {
   it('exposes field definitions for the concerns panel', () => {
     expect(planConcernsPanelFields.length).toBe(3);
-    expect(planConcernsPanelFields.map((field) => f.resourceFieldId)).toEqual([
+    expect(planConcernsPanelFields.map((field) => field.resourceFieldId)).toEqual([
       'severity',
       'type',
       'resource',

--- a/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
+++ b/src/plans/details/components/PlanConcernsPanel/utils/__tests__/planConcernsPanelFields.fields.test.ts
@@ -5,7 +5,7 @@ import { planConcernsPanelFields } from '../planConcernsPanelFields';
 describe('planConcernsPanelFields - fields', () => {
   it('exposes field definitions for the concerns panel', () => {
     expect(planConcernsPanelFields.length).toBe(3);
-    expect(planConcernsPanelFields.map((f) => f.resourceFieldId)).toEqual([
+    expect(planConcernsPanelFields.map((field) => f.resourceFieldId)).toEqual([
       'severity',
       'type',
       'resource',

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -2,10 +2,10 @@ import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/consta
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn() as jest.Mock;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmMigrationType } from '../utils';

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockK8sPatch = jest.fn();
 

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/constants';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmMigrationType } from '../utils';
+
+describe('EditPlanMigrationType utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('sets warm true for warm migrations', async () => {
+    await onConfirmMigrationType({
+      newValue: MigrationTypeValue.Warm,
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+
+    expect(mockK8sPatch.mock.calls[0][0].data).toEqual([
+      { op: 'add', path: '/spec/warm', value: true },
+      { op: 'replace', path: '/spec/type', value: MigrationTypeValue.Warm },
+    ]);
+  });
+
+  it('sets warm false for cold migrations', async () => {
+    await onConfirmMigrationType({
+      newValue: MigrationTypeValue.Cold,
+      resource: { metadata: { name: 'p' }, spec: { warm: true } } as never,
+    });
+
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/warm',
+      value: false,
+    });
+  });
+});

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -35,10 +35,9 @@ describe('EditPlanMigrationType utils - confirm', () => {
       resource: { metadata: { name: 'p' }, spec: { warm: true } } as never,
     });
 
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
-      op: 'replace',
-      path: '/spec/warm',
-      value: false,
-    });
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown }])[0].data).toEqual([
+      { op: 'replace', path: '/spec/warm', value: false },
+      { op: 'replace', path: '/spec/type', value: MigrationTypeValue.Cold },
+    ]);
   });
 });

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -13,7 +13,7 @@ import { onConfirmMigrationType } from '../utils';
 describe('EditPlanMigrationType utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('sets warm true for warm migrations', async () => {

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -2,10 +2,11 @@ import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/consta
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmMigrationType } from '../utils';
@@ -13,7 +14,7 @@ import { onConfirmMigrationType } from '../utils';
 describe('EditPlanMigrationType utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('sets warm true for warm migrations', async () => {
@@ -22,7 +23,7 @@ describe('EditPlanMigrationType utils - confirm', () => {
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
 
-    expect(mockK8sPatch.mock.calls[0][0].data).toEqual([
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown }])[0].data).toEqual([
       { op: 'add', path: '/spec/warm', value: true },
       { op: 'replace', path: '/spec/type', value: MigrationTypeValue.Warm },
     ]);
@@ -34,7 +35,7 @@ describe('EditPlanMigrationType utils - confirm', () => {
       resource: { metadata: { name: 'p' }, spec: { warm: true } } as never,
     });
 
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'replace',
       path: '/spec/warm',
       value: false,

--- a/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/DetailsSection/components/EditPlanMigrationType/utils/__tests__/onConfirmMigrationType.confirm.test.ts
@@ -2,7 +2,7 @@ import { MigrationTypeValue } from 'src/plans/create/steps/migration-type/consta
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn() as jest.Mock;
+const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/guestConversion.selectors.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/guestConversion.selectors.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getSkipGuestConversion, getUseCompatibilityMode } from '../utils';
+
+describe('guest conversion utils - selectors', () => {
+  it('reads skipGuestConversion and useCompatibilityMode', () => {
+    const plan = {
+      spec: { skipGuestConversion: true, useCompatibilityMode: false },
+    } as never;
+
+    expect(getSkipGuestConversion(plan)).toBe(true);
+    expect(getUseCompatibilityMode(plan)).toBe(false);
+    expect(getSkipGuestConversion({} as never)).toBeUndefined();
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn() as jest.Mock;
+const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn() as jest.Mock;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmPlanNetworkNameTemplate } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmPlanNetworkNameTemplate } from '../utils';
 describe('NetworkNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('ADDs and REPLACEs networkNameTemplate', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmPlanNetworkNameTemplate } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmPlanNetworkNameTemplate } from '../utils';
 describe('NetworkNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('ADDs and REPLACEs networkNameTemplate', async () => {
@@ -19,12 +20,16 @@ describe('NetworkNameTemplate utils - confirm', () => {
       newValue: 'tpl',
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+    expect(
+      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('add');
 
     await onConfirmPlanNetworkNameTemplate({
       newValue: undefined,
       resource: { metadata: { name: 'p' }, spec: { networkNameTemplate: 'old' } } as never,
     });
-    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+    expect(
+      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
+    ).toBe('replace');
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -20,16 +20,20 @@ describe('NetworkNameTemplate utils - confirm', () => {
       newValue: 'tpl',
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(
-      (mockK8sPatch.mock.calls[0] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('add');
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/networkNameTemplate',
+      value: 'tpl',
+    });
 
     await onConfirmPlanNetworkNameTemplate({
       newValue: undefined,
       resource: { metadata: { name: 'p' }, spec: { networkNameTemplate: 'old' } } as never,
     });
-    expect(
-      (mockK8sPatch.mock.calls[1] as unknown as [{ data: { op: string }[] }])[0].data[0].op,
-    ).toBe('replace');
+    expect((mockK8sPatch.mock.calls[1] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/networkNameTemplate',
+      value: undefined,
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/NetworkNameTemplate/utils/__tests__/networkNameTemplate.confirm.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmPlanNetworkNameTemplate } from '../utils';
+
+describe('NetworkNameTemplate utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('ADDs and REPLACEs networkNameTemplate', async () => {
+    await onConfirmPlanNetworkNameTemplate({
+      newValue: 'tpl',
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].op).toBe('add');
+
+    await onConfirmPlanNetworkNameTemplate({
+      newValue: undefined,
+      resource: { metadata: { name: 'p' }, spec: { networkNameTemplate: 'old' } } as never,
+    });
+    expect(mockK8sPatch.mock.calls[1][0].data[0].op).toBe('replace');
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn() as jest.Mock;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmPVCNameTemplate } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -15,12 +15,27 @@ describe('PVCNameTemplate utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('patches pvcNameTemplate', async () => {
+  it('ADDs pvcNameTemplate when unset', async () => {
     await onConfirmPVCNameTemplate({
       newValue: 'pvc-{{.vmName}}',
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    const [patchArg] = mockK8sPatch.mock.calls[0] as unknown as [{ data: { path: string }[] }];
-    expect(patchArg.data[0].path).toBe('/spec/pvcNameTemplate');
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/pvcNameTemplate',
+      value: 'pvc-{{.vmName}}',
+    });
+  });
+
+  it('REPLACEs pvcNameTemplate when set', async () => {
+    await onConfirmPVCNameTemplate({
+      newValue: 'new-tpl',
+      resource: { metadata: { name: 'p' }, spec: { pvcNameTemplate: 'old' } } as never,
+    });
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/pvcNameTemplate',
+      value: 'new-tpl',
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn() as jest.Mock;
+const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmPVCNameTemplate } from '../utils';
 describe('PVCNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('patches pvcNameTemplate', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmPVCNameTemplate } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmPVCNameTemplate } from '../utils';
 describe('PVCNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('patches pvcNameTemplate', async () => {
@@ -19,6 +20,7 @@ describe('PVCNameTemplate utils - confirm', () => {
       newValue: 'pvc-{{.vmName}}',
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0].path).toBe('/spec/pvcNameTemplate');
+    const [patchArg] = mockK8sPatch.mock.calls[0] as unknown as [{ data: { path: string }[] }];
+    expect(patchArg.data[0].path).toBe('/spec/pvcNameTemplate');
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/PVCNameTemplate/utils/__tests__/pvcNameTemplate.confirm.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmPVCNameTemplate } from '../utils';
+
+describe('PVCNameTemplate utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('patches pvcNameTemplate', async () => {
+    await onConfirmPVCNameTemplate({
+      newValue: 'pvc-{{.vmName}}',
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0].path).toBe('/spec/pvcNameTemplate');
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn() as jest.Mock;
+const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -11,7 +11,7 @@ import { onConfirmVolumeNameTemplate } from '../utils';
 describe('VolumeNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('patches volumeNameTemplate', async () => {

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn() as jest.Mock;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { onConfirmVolumeNameTemplate } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { onConfirmVolumeNameTemplate } from '../utils';
+
+describe('VolumeNameTemplate utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('patches volumeNameTemplate', async () => {
+    await onConfirmVolumeNameTemplate({
+      newValue: 'vol',
+      resource: { metadata: { name: 'p' }, spec: { volumeNameTemplate: 'old' } } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual(
+      expect.objectContaining({ op: 'replace', path: '/spec/volumeNameTemplate', value: 'vol' }),
+    );
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -15,13 +15,27 @@ describe('VolumeNameTemplate utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('patches volumeNameTemplate', async () => {
+  it('ADDs volumeNameTemplate when unset', async () => {
+    await onConfirmVolumeNameTemplate({
+      newValue: 'vol',
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/volumeNameTemplate',
+      value: 'vol',
+    });
+  });
+
+  it('REPLACEs volumeNameTemplate when set', async () => {
     await onConfirmVolumeNameTemplate({
       newValue: 'vol',
       resource: { metadata: { name: 'p' }, spec: { volumeNameTemplate: 'old' } } as never,
     });
-    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual(
-      expect.objectContaining({ op: 'replace', path: '/spec/volumeNameTemplate', value: 'vol' }),
-    );
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/volumeNameTemplate',
+      value: 'vol',
+    });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/VolumeNameTemplate/utils/__tests__/volumeNameTemplate.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { onConfirmVolumeNameTemplate } from '../utils';
@@ -11,7 +12,7 @@ import { onConfirmVolumeNameTemplate } from '../utils';
 describe('VolumeNameTemplate utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('patches volumeNameTemplate', async () => {
@@ -19,7 +20,7 @@ describe('VolumeNameTemplate utils - confirm', () => {
       newValue: 'vol',
       resource: { metadata: { name: 'p' }, spec: { volumeNameTemplate: 'old' } } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual(
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual(
       expect.objectContaining({ op: 'replace', path: '/spec/volumeNameTemplate', value: 'vol' }),
     );
   });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn() as jest.Mock;
+const mockK8sPatch = jest.fn();
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -15,7 +15,7 @@ describe('XfsCompatibility utils - confirm', () => {
     mockK8sPatch.mockResolvedValue({});
   });
 
-  it('reads and patches xfsCompatibility', async () => {
+  it('reads and ADDs xfsCompatibility when unset', async () => {
     expect(getPlanXfsCompatibility({ spec: { xfsCompatibility: true } } as never)).toBe(true);
     await onConfirmXfsCompatibility({
       newValue: false,
@@ -25,6 +25,18 @@ describe('XfsCompatibility utils - confirm', () => {
       op: 'add',
       path: '/spec/xfsCompatibility',
       value: false,
+    });
+  });
+
+  it('REPLACEs xfsCompatibility when already set', async () => {
+    await onConfirmXfsCompatibility({
+      newValue: true,
+      resource: { metadata: { name: 'p' }, spec: { xfsCompatibility: false } } as never,
+    });
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
+      op: 'replace',
+      path: '/spec/xfsCompatibility',
+      value: true,
     });
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockK8sPatch = jest.fn();
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+}));
+
+import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from '../utils';
+
+describe('XfsCompatibility utils - confirm', () => {
+  beforeEach(() => {
+    mockK8sPatch.mockReset();
+    mockK8sPatch.mockResolvedValue({});
+  });
+
+  it('reads and patches xfsCompatibility', async () => {
+    expect(getPlanXfsCompatibility({ spec: { xfsCompatibility: true } } as never)).toBe(true);
+    await onConfirmXfsCompatibility({
+      newValue: false,
+      resource: { metadata: { name: 'p' }, spec: {} } as never,
+    });
+    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+      op: 'add',
+      path: '/spec/xfsCompatibility',
+      value: false,
+    });
+  });
+});

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn() as jest.Mock;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]) => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
 }));
 
 import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from '../utils';

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockK8sPatch = jest.fn();
+const mockK8sPatch = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
-  k8sPatch: (...args: unknown[]): unknown => mockK8sPatch(...args),
+  k8sPatch: (...args: unknown[]): unknown =>
+    (mockK8sPatch as (...a: unknown[]) => unknown)(...args),
 }));
 
 import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from '../utils';
@@ -11,7 +12,7 @@ import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from '../utils';
 describe('XfsCompatibility utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue(undefined as never);
+    mockK8sPatch.mockResolvedValue({});
   });
 
   it('reads and patches xfsCompatibility', async () => {
@@ -20,7 +21,7 @@ describe('XfsCompatibility utils - confirm', () => {
       newValue: false,
       resource: { metadata: { name: 'p' }, spec: {} } as never,
     });
-    expect(mockK8sPatch.mock.calls[0][0].data[0]).toEqual({
+    expect((mockK8sPatch.mock.calls[0] as unknown as [{ data: unknown[] }])[0].data[0]).toEqual({
       op: 'add',
       path: '/spec/xfsCompatibility',
       value: false,

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/XfsCompatibility/utils/__tests__/xfsCompatibility.confirm.test.ts
@@ -11,7 +11,7 @@ import { getPlanXfsCompatibility, onConfirmXfsCompatibility } from '../utils';
 describe('XfsCompatibility utils - confirm', () => {
   beforeEach(() => {
     mockK8sPatch.mockReset();
-    mockK8sPatch.mockResolvedValue({});
+    mockK8sPatch.mockResolvedValue(undefined as never);
   });
 
   it('reads and patches xfsCompatibility', async () => {

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
@@ -21,7 +21,7 @@ describe('concernSeverityOrTypeFilter - filter', () => {
       },
     ]);
 
-    expect(values?.values?.map((v) => v.id)).toEqual(
+    expect(values?.values?.map((value) => v.id)).toEqual(
       expect.arrayContaining(['Shared disk', 'Ready']),
     );
     expect(filter.type).toBeDefined();

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
@@ -21,9 +21,7 @@ describe('concernSeverityOrTypeFilter - filter', () => {
       },
     ]);
 
-    expect(values?.values?.map((value) => value.id)).toEqual(
-      expect.arrayContaining(['Shared disk', 'Ready']),
-    );
+    expect(values?.values?.map((value) => value.id)).toEqual(['Shared disk', 'Ready']);
     expect(filter.type).toBeDefined();
   });
 });

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
+
+import { concernSeverityOrTypeFilter } from '../concernSeverityOrTypeFilter';
+
+describe('concernSeverityOrTypeFilter - filter', () => {
+  it('builds unique concern and condition values by category', () => {
+    const filter = concernSeverityOrTypeFilter();
+    const values = filter.dynamicFilter?.([
+      {
+        conditions: [{ category: ConcernCategory.Warning, type: 'Ready' }],
+        inventoryVmData: {
+          vm: {
+            concerns: [
+              { category: ConcernCategory.Critical, label: 'Shared disk' },
+              { category: ConcernCategory.Critical, label: 'Shared disk' },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(values?.values?.map((v) => v.id)).toEqual(
+      expect.arrayContaining(['Shared disk', 'Ready']),
+    );
+    expect(filter.type).toBeDefined();
+  });
+});

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
 import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
+
+import { describe, expect, it } from '@jest/globals';
 
 import { concernSeverityOrTypeFilter } from '../concernSeverityOrTypeFilter';
 

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/concernSeverityOrTypeFilter.filter.test.ts
@@ -21,7 +21,7 @@ describe('concernSeverityOrTypeFilter - filter', () => {
       },
     ]);
 
-    expect(values?.values?.map((value) => v.id)).toEqual(
+    expect(values?.values?.map((value) => value.id)).toEqual(
       expect.arrayContaining(['Shared disk', 'Ready']),
     );
     expect(filter.type).toBeDefined();

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
 import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
+
+import { describe, expect, it } from '@jest/globals';
 
 import { createInitialUniqueMaps, getUniqueMapByCategory } from '../getUniqueMapByCategory';
 

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConcernCategory } from 'src/providers/details/tabs/VirtualMachines/constants';
+
+import { createInitialUniqueMaps, getUniqueMapByCategory } from '../getUniqueMapByCategory';
+
+describe('getUniqueMapByCategory - category', () => {
+  it('routes categories to the matching map', () => {
+    const maps = createInitialUniqueMaps();
+    expect(getUniqueMapByCategory(maps, ConcernCategory.Critical)).toBe(maps.critical);
+    expect(getUniqueMapByCategory(maps, ConcernCategory.Warning)).toBe(maps.warning);
+    expect(getUniqueMapByCategory(maps, ConcernCategory.Information)).toBe(maps.information);
+    expect(getUniqueMapByCategory(maps, 'unknown')).toBe(maps.information);
+  });
+});

--- a/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
+++ b/src/plans/details/tabs/VirtualMachines/components/PlanSpecVirtualMachinesList/utils/__tests__/getUniqueMapByCategory.category.test.ts
@@ -11,5 +11,8 @@ describe('getUniqueMapByCategory - category', () => {
     expect(getUniqueMapByCategory(maps, ConcernCategory.Warning)).toBe(maps.warning);
     expect(getUniqueMapByCategory(maps, ConcernCategory.Information)).toBe(maps.information);
     expect(getUniqueMapByCategory(maps, 'unknown')).toBe(maps.information);
+    expect(getUniqueMapByCategory(maps, 'Warn')).toBe(maps.warning);
+    expect(getUniqueMapByCategory(maps, 'Error')).toBe(maps.information);
+    expect(getUniqueMapByCategory(maps, 'Advisory')).toBe(maps.information);
   });
 });


### PR DESCRIPTION
## Summary
- Add unit tests for settings batch B (name templates, XFS compatibility, migration type confirm) and concerns filters (`concernSeverityOrTypeFilter`, `getUniqueMapByCategory`, panel fields)

## Test plan
- [x] `npm test -- <new test paths>`
- [ ] CI green

Resolves: MTV-6266

Made with [Cursor](https://cursor.com)