### PR TITLE
test(MTV-6266): Tier 3-9 weak partials toward ≥60%

### DIFF
--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
@@ -4,11 +4,7 @@ import { getSkipGuestConversion, getUseCompatibilityMode } from '../utils';
 
 describe('guest conversion selectors - weakPartials', () => {
   it('reads boolean flags from plan spec', () => {
-    expect(
-      getSkipGuestConversion({ spec: { skipGuestConversion: false } } as never),
-    ).toBe(false);
-    expect(
-      getUseCompatibilityMode({ spec: { useCompatibilityMode: true } } as never),
-    ).toBe(true);
+    expect(getSkipGuestConversion({ spec: { skipGuestConversion: false } } as never)).toBe(false);
+    expect(getUseCompatibilityMode({ spec: { useCompatibilityMode: true } } as never)).toBe(true);
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
@@ -1,10 +1,24 @@
+import type { V1beta1Plan } from '@forklift-ui/types';
 import { describe, expect, it } from '@jest/globals';
 
 import { getSkipGuestConversion, getUseCompatibilityMode } from '../utils';
 
+type PartialPlan = {
+  spec?: Partial<V1beta1Plan['spec']>;
+};
+
+const asPlan = (plan: PartialPlan): V1beta1Plan => plan as V1beta1Plan;
+
 describe('guest conversion selectors - weakPartials', () => {
   it('reads boolean flags from plan spec', () => {
-    expect(getSkipGuestConversion({ spec: { skipGuestConversion: false } } as never)).toBe(false);
-    expect(getUseCompatibilityMode({ spec: { useCompatibilityMode: true } } as never)).toBe(true);
+    expect(getSkipGuestConversion(asPlan({ spec: { skipGuestConversion: false } }))).toBe(false);
+    expect(getUseCompatibilityMode(asPlan({ spec: { useCompatibilityMode: true } }))).toBe(true);
+  });
+
+  it('returns undefined when flags are absent', () => {
+    expect(getSkipGuestConversion(asPlan({}))).toBeUndefined();
+    expect(getUseCompatibilityMode(asPlan({}))).toBeUndefined();
+    expect(getSkipGuestConversion(asPlan({ spec: {} }))).toBeUndefined();
+    expect(getUseCompatibilityMode(asPlan({ spec: {} }))).toBeUndefined();
   });
 });

--- a/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
+++ b/src/plans/details/tabs/Details/components/SettingsSection/components/GuestConversion/utils/__tests__/getSkipGuestConversion.weakPartials.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getSkipGuestConversion, getUseCompatibilityMode } from '../utils';
+
+describe('guest conversion selectors - weakPartials', () => {
+  it('reads boolean flags from plan spec', () => {
+    expect(
+      getSkipGuestConversion({ spec: { skipGuestConversion: false } } as never),
+    ).toBe(false);
+    expect(
+      getUseCompatibilityMode({ spec: { useCompatibilityMode: true } } as never),
+    ).toBe(true);
+  });
+});

--- a/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
+++ b/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
@@ -6,16 +6,16 @@ describe('mergeConcernsMaps - weakPartials', () => {
   it('prefers larger counts when merging inventory and inspection maps', () => {
     const merged = mergeConcernsMaps(
       new Map([
-        ['a', 2],
-        ['b', 1],
+        ['alpha', 2],
+        ['beta', 1],
       ]),
       new Map([
-        ['a', 5],
-        ['c', 3],
+        ['alpha', 5],
+        ['keyC', 3],
       ]),
     );
 
-    expect(Object.fromEntries(merged)).toEqual({ a: 5, b: 1, c: 3 });
+    expect(Object.fromEntries(merged)).toEqual({ a: 5, b: 1, keyC: 3 });
   });
 
   it('handles empty maps', () => {

--- a/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
+++ b/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
@@ -15,7 +15,7 @@ describe('mergeConcernsMaps - weakPartials', () => {
       ]),
     );
 
-    expect(Object.fromEntries(merged)).toEqual({ a: 5, b: 1, keyC: 3 });
+    expect(Object.fromEntries(merged)).toEqual({ alpha: 5, beta: 1, keyC: 3 });
   });
 
   it('handles empty maps', () => {

--- a/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
+++ b/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { mergeConcernsMaps } from '../utils';
+
+describe('mergeConcernsMaps - weakPartials', () => {
+  it('prefers larger counts when merging inventory and inspection maps', () => {
+    const merged = mergeConcernsMaps(
+      new Map([
+        ['a', 2],
+        ['b', 1],
+      ]),
+      new Map([
+        ['a', 5],
+        ['c', 3],
+      ]),
+    );
+
+    expect(Object.fromEntries(merged)).toEqual({ a: 5, b: 1, c: 3 });
+  });
+
+  it('handles empty maps', () => {
+    expect(Object.fromEntries(mergeConcernsMaps(new Map(), new Map()))).toEqual({});
+  });
+});

--- a/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
+++ b/src/plans/details/utils/__tests__/mergeConcernsMaps.weakPartials.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from '@jest/globals';
 import { mergeConcernsMaps } from '../utils';
 
 describe('mergeConcernsMaps - weakPartials', () => {
-  it('prefers larger counts when merging inventory and inspection maps', () => {
+  it('prefers larger counts when inspection exceeds inventory', () => {
     const merged = mergeConcernsMaps(
       new Map([
         ['alpha', 2],
@@ -16,6 +16,12 @@ describe('mergeConcernsMaps - weakPartials', () => {
     );
 
     expect(Object.fromEntries(merged)).toEqual({ alpha: 5, beta: 1, keyC: 3 });
+  });
+
+  it('prefers larger counts when inventory exceeds inspection', () => {
+    const merged = mergeConcernsMaps(new Map([['alpha', 5]]), new Map([['alpha', 2]]));
+
+    expect(Object.fromEntries(merged)).toEqual({ alpha: 5 });
   });
 
   it('handles empty maps', () => {

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/getDecodedValue.decode.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/getDecodedValue.decode.test.ts
@@ -1,0 +1,12 @@
+import { encode } from 'js-base64';
+import { describe, expect, it } from '@jest/globals';
+
+import { getDecodedValue } from '../getDecodedValue';
+
+describe('getDecodedValue - decode', () => {
+  it('decodes values and returns falsy for empty input', () => {
+    expect(getDecodedValue(undefined)).toBeUndefined();
+    expect(getDecodedValue('')).toBe('');
+    expect(getDecodedValue(encode('hello'))).toBe('hello');
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/getDecodedValue.decode.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/getDecodedValue.decode.test.ts
@@ -1,4 +1,5 @@
 import { encode } from 'js-base64';
+
 import { describe, expect, it } from '@jest/globals';
 
 import { getDecodedValue } from '../getDecodedValue';

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
@@ -5,14 +5,27 @@ import { ValidationState } from '@utils/validation/Validation';
 
 import { openstackSecretFieldValidator } from '../openstackSecretFieldValidator';
 
+const requiredFieldIds = [
+  OpenstackSecretFieldsId.Username,
+  OpenstackSecretFieldsId.Password,
+  OpenstackSecretFieldsId.Token,
+  OpenstackSecretFieldsId.UserId,
+  OpenstackSecretFieldsId.ProjectId,
+  OpenstackSecretFieldsId.DomainName,
+  OpenstackSecretFieldsId.RegionName,
+  OpenstackSecretFieldsId.ProjectName,
+  OpenstackSecretFieldsId.ApplicationCredentialId,
+  OpenstackSecretFieldsId.ApplicationCredentialSecret,
+  OpenstackSecretFieldsId.ApplicationCredentialName,
+] as const;
+
 describe('openstackSecretFieldValidator - dispatch', () => {
-  it('validates required username and trims input', () => {
-    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.Username, '').type).toBe(
-      ValidationState.Error,
-    );
-    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.Username, '  admin  ').type).toBe(
-      ValidationState.Success,
-    );
+  it('validates required fields and trims input', () => {
+    for (const id of requiredFieldIds) {
+      expect(openstackSecretFieldValidator(id, '').type).toBe(ValidationState.Error);
+      expect(openstackSecretFieldValidator(id, '   ').type).toBe(ValidationState.Error);
+      expect(openstackSecretFieldValidator(id, '  value  ').type).toBe(ValidationState.Success);
+    }
   });
 
   it('validates insecure skip verify and cacert fields', () => {
@@ -31,5 +44,8 @@ describe('openstackSecretFieldValidator - dispatch', () => {
     expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.AuthType, 'password').type).toBe(
       ValidationState.Default,
     );
+    expect(
+      openstackSecretFieldValidator('unknownField' as OpenstackSecretFieldsId, 'anything').type,
+    ).toBe(ValidationState.Default);
   });
 });

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
 import { OpenstackSecretFieldsId } from 'src/providers/utils/constants';
+
+import { describe, expect, it } from '@jest/globals';
 import { ValidationState } from '@utils/validation/Validation';
 
 import { openstackSecretFieldValidator } from '../openstackSecretFieldValidator';

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidator.dispatch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from '@jest/globals';
+import { OpenstackSecretFieldsId } from 'src/providers/utils/constants';
+import { ValidationState } from '@utils/validation/Validation';
+
+import { openstackSecretFieldValidator } from '../openstackSecretFieldValidator';
+
+describe('openstackSecretFieldValidator - dispatch', () => {
+  it('validates required username and trims input', () => {
+    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.Username, '').type).toBe(
+      ValidationState.Error,
+    );
+    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.Username, '  admin  ').type).toBe(
+      ValidationState.Success,
+    );
+  });
+
+  it('validates insecure skip verify and cacert fields', () => {
+    expect(
+      openstackSecretFieldValidator(OpenstackSecretFieldsId.InsecureSkipVerify, 'true').type,
+    ).toBe(ValidationState.Success);
+    expect(
+      openstackSecretFieldValidator(OpenstackSecretFieldsId.InsecureSkipVerify, 'maybe').type,
+    ).toBe(ValidationState.Error);
+    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.CaCert, '').type).toBe(
+      ValidationState.Default,
+    );
+  });
+
+  it('returns default for auth type and unknown ids', () => {
+    expect(openstackSecretFieldValidator(OpenstackSecretFieldsId.AuthType, 'password').type).toBe(
+      ValidationState.Default,
+    );
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidators.required.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidators.required.test.ts
@@ -8,10 +8,24 @@ import {
   validateUsername,
 } from '../openstackSecretFieldValidators';
 
+const requiredValidators = [
+  validateUsername,
+  validatePassword,
+  validateRegionName,
+  validateProjectName,
+] as const;
+
 describe('openstackSecretFieldValidators - required', () => {
-  it('errors on empty values and spaces', () => {
-    expect(validateUsername('').type).toBe(ValidationState.Error);
-    expect(validatePassword('bad pass').type).toBe(ValidationState.Error);
+  it('errors on empty values and spaces for each validator', () => {
+    for (const validate of requiredValidators) {
+      expect(validate('').type).toBe(ValidationState.Error);
+      expect(validate('has space').type).toBe(ValidationState.Error);
+    }
+  });
+
+  it('succeeds for non-empty values without spaces', () => {
+    expect(validateUsername('admin').type).toBe(ValidationState.Success);
+    expect(validatePassword('secret').type).toBe(ValidationState.Success);
     expect(validateRegionName('RegionOne').type).toBe(ValidationState.Success);
     expect(validateProjectName('admin').type).toBe(ValidationState.Success);
   });

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidators.required.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/openstackSecretFieldValidators.required.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@jest/globals';
+import { ValidationState } from '@utils/validation/Validation';
+
+import {
+  validatePassword,
+  validateProjectName,
+  validateRegionName,
+  validateUsername,
+} from '../openstackSecretFieldValidators';
+
+describe('openstackSecretFieldValidators - required', () => {
+  it('errors on empty values and spaces', () => {
+    expect(validateUsername('').type).toBe(ValidationState.Error);
+    expect(validatePassword('bad pass').type).toBe(ValidationState.Error);
+    expect(validateRegionName('RegionOne').type).toBe(ValidationState.Success);
+    expect(validateProjectName('admin').type).toBe(ValidationState.Success);
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateCacert.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateCacert.validation.test.ts
@@ -1,7 +1,16 @@
+/* eslint-disable @cspell/spellchecker */
 import { describe, expect, it } from '@jest/globals';
 import { ValidationState } from '@utils/validation/Validation';
 
 import { validateCacert } from '../validateCacert';
+
+// Known-good PEM reused from validatePublicCert.test.ts
+const VALID_PEM = `
+-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiIMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRtZSBXaWRn
+-----END CERTIFICATE-----
+`.trim();
 
 describe('validateCacert - validation', () => {
   it('defaults for empty and errors for invalid PEM', () => {
@@ -10,14 +19,6 @@ describe('validateCacert - validation', () => {
   });
 
   it('succeeds for a valid PEM certificate', () => {
-    const pem = `-----BEGIN CERTIFICATE-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWy
-F5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8
-GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/
-ygWyF5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw
-5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8GqVxwIDAQAB
------END CERTIFICATE-----`;
-    // May be Error or Success depending on validatePublicCert strictness; assert not Default
-    expect(validateCacert(pem).type).not.toBe(ValidationState.Default);
+    expect(validateCacert(VALID_PEM).type).toBe(ValidationState.Success);
   });
 });

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateCacert.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateCacert.validation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@jest/globals';
+import { ValidationState } from '@utils/validation/Validation';
+
+import { validateCacert } from '../validateCacert';
+
+describe('validateCacert - validation', () => {
+  it('defaults for empty and errors for invalid PEM', () => {
+    expect(validateCacert('').type).toBe(ValidationState.Default);
+    expect(validateCacert('not-a-cert').type).toBe(ValidationState.Error);
+  });
+
+  it('succeeds for a valid PEM certificate', () => {
+    const pem = `-----BEGIN CERTIFICATE-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0Z3VS5JJcds3xfn/ygWy
+F5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8
+GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/
+ygWyF5PZGPxwnz9z/CYw5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw
+5pN8GqVx0Z3VS5JJcds3xfn/ygWyF5PZGPxwnz9z/CYw5pN8GqVxwIDAQAB
+-----END CERTIFICATE-----`;
+    // May be Error or Success depending on validatePublicCert strictness; assert not Default
+    expect(validateCacert(pem).type).not.toBe(ValidationState.Default);
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateInsecureSkipVerify.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateInsecureSkipVerify.validation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { ValidationState } from '@utils/validation/Validation';
+
+import { validateInsecureSkipVerify } from '../validateInsecureSkipVerify';
+
+describe('validateInsecureSkipVerify - validation', () => {
+  it('accepts true/false/empty and rejects other values', () => {
+    expect(validateInsecureSkipVerify(undefined as never).type).toBe(ValidationState.Default);
+    expect(validateInsecureSkipVerify('true').type).toBe(ValidationState.Success);
+    expect(validateInsecureSkipVerify('false').type).toBe(ValidationState.Success);
+    expect(validateInsecureSkipVerify('').type).toBe(ValidationState.Success);
+    expect(validateInsecureSkipVerify('yes').type).toBe(ValidationState.Error);
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateInsecureSkipVerify.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateInsecureSkipVerify.validation.test.ts
@@ -5,7 +5,9 @@ import { validateInsecureSkipVerify } from '../validateInsecureSkipVerify';
 
 describe('validateInsecureSkipVerify - validation', () => {
   it('accepts true/false/empty and rejects other values', () => {
-    expect(validateInsecureSkipVerify(undefined as never).type).toBe(ValidationState.Default);
+    expect(validateInsecureSkipVerify(undefined as unknown as string).type).toBe(
+      ValidationState.Default,
+    );
     expect(validateInsecureSkipVerify('true').type).toBe(ValidationState.Success);
     expect(validateInsecureSkipVerify('false').type).toBe(ValidationState.Success);
     expect(validateInsecureSkipVerify('').type).toBe(ValidationState.Success);

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateOpenstackRequiredNoSpacesField.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateOpenstackRequiredNoSpacesField.validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { ValidationState } from '@utils/validation/Validation';
+
+import { validateOpenstackRequiredNoSpacesField } from '../validateOpenstackRequiredNoSpacesField';
+
+const msgs = {
+  invalidMsg: 'invalid',
+  requiredMsg: 'required',
+  successMsg: 'ok',
+};
+
+describe('validateOpenstackRequiredNoSpacesField - validation', () => {
+  it('handles undefined, empty, valid, and spaced values', () => {
+    expect(validateOpenstackRequiredNoSpacesField(undefined as never, msgs)).toEqual({
+      msg: 'required',
+      type: ValidationState.Default,
+    });
+    expect(validateOpenstackRequiredNoSpacesField('', msgs).type).toBe(ValidationState.Error);
+    expect(validateOpenstackRequiredNoSpacesField('ok', msgs)).toEqual({
+      msg: 'ok',
+      type: ValidationState.Success,
+    });
+    expect(validateOpenstackRequiredNoSpacesField('has space', msgs).type).toBe(
+      ValidationState.Error,
+    );
+  });
+});

--- a/src/providers/details/tabs/Credentials/components/utils/__tests__/validateOpenstackRequiredNoSpacesField.validation.test.ts
+++ b/src/providers/details/tabs/Credentials/components/utils/__tests__/validateOpenstackRequiredNoSpacesField.validation.test.ts
@@ -11,17 +11,21 @@ const msgs = {
 
 describe('validateOpenstackRequiredNoSpacesField - validation', () => {
   it('handles undefined, empty, valid, and spaced values', () => {
-    expect(validateOpenstackRequiredNoSpacesField(undefined as never, msgs)).toEqual({
+    expect(validateOpenstackRequiredNoSpacesField(undefined as unknown as string, msgs)).toEqual({
       msg: 'required',
       type: ValidationState.Default,
     });
-    expect(validateOpenstackRequiredNoSpacesField('', msgs).type).toBe(ValidationState.Error);
+    expect(validateOpenstackRequiredNoSpacesField('', msgs)).toEqual({
+      msg: 'required',
+      type: ValidationState.Error,
+    });
     expect(validateOpenstackRequiredNoSpacesField('ok', msgs)).toEqual({
       msg: 'ok',
       type: ValidationState.Success,
     });
-    expect(validateOpenstackRequiredNoSpacesField('has space', msgs).type).toBe(
-      ValidationState.Error,
-    );
+    expect(validateOpenstackRequiredNoSpacesField('has space', msgs)).toEqual({
+      msg: 'invalid',
+      type: ValidationState.Error,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Raise coverage on weak partials: `openstackSecretFieldValidator` (+ field validators), cacert/insecureSkipVerify, `getDecodedValue`, and plan concerns merge/selectors

## Test plan
- [x] `npm test -- <new test paths>`
- [ ] CI green

Resolves: MTV-6266

Made with [Cursor](https://cursor.com)