### PR TITLE
chore(deps): group MintMaker updates and drop unsupported branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "ignorePresets": ["group:monorepos", "group:recommended"],
   "vulnerabilityAlerts": {
     "enabled": true
   },
   "packageRules": [
     {
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupName": "npm non-major",
-      "schedule": ["before 6am on Monday"]
+      "description": "Disable updates on unsupported release branches",
+      "enabled": false,
+      "matchBaseBranches": ["release-2.7", "release-2.8", "release-2.9"]
     },
     {
-      "matchManagers": ["dockerfile"],
-      "groupName": "container base images"
+      "description": "One grouped non-major PR per supported branch",
+      "groupName": "all non-major dependencies",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
+    },
+    {
+      "description": "One grouped major PR per supported branch",
+      "groupName": "all major dependencies",
+      "matchUpdateTypes": ["major"]
     }
   ],
   "tekton": {


### PR DESCRIPTION
## Summary
- Group all non-major dependency updates into one PR per supported branch (`main`, `release-2.12`, `release-2.11`, `release-2.10`)
- Group all major dependency updates into a separate PR per supported branch
- Disable Renovate updates on unsupported `release-2.7`, `release-2.8`, and `release-2.9`
- Ignore `group:monorepos` / `group:recommended` presets so monorepo splits cannot override the catch-all groups

## After merge
1. Disable MintMaker on unsupported Konflux components:
   `oc -n <namespace> annotate component/<name> mintmaker.appstudio.redhat.com/disabled=true`
2. Close existing individual MintMaker PRs (they will not block the new grouped ones)
3. Wait for the next MintMaker cycle (~4h) for the new grouped PRs
4. Do **not** close a new grouped PR just because CI is red — grouped PRs are immortal and will be recreated

## Test plan
- [ ] Confirm `renovate.json` schema is valid
- [ ] After merge, verify MintMaker opens one non-major and one major PR per supported branch
- [ ] Verify no new MintMaker PRs appear for `release-2.7` / `release-2.8` / `release-2.9` (after component annotation)
- [ ] Confirm Tekton automerge path is unchanged


Made with [Cursor](https://cursor.com)